### PR TITLE
colorcontrol: Add version 4.1.0.0

### DIFF
--- a/bucket/colorcontrol.json
+++ b/bucket/colorcontrol.json
@@ -2,6 +2,7 @@
     "version": "4.1.0.0",
     "description": "Easily change NVIDIA display settings and/or control LG TV's",
     "homepage": "https://github.com/Maassoft/ColorControl",
+    "license": "Freeware",
     "extract_dir": "ColorControl",
     "url": "https://github.com/Maassoft/ColorControl/releases/download/v4.1.0.0/ColorControl.zip",
     "hash": "88de90edb5fa7f5a282b7c82c8ac43a6f01d11bae68fada44941a57322f6c7f4",

--- a/bucket/colorcontrol.json
+++ b/bucket/colorcontrol.json
@@ -1,0 +1,18 @@
+{
+    "version": "4.1.0.0",
+    "description": "Easily change NVIDIA display settings and/or control LG TV's",
+    "homepage": "https://github.com/Maassoft/ColorControl",
+    "extract_dir": "ColorControl",
+    "url": "https://github.com/Maassoft/ColorControl/releases/download/v4.1.0.0/ColorControl.zip",
+    "hash": "88de90edb5fa7f5a282b7c82c8ac43a6f01d11bae68fada44941a57322f6c7f4",
+    "shortcuts": [
+        [
+            "ColorControl.exe",
+            "ColorControl"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Maassoft/ColorControl/releases/download/v$version/ColorControl.zip"
+    }
+}


### PR DESCRIPTION
[ColorControl](https://github.com/Maassoft/ColorControl) is a useful tool to change NVIDIA display settings and control LG TV.