### PR TITLE
trafficmonitor: Adopt portable configuration

### DIFF
--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -17,13 +17,11 @@
         }
     },
     "extract_dir": "TrafficMonitor",
-    "installer": {
-        "script": [
-            "if (!(Test-Path \"$persist_dir\\config.ini\")) { Set-Content \"$dir\\config.ini\" @('[general]', 'check_update_when_start = false') -Encoding Ascii }",
-            "if (!(Test-Path \"$persist_dir\\history_traffic.dat\")) { New-Item \"$dir\\history_traffic.dat\" -ItemType File | Out-Null }",
-            "if (!(Test-Path \"$persist_dir\\global_cfg.ini\")) { Set-Content \"$dir\\global_cfg.ini\" @('[config]', 'portable_mode = true') -Encoding Ascii }"
-        ]
-    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\config.ini\")) { Set-Content \"$dir\\config.ini\" @('[general]', 'check_update_when_start = false') -Encoding Ascii }",
+        "if (!(Test-Path \"$persist_dir\\history_traffic.dat\")) { New-Item \"$dir\\history_traffic.dat\" | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\global_cfg.ini\")) { Set-Content \"$dir\\global_cfg.ini\" @('[config]', 'portable_mode = true') -Encoding Ascii }"
+    ],
     "shortcuts": [
         [
             "TrafficMonitor.exe",

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -1,8 +1,9 @@
 {
     "version": "1.78",
-    "description": "TrafficMonitor is a network monitoring suspension window software in Windows platform. It can display the current network speed, CPU and memory usage. It also support the functions of display in the taskbar, change skin and historical traffic statistics.",
+    "description": "Network monitoring suspension window software",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor",
     "license": {
+        "identifier": "Anti 996-License-1.0",
         "url": "https://github.com/zhongyang219/TrafficMonitor/blob/master/LICENSE"
     },
     "architecture": {
@@ -18,16 +19,9 @@
     "extract_dir": "TrafficMonitor",
     "installer": {
         "script": [
-            "if (!(Test-Path \"$persist_dir\\config.ini\")) { Set-Content \"$dir\\config.ini\" @('[general]', 'check_update_when_start = false') }",
-            "Set-Content \"$dir\\global_cfg.ini\" @('[config]', 'portable_mode = true')"
-        ]
-    },
-    "uninstaller": {
-        "script": [
-            "if (!(Test-Path \"$persist_dir\")) {",
-            "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
-            "   Copy-Item \"$dir\\config.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
-            "}"
+            "if (!(Test-Path \"$persist_dir\\config.ini\")) { Set-Content \"$dir\\config.ini\" @('[general]', 'check_update_when_start = false') -Encoding Ascii }",
+            "if (!(Test-Path \"$persist_dir\\history_traffic.dat\")) { New-Item \"$dir\\history_traffic.dat\" -ItemType File | Out-Null }",
+            "if (!(Test-Path \"$persist_dir\\global_cfg.ini\")) { Set-Content \"$dir\\global_cfg.ini\" @('[config]', 'portable_mode = true') -Encoding Ascii }"
         ]
     },
     "shortcuts": [
@@ -36,7 +30,12 @@
             "TrafficMonitor"
         ]
     ],
-    "persist": "config.ini",
+    "persist": [
+        "skins",
+        "config.ini",
+        "history_traffic.dat",
+        "global_cfg.ini"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -1,8 +1,10 @@
 {
-    "homepage": "https://github.com/zhongyang219/TrafficMonitor",
-    "description": "TrafficMonitor is a network monitoring suspension window software in Windows platform. It can display the current network speed, CPU and memory usage. It also support the functions of display in the taskbar, change skin and historical traffic statistics.",
-    "license": "MIT",
     "version": "1.78",
+    "description": "TrafficMonitor is a network monitoring suspension window software in Windows platform. It can display the current network speed, CPU and memory usage. It also support the functions of display in the taskbar, change skin and historical traffic statistics.",
+    "homepage": "https://github.com/zhongyang219/TrafficMonitor",
+    "license": {
+        "url": "https://github.com/zhongyang219/TrafficMonitor/blob/master/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.78/TrafficMonitor_V1.78_x64.7z",
@@ -14,7 +16,27 @@
         }
     },
     "extract_dir": "TrafficMonitor",
-    "bin": "TrafficMonitor.exe",
+    "installer": {
+        "script": [
+            "if (!(Test-Path \"$persist_dir\\config.ini\")) { Set-Content \"$dir\\config.ini\" @('[general]', 'check_update_when_start = false') }",
+            "Set-Content \"$dir\\global_cfg.ini\" @('[config]', 'portable_mode = true')"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (!(Test-Path \"$persist_dir\")) {",
+            "   New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
+            "   Copy-Item \"$dir\\config.ini\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
+            "}"
+        ]
+    },
+    "shortcuts": [
+        [
+            "TrafficMonitor.exe",
+            "TrafficMonitor"
+        ]
+    ],
+    "persist": "config.ini",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
@@ -25,11 +47,5 @@
                 "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V$version/TrafficMonitor_V$version_x86.7z"
             }
         }
-    },
-    "shortcuts": [
-        [
-            "TrafficMonitor.exe",
-            "TrafficMonitor"
-        ]
-    ]
+    }
 }

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.78",
+    "version": "1.79",
     "description": "Network monitoring suspension window software",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.78/TrafficMonitor_V1.78_x64.7z",
-            "hash": "ce16a79ca8b8bed2b50c2e33a3415e58ef50481677dca1024305d4214f864610"
+            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.79/TrafficMonitor_V1.79_x64.7z",
+            "hash": "d489dfd6f0231cc317ab66fe26095cf5b9a8e9a88584d3d75d0815dcdf0394a4"
         },
         "32bit": {
-            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.78/TrafficMonitor_V1.78_x86.7z",
-            "hash": "d5c5bbf7d9b8c0a7a6052f0c0622664e1bf832d6b685a22e1caef70b56acbca6"
+            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.79/TrafficMonitor_V1.79_x86.7z",
+            "hash": "cbb09e38b65e874edaa64ac183283e297ea66fbe428b0190db9b1b399b67b05a"
         }
     },
     "extract_dir": "TrafficMonitor",

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.79",
+    "version": "1.79.1",
     "description": "Network monitoring suspension window software",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.79/TrafficMonitor_V1.79_x64.7z",
-            "hash": "d489dfd6f0231cc317ab66fe26095cf5b9a8e9a88584d3d75d0815dcdf0394a4"
+            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.79.1/TrafficMonitor_V1.79.1_x64.7z",
+            "hash": "b23c94c8c4c3e9baf6e7da52c91b91523f23cbbb4605c9900df3553b2d91d294"
         },
         "32bit": {
-            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.79/TrafficMonitor_V1.79_x86.7z",
-            "hash": "cbb09e38b65e874edaa64ac183283e297ea66fbe428b0190db9b1b399b67b05a"
+            "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.79.1/TrafficMonitor_V1.79.1_x86.7z",
+            "hash": "7a203c2ccc7425de26d19fc12f5dc95b725e8f48954ba62c7fe5e8836dbf3d86"
         }
     },
     "extract_dir": "TrafficMonitor",


### PR DESCRIPTION
- The license is [no longer MIT](https://github.com/zhongyang219/TrafficMonitor/blob/master/LICENSE)
- Persist configuration between installations (~~and migrate from the old manifest if needed~~)
- Ensure the app runs in portable mode
- Disable update check upon the first launch