### PR TITLE
Add BeatDrop v1.0.0.0

### DIFF
--- a/beatdrop.json
+++ b/beatdrop.json
@@ -7,5 +7,8 @@
     "extract_dir": "BeatDrop",
     "bin": "BeatDrop.exe",
     "hash": "0587e1b3cf29b573bbe96cb2f62390e4ac3281e1423d75b24a05801889af8fce",
-    "checkver": "github"
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/mvsoft74/BeatDrop/releases/download/v$version/BeatDrop-bin-$version.zip"
+    }
 }


### PR DESCRIPTION
Note: There's no autoupdate (yet) since there's only been 1 release so far.