### PR TITLE
Removed persistent directories as it caused kicad to not have all libraries

### DIFF
--- a/kicad.json
+++ b/kicad.json
@@ -23,12 +23,6 @@
         "KISYSMOD": "$dir\\share\\kicad\\modules\\"
     },
     "bin": "bin\\kicad.exe",
-    "persist": [
-        "$dir\\share\\kicad\\template",
-        "$dir\\share\\kicad\\modules\\packages3d",
-        "$dir\\share\\kicad\\modules",
-        "$dir\\share\\kicad\\library"
-    ],
     "shortcuts": [
         [
             "bin\\kicad.exe",


### PR DESCRIPTION
As described [here](https://github.com/lukesampson/scoop-extras/pull/948#issuecomment-392764803), the `persist` tag really messed with Kicad and new installation did not have the component libraries and models included, as the persistent folders were empty.