### PR TITLE
Add OneGet

### DIFF
--- a/oneget.json
+++ b/oneget.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "http://oneget.org",
+    "version": "nightly",
+    "license": "Apache 2.0",
+    "architecture": {
+      "64bit": {
+        "url": "http://oneget.org/oneget.zip"
+      },
+      "32bit": {
+        "url": "http://oneget.org/oneget.zip"
+      }
+    },
+    "post_install": "
+      Import-Module \"$dir\\oneget\"
+    "
+}


### PR DESCRIPTION
Windows 10 will include a package manager OneGet, here is a Scoop
manifest to get the latest "nightly"
- This most likely will need some tweaks as the PowerShell module
  version changes I'm not sure if `Import-Module` will actually update the
  module.
- Some resources about OneGet if your curious [Hacker
  News](https://news.ycombinator.com/item?id=8524919) [Twitter
  @PSOneGet](https://twitter.com/PSOneGet)
- As OneGet is fully extensible a plugin could be written to include
  Scoop as a "Package Provider"
