### PR TITLE
Pyzo: Add version 4.11.7

### DIFF
--- a/bucket/josm.json
+++ b/bucket/josm.json
@@ -1,5 +1,5 @@
 {
-    "version": "18191",
+    "version": "18193",
     "description": "An extensible editor for OpenStreetMap (OSM)",
     "homepage": "https://josm.openstreetmap.de",
     "license": "GPL-2.0-or-later",
@@ -7,11 +7,11 @@
         "JRE": "java/adopt8-hotspot-jre"
     },
     "url": [
-        "https://josm.openstreetmap.de/download/josm-snapshot-18191.jar#/josm.jar",
+        "https://josm.openstreetmap.de/download/josm-snapshot-18193.jar#/josm.jar",
         "https://josm.openstreetmap.de/favicon.ico#/icon.ico"
     ],
     "hash": [
-        "39fbc934feed0f1c8c844270dc83274dffc417e80dc6073443d0d59bf35876eb",
+        "e7996b3ce950431d6b9a6233049e76db34a26bb46654d4de1ee136d2f13577a0",
         "0e78546d0a884a22a6badeb3cfadbae4b85ab2091240ed2d50ee7f78f0da5e03"
     ],
     "pre_install": "Set-Content \"$dir\\JOSM.bat\" \"@start javaw.exe -Djosm.cache=$dir\\data\\cache -Djosm.userdata=$dir\\data -Djosm.pref=$dir\\data -jar \"\"%~dp0josm.jar\"\"\" -Encoding Ascii",

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -7,8 +7,7 @@
         "64bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win64.zip",
             "hash": "435cfb5ee617c30dac5fc7880a41c0046c3375067e7b24da3e7e0f121099ec6a",
-            "extract_dir": "pyzo-4.11.2",
-            "extract_to": "pyzo-4.11.2-win64"
+            "extract_dir": "pyzo-4.11.2"
         },
         "32bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -1,18 +1,18 @@
 {
-    "version": "4.11.2",
+    "version": "4.11.4",
     "description": "The Interactive editor for scientific Python",
     "homepage": "https://pyzo.org/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win64.zip",
-            "hash": "435cfb5ee617c30dac5fc7880a41c0046c3375067e7b24da3e7e0f121099ec6a",
-            "extract_dir": "pyzo-4.11.2"
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.4/pyzo-4.11.4-win64.zip",
+            "hash": "4c429c2861a641ef12c4f34d26a71dd3c7ddb70bd034afc671f0cd6606c325d8",
+            "extract_dir": "pyzo-4.11.4"
         },
         "32bit": {
-            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",
-            "hash": "9be1a82b428bc74c1c395f401d473054612eb383d7dd3c352d54324b57e39390",
-            "extract_dir": "pyzo-4.11.2"
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.4/pyzo-4.11.4-win32.zip",
+            "hash": "99b337ae08cd69c34398e45374779a92405e640851ffa77c90b06ef0b106b5a9",
+            "extract_dir": "pyzo-4.11.4"
         }
     },
     "bin": "pyzo.exe",

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -1,0 +1,38 @@
+{
+    "version": "4.11.2",
+    "description": "The Interactive editor for scientific Python",
+    "homepage": "https://pyzo.org/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win64.zip",
+            "hash": "435CFB5EE617C30DAC5FC7880A41C0046C3375067E7B24DA3E7E0F121099EC6A",
+            "extract_dir": "pyzo-4.11.2"
+        },
+        "32bit": {
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",
+            "hash": "9BE1A82B428BC74C1C395F401D473054612EB383D7DD3C352D54324B57E39390",
+            "extract_dir": "pyzo-4.11.2"
+        }
+    },
+    "bin": "pyzo.exe",
+    "shortcuts": [
+        [
+            "pyzo.exe",
+            "Pyzo"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/pyzo/pyzo"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win32.zip"
+            }
+        }
+    }
+}

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -1,19 +1,19 @@
 {
-    "version": "4.11.4",
+    "version": "4.11.2",
     "description": "The Interactive editor for scientific Python",
     "homepage": "https://pyzo.org/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.4/pyzo-4.11.4-win64.zip",
-            "hash": "4c429c2861a641ef12c4f34d26a71dd3c7ddb70bd034afc671f0cd6606c325d8"
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win64.zip",
+            "hash": "435cfb5ee617c30dac5fc7880a41c0046c3375067e7b24da3e7e0f121099ec6a"
         },
         "32bit": {
-            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.4/pyzo-4.11.4-win32.zip",
-            "hash": "99b337ae08cd69c34398e45374779a92405e640851ffa77c90b06ef0b106b5a9"
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",
+            "hash": "9be1a82b428bc74c1c395f401d473054612eb383d7dd3c352d54324b57e39390"
         }
     },
-    "extract_dir": "pyzo-4.11.4",
+    "extract_dir": "pyzo-4.11.2",
     "pre_install": [
         "Rename-Item \"$dir\\_settings\" \"$dir\\settings\"",
         "New-item \"$dir\\settings\\pyzo\" -ItemType Directory | Out-Null"

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -1,19 +1,19 @@
 {
-    "version": "4.11.2",
+    "version": "4.11.7",
     "description": "The Interactive editor for scientific Python",
     "homepage": "https://pyzo.org/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win64.zip",
-            "hash": "435cfb5ee617c30dac5fc7880a41c0046c3375067e7b24da3e7e0f121099ec6a"
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.7/pyzo-4.11.7-win64.zip",
+            "hash": "f589a61c7c0cc486bd526984bf7c7dca59619f3e6a231dd99f2c2f79be99860d"
         },
         "32bit": {
-            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",
-            "hash": "9be1a82b428bc74c1c395f401d473054612eb383d7dd3c352d54324b57e39390"
+            "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.7/pyzo-4.11.7-win32.zip",
+            "hash": "3c1cc58b44a6fc52f751940938a00c4778d18125aa1002cbba8f641d04366251"
         }
     },
-    "extract_dir": "pyzo-4.11.2",
+    "extract_dir": "pyzo-4.11.7",
     "pre_install": [
         "Rename-Item \"$dir\\_settings\" \"$dir\\settings\"",
         "New-item \"$dir\\settings\\pyzo\" -ItemType Directory | Out-Null"

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -13,8 +13,7 @@
         "32bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",
             "hash": "9be1a82b428bc74c1c395f401d473054612eb383d7dd3c352d54324b57e39390",
-            "extract_dir": "pyzo-4.11.2",
-            "extract_to": "pyzo-4.11.2-win32"
+            "extract_dir": "pyzo-4.11.2"
         }
     },
     "bin": "pyzo.exe",
@@ -31,13 +30,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win64.zip",
-                "extract_dir": "pyzo-$version",
-                "extract_to": "pyzo-$version-win64"
+                "extract_dir": "pyzo-$version"
             },
             "32bit": {
                 "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win32.zip",
-                "extract_dir": "pyzo-$version",
-                "extract_to": "pyzo-$version-win32"
+                "extract_dir": "pyzo-$version"
             }
         }
     }

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -6,13 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win64.zip",
-            "hash": "435CFB5EE617C30DAC5FC7880A41C0046C3375067E7B24DA3E7E0F121099EC6A",
-            "extract_dir": "pyzo-4.11.2"
+            "hash": "435cfb5ee617c30dac5fc7880a41c0046c3375067e7b24da3e7e0f121099ec6a",
+            "extract_dir": "pyzo-4.11.2",
+            "extract_to": "pyzo-4.11.2-win64"
         },
         "32bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.2/pyzo-4.11.2-win32.zip",
-            "hash": "9BE1A82B428BC74C1C395F401D473054612EB383D7DD3C352D54324B57E39390",
-            "extract_dir": "pyzo-4.11.2"
+            "hash": "9be1a82b428bc74c1c395f401d473054612eb383d7dd3c352d54324b57e39390",
+            "extract_dir": "pyzo-4.11.2",
+            "extract_to": "pyzo-4.11.2-win32"
         }
     },
     "bin": "pyzo.exe",
@@ -28,10 +30,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win64.zip"
+                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win64.zip",
+                "extract_dir": "pyzo-$version",
+                "extract_to": "pyzo-$version-win64"
             },
             "32bit": {
-                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win32.zip"
+                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win32.zip",
+                "extract_dir": "pyzo-$version",
+                "extract_to": "pyzo-$version-win32"
             }
         }
     }

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -14,6 +14,10 @@
         }
     },
     "extract_dir": "pyzo-4.11.4",
+    "pre_install": [
+        "Rename-Item \"$dir\\_settings\" \"$dir\\settings\"",
+        "New-item \"$dir\\settings\\pyzo\" -ItemType Directory | Out-Null"
+    ],
     "bin": "pyzo.exe",
     "shortcuts": [
         [
@@ -21,6 +25,7 @@
             "Pyzo"
         ]
     ],
+    "persist": "settings",
     "checkver": {
         "github": "https://github.com/pyzo/pyzo"
     },

--- a/bucket/pyzo.json
+++ b/bucket/pyzo.json
@@ -6,15 +6,14 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.4/pyzo-4.11.4-win64.zip",
-            "hash": "4c429c2861a641ef12c4f34d26a71dd3c7ddb70bd034afc671f0cd6606c325d8",
-            "extract_dir": "pyzo-4.11.4"
+            "hash": "4c429c2861a641ef12c4f34d26a71dd3c7ddb70bd034afc671f0cd6606c325d8"
         },
         "32bit": {
             "url": "https://github.com/pyzo/pyzo/releases/download/v4.11.4/pyzo-4.11.4-win32.zip",
-            "hash": "99b337ae08cd69c34398e45374779a92405e640851ffa77c90b06ef0b106b5a9",
-            "extract_dir": "pyzo-4.11.4"
+            "hash": "99b337ae08cd69c34398e45374779a92405e640851ffa77c90b06ef0b106b5a9"
         }
     },
+    "extract_dir": "pyzo-4.11.4",
     "bin": "pyzo.exe",
     "shortcuts": [
         [
@@ -26,14 +25,13 @@
         "github": "https://github.com/pyzo/pyzo"
     },
     "autoupdate": {
+        "extract_dir": "pyzo-$version",
         "architecture": {
             "64bit": {
-                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win64.zip",
-                "extract_dir": "pyzo-$version"
+                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win64.zip"
             },
             "32bit": {
-                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win32.zip",
-                "extract_dir": "pyzo-$version"
+                "url": "https://github.com/pyzo/pyzo/releases/download/v$version/pyzo-$version-win32.zip"
             }
         }
     }


### PR DESCRIPTION
Review warranted as this is my first attempt at adding a package to Scoop. Local install of 64bit was successful on my machine with:

    scoop install .\bucket\pyzo.json