### PR TITLE
MagicaVoxel@0.99.6: Fix URL

### DIFF
--- a/bucket/MagicaVoxel.json
+++ b/bucket/MagicaVoxel.json
@@ -5,14 +5,14 @@
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win64.zip",
-            "hash": "2de37d619ecc53f411cfcf914329685d57903288d2b993f9e5c3ec906521a9c2",
-            "extract_dir": "MagicaVoxel-0.99.6-win64"
+            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6.2-win64.zip",
+            "hash": "169dcddbea7dad30c0713d9ca211d445525501aceb9e12c8a6b51e7afad11420",
+            "extract_dir": "MagicaVoxel-0.99.6.2-win64"
         },
         "32bit": {
-            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win32.zip",
-            "hash": "4d6d8b277c2c2c5911b3f3b7be680e6368c7e7ce7754aba8efd847a14a826e54",
-            "extract_dir": "MagicaVoxel-0.99.6-win32"
+            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6.2-win32.zip",
+            "hash": "ab6ca0d2a6dec93fb362bd5184fde1ce23287b695eced3021809bd302566630f",
+            "extract_dir": "MagicaVoxel-0.99.6.2-win32"
         }
     },
     "bin": "MagicaVoxel.exe",


### PR DESCRIPTION
- Closes #4964
- Closes #5290

new version of 0.99.6 changed download paths.
the commit contains updated download path and corresponding hashes.