### PR TITLE
Correct installation #7260

### DIFF
--- a/bucket/makehuman.json
+++ b/bucket/makehuman.json
@@ -5,13 +5,18 @@
     "license": "AGPL-3.0-or-later",
     "url": "http://download.tuxfamily.org/makehuman/releases/makehuman-community-1.2.0-windows.zip",
     "hash": "7f801801f4307a89c8dc91e5713553000a37d1225f25cb1c32afad20f3b0f4ee",
-    "bin": "makehuman.exe",
-    "shortcuts": [
-        [
-            "makehuman.exe",
+    "bin": "makehuman.ps1",
+    "shortcuts": [[
+            "makehuman.ps1",
             "MakeHuman"
-        ]
-    ],
+    ]],
+    "installer": {
+        "script": [
+              "Expand-7zipArchive \"$dir\\makehuman-community-$version-windows.exe\" \"$dir\"",
+	      "Write-Output \"& $dir\\Python\\pythonw.exe $dir\\mhstartwrapper.py @args\" | Out-File -Encoding utf8  \"$dir\\makehuman.ps1\"",
+              "Remove-Item \"$dir\\makehuman-community-$version-windows.exe\""
+             ]
+    },
     "checkver": {
         "url": "http://download.tuxfamily.org/makehuman/releases/",
         "regex": "([\\d.]+)-windows.zip"


### PR DESCRIPTION
Correct installation method for makehuman : 
- zip contains exe
- exe contain packaged python application
The installation currently manage double unzip, and create a ps1 script to launch local python from current pakage with mhstartwrapper.py argument. This script name is makehuman, and create shim makehuman.

Tested here.

Only problem is that I don't manage icon in Windows Start Menu (MakeHuman use powershell icon)

Closes #7260
