### PR TITLE
imdone: Add version 1.23.2

### DIFF
--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.17.4",
+    "version": "1.17.6",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
     "license": "Propietary",
@@ -15,8 +15,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://imdone.io/downloads/imdone-1.17.4.exe#/dl.7z",
-            "hash": "d6e69b83ae4879c4a78f8d3d699d5efa6a904f8a3bbcadfe5d71795898bc1b0c",
+            "url": "https://imdone.io/downloads/imdone-1.17.6.exe#/dl.7z",
+            "hash": "2601f99fbb3bfd7ad53790f8b2e85ee9b146e4fa889340f864aad0b5ea164dbf",
             "installer": {
                 "script": "Expand-7zipArchive \"$dir\\$PLUGINSDIR\\app-64.7z\" \"$dir\""
             }

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.17.4",
+    "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
+    "homepage": "https://imdone.io/",
+    "license": "Propietary",
+    "extract_dir": "$PLUGINSDIR",
+    "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z' | Remove-Item -Force -Recurse",
+    "post_install": "Remove-Item \"$dir\\app-64.7z\" -Force -ErrorAction SilentlyContinue",
+    "bin": "imdone.exe",
+    "shortcuts": [
+        [
+            "imdone.exe",
+            "imdone"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://imdone.io/downloads/imdone-1.17.4.exe#/dl.7z",
+            "hash": "d6e69b83ae4879c4a78f8d3d699d5efa6a904f8a3bbcadfe5d71795898bc1b0c",
+            "installer": {
+                "script": "Expand-7zipArchive \"$dir\\$PLUGINSDIR\\app-64.7z\" \"$dir\""
+            }
+        }
+    },
+    "checkver": {
+        "url": "https://imdone.io",
+        "regex": "/downloads/imdone-([\\d.]+)\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://imdone.io/downloads/imdone-$version.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.22.2",
+    "version": "1.23.2",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
     "license": {
@@ -9,7 +9,6 @@
     "extract_dir": "$PLUGINSDIR",
     "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z' | Remove-Item -Force -Recurse",
     "post_install": "Remove-Item \"$dir\\app-64.7z\" -Force -ErrorAction SilentlyContinue",
-    "bin": "imdone.exe",
     "shortcuts": [
         [
             "imdone.exe",
@@ -18,8 +17,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://imdone.io/downloads/imdone-1.22.2.exe#/dl.7z",
-            "hash": "9ee5fbd34237e3f60329cc4392ddfecb75e4c5d53cb8bc5840e27ca5ad4305d0",
+            "url": "https://imdone.io/downloads/imdone-1.23.2-portable.exe#/dl.7z",
+            "hash": "8012a4048b029433ed9664257a5b4fd3916cd24919ffd964cc40093be1557f0c",
             "installer": {
                 "script": "Expand-7zipArchive \"$dir\\$PLUGINSDIR\\app-64.7z\" \"$dir\""
             }
@@ -27,12 +26,12 @@
     },
     "checkver": {
         "url": "https://imdone.io",
-        "regex": "/downloads/imdone-([\\d.]+)\\.exe"
+        "regex": "/downloads/imdone-([\\d.]+)-portable\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://imdone.io/downloads/imdone-$version.exe#/dl.7z"
+                "url": "https://imdone.io/downloads/imdone-$version-portable.exe#/dl.7z"
             }
         }
     }

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -3,7 +3,7 @@
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
     "license": {
-        "identifier": "Unknown",
+        "identifier": "Proprietary",
         "url": "https://imdone.io/eula"
     },
     "extract_dir": "$PLUGINSDIR",

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -2,7 +2,10 @@
     "version": "1.22.2",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
-    "license": "Unknown",
+    "license": {
+        "identifier": "Unknown",
+        "url": "https://imdone.io/eula"
+    },
     "extract_dir": "$PLUGINSDIR",
     "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z' | Remove-Item -Force -Recurse",
     "post_install": "Remove-Item \"$dir\\app-64.7z\" -Force -ErrorAction SilentlyContinue",

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -1,8 +1,8 @@
 {
-    "version": "1.21.0",
+    "version": "1.22.2",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
-    "license": "Unknown",
+    "license": "Propietary",
     "extract_dir": "$PLUGINSDIR",
     "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z' | Remove-Item -Force -Recurse",
     "post_install": "Remove-Item \"$dir\\app-64.7z\" -Force -ErrorAction SilentlyContinue",
@@ -15,8 +15,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://imdone.io/downloads/imdone-1.21.0.exe#/dl.7z",
-            "hash": "5d66c72833afaca5daa0590e6f1d5d8cb41e3e13dd48afb3abc50e285bc6e082",
+            "url": "https://imdone.io/downloads/imdone-1.22.2.exe#/dl.7z",
+            "hash": "9ee5fbd34237e3f60329cc4392ddfecb75e4c5d53cb8bc5840e27ca5ad4305d0",
             "installer": {
                 "script": "Expand-7zipArchive \"$dir\\$PLUGINSDIR\\app-64.7z\" \"$dir\""
             }

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.17.6",
+    "version": "1.21.0",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
     "license": "Propietary",
@@ -15,8 +15,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://imdone.io/downloads/imdone-1.17.6.exe#/dl.7z",
-            "hash": "2601f99fbb3bfd7ad53790f8b2e85ee9b146e4fa889340f864aad0b5ea164dbf",
+            "url": "https://imdone.io/downloads/imdone-1.21.0.exe#/dl.7z",
+            "hash": "5d66c72833afaca5daa0590e6f1d5d8cb41e3e13dd48afb3abc50e285bc6e082",
             "installer": {
                 "script": "Expand-7zipArchive \"$dir\\$PLUGINSDIR\\app-64.7z\" \"$dir\""
             }

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -2,7 +2,7 @@
     "version": "1.21.0",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
-    "license": "Propietary",
+    "license": "Unknown",
     "extract_dir": "$PLUGINSDIR",
     "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z' | Remove-Item -Force -Recurse",
     "post_install": "Remove-Item \"$dir\\app-64.7z\" -Force -ErrorAction SilentlyContinue",

--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -2,7 +2,7 @@
     "version": "1.22.2",
     "description": "Simple and powerful kanban board built on top of plain text markdown files or code.",
     "homepage": "https://imdone.io/",
-    "license": "Propietary",
+    "license": "Unknown",
     "extract_dir": "$PLUGINSDIR",
     "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z' | Remove-Item -Force -Recurse",
     "post_install": "Remove-Item \"$dir\\app-64.7z\" -Force -ErrorAction SilentlyContinue",


### PR DESCRIPTION
Simple and powerful kanban board built on top of plain text markdown files or code.

Regarding the criteria for inclussion in the main bucket: this is not a developer tool, and it is GUI based which excludes it from main.

Hence, because the first criteria is not met, this is proposed for inclusion in extras.

The project does not publish hashes, if this is an absolute requirement for inclusion into extras please say so I can open an issue there.

Licensing is not clear, yet,  PR kept as draft until https://github.com/imdone/imdone/issues/109 is closed.

Closes #7170
