### PR TITLE
Ungoogled-chromium-portable: Update to version 89.0.4389.114

### DIFF
--- a/bucket/ungoogled-chromium-portable.json
+++ b/bucket/ungoogled-chromium-portable.json
@@ -1,19 +1,19 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "85.0.4183.83",
+    "version": "89.0.4389.114",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v85.0.4183.83-r782793-Win64/ungoogled-chromium-85.0.4183.83-2_Win64.7z",
-            "hash": "sha1:e2a561650ca6f3622acc1d170a6e76ef87405152",
-            "extract_dir": "ungoogled-chromium-85.0.4183.83-2_Win64"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v89.0.4389.114-r843830-Win64/ungoogled-chromium-89.0.4389.114-1_Win64.7z",
+            "hash": "sha1:392C9517EF45FBFAF0D92DE297B562835B5A2938",
+            "extract_dir": "ungoogled-chromium-89.0.4389.114-1_Win64"
         },
         "32bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v85.0.4183.83-r782793-Win64/Ungoogled-Chromium-85.0.4183.83-2_Win32.7z",
-            "hash": "sha1:7be72395b89ce0cc5f6fdbcd3a90835baf4051e8",
-            "extract_dir": "Ungoogled-Chromium-85.0.4183.83-2_Win32"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v89.0.4389.114-r843830-Win64/ungoogled-chromium-89.0.4389.114-1_Win32.7z",
+            "hash": "sha1:0183350321016DB47245A61B15F47CB7EE368E56",
+            "extract_dir": "Ungoogled-Chromium-89.0.4389.114-1_Win32"
         }
     },
     "bin": [
@@ -37,18 +37,18 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "github": "https://github.com/macchrome/winchrome",
-        "regex": "v([\\d.]+)-r(?<build>\\d+)-Win64"
+        "url": "https://github.com/macchrome/winchrome/releases",
+        "regex": "v([\\d.]+)-r(?<build>\\d+)-Win64.*Ungoogled\\-Chromium-[\\d.]+-(?<id>\\d+)_Win32"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-2_Win64.7z",
-                "extract_dir": "ungoogled-chromium-$version-2_Win64"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-$matchID_Win64.7z",
+                "extract_dir": "ungoogled-chromium-$version-1_Win64"
             },
             "32bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-2_Win32.7z",
-                "extract_dir": "Ungoogled-Chromium-$version-2_Win32"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-$matchID_Win32.7z",
+                "extract_dir": "Ungoogled-Chromium-$version-1_Win32"
             }
         },
         "hash": {

--- a/bucket/ungoogled-chromium-portable.json
+++ b/bucket/ungoogled-chromium-portable.json
@@ -43,12 +43,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-$matchID_Win64.7z",
-                "extract_dir": "ungoogled-chromium-$version-1_Win64"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-$matchId_Win64.7z",
+                "extract_dir": "ungoogled-chromium-$version-$matchId_Win64"
             },
             "32bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-$matchID_Win32.7z",
-                "extract_dir": "Ungoogled-Chromium-$version-1_Win32"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-$matchId_Win32.7z",
+                "extract_dir": "Ungoogled-Chromium-$version-$matchId_Win32"
             }
         },
         "hash": {


### PR DESCRIPTION
Autoupdate has been also modified and updated.
This app is basically the portable version for ungoogled-chromium, so it will temporary provide an alternative workaround for #5479.