### PR TITLE
cryptomator: Update to version 1.6.1

### DIFF
--- a/bucket/cryptomator.json
+++ b/bucket/cryptomator.json
@@ -11,7 +11,7 @@
     },
     "extract_dir": "Cryptomator",
     "post_install": [
-        "# change appdata settings folder",
+        "    # Change appdata settings folder",
         "(Get-Content \"$dir\\app\\Cryptomator.cfg\" -Encoding ASCII).replace('~/AppData/Roaming/Cryptomator', './data') | Set-Content \"$dir\\app\\Cryptomator.cfg\" -Encoding ASCII"
     ],
     "bin": "Cryptomator.exe",
@@ -24,13 +24,17 @@
     "persist": "data",
     "checkver": {
         "url": "https://github.com/cryptomator/cryptomator/releases",
-        "regex": "Cryptomator-([\\d.]+)-x64\\.exe"
+        "regex": "Cryptomator-([\\d.]+)-x64\\.msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/cryptomator/cryptomator/releases/download/$version/Cryptomator-$version-x64.msi"
             }
+        },
+        "hash": {
+            "url": "https://github.com/cryptomator/cryptomator/releases/tag/$version",
+            "regex": "$sha256\\s*\\./$basename"
         }
     }
 }


### PR DESCRIPTION
Update cryptomator to version 1.6.1

Additionally:
- Switch from `.exe` to `.msi` since cryptomator is now pubished as msi instead of exe
- Remove the bintray.com hash check, since the service is deprecated:
![image](https://user-images.githubusercontent.com/1368405/138058868-1b6e46a0-3c21-423e-8b96-c813bbb05ff2.png)
