### PR TITLE
foxit-reader: Deprecate manifest in favour of foxit-pdf-reader

### DIFF
--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -6,6 +6,7 @@
         "identifier": "Freeware",
         "url": "https://www.foxitsoftware.com/pdf-reader/eula.html"
     },
+    "notes": "Deprecated. Use extras/foxit-pdf-reader",
     "url": "https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/win/10.x/10.0/en_us/FoxitReader100_Setup_Prom_IS.exe#/dl.7z",
     "hash": "2fa85149ee0a98b6ed7e316c7efd483fc397b653790057ab19e085356b710e65",
     "extract_dir": "$PLUGINSDIR",


### PR DESCRIPTION
Foxit has renamed most of their products, see https://www.foxit.com/.

> Foxit has changed some product names. To learn more click here.

"Foxit Reader" is now called "Foxit PDF Reader". How are changes like this handled usually?
- create a separate manifest `foxit-pdf-reader.json`
- rename the manifest file
- just keep using the old manifest