### PR TITLE
xyplorerfree: rename xyplorer to xyplorerfree

### DIFF
--- a/bucket/xyplorerfree.json
+++ b/bucket/xyplorerfree.json
@@ -1,0 +1,23 @@
+{
+    "version": "17.40.0100",
+    "description": "A file manager for Windows.",
+    "homepage": "https://www.xyplorer.com/free.php",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.xyplorer.com/company.php#legal"
+    },
+    "url": "https://www.xyplorer.com/download/xyplorer_free_noinstall.zip",
+    "hash": "38cb3abc8a699023e5f74fe19c167e91e59be67a09c9e1fc7f589b98324b9ee9",
+    "bin": "XYplorerFree.exe",
+    "shortcuts": [
+        [
+            "XYplorerFree.exe",
+            "XYplorer"
+        ]
+    ],
+    "persist": "Data",
+    "checkver": "XYFreeHash-([\\d.]+)\\.txt",
+    "autoupdate": {
+        "url": "https://www.xyplorer.com/download/xyplorer_free_noinstall.zip"
+    }
+}


### PR DESCRIPTION
[Old xyplorer](https://www.xyplorer.com/free.php) is a free edition which has been discontinued as of 10-Jan-2017.