### PR TITLE
Revert "fix(checkver): use `scoop prefix` to correctly find scoop's path"

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -1,4 +1,4 @@
-if(!$env:SCOOP_HOME) { $env:SCOOP_HOME = resolve-path (split-path (split-path (scoop prefix scoop))) }
+if(!$env:SCOOP_HOME) { $env:SCOOP_HOME = resolve-path (split-path (split-path (scoop which scoop))) }
 $checkver = "$env:SCOOP_HOME/bin/checkver.ps1"
 $dir = "$psscriptroot/../bucket" # checks the parent dir
 Invoke-Expression -command "& '$checkver' -dir '$dir' $($args | ForEach-Object { "$_ " })"


### PR DESCRIPTION
Reverts ScoopInstaller/Extras#7223