### PR TITLE
cloudfoundry-cli@8.0.0: Change bin to just cf.exe

### DIFF
--- a/bucket/cloudfoundry-cli.json
+++ b/bucket/cloudfoundry-cli.json
@@ -13,9 +13,7 @@
             "hash": "26bd20664315e7263f0f0d0ba4b20e1682ac797e1a55e3adedd9a419797bb6e4"
         }
     },
-    "bin": [
-        "cf.exe"
-    ],
+    "bin": "cf.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Closes #4851 
- Closes #6946

Remove the versioned binary as it constantly makes problems whenever the major version changes.
