### PR TITLE
Fix git claiming modified working copy even after reset --hard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # retain windows line-endings in case checked out on mac or linux
-* text eol=crlf
+* text=auto eol=crlf


### PR DESCRIPTION
This is due to EOL.