### PR TITLE
Added MSMPI runtime environment

### DIFF
--- a/msmpi.json
+++ b/msmpi.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://www.microsoft.com/en-us/download/details.aspx?id=56727",
+    "version": "v9.0.1",
+    "license": "license.rtf",
+    "env_add_path": ".",
+    "url": "https://download.microsoft.com/download/4/A/6/4A6AAED8-200C-457C-AB86-37505DE4C90D/msmpisetup.exe",
+    "hash": "2fa35146e3d7dce6aba3d9cd81c1e16166a405bfe7094d1ae03c60fcdeb8e455",
+    "architecture": {
+        "64bit": {
+            "installer" : {
+                "script": "
+                cd $dir
+                7z x -t# msmpisetup.exe 4.msi
+                7z x 4.msi
+                del msmpires.dll
+                del msmpi.dll
+                move msmpires64.dll msmpires.dll
+                move msmpi64.dll msmpi.dll
+                del msmpisetup.exe
+                del *.msi
+                "
+            }
+        },
+        "32bit": {
+            "installer" : {
+                "script": "
+                cd $dir
+                7z x -t# msmpisetup.exe 2.msi
+                7z x 2.msi
+                del msmpisetup.exe
+                del *.msi
+                "
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
The installer itself requires administrative permissions, so the script I wrote uses 7z to
extract the MSI, and then extract the platform-specific MSI.