### PR TITLE
scoop-completion: Add version 0.2.3

### DIFF
--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -3,17 +3,18 @@
     "description": "A Scoop tab completion module for PowerShell",
     "homepage": "https://github.com/Moeologist/scoop-completion",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/scoop-completion.0.2.3.nupkg",
-    "hash": "01d1d889c516e16ba793f9e1cde1d6daf0420982a82249cd10ef8b58853d1704",
-    "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
+    "url": "https://github.com/Moeologist/scoop-completion/archive/v0.2.3.zip",
+    "hash": "59fcda6e723b2c0bf7430668ccfb57086d82e9472733a01f9f7f9315768b5e5f",
+    "extract_dir": "scoop-completion-0.2.3\\src",
     "psmodule": {
         "name": "scoop-completion"
     },
     "checkver": {
-        "url": "https://www.powershellgallery.com/packages/scoop-completion",
-        "regex": "<h2>([\\d.]+)</h2>"
+        "url": "https://github.com/Moeologist/scoop-completion/releases/",
+        "regex": "/releases/tag/v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/scoop-completion.$version.nupkg"
+        "url": "https://github.com/Moeologist/scoop-completion/archive/v$version.zip",
+        "extract_dir": "scoop-completion-$version\\src"
     }
 }

--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.3",
+    "description": "A Scoop tab completion module for PowerShell",
+    "homepage": "https://github.com/Moeologist/scoop-completion",
+    "license": "MIT",
+    "url": "https://psg-prod-eastus.azureedge.net/packages/scoop-completion.0.2.3.nupkg",
+    "hash": "01d1d889c516e16ba793f9e1cde1d6daf0420982a82249cd10ef8b58853d1704",
+    "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
+    "psmodule": {
+        "name": "scoop-completion"
+    },
+    "checkver": {
+        "url": "https://www.powershellgallery.com/packages/scoop-completion",
+        "regex": "<h2>([\\d.]+)</h2>"
+    },
+    "autoupdate": {
+        "url": "https://psg-prod-eastus.azureedge.net/packages/scoop-completion.$version.nupkg"
+    }
+}


### PR DESCRIPTION
This can be use to enable scoop auto-completion command for PowerShell