### PR TITLE
ilspy: update to 7.1.0.6543

### DIFF
--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -1,10 +1,10 @@
 {
-    "version": "6.2.1.6137",
+    "version": "7.1.0.6543",
     "description": ".NET assembly browser and decompiler",
     "homepage": "http://ilspy.net",
     "license": "MIT",
-    "url": "https://github.com/icsharpcode/ILSpy/releases/download/v6.2.1/ILSpy_binaries_6.2.1.6137.zip",
-    "hash": "adc6e4350385fccd02d566e0267d8289c9f5ae07735ac4cefa0fae2a5cb31a70",
+    "url": "https://github.com/icsharpcode/ILSpy/releases/download/v7.1/ILSpy_binaries_7.1.0.6543.zip",
+    "hash": "ad61ec674510893c77f4795d27c1733493856230d03574e9490891676e397d0f",
     "bin": "ILSpy.exe",
     "shortcuts": [
         [
@@ -15,5 +15,8 @@
     "checkver": {
         "github": "https://github.com/icsharpcode/ILSpy",
         "regex": "v[\\d.]+/ILSpy_binaries_([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$majorVersion.$minorVersion/ILSpy_binaries_$version.zip"
     }
 }


### PR DESCRIPTION
add missing autoupdate

close https://github.com/ScoopInstaller/Extras/issues/6293

@rubenprins could you check this once?

I personally don't use ILSPY