### PR TITLE
conemu@21.09.12: Fix bin and shortcut

### DIFF
--- a/bucket/conemu.json
+++ b/bucket/conemu.json
@@ -35,9 +35,7 @@
             ]
         },
         "32bit": {
-            "bin": [
-                "ConEmu.exe"
-            ],
+            "bin": "ConEmu.exe",
             "shortcuts": [
                 [
                     "ConEmu.exe",


### PR DESCRIPTION
This cleans up some stuff:
- There's no reason to setup 64bit shim and 64bit shortcut on 32bit PCs - they won't work anyway.
- 32bit shortcut on 64bit PC just pollutes the Scoop Start Menu entries - it's not needed. Likewise, a 32bit shim in 64bit PC pollutes the shim path.
- Proper use of `architecture` block.

ConEmu is an extremely flexible terminal emulator - if someone wants to use 32bit shells on their 64bit PC, they can configure startup tasks for that.