### PR TITLE
Fix nircmd issues

### DIFF
--- a/nircmd.json
+++ b/nircmd.json
@@ -4,5 +4,5 @@
 	"url": "http://www.nirsoft.net/utils/nircmd.zip",
 	"hash": "414cd4db433b92ae1847053cad40d34e",
 	"extract_dir": "nircmd",
-	"bin": "nircmdc.exe,
+	"bin": "nircmdc.exe"
 }


### PR DESCRIPTION
`nircmd` should now be fixed. There was an unclosed string as well as a trailing comma (should be legal for JSON, but does PowerShell handle it well?). Next time perhaps test the manifest before requesting the manifest to be pulled into the main repo, thats all. :stuck_out_tongue_winking_eye: 
