### PR TITLE
kindlegen@2.9: replaced a backup download link

### DIFF
--- a/bucket/kindlegen.json
+++ b/bucket/kindlegen.json
@@ -3,7 +3,7 @@
     "description": "Convert files to the Kindle format.",
     "homepage": "https://www.amazon.com/gp/feature.html?docId=1000765211",
     "license": "Unknown",
-    "url": "https://kindlegen.s3.amazonaws.com/kindlegen_win32_v2_9.zip",
+    "url": "https://github.com/ystyle/kaf-cli/releases/download/kindlegen/kindlegen_win32_v2_9.zip",
     "hash": "70b8401736684a1c390d4a95ba918283fcb3a36405c9a9895732deb50274540b",
     "bin": "kindlegen.exe"
 }


### PR DESCRIPTION
Kindlegen is no longer available for downloading, I replaced a backup download link