### PR TITLE
fftw: Add version 3.3.5

### DIFF
--- a/fftw.json
+++ b/fftw.json
@@ -5,14 +5,14 @@
         "64bit": {
             "url": [
                 "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip",
-                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/8ac3246668acb7f70ac955a04efd8b951c5670fc/fftw3f.pc"
+                "https://raw.githubusercontent.com/FFTW/fftw3/6e615417da7e1c7cba49b1a73c9edcc15d938cf9/fftw.pc.in"
             ],
             "hash": "cfd88dc0e8d7001115ea79e069a2c695d52c8947f5b4f3b7ac54a192756f439f"
         },
         "32bit": {
             "url": [
                 "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
-                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/8ac3246668acb7f70ac955a04efd8b951c5670fc/fftw3f.pc"
+                "https://raw.githubusercontent.com/FFTW/fftw3/6e615417da7e1c7cba49b1a73c9edcc15d938cf9/fftw.pc.in"
             ],
             "hash": "29882a43033c9393479a4df52a2e9120589c06a2b724155b1a682747fa3e57d4"
         }
@@ -36,9 +36,24 @@
             mv \"$dir\\*.dll\" \"$dir\\lib\"
             mv \"$dir\\*.def\" \"$dir\\lib\"
             mv \"$dir\\*.exe\" \"$dir\\lib\"
-            mv \"$dir\\*.pc\" \"$dir\\lib\\pkgconfig\"
             mv \"$dir\\*.h\" \"$dir\\include\"
             mv \"$dir\\*.f*\" \"$dir\\include\"
+
+            # generate normal, float and long pkgconfig files
+            $types = @(\"\",\"f\",\"l\")
+            foreach ($type in $types) {
+                $source = \"$dir\\fftw.pc.in\"
+                $target = \"$dir\\lib\\pkgconfig\\fftw3$($type).pc\"
+                sc $target ((gc $source) `
+                    -replace \"@prefix@\",\"\" `
+                    -replace \"@exec_prefix@\",\"`${prefix}\" `
+                    -replace \"@libdir@\",\"`${exec_prefix}/lib\" `
+                    -replace \"@includedir@\",\"`${prefix}/include\" `
+                    -replace \"@VERSION@\",\"$version\" `
+                    -replace \"@PREC_SUFFIX@\",\"$type\" `
+                    -replace \"@LIBQUADMATH@\",\"\" `
+                )
+            }
 
             # exes expect adjacent dlls, leave them together
             cmd /c mklink /j \"$dir\\bin\" \"$dir\\lib\" > $null
@@ -54,6 +69,9 @@
             $env:PKG_CONFIG_PATH = \"$pcdir;$env:PKG_CONFIG_PATH\"
         "
     },
+    "post_install": "
+        rm \"$dir\\fftw.pc.in\"
+    ",
     "uninstaller": {
         "script": "
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"

--- a/fftw.json
+++ b/fftw.json
@@ -5,6 +5,7 @@
         "64bit": {
             "url": [
                 "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip",
+                "https://github.com/tresf/fftw3/releases/download/fftw-3.3.5/fftw-3.3.5-lib64.zip",
                 "https://raw.githubusercontent.com/FFTW/fftw3/6e615417da7e1c7cba49b1a73c9edcc15d938cf9/fftw.pc.in"
             ],
             "hash": "cfd88dc0e8d7001115ea79e069a2c695d52c8947f5b4f3b7ac54a192756f439f"
@@ -12,6 +13,7 @@
         "32bit": {
             "url": [
                 "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
+                "https://github.com/tresf/fftw3/releases/download/fftw-3.3.5/fftw-3.3.5-lib32.zip",
                 "https://raw.githubusercontent.com/FFTW/fftw3/6e615417da7e1c7cba49b1a73c9edcc15d938cf9/fftw.pc.in"
             ],
             "hash": "29882a43033c9393479a4df52a2e9120589c06a2b724155b1a682747fa3e57d4"

--- a/fftw.json
+++ b/fftw.json
@@ -5,14 +5,14 @@
         "64bit": {
             "url": [
                 "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip",
-                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/895af98eddd9b755dbfe74245a03aa38fc0dc1f8/fftw3.pc"
+                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/8ac3246668acb7f70ac955a04efd8b951c5670fc/fftw3f.pc"
             ],
             "hash": "cfd88dc0e8d7001115ea79e069a2c695d52c8947f5b4f3b7ac54a192756f439f"
         },
         "32bit": {
             "url": [
                 "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
-                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/895af98eddd9b755dbfe74245a03aa38fc0dc1f8/fftw3.pc"
+                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/8ac3246668acb7f70ac955a04efd8b951c5670fc/fftw3f.pc"
             ],
             "hash": "29882a43033c9393479a4df52a2e9120589c06a2b724155b1a682747fa3e57d4"
         }

--- a/fftw.json
+++ b/fftw.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "www.fftw.org",
+    "homepage": "http://www.fftw.org",
     "version": "3.3.5",
     "architecture": {
         "64bit": {

--- a/fftw.json
+++ b/fftw.json
@@ -61,14 +61,19 @@
             cmd /c mklink /j \"$dir\\bin\" \"$dir\\lib\" > $null
 
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
+            $cmdir = \"$(current_dir $dir)\"
 
             # future sessions
             $null, $currpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir
             env 'PKG_CONFIG_PATH' $global \"$pcdir;$currpath\"
+            $null, $currpath = strip_path (env 'CMAKE_PREFIX_PATH' $global) $cmddir
+            env 'CMAKE_PREFIX_PATH' $global \"$cmddir;$currpath\"
 
             # this session
             $null, $env:PKG_CONFIG_PATH = strip_path $env:PKG_CONFIG_PATH $pcdir
             $env:PKG_CONFIG_PATH = \"$pcdir;$env:PKG_CONFIG_PATH\"
+            $null, $env:CMAKE_PREFIX_PATH = strip_path $env:CMAKE_PREFIX_PATH $cmdir
+            $env:CMAKE_PREFIX_PATH = \"$cmdir;$env:CMAKE_PREFIX_PATH\"
         "
     },
     "post_install": "
@@ -77,15 +82,27 @@
     "uninstaller": {
         "script": "
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
+            $cmdir = \"$(current_dir $dir)\"
+
             # future sessions
             $was_in_path, $newpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir
             if($was_in_path) {
                 write-host \"Removing $(friendly_path $pcdir) from your path.\"
                 env 'PKG_CONFIG_PATH' $global $newpath
             }
+
+            $was_in_path, $newpath = strip_path (env 'CMAKE_PREFIX_PATH' $global) $cmdir
+            if($was_in_path) {
+                write-host \"Removing $(friendly_path $cmdir) from your path.\"
+                env 'CMAKE_PREFIX_PATH' $global $newpath
+            }
+
             # current session
             $was_in_path, $newpath = strip_path $env:PKG_CONFIG_PATH $pcdir
             if($was_in_path) { $env:PKG_CONFIG_PATH = $newpath }
+
+            $was_in_path, $newpath = strip_path $env:CMAKE_PREFIX_PATH $cmdir
+            if($was_in_path) { $env:CMAKE_PREFIX_PATH = $newpath }
         "
     }
 }

--- a/fftw.json
+++ b/fftw.json
@@ -1,0 +1,71 @@
+{
+    "homepage": "www.fftw.org",
+    "version": "3.3.5",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip",
+                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/895af98eddd9b755dbfe74245a03aa38fc0dc1f8/fftw3.pc"
+            ],
+            "hash": "cfd88dc0e8d7001115ea79e069a2c695d52c8947f5b4f3b7ac54a192756f439f"
+        },
+        "32bit": {
+            "url": [
+                "ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip",
+                "https://gist.githubusercontent.com/tresf/7687a9b45ab260762631af60bb89621f/raw/895af98eddd9b755dbfe74245a03aa38fc0dc1f8/fftw3.pc"
+            ],
+            "hash": "29882a43033c9393479a4df52a2e9120589c06a2b724155b1a682747fa3e57d4"
+        }
+    },
+    "bin": [
+        "bin\\fftwf-wisdom.exe",
+        "bin\\fftwl-wisdom.exe",
+        "bin\\fftw-wisdom.exe"
+    ],
+    "checkver": {
+        "url": "http://www.fftw.org/install/windows.html",
+        "re": "\"ftp://ftp.fftw.org/pub/fftw/fftw-([\\d.]+)-dll64.zip\""
+    },
+    "installer": {
+        "script": "
+            # organize files
+            mkdir -f \"$dir\\lib\" > $null
+            mkdir -f \"$dir\\lib\\pkgconfig\" > $null
+            mkdir -f \"$dir\\include\" > $null
+
+            mv \"$dir\\*.dll\" \"$dir\\lib\"
+            mv \"$dir\\*.def\" \"$dir\\lib\"
+            mv \"$dir\\*.exe\" \"$dir\\lib\"
+            mv \"$dir\\*.pc\" \"$dir\\lib\\pkgconfig\"
+            mv \"$dir\\*.h\" \"$dir\\include\"
+            mv \"$dir\\*.f*\" \"$dir\\include\"
+
+            # exes expect adjacent dlls, leave them together
+            cmd /c mklink /j \"$dir\\bin\" \"$dir\\lib\" > $null
+
+            $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
+
+            # future sessions
+            $null, $currpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir
+            env 'PKG_CONFIG_PATH' $global \"$pcdir;$currpath\"
+
+            # this session
+            $null, $env:PKG_CONFIG_PATH = strip_path $env:PKG_CONFIG_PATH $pcdir
+            $env:PKG_CONFIG_PATH = \"$pcdir;$env:PKG_CONFIG_PATH\"
+        "
+    },
+    "uninstaller": {
+        "script": "
+            $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
+            # future sessions
+            $was_in_path, $newpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir
+            if($was_in_path) {
+                write-host \"Removing $(friendly_path $pcdir) from your path.\"
+                env 'PKG_CONFIG_PATH' $global $newpath
+            }
+            # current session
+            $was_in_path, $newpath = strip_path $env:PKG_CONFIG_PATH $pcdir
+            if($was_in_path) { $env:PKG_CONFIG_PATH = $newpath }
+        "
+    }
+}


### PR DESCRIPTION
Adds fftw library and pkg-config files.
 * Since `fftw3.pc`, `fftw3l.pc` and `fftw3f.pc` files were not included in the Windows distribution, I pulled the template file from upstream and configure it by hand.
 * The standard `/lib`, `/bin` structure is created at install time since this library is shipped as a flat directory for windows.
    * Why?   Well, `pkg-config` expects the prefix to be `... prefix for that package is assumed to be the grandparent of the directory where the file was found... `, so the structure has been mimicked accordingly.
 * As a flat directory, `bin/fftw-wisdom.exe` expects `lib/libfftw3-3.dll` side-by-side, so `bin/` is a symlink to `lib/` to accommodate.

This PR shouldn't be merged it is first unit tested against a basic program.