### PR TITLE
capframex: Add extract dir

### DIFF
--- a/bucket/capframex.json
+++ b/bucket/capframex.json
@@ -8,6 +8,7 @@
     },
     "url": "https://github.com/CXWorld/CapFrameX/releases/download/v1.6.6/CapFrameX_v1.6.6_Portable.zip",
     "hash": "f889bd33d52c05172f79d18579cc2249b3e1c750a6ec4daef735e840f637608b",
+    "extract_dir": "CapFrameX 1.6.6 Portable",
     "bin": "CapFrameX.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Currently breaks with `Can't shim 'CapFrameX.exe': File doesn't exist.` because the files are now in a folder.