### PR TITLE
xampp: Add version 8.0.12-0

### DIFF
--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-only",
     "description": "Apache distribution containing MariaDB, PHP, and Perl",
     "notes": "Follow the instructions on '$dir\\readme_en.txt' to set up XAMPP.",
-    "suggests": {
+    "suggest": {
         "Visual C++ 2017 Redistributable": "extras/vcredist2017"
     },
     "architecture": {

--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -1,0 +1,55 @@
+{
+    "homepage": "https://www.apachefriends.org/index.html",
+    "version": "7.4.2-0",
+    "license": "GPL-2.0-only",
+    "description": "Apache distribution containing MariaDB, PHP, and Perl",
+    "notes": "Follow the instructions on '$dir\\readme_en.txt' to set up XAMPP.",
+    "suggests": {
+        "Visual C++ 2017 Redistributable": "extras/vcredist2017"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/7.4.2/xampp-portable-windows-x64-7.4.2-0-VC15.7z",
+            "hash": "sha1:f1cd06b36ca6180ef1df09535f2e6cb7a6c08cb3"
+        }
+    },
+    "extract_dir": "xampp",
+    "bin": [
+        "apache\\bin\\httpd.exe",
+        "mysql\\bin\\mysql.exe",
+        "mysql\\bin\\mysqld.exe",
+        "sendmail\\sendmail.exe",
+        "perl\\bin\\perl.exe",
+        "perl\\bin\\wperl.exe",
+        "php\\php.exe",
+        "tomcat\\bin\\tomcat7.exe",
+        "xampp-control.exe",
+        "xampp_start.exe",
+        "xampp_stop.exe"
+    ],
+    "shortcuts": [
+        [
+            "xampp-control.exe",
+            "XAMPP Control Panel"
+        ]
+    ],
+    "persist": [
+        "apache\\conf",
+        "apache\\logs",
+        "htdocs",
+        "mysql\\data",
+        "php\\php.ini",
+        "sendmail\\sendmail.ini",
+        "tomcat\\conf",
+        "tomcat\\logs",
+        "xampp-control.ini"
+    ],
+    "checkver": "xampp-windows-x64-([\\d.-]+)-VC(?<vcversion>\\d+)-installer\\.exe",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/$matchHead/xampp-portable-windows-x64-$version-VC$matchVcversion.7z"
+            }
+        }
+    }
+}

--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "https://www.apachefriends.org/index.html",
     "version": "7.4.2-0",
-    "license": "GPL-2.0-only",
     "description": "Apache distribution containing MariaDB, PHP, and Perl",
+    "homepage": "https://www.apachefriends.org/index.html",
+    "license": "GPL-2.0-only",
     "notes": "Follow the instructions on '$dir\\readme_en.txt' to set up XAMPP.",
     "suggest": {
         "Visual C++ 2017 Redistributable": "extras/vcredist2017"

--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -20,7 +20,6 @@
         "mysql\\bin\\mysqld.exe",
         "sendmail\\sendmail.exe",
         "perl\\bin\\perl.exe",
-        "perl\\bin\\wperl.exe",
         "php\\php.exe",
         "tomcat\\bin\\tomcat7.exe",
         "xampp-control.exe",

--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-only",
     "notes": "Follow the instructions on '$dir\\readme_en.txt' to set up XAMPP.",
     "suggest": {
-        "Visual C++ 2017 Redistributable": "extras/vcredist2017"
+        "Visual C++ 2019 Redistributable": "extras/vcredist2019"
     },
     "architecture": {
         "64bit": {

--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -43,11 +43,11 @@
         "tomcat\\logs",
         "xampp-control.ini"
     ],
-    "checkver": "xampp-windows-x64-([\\d.-]+)-VC(?<vcversion>\\d+)-installer\\.exe",
+    "checkver": "xampp-windows-x64-([\\d.-]+)-VC(?<vc>\\d+)-installer\\.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/$matchHead/xampp-portable-windows-x64-$version-VC$matchVcversion.7z"
+                "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/$matchHead/xampp-portable-windows-x64-$version-VC$matchVc.7z"
             }
         }
     }

--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.4.2-0",
+    "version": "8.0.12-0",
     "description": "Apache distribution containing MariaDB, PHP, and Perl",
     "homepage": "https://www.apachefriends.org/index.html",
     "license": "GPL-2.0-only",
@@ -9,8 +9,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/7.4.2/xampp-portable-windows-x64-7.4.2-0-VC15.7z",
-            "hash": "sha1:f1cd06b36ca6180ef1df09535f2e6cb7a6c08cb3"
+            "url": "https://download.sourceforge.net/project/xampp/XAMPP%20Windows/8.0.12/xampp-windows-x64-8.0.12-0-VS16.7z",
+            "hash": "sha1:4bd98e8ec605c3181a1c8f9165abba81eeaa1df8"
         }
     },
     "extract_dir": "xampp",
@@ -21,7 +21,7 @@
         "sendmail\\sendmail.exe",
         "perl\\bin\\perl.exe",
         "php\\php.exe",
-        "tomcat\\bin\\tomcat7.exe",
+        "tomcat\\bin\\tomcat8.exe",
         "xampp-control.exe",
         "xampp_start.exe",
         "xampp_stop.exe"
@@ -43,11 +43,11 @@
         "tomcat\\logs",
         "xampp-control.ini"
     ],
-    "checkver": "xampp-windows-x64-([\\d.-]+)-VC(?<vc>\\d+)-installer\\.exe",
+    "checkver": "xampp-windows-x64-([\\d.-]+)-VS(?<vs>\\d+)-installer\\.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/$matchHead/xampp-portable-windows-x64-$version-VC$matchVc.7z"
+                "url": "https://download.sourceforge.net/project/xampp/XAMPP%20Windows/$matchHead/xampp-windows-x64-$version-VS$matchVs.7z"
             }
         }
     }


### PR DESCRIPTION
close #3570

**XAMPP** ([homepage](https://www.apachefriends.org/)) is an Apache distribution containing MariaDB, PHP, and Perl.

Notes:

* If there are more files that needs to be in *bin* / *shortcut* / *persist* , please tell me.

* The Portable Version **does not** contain *FileZilla FTP* and *Mercury Mail Server*. The service installations are also disabled. I tried to extract files from the non-portable installer, but the installer could not be properly extracted by *7-zip*, *innounp* or *Uniextract*.

* `vcredist2017` is required according to the readme file.
> PHP in this package needs the Microsoft Visual C++ 2017 Redistributable package from
http://www.microsoft.com/en-us/download/. Please ensure that the VC++ 2017 runtime
libraries are installed on your system.

Since Visual C++ 2015, 2017 and 2019 all share the same redistributable files, I use **vcredist 2019** in `suggest`.
(https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)

* *Sendmail* can work independently without *Mercury Mail Server*. (see `$dir\sendmail\ReadMe.html` for details)

* The `$dir\tmp` folder is for saving PHP sessions. I think it does not need to be in *persist*. (see `$dir\tmp\why.tmp`)
> Why this tmp-Folder?
PHP need it for saving
the Sessions. 
So please do not delete it!