### PR TITLE
quicklook: persist 'UserData' directory

### DIFF
--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -11,6 +11,7 @@
             "QuickLook"
         ]
     ],
+    "persist": "UserData",
     "checkver": {
         "github": "https://github.com/QL-Win/QuickLook"
     },

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -5,9 +5,10 @@
     "license": "GPL-3.0-or-later",
     "url": "https://github.com/QL-Win/QuickLook/releases/download/3.7.0/QuickLook-3.7.0.zip",
     "hash": "c08ae6a5ec545819b5a1961dde872fa50095874777ba603ca76fcc0f381731b7",
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\UserData\")) { New-Item -ItemType Directory -Path \"$persist_dir\\UserData\" | Out-Null }",
+    "post_install": [
+        "   # Migration",
         "if (Test-Path \"$env:APPDATA\\pooi.moe\\QuickLook\") {",
+        "   warn 'Migrating QuickLook Configs...'",
         "   Move-Item -Path \"$env:APPDATA\\pooi.moe\\QuickLook\\*.config\" -Destination \"$persist_dir\\UserData\" -Force",
         "   Remove-Item \"$env:APPDATA\\pooi.moe\\QuickLook\" -Force -Recurse }"
     ],

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -5,6 +5,11 @@
     "license": "GPL-3.0-or-later",
     "url": "https://github.com/QL-Win/QuickLook/releases/download/3.7.0/QuickLook-3.7.0.zip",
     "hash": "c08ae6a5ec545819b5a1961dde872fa50095874777ba603ca76fcc0f381731b7",
+    "pre_install": [
+        "if (Test-Path \"$env:APPDATA\\pooi.moe\\QuickLook\") {",
+        "   Move-Item -Path \"$env:APPDATA\\pooi.moe\\QuickLook\\*.config\" -Destination \"$persist_dir\\UserData\" -Force",
+        "   Remove-Item \"$env:APPDATA\\pooi.moe\\QuickLook\" -Force -Recurse }"
+    ],
     "shortcuts": [
         [
             "QuickLook.exe",

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/QL-Win/QuickLook/releases/download/3.7.0/QuickLook-3.7.0.zip",
     "hash": "c08ae6a5ec545819b5a1961dde872fa50095874777ba603ca76fcc0f381731b7",
     "post_install": [
-        "   # Migration",
+        "# Migration",
         "if (Test-Path \"$env:APPDATA\\pooi.moe\\QuickLook\") {",
         "   warn 'Migrating QuickLook Configs...'",
         "   Move-Item -Path \"$env:APPDATA\\pooi.moe\\QuickLook\\*.config\" -Destination \"$persist_dir\\UserData\" -Force",

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/QL-Win/QuickLook/releases/download/3.7.0/QuickLook-3.7.0.zip",
     "hash": "c08ae6a5ec545819b5a1961dde872fa50095874777ba603ca76fcc0f381731b7",
     "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\UserData\")) { New-Item -ItemType Directory -Path \"$persist_dir\\UserData\" | Out-Null }",
         "if (Test-Path \"$env:APPDATA\\pooi.moe\\QuickLook\") {",
         "   Move-Item -Path \"$env:APPDATA\\pooi.moe\\QuickLook\\*.config\" -Destination \"$persist_dir\\UserData\" -Force",
         "   Remove-Item \"$env:APPDATA\\pooi.moe\\QuickLook\" -Force -Recurse }"


### PR DESCRIPTION
persist **UserData** directory for keeping the installed plugins.

project doc.:
https://github.com/QL-Win/QuickLook/wiki/Differences-Between-Distributions