### PR TITLE
Add x64 version for Qalculate

### DIFF
--- a/bucket/qalculate.json
+++ b/bucket/qalculate.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Qalculate/libqalculate/releases/download/v$version/qalculate-$version-x64.zip",
+            "url": "https://github.com/Qalculate/libqalculate/releases/download/v3.21.0/qalculate-3.21.0-x64.zip",
             "hash": "08937e08c85cb3f0bd457a5a33cdcab71b42d026f2bc08fc5dcd810d740ccc31"
         },
         "32bit": {
-            "url": "https://github.com/Qalculate/libqalculate/releases/download/v$version/qalculate-$version-i386.zip",
+            "url": "https://github.com/Qalculate/libqalculate/releases/download/v3.21.0/qalculate-3.21.0-i386.zip",
             "hash": "f7194f8d56a82993d39532f93d8e1b958afd69b0d3c6c31ef385a8f763900d3d"
         }
     },


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Extras/issues/6533 myself. Thank you for review.