### PR TITLE
mpc-hc-fork: persist default.mpcpl like mpc-be.json does it

### DIFF
--- a/bucket/mpc-hc-fork.json
+++ b/bucket/mpc-hc-fork.json
@@ -40,7 +40,8 @@
     ],
     "persist": [
         "mpc-hc64.ini",
-        "mpc-hc.ini"
+        "mpc-hc.ini",
+        "default.mpcpl"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
The active playlist file should carry over just like the other configuration files that are already persisted.