### PR TITLE
text-grab: Add version 2.3

### DIFF
--- a/bucket/text-grab.json
+++ b/bucket/text-grab.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.3",
+    "description": "Minimal Windows utility for copying and pasting any visible text, without internet access.",
+    "homepage": "https://github.com/TheJoeFin/Text-Grab",
+    "license": "MIT",
+    "suggest": {
+        "windowsdesktop-runtime": "extras/windowsdesktop-runtime"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TheJoeFin/Text-Grab/releases/download/v2.3/Text-Grab.exe",
+            "hash": "d1e5d08984aef4500b7e080eba7e55a47dc9acd1bdb61362d7ac6cf6265c340d"
+        }
+    },
+    "bin": "Text-Grab.exe",
+    "shortcuts": [
+        [
+            "Text-Grab.exe",
+            "Text Grab"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TheJoeFin/Text-Grab/releases/download/v$version/Text-Grab.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Text-Grab](https://github.com/TheJoeFin/Text-Grab) is a minimal Windows utility which makes all visible text available for copy and paste. It accomplishes this locally with the Windows 10/11 OCR API.