### PR TITLE
clash.net: Add version 1.0.1

### DIFF
--- a/bucket/clash.net.json
+++ b/bucket/clash.net.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://github.com/ClashDotNetFramework/ClashDotNetFramework",
+    "description": "A Clash GUI Proxy For Windows Based On .NET 5",
+    "version": "1.0.1",
+    "license": "none",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/download/v1.0.1/Clash.NET.1.0.1.x64.7z",
+            "hash": "97937c4e94826b248b8787dc141963ea6dc3cdc8daddc46eca7c75a06ef073f5"
+        },
+        "32bit": {
+            "url": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/download/v1.0.1/Clash.NET.1.0.1.x86.7z",
+            "hash": "c3691cae9ab7f43e7c85650a435b42e167984c4d7c9202f552132e9ef86607a8"
+        }
+    },
+    "extract_dir": "Clash .NET 1.0.1",
+    "shortcuts": [
+        [
+            "ClashDotNet.exe",
+            "Clash.NET"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/latest"
+    }
+}

--- a/bucket/clash.net.json
+++ b/bucket/clash.net.json
@@ -2,7 +2,7 @@
     "homepage": "https://github.com/ClashDotNetFramework/ClashDotNetFramework",
     "description": "A Clash GUI Proxy For Windows Based On .NET 5",
     "version": "1.0.1",
-    "license": "none",
+    "license": "Unknown",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/download/v1.0.1/Clash.NET.1.0.1.x64.7z",


### PR DESCRIPTION
A Clash GUI Proxy For Windows Based On .NET 5

> scoop install clash.net
Installing 'clash.net' (1.0.1) [64bit]
Loading Clash.NET.1.0.1.x64.7z from cache
Checking hash of Clash.NET.1.0.1.x64.7z ... ok.
Extracting Clash.NET.1.0.1.x64.7z ... done.
Linking ~\scoop\apps\clash.net\current => ~\scoop\apps\clash.net\1.0.1
Creating shortcut for Clash.NET (ClashDotNet.exe)
'clash.net' (1.0.1) was installed successfully!