### PR TITLE
paperwork: Add version 2.0

### DIFF
--- a/bucket/paperwork.json
+++ b/bucket/paperwork.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "description": "Personal document manager",
     "homepage": "https://openpaper.work",
-    "license": "GPL-3.0-only",
+    "license": "GPL-3.0-or-later",
     "url": "https://download.openpaper.work/windows/x86/paperwork-master-24ba2639.zip",
     "hash": "85414f4789e000b60ede495df8e314c7328d47ae16a163c1110e0d1a0b9cbdcd",
     "shortcuts": [

--- a/bucket/paperwork.json
+++ b/bucket/paperwork.json
@@ -1,0 +1,24 @@
+{
+    "version": "2.0",
+    "description": "Personal document manager",
+    "homepage": "https://openpaper.work",
+    "license": "GPL-3.0-only",
+    "url": "https://download.openpaper.work/windows/x86/paperwork-master-24ba2639.zip",
+    "hash": "85414f4789e000b60ede495df8e314c7328d47ae16a163c1110e0d1a0b9cbdcd",
+    "shortcuts": [
+        [
+            "paperwork.exe",
+            "Paperwork",
+            "",
+            "data/paperwork_64.ico"
+        ]
+    ],
+    "checkver": {
+        "url": "https://gitlab.gnome.org/api/v4/projects/World%2FOpenPaperwork%2Fpaperwork/repository/tags?order_by=name",
+        "regex": "{[^{}]*\"name\":\"(?<version>[0-9.]+)\"[^{}]*\"commit\":{[^}]*\"short_id\":\"(?<hash>[^\"]+)\"",
+        "replace": "${version}"
+    },
+    "autoupdate": {
+        "url": "https://download.openpaper.work/windows/x86/paperwork-master-$matchHash.zip"
+    }
+}

--- a/bucket/paperwork.json
+++ b/bucket/paperwork.json
@@ -10,7 +10,7 @@
             "paperwork.exe",
             "Paperwork",
             "",
-            "data/paperwork_64.ico"
+            "data\\paperwork_64.ico"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
`checkver` is a bit ugly because the jsonpath implementation does not allow selecting multiple fields which would make the regex simpler. Currently it heavily relies on the format of the Gitlab API response.