### PR TITLE
totalcommander@9.51: Update persist

### DIFF
--- a/bucket/totalcommander.json
+++ b/bucket/totalcommander.json
@@ -33,15 +33,22 @@
         "Move-Item \"$dir\\e\\*\" \"$dir\"",
         "Remove-Item -Recurse \"$dir\\d\", \"$dir\\e\", \"$dir\\_tmp\", \"$dir\\$fname\"",
         "\"[Configuration]`r`nUseIniInProgramDir=7\" | Out-File -Encoding ASCII \"$dir\\wincmd.ini\"",
-        "ForEach ($emptyFile in $manifest.persist) {New-Item \"$dir\\$emptyFile\" -ItemType file -ErrorAction SilentlyContinue | Out-Null}"
+        "ForEach ($emptyFile in $manifest.persist | Where-Object { $_ -ne 'plugins' }) {New-Item \"$dir\\$emptyFile\" -ItemType file -ErrorAction SilentlyContinue | Out-Null}"
     ],
     "persist": [
+        "plugins",
         "DEFAULT.BAR",
         "default.br2",
+        "VERTICAL.BAR",
+        "vertical.br2",
         "usercmd.ini",
         "wcx_ftp.ini",
         "wincmd.ini",
-        "wincmd.key"
+        "wincmd.key",
+        "contplug.ini",
+        "fsplugin.ini",
+        "lsplugin.ini",
+        "pkplugin.ini"
     ],
     "checkver": {
         "url": "https://www.ghisler.com/download.htm",


### PR DESCRIPTION
Total Commander: update persistent files.

* **plugins**: default installation directory for plugins (e.g. if you open plugin archive, totalcmd by default installs it in this directory)
* **VERTICAL.BAR**, **vertical.br2**: vertical (between panels) button bar
* **contplug.ini**, **fsplugin.ini**, **lsplugin.ini**, **pkplugin.ini**: default config files for plugins settings (https://www.ghisler.ch/wiki/index.php/Ini-settings)

Unfortunately it's not the all possible files. Various plugins can use their own config files. For example SFTP plugin from Total Commander developer is using sftpplug.ini, his WebDAV plugin uses tcwebdav.ini and so on. It's the same problem as in foobar2000: #2884. So it could be better to split it to normal and portable version. But this PR should cover most cases.