### PR TITLE
Update openocd to 0.11.0

### DIFF
--- a/bucket/openocd.json
+++ b/bucket/openocd.json
@@ -1,29 +1,15 @@
 {
-    "version": "0.10.0",
+    "version": "0.11.0",
     "description": "Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing.",
     "homepage": "http://openocd.org/",
     "license": "GPL-2.0-or-later",
-    "url": "http://www.freddiechopin.info/en/download/category/4-openocd?download=154%3Aopenocd-0.10.0#/dl.7z",
-    "hash": "f46687cd783a7a86716c78474e8132e32de84b773914f23f2226f81509ffcfca",
-    "extract_dir": "openocd-0.10.0",
-    "architecture": {
-        "64bit": {
-            "bin": "bin-x64\\openocd.exe"
-        },
-        "32bit": {
-            "bin": "bin\\openocd.exe"
-        }
-    },
+    "url": "https://github.com/openocd-org/openocd/releases/download/v0.11.0/openocd-v0.11.0-i686-w64-mingw32.tar.gz",
+    "bin": "bin\\openocd.exe",
     "checkver": {
-        "url": "https://freddiechopin.info/en/download/category/4-openocd",
-        "regex": "OpenOCD\\s+([\\d.]+)"
+        "url": "https://github.com/openocd-org/openocd/releases/",
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://www.freddiechopin.info/en/download/category/4-openocd?download=154%3Aopenocd-$version#/dl.7z",
-        "hash": {
-            "url": "http://www.freddiechopin.info/en/download/category/4-openocd",
-            "regex": "$sha256"
-        },
-        "extract_dir": "openocd-$version"
+        "url": "https://github.com/openocd-org/openocd/releases/download/v$version/openocd-v$version-i686-w64-mingw32.tar.gz"
     }
 }


### PR DESCRIPTION
As in #6631, this PR is now from the [official mirror](https://github.com/openocd-org/openocd). 