### PR TITLE
firefox-developer: Update to version 94.0b6

### DIFF
--- a/bucket/firefox-developer.json
+++ b/bucket/firefox-developer.json
@@ -1,16 +1,16 @@
 {
-    "version": "72.0b11",
-    "description": "Developer builds of Firefox: the popular open source web browser.",
+    "version": "94.0b6",
+    "description": "Developer builds of Firefox: the popular open source web browser",
     "homepage": "https://www.mozilla.org/en-US/firefox/developer/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/devedition/releases/72.0b11/win64/en-US/Firefox%20Setup%2072.0b11.exe#/dl.7z",
-            "hash": "sha512:d63c9a8c57c7d5aa949bee0f77a7d0bbcb8a73fee3e12f7c9b0be31b60ab0f20784ce86a58bf204d6a1199b325d670c3ea1d935eb821852d3b9de489643ac5be"
+            "url": "https://archive.mozilla.org/pub/devedition/releases/94.0b6/win64/en-US/Firefox%20Setup%2094.0b6.exe#/dl.7z",
+            "hash": "sha512:1283d12ca4fe0a5d1b4e2660acf92fd20df840c14c1bf05af953db72ed71683f3bb2dd9b53e83b1af4c8e51777d7708987eda8f155c196b8bd7cf1ee3f736db5"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/devedition/releases/72.0b11/win32/en-US/Firefox%20Setup%2072.0b11.exe#/dl.7z",
-            "hash": "sha512:9aef2e0509feb8d3a6814348a7aeae957f9ed2d0df8f96365492121607a4760ecf3a21ee7ead85bf0663664a7d3d36fcc5e03fc1d0fc66d24207021d1305bd76"
+            "url": "https://archive.mozilla.org/pub/devedition/releases/94.0b6/win32/en-US/Firefox%20Setup%2094.0b6.exe#/dl.7z",
+            "hash": "sha512:8d4e560e963a7d07155433f1167787dc5b8c6d66cb57acf0ededddaf5d58c2b9ee97ddb9c074c74e8e53060de4d8d19c981292acec1ac73c5d5f4db349d197d9"
         }
     },
     "extract_dir": "core",


### PR DESCRIPTION
- Closes #7018

Checkver url for firefox-developer is currently returning an old version of the program (72.0b11 instead of current 94.0b6). This change will fix the version at the next autoupdate.