### PR TITLE
Revert "Merge qbittorrent-portable into qbittorrent"

### DIFF
--- a/bucket/qbittorrent.json
+++ b/bucket/qbittorrent.json
@@ -16,26 +16,7 @@
             "hash": "01487a0e2594a5065e4d780eb012dcd0dafadc218d1b6aba69528bd6ede6afb5"
         }
     },
-    "pre_install": [
-        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
-        "if ( (!(Test-Path \"$persist_dir\\profile\")) -and (Test-Path \"$env:APPDATA\\qBittorrent\") ) {",
-        "    Write-Host \"Scoop is migrating qbittorrent to use portable mode by default.\" -ForeGroundColor Yellow",
-        "    Write-Host \"For details, see: https://github.com/ScoopInstaller/Extras/pull/7173\" -ForeGroundColor Yellow",
-        "    Write-Host \"Copying files from APPDATA to Scoop directory...\" -ForeGroundColor Yellow",
-        "    New-Item \"$persist_dir\\profile\\config\", \"$persist_dir\\profile\\data\" -ItemType Directory | Out-Null",
-        "    Copy-Item \"$env:APPDATA\\qBittorrent\\*\" \"$persist_dir\\profile\\config\" -Force -Recurse | Out-Null",
-        "    Copy-Item \"$env:LOCALAPPDATA\\qBittorrent\\*\" \"$persist_dir\\profile\\data\" -Force -Recurse | Out-Null",
-        "}"
-    ],
-    "post_install": [
-        "if ( (!(Test-Path \"$persist_dir\\profile\")) -and (Test-Path \"$env:APPDATA\\qBittorrent\") ) {",
-        "    Write-Host \"Scoop is migrating qbittorrent to use portable mode by default.\" -ForeGroundColor Yellow",
-        "    Write-Host \"For details, see: https://github.com/ScoopInstaller/Extras/pull/7173\" -ForeGroundColor Yellow",
-        "    Write-Host \"Copying files from APPDATA to Scoop directory...\" -ForeGroundColor Yellow",
-        "    Copy-Item \"$env:APPDATA\\qBittorrent\\*\" \"$persist_dir\\profile\\config\" -Force | Out-Null",
-        "    Copy-Item \"$env:LOCALAPPDATA\\qBittorrent\\*\" \"$persist_dir\\profile\\data\" -Force | Out-Null",
-        "}"
-    ],
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
     "bin": "qbittorrent.exe",
     "shortcuts": [
         [
@@ -43,7 +24,6 @@
             "qBittorrent"
         ]
     ],
-    "persist": "profile",
     "checkver": {
         "url": "https://www.qbittorrent.org/download.php",
         "regex": "Latest:\\s+v([\\d.]+)"


### PR DESCRIPTION
Reverts ScoopInstaller/Extras#7173

Due to the comment in my opinion, the safest thing to do would be to revert
https://github.com/ScoopInstaller/Extras/pull/7173#issuecomment-962463851

