### PR TITLE
Fix elasticsearch 'emptystring' error

### DIFF
--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -5,5 +5,9 @@
 	"url": "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.0.zip",
 	"hash": "sha1:ffba14b85e4f03f9fbcfb86dc65c4a83390514d1",
 	"extract_dir": "elasticsearch-1.4.0",
-	"bin": [["bin\\elasticsearch.bat"],["bin\\service.bat", "elssrv", ""]]
+	"bin": [
+		"bin\\elasticsearch.bat",
+		"bin\\service.bat",
+		"elssrv"
+	]
 }


### PR DESCRIPTION
This error has been urking me for a while and today I decided to hunt it down.

When using `scoop search` I have been getting the following error (only sometimes, which was weird):

```
Split-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At C:\Users\Scott\appdata\local\scoop\apps\scoop\current\libexec\scoop-search.ps1:16 char:23
+         $fname = split-path $bin -leaf
+                             ~~~~
```

I figured out what the error message was saying, however I spent far too much time looking through scoops main bucket and completely forgot about scoops extras bucket. Many hours wasted, :disappointed_relieved: however it has now been resolved. :smile:.

The issue occurs when an `emptystring` is passed through the search system, which breaks `split-path`. I don't know whether some extra code should be created, or whether new and modified manifests should be checked over more thoroughly.

Side note: First is `service.bat` and `elssrv` required, I do not use elasticsearch, but `service.bat` is very generic and `elssrv` does not look like it does anything. Also I was looking through the history of this file and it appears you fixed it at one point only to revert the file back?
