### PR TITLE
foobar2000-portable: use profile for persist

### DIFF
--- a/bucket/foobar2000-portable.json
+++ b/bucket/foobar2000-portable.json
@@ -15,41 +15,20 @@
             "Foobar2000"
         ]
     ],
-    "persist": [
-        "configuration",
-        "index-data",
-        "library",
-        "user-components"
-    ],
+    "persist": "profile",
     "installer": {
         "script": [
             "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
-            "New-Item \"$dir\\portable_mode_enabled\" -Force | Out-Null",
-            "if(!(Test-Path \"$persist_dir\\playlists\")) {",
-            "    New-Item \"$persist_dir\\playlists\" -ItemType Directory -Force | Out-Null",
-            "    if (Test-Path \"$env:Appdata\\foobar2000\") {",
-            "        Write-Host -F yellow \"Copying old '$env:Appdata\\foobar2000' to '$persist_dir'\"",
-            "        Copy-Item \"$env:Appdata\\foobar2000\\*\" \"$dir\" -Recurse -Force",
-            "    }",
-            "}",
-            "else {",
-            "    $shortVersion = $version.Split('.')[0, 1] -Join '.'",
-            "    Copy-Item \"$persist_dir\\playlists\" \"$dir\\playlist-v$shortVersion\" -Force -Recurse",
-            "}",
-            "if (Test-Path \"$persist_dir\\theme.fth\") {",
-            "    Copy-Item \"$persist_dir\\theme.fth\" \"$dir\" -Force",
-            "}"
+            "New-Item \"$dir\\portable_mode_enabled\" -Force | Out-Null"
         ]
     },
-    "post_install": "if (is_directory \"$dir\\theme.fth\") { Remove-Item \"$dir\\theme.fth\" -Force }",
-    "uninstaller": {
-        "script": [
-            "Copy-Item \"$dir\\playlists-v*\\*\" \"$persist_dir\\playlists\" -Force  -Recurse",
-            "if (Test-Path \"$dir\\theme.fth\") {",
-            "    Copy-Item \"$dir\\theme.fth\" \"$persist_dir\" -Force",
-            "}"
-        ]
-    },
+    "post_install": [
+        "if(Test-Path \"$persist_dir\\playlists\") {",
+        "    Rename-Item -Path \"$persist_dir\\playlists\" -NewName playlists-v1.4 -Force",
+        "    Get-ChildItem -Exclude \"profile\" -Path \"$persist_dir\" |",
+        "        Move-Item -Destination \"$persist_dir\\profile\" -Force",
+        "}"
+    ],
     "checkver": {
         "url": "https://www.foobar2000.org/download",
         "regex": "foobar2000_v([\\d.]+)\\."


### PR DESCRIPTION
Foobar2000 version 1.6 introduced new 'profile' directory for portable mode. From changelog:

> New portable install puts all configuration data in 'profile' subfolder of install folder instead of saving in the installation folder directly. Doesn't affect upgraded installs or non-portable.

The playlist directory in current version is named 'playlists-v1.4', not 'playlist-v$shortVersion', so playlist migration is completely broken in current manifest.

In current PR I changed persist to use new 'profile' directory. Also in 'post_install' section after scoop will create 'profile' directory, I renamed playlists to 'playlists-v1.4' and moved all files to 'profile' directory. 'playlists' directory was always created, so it should be pretty reliable condition to trigger migration from previous version of the manifest.