### PR TITLE
shadowsocks-v2ray-plugin: Add version 1.3.1

### DIFF
--- a/bucket/shadowsocks-v2ray-plugin.json
+++ b/bucket/shadowsocks-v2ray-plugin.json
@@ -38,7 +38,7 @@
         },
         "hash": {
             "url": "https://github.com/shadowsocks/v2ray-plugin/releases/tag/v$version",
-            "regex": "([.*])[\\s]+$basename"
+            "regex": "$sha1\\s+$basename"
         }
     }
 }

--- a/bucket/shadowsocks-v2ray-plugin.json
+++ b/bucket/shadowsocks-v2ray-plugin.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.3.1",
+    "description": "Yet another SIP003 plugin for shadowsocks, based on v2ray",
+    "homepage": "https://github.com/shadowsocks/v2ray-plugin",
+    "license": "MIT",
+    "depends": "shadowsocks",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/shadowsocks/v2ray-plugin/releases/download/v1.3.1/v2ray-plugin-windows-amd64-v1.3.1.tar.gz",
+            "hash": "sha1:8b7ebfbb98a26f5a9cb206a631bda17fcd418bd6",
+            "bin": [
+                [ "v2ray-plugin_windows_amd64.exe", "v2ray-plugin"]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/shadowsocks/v2ray-plugin/releases/download/v1.3.1/v2ray-plugin-windows-386-v1.3.1.tar.gz",
+            "hash": "sha1:fcb25cae77b392178efb91c6fb2450fb3f9e7da3",
+            "bin": [
+                ["v2ray-plugin_windows_386.exe", "v2ray-plugin"]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/shadowsocks/v2ray-plugin/releases/download/v$version/v2ray-plugin-windows-amd64-v$version.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/shadowsocks/v2ray-plugin/releases/download/v$version/v2ray-plugin-windows-386-v$version.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/shadowsocks/v2ray-plugin/releases/tag/v$version",
+            "regex": "([.*])[\\s]+$basename"
+        }
+    }
+}

--- a/bucket/shadowsocks-v2ray-plugin.json
+++ b/bucket/shadowsocks-v2ray-plugin.json
@@ -1,6 +1,6 @@
 {
     "version": "1.3.1",
-    "description": "Yet another SIP003 plugin for shadowsocks, based on v2ray",
+    "description": "SIP003 plugin based on v2ray for shadowsocks",
     "homepage": "https://github.com/shadowsocks/v2ray-plugin",
     "license": "MIT",
     "depends": "shadowsocks",

--- a/bucket/shadowsocks-v2ray-plugin.json
+++ b/bucket/shadowsocks-v2ray-plugin.json
@@ -38,7 +38,7 @@
         },
         "hash": {
             "url": "https://github.com/shadowsocks/v2ray-plugin/releases/tag/v$version",
-            "regex": "$sha1\\s+$basename"
+            "regex": "$sha1\\s+bin/$basename"
         }
     }
 }

--- a/bucket/shadowsocks-v2ray-plugin.json
+++ b/bucket/shadowsocks-v2ray-plugin.json
@@ -9,14 +9,20 @@
             "url": "https://github.com/shadowsocks/v2ray-plugin/releases/download/v1.3.1/v2ray-plugin-windows-amd64-v1.3.1.tar.gz",
             "hash": "sha1:8b7ebfbb98a26f5a9cb206a631bda17fcd418bd6",
             "bin": [
-                [ "v2ray-plugin_windows_amd64.exe", "v2ray-plugin"]
+                [
+                    "v2ray-plugin_windows_amd64.exe",
+                    "shadowsocks-v2ray-plugin"
+                ]
             ]
         },
         "32bit": {
             "url": "https://github.com/shadowsocks/v2ray-plugin/releases/download/v1.3.1/v2ray-plugin-windows-386-v1.3.1.tar.gz",
             "hash": "sha1:fcb25cae77b392178efb91c6fb2450fb3f9e7da3",
             "bin": [
-                ["v2ray-plugin_windows_386.exe", "v2ray-plugin"]
+                [
+                    "v2ray-plugin_windows_386.exe",
+                    "shadowsocks-v2ray-plugin"
+                ]
             ]
         }
     },


### PR DESCRIPTION
The very useful [v2ray plugin for shadowsocks](https://github.com/shadowsocks/v2ray-plugin).

Manually tested.
