### PR TITLE
Add postinstall to remove autoupdate file

### DIFF
--- a/bucket/bitwarden.json
+++ b/bucket/bitwarden.json
@@ -14,6 +14,7 @@
         }
     },
     "bin": "Bitwarden.exe",
+    "post_install": "Remove-Item \"$dir\\resources\\app-update.yml\" -Recurse",
     "shortcuts": [
         [
             "Bitwarden.exe",

--- a/bucket/bitwarden.json
+++ b/bucket/bitwarden.json
@@ -14,7 +14,7 @@
         }
     },
     "bin": "Bitwarden.exe",
-    "post_install": "Remove-Item \"$dir\\resources\\app-update.yml\" -Recurse",
+    "post_install": "Remove-Item \"$dir\\resources\\app-update.yml\"",
     "shortcuts": [
         [
             "Bitwarden.exe",


### PR DESCRIPTION
When an update is present and scoop is late, a popup propose to update bitwarden. But this installation will end in program files.... So not really what we want here.

The post install delete the file used to check if there is an update. So now, should use scoop to update. No more popup