### PR TITLE
flutter: Depends on android-clt

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -4,7 +4,7 @@
     "homepage": "https://flutter.dev",
     "license": "BSD-3-Clause",
     "depends": [
-        "android-sdk",
+        "android-clt",
         "java/adopt8-hotspot"
     ],
     "suggest": {


### PR DESCRIPTION
[Android Command Line Tools is the successor of android-sdk.](https://github.com/ScoopInstaller/Main/pull/1362)