### PR TITLE
Add glogg version 1.1.4 (closes #1341)

### DIFF
--- a/glogg.json
+++ b/glogg.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://glogg.bonnefon.org/files/glogg-latest-x86_64-setup.exe#dl.7z",
+            "url": "https://glogg.bonnefon.org/files/glogg-latest-x86_64-setup.exe#/dl.7z",
             "hash": "08fe13b713327bef93298b6d11717a93bbaa9d49165995be93f4a3282e76b22f",
             "bin": "glogg.exe",
             "shortcuts": [
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://glogg.bonnefon.org/files/glogg-latest-x86_64-setup.exe#dl.7z"
+                "url": "https://glogg.bonnefon.org/files/glogg-latest-x86_64-setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Add glogg v1.1.4. It has been 64-bit only since version 1.0.3, so I ignored x86. It uses NSIS to install by default, but seems to merely require administrative permission to write to Program Files. I have opted to extract the contents instead since it seems quite happy running as a portable app.