### PR TITLE
OnionShare: update to 2.4

### DIFF
--- a/bucket/onionshare.json
+++ b/bucket/onionshare.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.2",
+    "version": "2.4",
     "description": "Securely and anonymously send and receive files.",
     "homepage": "https://onionshare.org/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/micahflee/onionshare/releases/download/v2.2/onionshare-2.2-setup.exe#/dl.7z",
-    "hash": "0ca64f3001d9bcee3c9be7b2e9c5b2ef61e93b63cddc6f328726280d1540df35",
+    "url": "https://github.com/onionshare/onionshare/releases/download/v2.4/OnionShare-2.4.msi",
+    "hash": "4dbd2183a4d406f9f201be47ecbba7370b6187b8ec6bf35c8041bf6dc0daa717",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force",
     "bin": [
         [
@@ -21,6 +21,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/micahflee/onionshare"
+        "github": "https://github.com/onionshare/onionshare"
+    },
+    "autoupdate": {
+        "url": "https://github.com/onionshare/onionshare/releases/download/v$version/OnionShare-$version.msi"
     }
 }


### PR DESCRIPTION
Closes #6198

URL has changed to https://github.com/onionshare/onionshare

Installer is now MSI

@yuuki76 @linsui can you check once?