### PR TITLE
Added util-linux-ng

### DIFF
--- a/util-linux-ng.json
+++ b/util-linux-ng.json
@@ -1,0 +1,22 @@
+{
+	"homepage": "http://gnuwin32.sourceforge.net/packages/util-linux-ng.htm",
+	"version": "2.14.1",
+	"url": [ 
+		"http://downloads.sourceforge.net/gnuwin32/util-linux-ng-2.14.1-bin.zip", 
+		"http://downloads.sourceforge.net/gnuwin32/util-linux-ng-2.14.1-dep.zip"
+		],
+	"hash": [ "md5:fec95f69807c5dbcdaf868f4c6b738c2", "md5:b28850af59f98d1ebd4d6bcdd058e0d7" ],
+	"bin": [
+		"bin\\col.exe",
+		"bin\\colcrt.exe",
+		"bin\\colrm.exe",
+		"bin\\ddate.exe",
+		"bin\\getopt.exe",
+		"bin\\hexdump.exe",
+		"bin\\line.exe",
+		"bin\\rename.exe",
+		"bin\\rev.exe",
+		"bin\\tailf.exe",
+		"bin\\whereis.exe"
+	]
+}


### PR DESCRIPTION
util-linux-ng contains "various system utilities" including getopt which allowed me to install git-flow whereas the busybox getopt doesn't work.
