### PR TITLE
librewolf: Add version 91.0-1

### DIFF
--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -1,0 +1,25 @@
+{
+    "version": "91.0-1",
+    "description": "A fork of Firefox, focused on privacy, security and freedom.",
+    "homepage": "https://librewolf-community.gitlab.io/",
+    "license": "MPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/a1ae23b163368b90cd13fda3aab9924f/librewolf-91.0.en-US.win64.zip",
+            "hash": "c5ffc2977fbe591e05c7b9512de6cf1a90777e417b299d6525a4200e833d839f"
+        }
+    },
+    "extract_dir": "librewolf-91.0/librewolf",
+    "bin": "librewolf.exe",
+    "shortcuts": [
+        [
+            "librewolf.exe",
+            "LibreWolf"
+        ]
+    ],
+    "checkver": {
+        "url": "https://gitlab.com/api/v4/projects/13852981/repository/tags",
+        "jsonpath": "$[0].name",
+        "regex": "v([\\w.-]+)"
+    }
+}


### PR DESCRIPTION
This adds the latest version of librewolf for windows, a firefox fork focused on privacy and security

Edit: this is an updated version of a closed PR that was never fixed https://github.com/lukesampson/scoop-extras/pull/5785

Closes #6333