### PR TITLE
visualvm: Add version 2.0.2

### DIFF
--- a/bucket/visualvm.json
+++ b/bucket/visualvm.json
@@ -13,11 +13,19 @@
     "hash": "e189e847cf299d0e5336690428b95ad1b9f3b88d4502bfc67e316502b56af56f",
     "extract_dir": "visualvm_202",
     "pre_install": [
-        "$conf = Get-Content \"$dir\\etc\\visualvm.conf\"",
-        "$conf = $conf -replace '^(visualvm_default_userdir=).*$', \"`$1\"\"$dir\\user\"\"\"",
-        "$conf = $conf -replace '^(visualvm_default_cachedir=).*$', \"`$1\"\"$dir\\cache\"\"\"",
-        "if ((!(Test-Path \"$persist_dir\\etc\")) -and $env:JAVA_HOME -and (Test-Path $env:JAVA_HOME)) { $conf = $conf -replace '^#(visualvm_jdkhome=).*$', \"`$1\"\"$env:JAVA_HOME\"\"\" }",
-        "Set-Content \"$dir\\etc\\visualvm.conf\" -Value $conf -Encoding Ascii"
+        "if (Test-Path \"$persist_dir\\etc\\visualvm.conf\") {",
+        "    Remove-Item -Recurse \"$dir\\etc\"",
+        "    $conf = Get-Content \"$persist_dir\\etc\\visualvm.conf\"",
+        "    $appdir = \"$((Split-Path $dir) -replace '\\\\', '\\\\')\\\\[\\d.]+\"",
+        "    $conf = $conf -replace \"^(visualvm_default_userdir=)`\"$appdir\\\\user`\"$\", \"`$1\"\"$dir\\user`\"\"",
+        "    $conf = $conf -replace \"^(visualvm_default_cachedir=)`\"$appdir\\\\cache`\"$\", \"`$1\"\"$dir\\cache`\"\"",
+        "    Set-Content \"$persist_dir\\etc\\visualvm.conf\" -Value $conf -Encoding Ascii",
+        "} else {",
+        "    $conf = $conf -replace '^(visualvm_default_userdir=).*$', \"`$1\"\"$dir\\user`\"\"",
+        "    $conf = $conf -replace '^(visualvm_default_cachedir=).*$', \"`$1\"\"$dir\\cache`\"\"",
+        "    if ($env:JAVA_HOME -and (Test-Path $env:JAVA_HOME)) { $conf = $conf -replace '^#(visualvm_jdkhome=).*$', \"`$1\"\"$env:JAVA_HOME`\"\" }",
+        "    Set-Content \"$dir\\etc\\visualvm.conf\" -Value $conf -Encoding Ascii",
+        "}"
     ],
     "bin": "bin\\visualvm.exe",
     "shortcuts": [

--- a/bucket/visualvm.json
+++ b/bucket/visualvm.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.2",
+    "description": "Java troubleshooting tool",
+    "homepage": "https://visualvm.github.io/index.html",
+    "license": "GPL-2.0-only",
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    },
+    "url": "https://github.com/oracle/visualvm/releases/download/2.0.2/visualvm_202.zip",
+    "hash": "e189e847cf299d0e5336690428b95ad1b9f3b88d4502bfc67e316502b56af56f",
+    "extract_dir": "visualvm_202",
+    "bin": "bin\\visualvm.exe",
+    "shortcuts": [
+        [
+            "bin\\visualvm.exe",
+            "VisualVM"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/oracle/visualvm"
+    },
+    "autoupdate": {
+        "url": "https://github.com/oracle/visualvm/releases/download/2.0.2/visualvm_$cleanVersion.zip",
+        "extract_dir": "visualvm_$cleanVersion"
+    }
+}

--- a/bucket/visualvm.json
+++ b/bucket/visualvm.json
@@ -12,7 +12,12 @@
     "url": "https://github.com/oracle/visualvm/releases/download/2.0.2/visualvm_202.zip",
     "hash": "e189e847cf299d0e5336690428b95ad1b9f3b88d4502bfc67e316502b56af56f",
     "extract_dir": "visualvm_202",
-    "post_install": "if (Test-Path $env:JAVA_HOME) { (Get-Content \"$dir\\etc\\visualvm.conf\") -replace '#visualvm_jdkhome.*', \"visualvm_jdkhome=`\"$env:JAVA_HOME`\"\" | Set-Content \"$dir\\etc\\visualvm.conf\" }",
+    "pre_install": [
+        "if ((!(Test-Path \"$persist_dir\\etc\")) -and $env:JAVA_HOME -and (Test-Path $env:JAVA_HOME)) {",
+        "    $forward = $env:JAVA_HOME -replace '\\\\', '/'",
+        "    (Get-Content \"$dir\\etc\\visualvm.conf\") -replace '^#(visualvm_jdkhome=).*$', \"`$1\"\"$forward\"\"\" | Out-File \"$dir\\etc\\visualvm.conf\" -Encoding Ascii",
+        "}"
+    ],
     "bin": "bin\\visualvm.exe",
     "shortcuts": [
         [

--- a/bucket/visualvm.json
+++ b/bucket/visualvm.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/oracle/visualvm/releases/download/2.0.2/visualvm_202.zip",
     "hash": "e189e847cf299d0e5336690428b95ad1b9f3b88d4502bfc67e316502b56af56f",
     "extract_dir": "visualvm_202",
+    "post_install": "if (Test-Path $env:JAVA_HOME) { (Get-Content \"$dir\\etc\\visualvm.conf\") -replace '#visualvm_jdkhome.*', \"visualvm_jdkhome=`\"$env:JAVA_HOME`\"\" | Set-Content \"$dir\\etc\\visualvm.conf\" }",
     "bin": "bin\\visualvm.exe",
     "shortcuts": [
         [
@@ -19,6 +20,7 @@
             "VisualVM"
         ]
     ],
+    "persist": "etc",
     "checkver": {
         "github": "https://github.com/oracle/visualvm"
     },

--- a/bucket/visualvm.json
+++ b/bucket/visualvm.json
@@ -13,10 +13,11 @@
     "hash": "e189e847cf299d0e5336690428b95ad1b9f3b88d4502bfc67e316502b56af56f",
     "extract_dir": "visualvm_202",
     "pre_install": [
-        "if ((!(Test-Path \"$persist_dir\\etc\")) -and $env:JAVA_HOME -and (Test-Path $env:JAVA_HOME)) {",
-        "    $forward = $env:JAVA_HOME -replace '\\\\', '/'",
-        "    (Get-Content \"$dir\\etc\\visualvm.conf\") -replace '^#(visualvm_jdkhome=).*$', \"`$1\"\"$forward\"\"\" | Out-File \"$dir\\etc\\visualvm.conf\" -Encoding Ascii",
-        "}"
+        "$conf = Get-Content \"$dir\\etc\\visualvm.conf\"",
+        "$conf = $conf -replace '^(visualvm_default_userdir=).*$', \"`$1\"\"$dir\\user\"\"\"",
+        "$conf = $conf -replace '^(visualvm_default_cachedir=).*$', \"`$1\"\"$dir\\cache\"\"\"",
+        "if ((!(Test-Path \"$persist_dir\\etc\")) -and $env:JAVA_HOME -and (Test-Path $env:JAVA_HOME)) { $conf = $conf -replace '^#(visualvm_jdkhome=).*$', \"`$1\"\"$env:JAVA_HOME\"\"\" }",
+        "Set-Content \"$dir\\etc\\visualvm.conf\" -Value $conf -Encoding Ascii"
     ],
     "bin": "bin\\visualvm.exe",
     "shortcuts": [
@@ -25,7 +26,11 @@
             "VisualVM"
         ]
     ],
-    "persist": "etc",
+    "persist": [
+        "cache",
+        "etc",
+        "user"
+    ],
     "checkver": {
         "github": "https://github.com/oracle/visualvm"
     },


### PR DESCRIPTION
- Closes #4194

VisualVM is an all-in-one Java troubleshooting tool.
To launch the tool, `visualvm_jdkhome` must be set in `etc\visualvm.conf` (see oracle/visualvm#112).