### PR TITLE
Fix git-flow issues with shFlags

### DIFF
--- a/git-flow.json
+++ b/git-flow.json
@@ -3,10 +3,18 @@
   "homepage": "https://github.com/nvie/gitflow",
   "url": "https://raw.githubusercontent.com/nvie/gitflow/develop/contrib/gitflow-installer.sh",
   "post_install": "
-    mkdir \"$dir\\bin\" | Out-Null
     $env:INSTALL_PREFIX=\"$dir\\bin\"
     $env:REPO_NAME=\"$dir\\repo\"
-    iex \"sh $dir\\gitflow-installer.sh\" | Out-Null
+    $env:REPO_HOME=\"https://github.com/nvie/gitflow\"
+
+    iex \"
+      busybox mkdir -p $dir\\bin;
+      git clone $env:REPO_HOME --recursive $env:REPO_NAME; 
+      sh $dir\\gitflow-installer.sh;
+      cp $env:REPO_NAME\\shFlags\\src\\shflags $dir\\bin\\gitflow-shFlags;
+    \" | Out-Null
+
+    Remove-Item Env:/REPO_HOME
     Remove-Item Env:/REPO_NAME
     Remove-Item Env:/INSTALL_PREFIX
   ",


### PR DESCRIPTION
I changed the install process to pull the gitflow repo recursively
before running the installer rather than let the installer do it,
because for some reason the installer thinks that the shFlags
submodule is there (when it isn't).

Going by the msysgit-install.cmd I copy the shflags file over the
gitflow-shFlags file which ultimately fixes the bug causing
git-flow not to work on a fresh install.

I also refactored the post_install script so that all the cmd calls
are in the same Invoke-Expression call
