### PR TITLE
janet: Add version 1.13.1

### DIFF
--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -14,7 +14,10 @@
         }
     },
     "extract_dir": "Janet",
-    "persist": "Library",
+    "bin": [
+        "bin\\janet.exe",
+        "bin\\jpm.bat"
+    ],
     "env_set": {
         "JANET_PATH": "$dir\\Library",
     },

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -19,7 +19,7 @@
         "bin\\jpm.bat"
     ],
     "env_set": {
-        "JANET_PATH": "$dir\\Library",
+        "JANET_PATH": "$dir\\Library"
     },
     "persist": "Library",
     "checkver": {

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -14,16 +14,18 @@
         }
     },
     "extract_dir": "Janet",
+    "post_install": "New-Item -Path $dir\\Library -ItemType Directory -Force",
+    "persist": "Library",
+    "env_set": {
+        "JANET_BINPATH": "$dir\\bin",
+        "JANET_PATH": "$persist_dir\\Library",
+        "JANET_HEADERPATH": "$dir\\C",
+        "JANET_LIBPATH": "$dir\\C"
+    },
     "bin": [
         "bin\\janet.exe",
         "bin\\jpm.bat"
     ],
-    "env_set": {
-        "JANET_BINPATH": "$dir\\bin",
-        "JANET_PATH": "$dir\\Library",
-        "JANET_HEADERPATH": "$dir\\C",
-        "JANET_LIBPATH": "$dir\\C"
-    },
     "checkver": {
         "github": "https://github.com/janet-lang/janet"
     },

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -18,10 +18,7 @@
     "env_set": {
         "JANET_PATH": "$dir\\Library",
     },
-    "bin": [
-        "bin\\janet.exe",
-        "bin\\jpm.bat"
-    ],
+    "persist": "Library",
     "checkver": {
         "github": "https://github.com/janet-lang/janet"
     },

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -14,7 +14,6 @@
         }
     },
     "extract_dir": "Janet",
-    "post_install": "New-Item -Path $dir\\Library -ItemType Directory -Force",
     "persist": "Library",
     "env_set": {
         "JANET_BINPATH": "$dir\\bin",

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -1,46 +1,40 @@
 {
-    "homepage": "https://janet-lang.org",
-    "description": "Janet is a lisp-like, embeddable, functional and imperative programming language and bytecode interpreter.",
-    "license": "MIT",
     "version": "1.13.1",
+    "description": "Janet is a lisp-like, embeddable, functional and imperative programming language and bytecode interpreter.",
+    "homepage": "https://janet-lang.org",
+    "license": "MIT",
     "architecture": {
-        "32bit": {
-            "hash": "627a0dccef7815fdde735caf3ea2eb3e16f2ec26ac3d0cc365cf8ea67589d5e3",
-            "url": "https://github.com/janet-lang/janet/releases/download/v1.13.1/janet-v1.13.1-windows-x86-installer.msi"
-        },
         "64bit": {
-            "hash": "ef5d32257594c8ab54aaa52fe8e84bb951a4883bbb6f6848e845759122d33a35",
-            "url": "https://github.com/janet-lang/janet/releases/download/v1.13.1/janet-v1.13.1-windows-x64-installer.msi"
+            "url": "https://github.com/janet-lang/janet/releases/download/v1.13.1/janet-v1.13.1-windows-x64-installer.msi",
+            "hash": "ef5d32257594c8ab54aaa52fe8e84bb951a4883bbb6f6848e845759122d33a35"
+        },
+        "32bit": {
+            "url": "https://github.com/janet-lang/janet/releases/download/v1.13.1/janet-v1.13.1-windows-x86-installer.msi",
+            "hash": "627a0dccef7815fdde735caf3ea2eb3e16f2ec26ac3d0cc365cf8ea67589d5e3"
         }
     },
-    "autoupdate": {
-        "architecture": {
-            "32bit": {
-                "url": "https://github.com/janet-lang/janet/releases/download/v$version/janet-v$version-windows-x86-installer.msi"
-            },
-            "64bit": {
-                "url": "https://github.com/janet-lang/janet/releases/download/v$version/janet-v$version-windows-x64-installer.msi"
-            }
-        }
-    },
-    "checkver": {
-        "github": "https://github.com/janet-lang/janet"
-    },
+    "extract_dir": "Janet",
     "bin": [
         "bin\\janet.exe",
-        ["bin\\janet.exe", "jpm", "$dir\\bin\\jpm"]
+        "bin\\jpm.bat"
     ],
-    "extract_dir": "Janet",
     "env_set": {
         "JANET_BINPATH": "$dir\\bin",
         "JANET_PATH": "$dir\\Library",
         "JANET_HEADERPATH": "$dir\\C",
         "JANET_LIBPATH": "$dir\\C"
     },
-    "installer": {
-        "script": "add_first_in_path \"$dir\\bin\" $global"
+    "checkver": {
+        "github": "https://github.com/janet-lang/janet"
     },
-    "uninstaller": {
-        "script": "remove_from_path \"$dir\\bin\" $global"
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/janet-lang/janet/releases/download/v$version/janet-v$version-windows-x64-installer.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/janet-lang/janet/releases/download/v$version/janet-v$version-windows-x86-installer.msi"
+            }
+        }
     }
 }

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -1,6 +1,6 @@
 {
     "version": "1.13.1",
-    "description": "Janet is a lisp-like, embeddable, functional and imperative programming language and bytecode interpreter.",
+    "description": "Lisp-like, embeddable, functional and imperative programming language and bytecode interpreter",
     "homepage": "https://janet-lang.org",
     "license": "MIT",
     "architecture": {

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -1,0 +1,46 @@
+{
+    "homepage": "https://janet-lang.org",
+    "description": "Janet is a lisp-like, embeddable, functional and imperative programming language and bytecode interpreter.",
+    "license": "MIT",
+    "version": "1.13.1",
+    "architecture": {
+        "32bit": {
+            "hash": "627a0dccef7815fdde735caf3ea2eb3e16f2ec26ac3d0cc365cf8ea67589d5e3",
+            "url": "https://github.com/janet-lang/janet/releases/download/v1.13.1/janet-v1.13.1-windows-x86-installer.msi"
+        },
+        "64bit": {
+            "hash": "ef5d32257594c8ab54aaa52fe8e84bb951a4883bbb6f6848e845759122d33a35",
+            "url": "https://github.com/janet-lang/janet/releases/download/v1.13.1/janet-v1.13.1-windows-x64-installer.msi"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/janet-lang/janet/releases/download/v$version/janet-v$version-windows-x86-installer.msi"
+            },
+            "64bit": {
+                "url": "https://github.com/janet-lang/janet/releases/download/v$version/janet-v$version-windows-x64-installer.msi"
+            }
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/janet-lang/janet"
+    },
+    "bin": [
+        "bin\\janet.exe",
+        ["bin\\janet.exe", "jpm", "$dir\\bin\\jpm"]
+    ],
+    "extract_dir": "Janet",
+    "env_set": {
+        "JANET_BINPATH": "$dir\\bin",
+        "JANET_PATH": "$dir\\Library",
+        "JANET_HEADERPATH": "$dir\\C",
+        "JANET_LIBPATH": "$dir\\C"
+    },
+    "installer": {
+        "script": "add_first_in_path \"$dir\\bin\" $global"
+    },
+    "uninstaller": {
+        "script": "remove_from_path \"$dir\\bin\" $global"
+    }
+}

--- a/bucket/janet.json
+++ b/bucket/janet.json
@@ -16,10 +16,7 @@
     "extract_dir": "Janet",
     "persist": "Library",
     "env_set": {
-        "JANET_BINPATH": "$dir\\bin",
-        "JANET_PATH": "$persist_dir\\Library",
-        "JANET_HEADERPATH": "$dir\\C",
-        "JANET_LIBPATH": "$dir\\C"
+        "JANET_PATH": "$dir\\Library",
     },
     "bin": [
         "bin\\janet.exe",


### PR DESCRIPTION
From the project homepage:

Janet is a functional and imperative programming language. It runs on Windows, Linux, macOS, BSDs, and should run on other systems with some porting. The entire language (core library, interpreter, compiler, assembler, PEG) is less than 1MB. You can also add Janet scripting to an application by embedding a single C file and two headers.

I did my best with this manifest. Suggestions welcome. Linked issue: https://github.com/janet-lang/janet/issues/533

Manifest declares following environment variables for the user:

`JANET_PATH`: The location to look for Janet libraries. This is the only environment variable Janet needs to
find native and source code modules. 

`JANET_HEADERPATH`: The location that jpm will look for janet header files (janet.h and janetconf.h) that are used
to build native modules and standalone executables. If janet.h and janetconf.h are available as
default includes on your system, this value is not required. If not provided, will default to
<jpm script location>/../include/janet. The --headerpath=/some/path option will override this

Unfortunately, defaults for location does not match the directory structure on Windows platform and it has to be modified.

`JANET_LIBPATH`: Similar to `JANET_HEADERPATH`, this path is where jpm will look for libjanet.a for creating standalone executables. This does not need to be set on a normal install.  If not provided, this will default to <jpm script location>/../lib.
The --libpath=/some/path option will override this variable.

Again. Unfortunately, the documentation says it sets it to default that does not exist on Windows platform.

`JANET_BINPATH`: The directory where jpm will install binary scripts and executables to. Defaults to `(dyn :syspath)/bin`. The --binpath=/some/path will override this variable.
