### PR TITLE
kicad-lite@5.1.9_1: multiple fixes

### DIFF
--- a/bucket/kicad-lite.json
+++ b/bucket/kicad-lite.json
@@ -3,7 +3,7 @@
     "description": "Electronics Design Automation Suite, stable build without libraries",
     "homepage": "https://www.kicad.org",
     "license": "GPL-3.0-only",
-    "notes": "Don't forget to configure KiCad's environment variables: https://docs.kicad.org/5.1/en/kicad/kicad.html#paths_configuration",
+    "notes": "To configure KiCad's environment variables, visit https://docs.kicad.org/5.1/en/kicad/kicad.html#paths_configuration",
     "architecture": {
         "64bit": {
             "url": "https://kicad-downloads.s3.cern.ch/windows/stable/kicad-5.1.10_1-x86_64-lite.exe#/dl.7z",


### PR DESCRIPTION
This PR addresses multiple issues with this manifest:

- Version updated to 5.1.10_1
- Homepage corrected (and matches the main kicad manifest)
- Notes simplified, with exact env variable names removed as these have changed over time
- `pre_install` simplified (there is no uninstaller to remove after unpacking any more)
-  Most importantly, the `checkver` was broken...fixed by using the same as in the main kicad manifest.

Closes #7066.