### PR TITLE
Upgraded ELS to 1.4.0

### DIFF
--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -1,9 +1,9 @@
 {
 	"homepage": "http://www.elasticsearch.org",
-	"version": "0.90.9",
+	"version": "1.4.0",
 	"depends": "openjdk",
-	"url": "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.90.9.zip",
-	"hash": "b7a9bc683a1742abd09e5d61252a7180bd78b7ee2f7ebf73790a65a167213303",
-	"extract_dir": "elasticsearch-0.90.9",
-	"bin": "bin\\elasticsearch.bat"
+	"url": "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.0.zip",
+	"hash": "sha1:ffba14b85e4f03f9fbcfb86dc65c4a83390514d1",
+	"extract_dir": "elasticsearch-1.4.0",
+	"bin": [["bin\\elasticsearch.bat"],["bin\\service.bat", "elssrv", ""]]
 }


### PR DESCRIPTION
Upgraded Elasticsearch to version 1.4.0.
Added shim alias "elssrv" to point to tool that allows to install, stop, start, remove windows service for ELS.

Examples:
elssrv install 
elssrv start
elssrv stop
elssrv remove
