### PR TITLE
add emacs to scoop-extras bucket

### DIFF
--- a/emacs.json
+++ b/emacs.json
@@ -1,0 +1,9 @@
+{
+	"url": "http://www.gnu.org/software/emacs/",
+	"license": "GPL3",
+	"version": "24.3",
+	"url": "http://ftp.gnu.org/gnu/emacs/windows/emacs-24.3-bin-i386.zip",
+        "hash": "md5:06033dc7a9869dacb10299a8df99b9c2",
+	"extract_dir": "emacs-24.3",
+	"bin": [ "bin\\runemacs.exe", "bin\\emacs.exe", "bin\\emacsclientw.exe" ]
+}


### PR DESCRIPTION
As discussed in lukesampson/scoop#30.

Note: I kept the other 2 executables:
- I almost always use runemacs from the command line, almost never emacs.exe, to get an emacs server going without blocking the console.
- I usually use emacsclientw to connect to an emacs server.

Since this is in extras, I thought it would be OK to have shims for all three. Let me know if this is not cool. Thanks!
