### PR TITLE
Include 'apm' - 'Atom Package Manager' binary

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -1,9 +1,12 @@
 {
-	"homepage": "https://atom.io/",
-	"version": "0.113.0",
-	"license": "MIT",
-	"url": "https://github.com/atom/atom/releases/download/v0.113.0/atom-windows.zip",
-	"hash": "a02d696c5063e4e5a147f2adfb07912c96e69b8489cf423d28e5b0f014c9c236",
+    "homepage": "https://atom.io/",
+    "version": "0.113.0",
+    "license": "MIT",
+    "url": "https://github.com/atom/atom/releases/download/v0.113.0/atom-windows.zip",
+    "hash": "a02d696c5063e4e5a147f2adfb07912c96e69b8489cf423d28e5b0f014c9c236",
     "extract_dir": "Atom",
-	"bin": "atom.exe"
+    "bin": [
+        "atom.exe",
+        "\\resources\\app\\apm\\node_modules\\atom-package-manager\\bin\\apm.cmd"
+    ]
 }


### PR DESCRIPTION
- Include 'apm' - 'Atom Package Manager' binary
- Reformats patch to use spaces for tab indentation (.json files should use spaces, not tabs) See http://yaml.org/spec/1.2/spec.html#id2777534
