### PR TITLE
Add oraclejdk manifest and install script

### DIFF
--- a/oraclejdk.json
+++ b/oraclejdk.json
@@ -1,0 +1,38 @@
+{
+	"homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
+	"version": "1.8.0-u25",
+	"architecture": {
+		"64bit": {
+			"url": [
+				"http://download.oracle.com/otn-pub/java/jdk/8u25-b18/jdk-8u25-windows-x64.exe#/dl.7z",
+				"https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
+			],
+			"hash": [
+				"b68acf3048672b7e744fe8d0d2dcf201c6aacedb75fb8ed90db23a806fc47c2b",
+				"f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
+			]
+		},
+		"32bit": {
+			"url": [
+				"http://download.oracle.com/otn-pub/java/jdk/8u25-b18/jdk-8u25-windows-i586.exe#/dl.7z",
+				"https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
+			],
+			"hash": [
+				"389c6f3cec9dd2fe8b0c32a4d540caa03598d5e3442f41c7c0ff46ae295e4de7",
+				"f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
+			]
+		}
+	},
+	"cookie": {
+		"oraclelicense": "accept-securebackup-cookie"
+	},
+	"installer": {
+		"_comment": "oraclejdk unpacks .pack into .jar files",
+		"file": "oraclejdk.ps1",
+		"args": [ "$dir" ]
+	},
+	"env_add_path": "bin",
+	"env_set": {
+		"JAVA_HOME": "$dir"
+	}
+}

--- a/scripts/oraclejdk.ps1
+++ b/scripts/oraclejdk.ps1
@@ -1,0 +1,13 @@
+param($dir)
+
+# Second extraction
+$output = 7z x $dir\tools.zip "-o$dir"
+rm $dir\tools.zip
+
+# Convert .pack to .jar, and removes .pack
+ls "$dir" -recurse | ? name -match '^[^_].*?\.(?i)pack$' | % {
+    $name = $_.fullname -replace '\.(?i)pack$', ''
+    $pack = "$name.pack"
+    $jar = "$name.jar"
+    & "$dir\bin\unpack200.exe" "-r" "$pack" "$jar"
+}


### PR DESCRIPTION
Hello,

Finally got a working manifest for the `oraaclejdk`. Much more complicated than anticipated however I finally got it to a state that it look like it works as intended.

Feel free to make changes to the names, code and way it works. I have set it up so it uses a custom install script due to the extra logic required to install it correctly. This is a double extraction as well as unpacking all `.pack` files and converting them to `.jar` files using a tool found in the jdk itself, `bin\unpack200.exe`.

If you do not want a separate install script, or wish to rename it feel free to do so as long as it doesn't break the manifest. I included a hash for the install script because the warning message that `scoop` presents can be annoying, plus it is easy to do.

Currently installs JDK 8 which is the latest, but I may include JDK 7 and potentially JDK 6 potentially in the future as many people still use these JDKs. When this happens a single, universal install script should be created, this one currently I believe should handle every JDK, unless there are significant differences.
- `oraclejdk8`
- `oraclejdk7`
- `oraclejdk6`

Something around those lines. Anyway enjoy. Please test it out, just in case it does not work for others, but has worked fine on my end so far. Havn't got far enough to actually compile programs yet.

Hoepfully the current source for `openjdk` can build a Java 8 compatible version soon as users who use the `openjdk` are currently missing out on new features, unless they build `openjdk` themselves. It appears they are working on it though. Which is good because a choice is always nice :smile:.
