### PR TITLE
keepass-plugin-keepasshttp: Add version 1.8.4.2

### DIFF
--- a/bucket/keepass-plugin-keepasshttp.json
+++ b/bucket/keepass-plugin-keepasshttp.json
@@ -3,7 +3,7 @@
     "description": "A plugin for KeePass 2.x and provides a secure means of exposing KeePass entries via HTTP for clients to consume",
     "homepage": "https://github.com/pfn/keepasshttp",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/pfn/keepasshttp/raw/b9a6813bfc9ccc9618938249c1bfff744a28ca44/KeePassHttp.plgx",
+    "url": "https://raw.githubusercontent.com/pfn/keepasshttp/b9a6813bfc9ccc9618938249c1bfff744a28ca44/KeePassHttp.plgx",
     "hash": "e00b456692e337e63d21e34cfe23e03d67d5ec1ce08e9b66ca2a88f6a687ef6d",
     "depends": "extras/keepass",
     "installer": {

--- a/bucket/keepass-plugin-keepasshttp.json
+++ b/bucket/keepass-plugin-keepasshttp.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "https://github.com/pfn/keepasshttp",
-    "description": "A plugin for KeePass 2.x and provides a secure means of exposing KeePass entries via HTTP for clients to consume",
-    "license": "GPL-3.0-or-later",
     "version": "1.8.4.2",
+    "description": "A plugin for KeePass 2.x and provides a secure means of exposing KeePass entries via HTTP for clients to consume",
+    "homepage": "https://github.com/pfn/keepasshttp",
+    "license": "GPL-3.0-or-later",
     "url": "https://github.com/pfn/keepasshttp/raw/b9a6813bfc9ccc9618938249c1bfff744a28ca44/KeePassHttp.plgx",
     "hash": "e00b456692e337e63d21e34cfe23e03d67d5ec1ce08e9b66ca2a88f6a687ef6d",
     "depends": "extras/keepass",

--- a/bucket/keepass-plugin-keepasshttp.json
+++ b/bucket/keepass-plugin-keepasshttp.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/pfn/keepasshttp",
+    "description": "A plugin for KeePass 2.x and provides a secure means of exposing KeePass entries via HTTP for clients to consume",
+    "license": "GPL-3.0-or-later",
+    "version": "1.8.4.2",
+    "url": "https://github.com/pfn/keepasshttp/raw/b9a6813bfc9ccc9618938249c1bfff744a28ca44/KeePassHttp.plgx",
+    "hash": "e00b456692e337e63d21e34cfe23e03d67d5ec1ce08e9b66ca2a88f6a687ef6d",
+    "depends": "extras/keepass",
+    "installer": {
+        "script": "Copy-Item \"$dir\\KeePassHttp.plgx\" \"$(appdir keepass $global)\\current\\Plugins\" -Recurse"
+    },
+    "uninstaller": {
+        "script": "Remove-Item \"$(appdir keepass $global)\\current\\Plugins\\KeePassHttp.plgx\" -Recurse"
+    }
+}


### PR DESCRIPTION
Notes:

* link to the binary is from the tree of the latest commit: https://github.com/pfn/keepasshttp/commit/b9a6813bfc9ccc9618938249c1bfff744a28ca44
* no auto update is set as author is not publishing binaries into releases
* License is GPL 3.0 but I do not know which format I should follow so I have copied it
* tested locally