### PR TITLE
scoop-search: Add version 0.6.5

### DIFF
--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.6.3",
+    "version": "0.6.5",
     "license": "MIT",
-    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.6.3/scoop-search.exe",
+    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.6.5/scoop-search.exe",
     "homepage": "https://github.com/tokiedokie/scoop-search",
     "description": "yet another scoop search",
-    "hash": "af5631b3d1ba2c5fc14449343035948bd36f5a7cc25a9d62ae1d0e68fbdf3a8a",
+    "hash": "9f180302f497cfcf371053a4ff151c230cdf62baebc2007da19ee0749d9b3fcf",
     "bin": "scoop-search.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.5.5",
+    "version": "0.5.8",
     "license": "MIT",
-    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.5/scoop-search.exe",
+    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.8/scoop-search.exe",
     "homepage": "https://github.com/tokiedokie/scoop-search",
     "description": "yet another scoop search",
-    "hash": "088285d27792438b688e7cf7307131245b27a4b0864fac8d4babb08d2858597d",
+    "hash": "dd685950744438794c1ba5a92532743352c7df278e89d36fc53680fe5acdcbfc",
     "bin": "scoop-search.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.5.0",
+    "version": "0.5.2",
     "license": "MIT",
-    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.0/scoop-search.exe",
+    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.2/scoop-search.exe",
     "homepage": "https://github.com/tokiedokie/scoop-search",
     "description": "yet another scoop search",
-    "hash": "dccdf7518f00138b81416940ec672fa9172651600ee936e2d1d84c362b11a484",
+    "hash": "63f8452458fc95b44fdca858b9f9cc9a1da6eee67a8d293215b1b1da07cd2a6c",
     "bin": "scoop-search.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.5.0",
+    "license": "MIT",
+    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.0/scoop-search.exe",
+    "homepage": "https://github.com/tokiedokie/scoop-search",
+    "description": "yet another scoop search",
+    "hash": "dccdf7518f00138b81416940ec672fa9172651600ee936e2d1d84c362b11a484",
+    "bin": "scoop-search.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/tokiedokie/scoop-search/releases/download/v$version/scoop-search.exe"
+    }
+}

--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.5.2",
+    "version": "0.5.5",
     "license": "MIT",
-    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.2/scoop-search.exe",
+    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.5/scoop-search.exe",
     "homepage": "https://github.com/tokiedokie/scoop-search",
     "description": "yet another scoop search",
-    "hash": "63f8452458fc95b44fdca858b9f9cc9a1da6eee67a8d293215b1b1da07cd2a6c",
+    "hash": "088285d27792438b688e7cf7307131245b27a4b0864fac8d4babb08d2858597d",
     "bin": "scoop-search.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.5.8",
+    "version": "0.6.3",
     "license": "MIT",
-    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.5.8/scoop-search.exe",
+    "url": "https://github.com/tokiedokie/scoop-search/releases/download/v0.6.3/scoop-search.exe",
     "homepage": "https://github.com/tokiedokie/scoop-search",
     "description": "yet another scoop search",
-    "hash": "dd685950744438794c1ba5a92532743352c7df278e89d36fc53680fe5acdcbfc",
+    "hash": "af5631b3d1ba2c5fc14449343035948bd36f5a7cc25a9d62ae1d0e68fbdf3a8a",
     "bin": "scoop-search.exe",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
I made yet another  `scoop search` called `scoop-search`

`scoop-search` is faster than `scoop search`, but doesn't search `bin` in manifest by default

please merge this