### PR TITLE
registry-workshop: Add version 5.0.1

### DIFF
--- a/bucket/registry-workshop.json
+++ b/bucket/registry-workshop.json
@@ -1,0 +1,49 @@
+{
+    "description": "An advanced registry editor.",
+    "homepage": "http://www.torchsoft.com/en/rw_information.html",
+    "license": "Shareware",
+    "url": "http://www.torchsoft.com/download/RegistryWorkshop.exe#/dl.7z",
+    "version": "5.0.1",
+    "hash": "cabbb998557c5e883200d082853ca0db1a9f0db66332a0731019b7485c2e95d0",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "RegWorkshopX64.exe",
+                    "regworkshop"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "RegWorkshopX64.exe",
+                    "Registry Workshop"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "RegWorkshop.exe",
+            "shortcuts": [
+                [
+                    "RegWorkshop.exe",
+                    "Registry Workshop"
+                ]
+            ]
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\RegWorkshop.ini\")) { New-Item \"$dir\\RegWorkshop.ini\" -ItemType File | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\favorites.dat\")) { New-Item \"$dir\\favorites.dat\" -ItemType File | Out-Null}"
+    ],
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
+    "persist": [
+        "RegWorkshop.ini",
+        "favorites.dat"
+    ],
+    "checkver": {
+        "url": "http://www.torchsoft.com/node/12",
+        "regex": "Version ([\\w.]+)"
+    },
+    "autoupdate": {
+        "url": "http://www.torchsoft.com/download/RegistryWorkshop.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
[Registry Workshop](http://www.torchsoft.com/en/rw_information.html) is an advanced registry editor. It is a perfect replacement for RegEdit and RegEdt32 which shipped with Windows.

PRed before, but closed because it is a paid application. https://github.com/lukesampson/scoop-extras/pull/2630
Although Registry Workshop is a paid application, it is the best registry editor and we should include it.