### PR TITLE
ungoogled-chromium-portable: fix autoupdate

### DIFF
--- a/bucket/ungoogled-chromium-portable.json
+++ b/bucket/ungoogled-chromium-portable.json
@@ -1,19 +1,19 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "85.0.4183.83",
+    "version": "86.0.4240.198",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v85.0.4183.83-r782793-Win64/ungoogled-chromium-85.0.4183.83-2_Win64.7z",
-            "hash": "sha1:e2a561650ca6f3622acc1d170a6e76ef87405152",
-            "extract_dir": "ungoogled-chromium-85.0.4183.83-2_Win64"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v86.0.4240.198-r800218-Win64/ungoogled-chromium-86.0.4240.198-1_Win64.7z",
+            "hash": "sha1:afab64028b9d980711437f3e3b8b1b47b1f70536",
+            "extract_dir": "ungoogled-chromium-86.0.4240.198-1_Win64"
         },
         "32bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v85.0.4183.83-r782793-Win64/Ungoogled-Chromium-85.0.4183.83-2_Win32.7z",
-            "hash": "sha1:7be72395b89ce0cc5f6fdbcd3a90835baf4051e8",
-            "extract_dir": "Ungoogled-Chromium-85.0.4183.83-2_Win32"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v86.0.4240.198-r800218-Win64/Ungoogled-Chromium-86.0.4240.198-1_Win32.7z",
+            "hash": "sha1:5ff21ca1e7e09ab5dea0c628264b6bab7fb35929",
+            "extract_dir": "Ungoogled-Chromium-86.0.4240.198-1_Win32"
         }
     },
     "bin": [
@@ -37,18 +37,18 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "github": "https://github.com/macchrome/winchrome",
-        "regex": "v([\\d.]+)-r(?<build>\\d+)-Win64"
+        "url": "https://github.com/macchrome/winchrome/releases",
+        "regex": "v([\\d.]+)-r(?<build>\\d+)-Win64.*Ungoogled\\-Chromium-[\\d.]+-(?<id>\\d+)_Win32"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-2_Win64.7z",
-                "extract_dir": "ungoogled-chromium-$version-2_Win64"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-$matchId_Win64.7z",
+                "extract_dir": "ungoogled-chromium-$version-$matchId_Win64"
             },
             "32bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-2_Win32.7z",
-                "extract_dir": "Ungoogled-Chromium-$version-2_Win32"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-$matchId_Win32.7z",
+                "extract_dir": "Ungoogled-Chromium-$version-$matchId_Win32"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixed hardcoded autoupdate url, and updated regex to match for 32 bit specifically since sometimes the release page is 64 bit only.