### PR TITLE
Fix bug of copying xnview.ini to wrong location if the persist directory was not created beforehand

### DIFF
--- a/bucket/xnviewmp.json
+++ b/bucket/xnviewmp.json
@@ -14,15 +14,9 @@
         }
     },
     "extract_dir": "XnViewMP",
-    "pre_install": [
-        "if (Test-Path \"$persist_dir\\xnview.ini\") {",
-        "    Copy-Item \"$persist_dir\\xnview.ini\" \"$dir\"",
-        "} else {",
-        "    New-Item \"$dir\\xnview.ini\" | Out-Null",
-        "}"
-    ],
+    "pre_install": "New-Item \"$persist_dir\\xnview.ini\" -ErrorAction SilentlyContinue",
     "uninstaller": {
-        "script": "Copy-Item \"$dir\\xnview.ini\" \"$persist_dir\" -Force"
+        "script": "Copy-Item \"$dir\\xnview.ini\" \"$persist_dir\\\" -Force"
     },
     "bin": "xnviewmp.exe",
     "shortcuts": [
@@ -31,6 +25,7 @@
             "XnViewMP"
         ]
     ],
+    "persist": "xnview.ini",
     "checkver": "Download <strong>XnView MP ([\\d.]+)",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
My [previous attempt](https://github.com/ScoopInstaller/Extras/pull/7181) to persist XnView MP missed a case, that when the app's persist directory was not existed beforehand, the .ini just get copied to the root directory.

This attempt uses the "persist" section to achieve two points in one stone: 1) guarantee the persist directory exist. 2) copy xnview.ini to the app dir. Thanks to this, we can simplify the "pre_install" section to just create empty new file.

Also added the trailing "\" in the uninstaller script to make sure this problem no longer happens.