### PR TITLE
handbrake: Use portable configuration

### DIFF
--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -9,14 +9,9 @@
             "hash": "f2adb660ff24aa62677aa5a67421e76e0c588f9a5567f74819384a351574d2e7"
         }
     },
+    "extract_dir": "HandBrake",
     "installer": {
         "script": [
-            "@(\"HandBrake\", \"HandBrake $version\") | %{",
-            "    if (Test-Path \"$dir\\$_\") {",
-            "        Get-ChildItem -Path \"$dir\\$_\" -Force -Recurse | Move-Item -Destination \"$dir\" -Force",
-            "        Remove-Item \"$dir\\$_\" -Force",
-            "    }",
-            "}",
             "if (!(Test-Path \"$persist_dir\\portable.ini\")) {",
             "    if (!(Test-Path \"$persist_dir\\storage\") -And (Test-Path \"$env:APPDATA\\HandBrake\")) {",
             "        New-Item \"$persist_dir\" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",

--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -5,11 +5,32 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.handbrake.fr/handbrake/releases/1.3.2/HandBrake-1.3.2-x86_64-Win_GUI.zip",
+            "url": "https://github.com/HandBrake/HandBrake/releases/download/1.3.2/HandBrake-1.3.2-x86_64-Win_GUI.zip",
             "hash": "3a01b6fa2588eeec80a6038af57feb20b8525bfc6090cbc1885d40c49310e139"
         }
     },
-    "extract_dir": "Handbrake",
+    "installer": {
+        "script": [
+            "@(\"HandBrake\", \"HandBrake $version\") | %{",
+            "    if (Test-Path \"$dir\\$_\") {",
+            "        Get-ChildItem -Path \"$dir\\$_\" -Force -Recurse | Move-Item -Destination \"$dir\" -Force",
+            "        Remove-Item \"$dir\\$_\" -Force",
+            "    }",
+            "}",
+            "if (!(Test-Path \"$persist_dir\\portable.ini\")) {",
+            "    if (!(Test-Path \"$persist_dir\\storage\") -And (Test-Path \"$env:APPDATA\\HandBrake\")) {",
+            "        New-Item \"$persist_dir\" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
+            "        Move-Item -Path \"$env:APPDATA\\HandBrake\" -Destination \"$persist_dir\\storage\" -Force",
+            "    }",
+            "    Copy-Item \"$dir\\portable.ini.template\" \"$dir\\portable.ini\" -Force",
+            "}"
+        ]
+    },
+    "persist": [
+        "portable.ini",
+        "storage",
+        "tmp"
+    ],
     "shortcuts": [
         [
             "HandBrake.exe",
@@ -22,7 +43,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.handbrake.fr/handbrake/releases/$version/HandBrake-$version-x86_64-Win_GUI.zip"
+                "url": "https://github.com/HandBrake/HandBrake/releases/download/$version/HandBrake-$version-x86_64-Win_GUI.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
This closes #3973, closes #3919

Prior to 1.1.1 the GUI version only came in exe.

Sometimes the data in the zip is in a Handbrake folder other times it's Handbrake $version, and with this release it's at the top level. It's a bit of a mess, maybe there's a more elegant way of handling it.

portable.ini might contain user settings hardware.enabled for example, and it looks like there's more planned, so that's persisted.

Not sure if I've gotten data migration right. ATM it moves data, but that might break separate non-portable installs so perhaps it should be copied instead. Temp data should only stick around if handbrake crashes, so it shouldn't need migration.
