### PR TITLE
x64dbg: Update to 2021-10-31_10-53

### DIFF
--- a/bucket/x64dbg.json
+++ b/bucket/x64dbg.json
@@ -1,10 +1,10 @@
 {
-    "version": "2021-10-25_12-11",
+    "version": "2021-10-31_10-53",
     "description": "x64/x32 debugger",
     "homepage": "https://x64dbg.com/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2021-10-25_12-11.zip",
-    "hash": "d1b331853e325101d3a10f9a0a3f7f1273bc30eec98303973526bfa775337f2b",
+    "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2021-10-31_10-53.zip",
+    "hash": "2e04d8fc7ca56648ef3e990c1993c6eb606f9db807989f61921c3d9f316610ea",
     "pre_install": [
         "'release\\x96dbg.ini', 'release\\x32\\x32dbg.ini', 'release\\x64\\x64dbg.ini' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",


### PR DESCRIPTION
Seems like
1. releases are updated very frequent sometimes _AND_
2. only the very last one is kept available on https://github.com/x64dbg/x64dbg/releases

which may mean, the manifest should be changed to download from https://sourceforge.net/projects/x64dbg/files/snapshots/ in the future?!?