### PR TITLE
Add oraclejdk7 manifest

### DIFF
--- a/oraclejdk7.json
+++ b/oraclejdk7.json
@@ -1,0 +1,38 @@
+{
+	"homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
+	"version": "1.7.0-u71",
+	"architecture": {
+		"64bit": {
+			"url": [
+				"http://download.oracle.com/otn-pub/java/jdk/7u71-b14/jdk-7u71-windows-x64.exe#/dl.7z",
+				"https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
+			],
+			"hash": [
+				"1de2387e821320850e6377c2987a76c30c1edf9895fd14b3c7abbaca7c203fd2",
+				"f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
+			]
+		},
+		"32bit": {
+			"url": [
+				"http://download.oracle.com/otn-pub/java/jdk/7u71-b14/jdk-7u71-windows-i586.exe#/dl.7z",
+				"https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
+			],
+			"hash": [
+				"389c6f3cec9dd2fe8b0c32a4d540caa03598d5e3442f41c7c0ff46ae295e4de7",
+				"f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
+			]
+		}
+	},
+	"cookie": {
+		"oraclelicense": "accept-securebackup-cookie"
+	},
+	"installer": {
+		"_comment": "oraclejdk unpacks .pack into .jar files",
+		"file": "oraclejdk.ps1",
+		"args": [ "$dir" ]
+	},
+	"env_add_path": "bin",
+	"env_set": {
+		"JAVA_HOME": "$dir"
+	}
+}


### PR DESCRIPTION
Works the same as the previous `oraclejdk`, lets hope Java 9 is just as easy.
