### PR TITLE
robo3t: update to 1.4.4

### DIFF
--- a/bucket/robo3t.json
+++ b/bucket/robo3t.json
@@ -18,13 +18,13 @@
     ],
     "checkver": {
         "github": "https://github.com/Studio3T/robomongo",
-        "regex": "robo3t-(?<version>[\\d.]+)-windows-x86_64-(?<hash>[0-9a-f]+)"
+        "regex": "robo3t-(?<version>[\\d.]+)-windows-x86_64-(?<commit>[0-9a-f]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Studio3T/robomongo/releases/download/v$version/robo3t-$version-windows-x86_64-$matchHash.zip",
-                "extract_dir": "robo3t-$version-windows-x86_64-$matchHash"
+                "url": "https://github.com/Studio3T/robomongo/releases/download/v$version/robo3t-$version-windows-x86_64-$matchCommit.zip",
+                "extract_dir": "robo3t-$version-windows-x86_64-$matchCommit"
             }
         }
     }

--- a/bucket/robo3t.json
+++ b/bucket/robo3t.json
@@ -16,11 +16,15 @@
             "Robo 3T"
         ]
     ],
+    "checkver": {
+        "github": "https://github.com/Studio3T/robomongo",
+        "regex": "robo3t-(?<version>[\\d.]+)-windows-x86_64-(?<hash>[0-9a-f]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.studio3t.com/robomongo/windows/robo3t-$version-windows-x86_64-$matchRandom.zip",
-                "extract_dir": "robo3t-$version-windows-x86_64-$matchRandom"
+                "url": "https://download.studio3t.com/robomongo/windows/robo3t-$version-windows-x86_64-$matchHash.zip",
+                "extract_dir": "robo3t-$version-windows-x86_64-$matchHash"
             }
         }
     }

--- a/bucket/robo3t.json
+++ b/bucket/robo3t.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.4.2",
+    "version": "1.4.4",
     "description": "The free lightweight GUI for MongoDB enthusiasts",
     "homepage": "https://robomongo.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.studio3t.com/robomongo/windows/robo3t-1.4.2-windows-x86_64-8650949.zip",
-            "hash": "6f4123c7a1d5ee7121d5f1af942e48140bb6e40008040d4caa17878324e34050",
-            "extract_dir": "robo3t-1.4.2-windows-x86_64-8650949"
+            "url": "https://download.studio3t.com/robomongo/windows/robo3t-1.4.4-windows-x86_64-e6ac9ec5.zip",
+            "hash": "b3731451d76cd499674f56cce2968a7e11a15ce74622e755f03dd9462c3f013d",
+            "extract_dir": "robo3t-1.4.4-windows-x86_64-e6ac9ec5"
         }
     },
     "shortcuts": [

--- a/bucket/robo3t.json
+++ b/bucket/robo3t.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.studio3t.com/robomongo/windows/robo3t-1.4.4-windows-x86_64-e6ac9ec5.zip",
+            "url": "https://github.com/Studio3T/robomongo/releases/download/v1.4.4/robo3t-1.4.4-windows-x86_64-e6ac9ec5.zip",
             "hash": "b3731451d76cd499674f56cce2968a7e11a15ce74622e755f03dd9462c3f013d",
             "extract_dir": "robo3t-1.4.4-windows-x86_64-e6ac9ec5"
         }
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.studio3t.com/robomongo/windows/robo3t-$version-windows-x86_64-$matchHash.zip",
+                "url": "https://github.com/Studio3T/robomongo/releases/download/v$version/robo3t-$version-windows-x86_64-$matchHash.zip",
                 "extract_dir": "robo3t-$version-windows-x86_64-$matchHash"
             }
         }


### PR DESCRIPTION
- Sets `checkver` to check the Github repo and sets custom regex to capture the commit hash value.
- Update to 1.4.4