### PR TITLE
vscode: Update context menu registry param

### DIFF
--- a/bucket/vscode-portable.json
+++ b/bucket/vscode-portable.json
@@ -45,7 +45,7 @@
             ],
             "hash": [
                 "4f8fad678178c5ba7a0e615a2b626a9ac6d84f92b181d9f1f8bfc5748293dce3",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         },
@@ -57,7 +57,7 @@
             ],
             "hash": [
                 "1dfa3eb57e96d63903831b8f49f3e4434e7be8fbdf25257fd505f1b378ccf7a6",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         }

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -39,7 +39,7 @@
             ],
             "hash": [
                 "4f8fad678178c5ba7a0e615a2b626a9ac6d84f92b181d9f1f8bfc5748293dce3",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         },
@@ -51,7 +51,7 @@
             ],
             "hash": [
                 "1dfa3eb57e96d63903831b8f49f3e4434e7be8fbdf25257fd505f1b378ccf7a6",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         }

--- a/bucket/vscodium-portable.json
+++ b/bucket/vscodium-portable.json
@@ -12,7 +12,7 @@
             ],
             "hash": [
                 "a2df4a049266e36efccf7a5359d3c40136e00da66aec29e6bb5dd41e2f8df341",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         },
@@ -24,7 +24,7 @@
             ],
             "hash": [
                 "665ece4fe44e839a5e43d59cb37cef8b9e1cc03caccaf026adde91620d899b42",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         }

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -12,7 +12,7 @@
             ],
             "hash": [
                 "a2df4a049266e36efccf7a5359d3c40136e00da66aec29e6bb5dd41e2f8df341",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         },
@@ -24,7 +24,7 @@
             ],
             "hash": [
                 "665ece4fe44e839a5e43d59cb37cef8b9e1cc03caccaf026adde91620d899b42",
-                "3673d7767da27418c4c7eea146043fa6a7c59df65199c79850e58367fd66fb56",
+                "0cc32891afe9321b655a4718fec14581781342dae2ec5b06251f88f11ccb05c2",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         }

--- a/scripts/vscode-install-context.reg
+++ b/scripts/vscode-install-context.reg
@@ -10,7 +10,7 @@ Windows Registry Editor Version 5.00
 @="Open with &Code"
 "Icon"="$code"
 [HKEY_CLASSES_ROOT\Directory\shell\Open with &Code\command]
-@="\"$code\" \"%1\""
+@="\"$code\" \"%V\""
 
 [HKEY_CLASSES_ROOT\Directory\Background\shell\Open with &Code]
 @="Open with &Code"


### PR DESCRIPTION
- Update vscode context menu registry param: `%1` => `%V`, more detail to official inno setup file `code.iss` https://github.com/microsoft/vscode/blob/a426717b50d68810ddfbf55558d777852bc21db0/build/win32/code.iss#L965.
- Update vscode-install-context.reg file hash value.