### PR TITLE
sdl2: Update to version 2.0.12

### DIFF
--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -3,82 +3,28 @@
     "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
     "version": "2.0.10",
     "license": "Zlib",
-    "url": [
-         "https://www.libsdl.org/release/SDL2-devel-2.0.10-VC.zip",
-         "https://www.libsdl.org/release/SDL2-2.0.10.zip"
-    ],
-    "hash": [
-         "f1930cf5033725b0e7829c7368f70f65a993bc946ca1197c36888ccecbf07891",
-         "658b0435f57d496e967c1996badbd83bac120689a693f57c4007698d0fe24543"
-    ],
-    "installer": {
-        "script": [
-            "# organize files",
-            "mkdir -f \"$dir\\lib\\pkgconfig\" > $null",
-            "mkdir -f \"$dir\\include\\SDL2\" > $null",
-            "# make arch consistent with scoop naming",
-            "mv \"$dir\\SDL2-$version\\lib\\x86\" \"$dir\\SDL2-$version\\lib\\32bit\"",
-            "mv \"$dir\\SDL2-$version\\lib\\x64\" \"$dir\\SDL2-$version\\lib\\64bit\"",
-            "# only install the requested architecture",
-            "mv \"$dir\\SDL2-$version\\lib\\$architecture\\*\" \"$dir\\lib\"",
-            "",
-            "$srcdir = \"$dir\\SDL2-$version\\\"",
-            "mv \"$srcdir\\include\\*.h\"  \"$dir\\include\\SDL2\"",
-            "rm \"$dir\\include\\*.h.*\"",
-            "$pcin = \"$srcdir\\sdl2.pc.in\"",
-            "$pcout = \"$dir\\lib\\pkgconfig\\sdl2.pc\"",
-            "sc $pcout ((gc $pcin) `",
-            "    -replace \"@prefix@\",\"\" `",
-            "    -replace \"@exec_prefix@\",\"`${prefix}\" `",
-            "    -replace \"@libdir@\",\"`${exec_prefix}/lib\" `",
-            "    -replace \"@includedir@\",\"`${prefix}/include\" `",
-            "    -replace \"@SDL_VERSION@\",\"$version\" `",
-            "    -replace \"@SDL_RLD_FLAGS@\",\"\" `",
-            "    -replace \"@SDL_LIBS@\",\"-lSDL2\" `",
-            "    -replace \"@SDL_STATIC_LIBS@\",\"-lSDL2\" `",
-            "    -replace \"@SDL_CFLAGS@\",\"-lpthread -lasound\" `",
-            ")",
-            "",
-            "rm -r \"$srcdir\"",
-            "",
-            "$pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"",
-            "$cmdir = \"$(current_dir $dir)\"",
-            "# future sessions",
-            "$null, $currpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir",
-            "env 'PKG_CONFIG_PATH' $global \"$pcdir;$currpath\"",
-            "$null, $currpath = strip_path (env 'CMAKE_PREFIX_PATH' $global) $cmddir",
-            "env 'CMAKE_PREFIX_PATH' $global \"$cmddir;$currpath\"",
-            "# this session",
-            "$null, $env:PKG_CONFIG_PATH = strip_path $env:PKG_CONFIG_PATH $pcdir",
-            "$env:PKG_CONFIG_PATH = \"$pcdir;$env:PKG_CONFIG_PATH\"",
-            "$null, $env:CMAKE_PREFIX_PATH = strip_path $env:CMAKE_PREFIX_PATH $cmdir",
-            "$env:CMAKE_PREFIX_PATH = \"$cmdir;$env:CMAKE_PREFIX_PATH\""
-        ]
-    },
-    "uninstaller": {
-        "script": [
-            "$pcdir = \"$(current_dir $dir)\\lib\\pkgconfig\"",
-            "$cmdir = \"$(current_dir $dir)\"",
-            "# future sessions",
-            "$was_in_path, $newpath = strip_path (env 'PKG_CONFIG_PATH' $global) $pcdir",
-            "if($was_in_path) {",
-            "    write-host \"Removing $(friendly_path $pcdir) from your path.\"",
-            "    env 'PKG_CONFIG_PATH' $global $newpath",
-            "}",
-            "$was_in_path, $newpath = strip_path (env 'CMAKE_PREFIX_PATH' $global) $cmdir",
-            "if($was_in_path) {",
-            "    write-host \"Removing $(friendly_path $cmdir) from your path.\"",
-            "    env 'CMAKE_PREFIX_PATH' $global $newpath",
-            "}",
-            "# current session",
-            "$was_in_path, $newpath = strip_path $env:PKG_CONFIG_PATH $pcdir",
-            "if($was_in_path) { $env:PKG_CONFIG_PATH = $newpath }",
-            "$was_in_path, $newpath = strip_path $env:CMAKE_PREFIX_PATH $cmdir",
-            "if($was_in_path) { $env:CMAKE_PREFIX_PATH = $newpath }"
-        ]
+    "architecture": {
+        "64bit": {
+            "url": "https://www.libsdl.org/release/SDL2-2.0.12-win32-x64.zip",
+            "hash": "9d3cd8b83e62ef209b603819c138d3b7c32c860cc1eb8342e853e04c3c81dbc2"
+        },
+        "32bit": {
+            "url": "https://www.libsdl.org/release/SDL2-2.0.12-win32-x86.zip",
+            "hash": "5c4d2801eeb86aa0fa9d0709438d4267503aeb76bd35c9c2582a47592ceeb670"
+        }
     },
     "checkver": {
         "url": "https://www.libsdl.org/download-2.0.php",
         "regex": "SDL version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.libsdl.org/release/SDL2-$version-win32-x64.zip"
+            },
+            "32bit": {
+                "url": "https://www.libsdl.org/release/SDL2-$version-win32-x86.zip"
+            }
+        }
     }
 }

--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.libsdl.org",
     "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
-    "version": "2.0.10",
+    "version": "2.0.12",
     "license": "Zlib",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
I dont know whats the point of downloading the source code instead of the actual runtime libraries and why theres no auto update in this manifest. Who made this ?
Ideally, this manifest should use regsvr32 to register the dlls, but that probably wont be allowed in the extras bucket.