### PR TITLE
Update libsndfile

### DIFF
--- a/libsndfile.json
+++ b/libsndfile.json
@@ -39,6 +39,8 @@
     },
     "installer": {
         "script": "
+            cmd /c mklink /h \"$dir\\lib\\sndfile.lib\" \"$dir\\lib\\libsndfile-1.lib\" > $null
+        
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
 
             # future sessions

--- a/libsndfile.json
+++ b/libsndfile.json
@@ -40,7 +40,7 @@
     "installer": {
         "script": "
             cmd /c mklink /h \"$dir\\lib\\sndfile.lib\" \"$dir\\lib\\libsndfile-1.lib\" > $null
-        
+
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
             $cmdir = \"$(current_dir $dir)\"
 
@@ -74,11 +74,11 @@
                 write-host \"Removing $(friendly_path $cmdir) from your path.\"
                 env 'CMAKE_PREFIX_PATH' $global $newpath
             }
-	
+
             # current session
             $was_in_path, $newpath = strip_path $env:PKG_CONFIG_PATH $pcdir
             if($was_in_path) { $env:PKG_CONFIG_PATH = $newpath }
-            
+
             $was_in_path, $newpath = strip_path $env:CMAKE_PREFIX_PATH $cmdir
             if($was_in_path) { $env:CMAKE_PREFIX_PATH = $newpath }
         "

--- a/libsndfile.json
+++ b/libsndfile.json
@@ -42,19 +42,25 @@
             cmd /c mklink /h \"$dir\\lib\\sndfile.lib\" \"$dir\\lib\\libsndfile-1.lib\" > $null
         
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
+            $cmdir = \"$(current_dir $dir)\"
 
             # future sessions
             $null, $currpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir
             env 'PKG_CONFIG_PATH' $global \"$pcdir;$currpath\"
+            $null, $currpath = strip_path (env 'CMAKE_PREFIX_PATH' $global) $cmddir
+            env 'CMAKE_PREFIX_PATH' $global \"$cmddir;$currpath\"
 
             # this session
             $null, $env:PKG_CONFIG_PATH = strip_path $env:PKG_CONFIG_PATH $pcdir
             $env:PKG_CONFIG_PATH = \"$pcdir;$env:PKG_CONFIG_PATH\"
+            $null, $env:CMAKE_PREFIX_PATH = strip_path $env:CMAKE_PREFIX_PATH $cmdir
+            $env:CMAKE_PREFIX_PATH = \"$cmdir;$env:CMAKE_PREFIX_PATH\"
         "
     },
     "uninstaller": {
         "script": "
             $pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"
+            $cmdir = \"$(current_dir $dir)\"
 
             # future sessions
             $was_in_path, $newpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir
@@ -63,9 +69,18 @@
                 env 'PKG_CONFIG_PATH' $global $newpath
             }
 
+            $was_in_path, $newpath = strip_path (env 'CMAKE_PREFIX_PATH' $global) $cmdir
+            if($was_in_path) {
+                write-host \"Removing $(friendly_path $cmdir) from your path.\"
+                env 'CMAKE_PREFIX_PATH' $global $newpath
+            }
+	
             # current session
             $was_in_path, $newpath = strip_path $env:PKG_CONFIG_PATH $pcdir
             if($was_in_path) { $env:PKG_CONFIG_PATH = $newpath }
+            
+            $was_in_path, $newpath = strip_path $env:CMAKE_PREFIX_PATH $cmdir
+            if($was_in_path) { $env:CMAKE_PREFIX_PATH = $newpath }
         "
     }
 }


### PR DESCRIPTION
* Fixes a missing `sndfile.lib` due to mismatched naming between pkg-config file versus what's the zip contains.
* Adds cmake support by configuring the environmental variable `CMAKE_PREFIX_PATH`