### PR TITLE
Persist xnview.ini in application directory for portability. Fix issue #6315

### DIFF
--- a/bucket/xnviewmp.json
+++ b/bucket/xnviewmp.json
@@ -15,10 +15,15 @@
     },
     "extract_dir": "XnViewMP",
     "pre_install": [
-        "if (!(Test-Path \"$env:APPDATA\\XnViewMP\\xnview.ini\")) {",
-        "    New-Item \"$env:APPDATA\\XnViewMP\\xnview.ini\" -Force | Out-Null",
+        "if (Test-Path \"$persist_dir\\xnview.ini\") {",
+        "    Copy-Item \"$persist_dir\\xnview.ini\" \"$dir\"",
+        "} else {",
+        "    New-Item \"$dir\\xnview.ini\" | Out-Null",
         "}"
     ],
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\xnview.ini\" \"$persist_dir\" -Force"
+    },
     "bin": "xnviewmp.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
As issue #6315 states, XnViewMP supports portable installation by placing xnview.ini in the application directory.

Unfortunately, XnViewMP overwrites the hardlinked file with a regular file, thus breaking the synchronization to the persist. To my knowledge, there is no way to create persist as symbolic link in Scoop, so the only approach is to copy the file back to persist dir during uninstall and copy it back when upgraded.

If any of you have better solution, all is welcomed.