### PR TITLE
Remove note about changing Library location

### DIFF
--- a/bucket/steam.json
+++ b/bucket/steam.json
@@ -6,7 +6,6 @@
         "identifier": "Freeware",
         "url": "https://store.steampowered.com/legal/"
     },
-    "notes": "Changing Steam library folder is HIGHLY recommended.",
     "url": "https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe#/dl.7z",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
     "uninstaller": {


### PR DESCRIPTION
As of the latest Steam version, setting Library location is no longer possible. There is only one, disk-global Library location. As such, the note no longer makes sense