### PR TITLE
freecad@0.18.4: multiple fixes

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -1,19 +1,15 @@
 {
-    "version": "0.18.4",
-    "description": "General-purpose parametric 3D CAD modeler and a building information modeling software with finite-element-method support.",
+    "version": "0.19.2",
+    "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD-0.18.4.980bf90-WIN-x64-installer.exe#/dl.7z",
-            "hash": "d70930110929117c3a198d3c815a9169e383ab88f650431a1a1ece7705d2ef1b"
-        },
-        "32bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD-0.18.4.980bf90-WIN-x32-installer.exe#/dl.7z",
-            "hash": "a3c00e00e5321d9786c56d58c501f8a8e43ba9d25f7147cd8b9c869d744be514"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.19.2/FreeCAD-0.19.2.7b5e18a-WIN-x64-portable1.7z",
+            "hash": "82679987ed1c56f13127085c4829f95b83d8505090fcde90c4f3cea9b7cb2176"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse -Force",
+    "extract_dir": "FreeCAD-0.19.2.7b5e18a-WIN-x64-portable1",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
@@ -24,5 +20,17 @@
     "checkver": {
         "github": "https://github.com/FreeCAD/FreeCAD",
         "regex": "releases/download/([\\d.]+)/FreeCAD-(?<build>[\\w.]+)-WIN"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$version/FreeCAD-$matchBuild-WIN-x64-portable1.7z"
+            }
+        },
+        "hash": {
+            "url": "$url-SHA256.txt",
+            "regex": "(?sm):\\s+([a-fA-F\\d\\s]+)CertUtil"
+        },
+        "extract_dir": "FreeCAD-$matchBuild-WIN-x64-portable1"
     }
 }


### PR DESCRIPTION
This PR fixes a few issues:

- updated to version 0.19.2 (resolves #5912)
- description simplified, copied from homepage
- 32-bit architecture removed (no longer exists)
- switch to portable 7z rather than installer exe (removed pre_install as a result)
- added a working `autoupdate`

I've tested this locally. Install, checkver, autoupdate all appear to be good to go, but would welcome anyone to double-check.