### PR TITLE
tumblthree: Fix `extract_dir`

### DIFF
--- a/bucket/tumblthree.json
+++ b/bucket/tumblthree.json
@@ -16,7 +16,6 @@
             "hash": "e588bc8daa376577962259f59e02558c444d13b6800ff04fb7788f23b8002783"
         }
     },
-    "extract_dir": "TumblThree",
     "pre_install": [
         "foreach ($name in @('Cookies.json', 'Manager.json', 'Queuelist.json')) {",
         "    if (!(Test-Path \"$persist_dir\\$name\")) { New-Item \"$dir\\$name\" | Out-Null }",


### PR DESCRIPTION
fix https://github.com/ScoopInstaller/Extras/issues/7193

> Note: The zip files no longer contain a root folder.
https://github.com/TumblThreeApp/TumblThree/releases/tag/v2.2.0