### PR TITLE
Add git-flow (latest)

### DIFF
--- a/git-flow.json
+++ b/git-flow.json
@@ -1,0 +1,15 @@
+{
+  "version": "latest",
+  "homepage": "https://github.com/nvie/gitflow",
+  "url": "https://raw.githubusercontent.com/nvie/gitflow/develop/contrib/gitflow-installer.sh",
+  "post_install": "
+    mkdir \"$dir\\bin\" | Out-Null
+    $env:INSTALL_PREFIX=\"$dir\\bin\"
+    $env:REPO_NAME=\"$dir\\repo\"
+    iex \"sh $dir\\gitflow-installer.sh\" | Out-Null
+    Remove-Item Env:/REPO_NAME
+    Remove-Item Env:/INSTALL_PREFIX
+  ",
+  "env_add_path": "bin",
+  "depends": [ "busybox", "git", "util-linux-ng" ]
+}


### PR DESCRIPTION
Stemming from https://github.com/lukesampson/scoop/issues/162 I worked out how to install git-flow, based on my own personal need to make it easy to install for collegues. 

I'm actually quite chuffed with this one. As long as the commands are on the path, git picks them up as sub commands so `git flow` works :)

It does have to clone a git repository, but `scoop uninstall git-flow` works with this setup.
