### PR TITLE
teamviewer: Add post_install to set nosave to 0 for user preferences

### DIFF
--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -16,6 +16,11 @@
         ]
     ],
     "persist": "teamviewer.ini",
+    "post_install": [
+        "$iniFile = \"$dir\\teamviewer.ini\"",
+        "$changeRegex = \"(?<=nosave=)[0-9]*\"",
+        "(Get-Content $iniFile) -replace $changeRegex, \"0\" | Set-Content $iniFile"
+    ],
     "checkver": {
         "url": "https://www.teamviewer.com/en/download/windows/",
         "re": ">\\s*([\\d.]+)\\s*<"


### PR DESCRIPTION
This installs the portable Teamviewer meaning that nosave defaults to 1. This means user preferences are not maintained between uses. Setting this to 0 with a regex replace on that line in the .ini file fixes this.