### PR TITLE
Update .editorconfig rules & Add .gitignore rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,3 @@ trim_trailing_whitespace = true
 
 [*.{yml,yaml}]
 indent_size = 2
-
-[*.{[Bb][Aa][Tt],[Cc][Mm][Dd]}]
-# DOS/Win *requires* BAT/CMD files to have CRLF newlines
-end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 ._*
 page.html
 checkver-*.html
+.vscode
+.idea
+.DS_Store


### PR DESCRIPTION
- Eol had already been handled by `.gitattributes` file, need not to be declared in `.editorconfig` file.
- Ignore VScode, IDEA and more files when commiting.