### PR TITLE
altserver: Add version 1.4.6

### DIFF
--- a/bucket/altserver.json
+++ b/bucket/altserver.json
@@ -9,7 +9,7 @@
     ],
     "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip",
     "hash": "d0544a465d2b1fbe31fcf9a0cd4ca203af63828dbc0c3f48bfff5806e96a089c",
-    "installer": {
+    "pre_install": {
         "script": [
             "if ([Environment]::OSVersion.Version.Major -ne \"10\") {",
             "    throw \"AltServer requires Windows 10 to work.\"",

--- a/bucket/altserver.json
+++ b/bucket/altserver.json
@@ -3,7 +3,7 @@
     "description": "A home for apps that push the boundaries of iOS. No jailbreak required.",
     "license": "AGPL-3.0",
     "version": "1.4.6",
-    "url": "https://f000.backblazeb2.com/file/altstore/altinstaller.zip",
+    "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip",
     "hash": "d0544a465d2b1fbe31fcf9a0cd4ca203af63828dbc0c3f48bfff5806e96a089c",
     "installer": {
         "script": [
@@ -24,7 +24,7 @@
         "github": "https://github.com/rileytestut/AltStore"
     },
     "autoupdate": {
-        "url": "https://f000.backblazeb2.com/file/altstore/altinstaller.zip"
+        "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip"
     },
     "notes": [
         "AltServer requires a 'Native' iTunes installed to work, you must download and install iTunes from Apple's webstie.",

--- a/bucket/altserver.json
+++ b/bucket/altserver.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://altstore.io/",
+    "description": "A home for apps that push the boundaries of iOS. No jailbreak required.",
+    "license": "AGPL-3.0",
+    "version": "1.4.6",
+    "url": "https://f000.backblazeb2.com/file/altstore/altinstaller.zip",
+    "hash": "d0544a465d2b1fbe31fcf9a0cd4ca203af63828dbc0c3f48bfff5806e96a089c",
+    "installer": {
+        "script": [
+            "if ([Environment]::OSVersion.Version.Major -ne \"10\") {",
+            "    throw \"AltServer requires Windows 10 to work.\"",
+            "}",
+            "Remove-Item \"$dir\\setup.exe\"",
+            "Expand-MsiArchive \"$dir\\AltInstaller.msi\" \"$dir\" -Removal"
+        ]
+    },
+    "shortcuts": [
+        [
+            "AltServer.exe",
+            "AltServer"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/rileytestut/AltStore"
+    },
+    "autoupdate": {
+        "url": "https://f000.backblazeb2.com/file/altstore/altinstaller.zip"
+    },
+    "notes": [
+        "AltServer requires a 'Native' iTunes installed to work, you must download and install iTunes from Apple's webstie.",
+        "Refer to https://altstore.io/faq/ for more inforamtion."
+    ]
+}

--- a/bucket/altserver.json
+++ b/bucket/altserver.json
@@ -1,8 +1,12 @@
 {
     "homepage": "https://altstore.io/",
-    "description": "A home for apps that push the boundaries of iOS. No jailbreak required.",
-    "license": "AGPL-3.0",
+    "description": "AltStore is an alternative app store for non-jailbroken iOS devices.",
+    "license": "AGPL-3.0-or-later",
     "version": "1.4.6",
+    "notes": [
+        "AltServer requires a 'Native' iTunes installed to work, you must download and install iTunes from Apple's webstie.",
+        "Refer to https://altstore.io/faq/ for more inforamtion."
+    ],
     "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip",
     "hash": "d0544a465d2b1fbe31fcf9a0cd4ca203af63828dbc0c3f48bfff5806e96a089c",
     "installer": {
@@ -25,9 +29,5 @@
     },
     "autoupdate": {
         "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip"
-    },
-    "notes": [
-        "AltServer requires a 'Native' iTunes installed to work, you must download and install iTunes from Apple's webstie.",
-        "Refer to https://altstore.io/faq/ for more inforamtion."
-    ]
+    }
 }

--- a/bucket/altserver.json
+++ b/bucket/altserver.json
@@ -1,33 +1,26 @@
 {
-    "homepage": "https://altstore.io/",
-    "description": "AltStore is an alternative app store for non-jailbroken iOS devices.",
-    "license": "AGPL-3.0-or-later",
-    "version": "1.4.6",
-    "notes": [
-        "AltServer requires a 'Native' iTunes installed to work, you must download and install iTunes from Apple's webstie.",
-        "Refer to https://altstore.io/faq/ for more inforamtion."
-    ],
-    "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip",
-    "hash": "d0544a465d2b1fbe31fcf9a0cd4ca203af63828dbc0c3f48bfff5806e96a089c",
-    "pre_install": {
-        "script": [
-            "if ([Environment]::OSVersion.Version.Major -ne \"10\") {",
-            "    throw \"AltServer requires Windows 10 to work.\"",
-            "}",
-            "Remove-Item \"$dir\\setup.exe\"",
-            "Expand-MsiArchive \"$dir\\AltInstaller.msi\" \"$dir\" -Removal"
-        ]
-    },
-    "shortcuts": [
-        [
-            "AltServer.exe",
-            "AltServer"
-        ]
-    ],
-    "checkver": {
-        "github": "https://github.com/rileytestut/AltStore"
-    },
-    "autoupdate": {
-        "url": "https://cdn.altstore.io/file/altstore/altinstaller.zip"
-    }
+	"homepage": "https://altstore.io/",
+	"description": "AltStore is an alternative app store for non-jailbroken iOS devices.",
+	"license": "AGPL-3.0-or-later",
+	"version": "1.4.6",
+	"notes": "AltServer requires iTunes and iCloud installed from Apple's website.",
+	"url": "https://cdn.altstore.io/file/altstore/altinstaller.zip",
+	"hash": "d0544a465d2b1fbe31fcf9a0cd4ca203af63828dbc0c3f48bfff5806e96a089c",
+	"pre_install": [
+		"if ([Environment]::OSVersion.Version.Major -ne \"10\") { throw \"AltServer requires Windows 10.\"}",
+		"Remove-Item \"$dir\\setup.exe\"",
+		"Expand-MsiArchive \"$dir\\AltInstaller.msi\" \"$dir\" -Removal"
+	],
+	"shortcuts": [
+		[
+			"AltServer.exe",
+			"AltServer"
+		]
+	],
+	"checkver": {
+		"github": "https://github.com/rileytestut/AltStore"
+	},
+	"autoupdate": {
+		"url": "https://cdn.altstore.io/file/altstore/altinstaller.zip"
+	}
 }


### PR DESCRIPTION
- Closes #6394

AltServer is a tool allowing for the sideloading of apps on iOS devices. 

The latest version is currently untagged in the GitHub repository for whatever reason, however the release is noted in the `develop` branch (and the version installed is 1.4.6 according to the about dialog.
