### PR TITLE
flutter: remove dependencies and add path

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -3,14 +3,17 @@
     "description": "Google’s mobile app SDK for crafting high-quality native interfaces on iOS and Android",
     "homepage": "https://flutter.dev",
     "license": "BSD-3-Clause",
-    "depends": [
-        "android-sdk",
-        "java/adopt8-hotspot"
-    ],
     "suggest": {
         "Visual Studio Code with Flutter Extension": [
             "vscode",
             "vscode-portable"
+        ],
+        "Android SDK and JDK":[
+            "android-sdk",
+            "java/adoptopenjdk-hotspot"
+        ],
+        "Android Studio":[
+            "android-studio"
         ]
     },
     "url": [
@@ -27,11 +30,7 @@
         "Write-Host 'Some licenses need to be accepted before developing. It is recommended to do by running ''flutter doctor --android-licenses''.' -ForegroundColor Yellow",
         "flutter doctor"
     ],
-    "bin": [
-        "bin\\flutter.bat",
-        "flutter-dev-setup.ps1"
-    ],
-    "env_add_path": "bin\\cache\\dart-sdk\\bin",
+    "env_add_path": ["bin","bin\\cache\\dart-sdk\\bin"],
     "checkver": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
         "regex": "windows_(v?[\\d.]+)(?<delim>[-+]?)(?<build>[\\w.]*)-stable",


### PR DESCRIPTION
flutter support desktop and web, which is not depend on android sdk and jdk.
According to official guide, the recommended way to set up android develop environment is using android studio.
Using shim for flutter.bat will cause error of vscode extension `unable to find flutter.bat`.