### PR TITLE
winscp: add commandline-friendly binary.

### DIFF
--- a/bucket/winscp.json
+++ b/bucket/winscp.json
@@ -15,7 +15,10 @@
     ],
     "bin": [
         "WinSCP.exe",
-        "WinSCP.com"
+        [
+            "WinSCP.com",
+            "WinSCP-cli"
+        ]
     ],
     "shortcuts": [
         [

--- a/bucket/winscp.json
+++ b/bucket/winscp.json
@@ -13,7 +13,10 @@
         "    ) | Add-Content -Path \"$dir\\winscp.ini\" -Encoding ASCII -Force",
         "}"
     ],
-    "bin": "WinSCP.exe",
+    "bin": [
+        "WinSCP.exe",
+        "WinSCP.com"
+    ],
     "shortcuts": [
         [
             "WinSCP.exe",


### PR DESCRIPTION
The `.exe` binary creates another command prompt instance while the `.com` one stays in the same one.