### PR TITLE
kicad@5.1.10_1: Remove redundant env variables & simplify pre_install

### DIFF
--- a/bucket/kicad.json
+++ b/bucket/kicad.json
@@ -13,7 +13,7 @@
             "hash": "705c4b72898a979209dc63ee6c469f45abef44ca813c0beccd86a75d47ef5183"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
     "bin": "bin\\kicad.exe",
     "shortcuts": [
         [
@@ -21,11 +21,6 @@
             "KiCad"
         ]
     ],
-    "env_set": {
-        "KICAD_PTEMPLATES": "$dir\\share\\kicad\\template\\",
-        "KISYS3DMOD": "$dir\\share\\kicad\\modules\\packages3d\\",
-        "KISYSMOD": "$dir\\share\\kicad\\modules\\"
-    },
     "checkver": {
         "url": "https://www.kicad.org/download/windows/",
         "regex": "kicad-([\\d._]+)-"


### PR DESCRIPTION
This PR fixes two issues with this manifest:

- One of the env variables set is deprecated (KICAD_PTEMPLATES), and all were just being set to the app default, accomplishing nothing. This may have been necessary in previous versions but shouldn't be any longer.
- The `pre_install` does not need to remove an uninstaller as that's no longer present in current versions once unpacked.