### PR TITLE
glimpse: Add version 0.2.0

### DIFF
--- a/bucket/glimpse.json
+++ b/bucket/glimpse.json
@@ -53,8 +53,5 @@
     "persist": [
         "etc\\glimpse",
         "share\\glimpse"
-    ],
-    "checkver": {
-        "github": "https://github.com/glimpse-editor/Glimpse"
-    }
+    ]
 }

--- a/bucket/glimpse.json
+++ b/bucket/glimpse.json
@@ -1,0 +1,60 @@
+{
+    "version": "0.2.0",
+    "description": "Open source image editor based on the GNU Image Manipulation Program",
+    "homepage": "https://glimpse-editor.github.io/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/glimpse-editor/Glimpse/releases/download/v0.2.0/glimpse-0.2.0-x64.msi",
+            "hash": "420dbbe11fef2a1d741083eb72f99732b9aec620d1d8274f9fb7a30e650030ff",
+            "extract_dir": "PFiles\\Glimpse Image Editor\\Glimpse 0.2.0 (64-bit)"
+        },
+        "32bit": {
+            "url": "https://github.com/glimpse-editor/Glimpse/releases/download/v0.2.0/glimpse-0.2.0-i686.msi",
+            "hash": "2163403ca13d27be399b7fc1348719b2a9a4ddc4bc8c4b00aa8edd608bacfdbd",
+            "extract_dir": "PFiles\\Glimpse Image Editor\\Glimpse 0.2.0"
+        }
+    },
+    "installer": {
+        "script": [
+            "$defpath = \"`nPATH=`${gimp_installation_dir}\\bin",
+            "if ($architecture -eq '64bit') { $defpath += \";`${gimp_installation_dir}\\32\\bin\" }",
+            "$defpath += \"`n\"",
+            "$defenv = Get-Content -Raw \"$dir\\lib\\glimpse\\2.0\\environ\\default.env\"",
+            "$defenv += $defpath",
+            "$defenv | Set-Content -Encoding UTF8 \"$dir\\lib\\glimpse\\2.0\\environ\\default.env\""
+        ]
+    },
+    "bin": [
+        "bin\\glimpse-console-0.2.exe",
+        [
+            "bin\\glimpse-console-0.2.exe",
+            "glimpse-console"
+        ],
+        [
+            "bin\\glimpse-console-0.2.exe",
+            "glimpse"
+        ],
+        [
+            "bin\\gimptool-2.0.exe",
+            "glimpsetool-0.2"
+        ],
+        [
+            "bin\\gimptool-2.0.exe",
+            "glimpsetool"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bin\\glimpse-0.2.exe",
+            "Glimpse"
+        ]
+    ],
+    "persist": [
+        "etc\\glimpse",
+        "share\\glimpse"
+    ],
+    "checkver": {
+        "github": "https://github.com/glimpse-editor/Glimpse"
+    }
+}


### PR DESCRIPTION
I don't know how to handle the `0.2` instances better in autoupdates (matching on GitHub version results?), but here's a patch anyways. (It's still correctly automatic on point releases, like the upcoming 0.2.1.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lukesampson/scoop-extras/4842)
<!-- Reviewable:end -->
