### PR TITLE
Fix broken zmc installer 💉

### DIFF
--- a/bucket/zmc.json
+++ b/bucket/zmc.json
@@ -5,9 +5,9 @@
     "license": "UPL-1.0",
     "architecture": {
         "64bit": {
-            "url": "http://static.azul.com/zmc/bin/zmc8.1.0.42-ca-win_x64.zip",
+            "url": "https://cdn.azul.com/zmc/bin/zmc8.1.0.42-ca-win_x64.zip",
             "hash": "a430e6b797c805d4e0e40bd66fbff79ff77d3de4b5394a75c6596c09abcb7143",
-            "extract_dir": "zmc8.1.0.42-ca-win_x64\\Zulu Mission Control"
+            "extract_dir": "zmc8.1.0.42-ca-win_x64\\Azul Mission Control"
         }
     },
     "bin": "zmc.exe",
@@ -17,15 +17,11 @@
             "Zulu Mission Control"
         ]
     ],
-    "persist": [
-        "configuration",
-        "dropins"
-    ],
     "checkver": "zmc([\\d.]+)-ca-win",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://static.azul.com/zmc/bin/zmc$version-ca-win_x64.zip",
+                "url": "http://cdn.azul.com/zmc/bin/zmc$version-ca-win_x64.zip",
                 "extract_dir": "zmc$version-ca-win_x64\\Zulu Mission Control"
             }
         }


### PR DESCRIPTION
The current manifest has wrong entries for extract directory and hence the install fails. Additionally, persistence causes the app to break at runtime.
```poweshell
❯ scoop install zmc
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
Installing 'zmc' (8.1.0.42) [64bit]
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 52d370|OK  |   3.3MiB/s|D:/scoop/cache/zmc#8.1.0.42#http_static.azul.com_zmc_bin_zmc8.1.0.42-ca-win_x64.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of zmc8.1.0.42-ca-win_x64.zip ... ok.
Extracting zmc8.1.0.42-ca-win_x64.zip ... DEBUG[1632594191] $out = -------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : Saturday, September 25, 2021 11:53:11 PM
   Source : D:\scoop\apps\zmc\8.1.0.42\zmc8.1.0.42-ca-win_x64\Zulu Mission Control\
     Dest : D:\scoop\apps\zmc\8.1.0.42\

    Files : *.*

  Options : *.* /S /E /DCOPY:DA /COPY:DAT /MOVE /R:1000000 /W:30

------------------------------------------------------------------------------

2021/09/25 23:53:11 ERROR 3 (0x00000003) Accessing Source Directory D:\scoop\apps\zmc\8.1.0.42\zmc8.1.0.42-ca-win_x64\Zulu Mission Control\
The system cannot find the path specified. -> D:\scoop\apps\scoop\current\lib\core.ps1:509:9
Exception: D:\scoop\apps\scoop\current\lib\core.ps1:510
Line |
 510 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'Zulu Mission Control'! (error 16)
```

The current PR fixes both.
