### PR TITLE
Add SoapUi

### DIFF
--- a/soapui.json
+++ b/soapui.json
@@ -1,16 +1,31 @@
 {
-    "homepage": "https://www.soapui.org/downloads/latest-release.html",
+    "homepage": "https://www.soapui.org/",
     "version": "5.4.0",
-    "license": "EUPL, Version 1.1",
+    "license": "EUPL-1.1",
     "architecture": {
         "64bit": {
-            "url": "https://s3.amazonaws.com/downloads.eviware/soapuios/5.4.0/SoapUI-5.4.0-windows-bin.zip"
+            "url": [
+                "https://s3.amazonaws.com/downloads.eviware/soapuios/5.4.0/SoapUI-5.4.0-windows-bin.zip",
+                "https://cdn.icon-icons.com/icons2/1381/ICO/512/soapui_93772.ico#/icon.ico"
+            ],
+            "hash": [
+                "067171e212bdb275f55586a1f080f6a0d3d0bd4335be42dcbe10bdf3437fb8a5",
+                "dc5f24885b3cb82e830781fc66127d8cb26b81857a58eb490d6c35ea3d92d351"
+            ]
         },
         "32bit": {
-            "url": "https://s3.amazonaws.com/downloads.eviware/soapuios/5.4.0/SoapUI-5.4.0-win32-standalone-bin.zip"
+            "url": [
+                "https://s3.amazonaws.com/downloads.eviware/soapuios/5.4.0/SoapUI-5.4.0-win32-standalone-bin.zip",
+                "https://cdn.icon-icons.com/icons2/1381/ICO/512/soapui_93772.ico#/icon.ico"
+            ],
+            "hash": [
+                "56f8a68e7163e2f8276538d4b83addce589dcc7e99aa608463399370c9df39fc",
+                "dc5f24885b3cb82e830781fc66127d8cb26b81857a58eb490d6c35ea3d92d351"
+            ]
         }
     },
     "checkver": {
+        "url": "https://www.soapui.org/downloads/latest-release.html",
         "re": "Downloads \\(Version ([\\d.]+)\\)"
     },
     "extract_dir": "SoapUI-5.4.0",
@@ -18,19 +33,20 @@
     "shortcuts": [
         [
             "bin/soapui.bat",
-            "SoapUI"
+            "SoapUI",
+            "",
+            "icon.ico"
         ]
     ],
-      "autoupdate": {
+    "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://s3.amazonaws.com/downloads.eviware/soapuios/$version/SoapUI-$version-windows-bin.zip",
-                "extract_dir": "SoapUI-$version"
+                "url": "https://s3.amazonaws.com/downloads.eviware/soapuios/$version/SoapUI-$version-windows-bin.zip"
             },
             "32bit": {
-                "url": "https://s3.amazonaws.com/downloads.eviware/soapuios/$version/SoapUI-$version-win32-standalone-bin.zip",
-                "extract_dir": "SoapUI-$version"
+                "url": "https://s3.amazonaws.com/downloads.eviware/soapuios/$version/SoapUI-$version-win32-standalone-bin.zip"
             }
-        }
+        },
+        "extract_dir": "SoapUI-$version"
     }
 }


### PR DESCRIPTION
The icon is missing in the installation folder, but I don't know how to use one of the [web ](https://cdn.icon-icons.com/icons2/1381/PNG/512/soapui_93772.png)(it says protocol not supported if I add it in the manifest).