### PR TITLE
anaconda3: Add "Library\\bin" to "env_add_path"

### DIFF
--- a/bucket/anaconda3.json
+++ b/bucket/anaconda3.json
@@ -35,7 +35,10 @@
         "file": "Uninstall-Anaconda3.exe",
         "args": "/S"
     },
-    "env_add_path": "Scripts",
+    "env_add_path": [
+        "Scripts",
+        "Library\\bin"
+    ],
     "persist": "envs",
     "checkver": {
         "url": "https://repo.continuum.io/archive",


### PR DESCRIPTION
There are many `.dll` files required by some libraries in the directory `Library\\bin`.
Like `ipython` needs `sqlite3.dll`, `spyder` or `jupyter-qtconsole` requires Qt's many `.dll`s.
This directory must exist in the environment variable `PATH`, otherwise, such commands cannot find these `.dll`s.