### PR TITLE
retroarch: hash fix

### DIFF
--- a/bucket/retroarch.json
+++ b/bucket/retroarch.json
@@ -6,12 +6,12 @@
     "architecture": {
         "64bit": {
             "url": "https://buildbot.libretro.com/stable/1.9.13/windows/x86_64/RetroArch.7z",
-            "hash": "c8929916acdab98785e476e992a24cb2ad18784d12839e99956a6f1803a7c01e",
+            "hash": "2e5a720dc478cc17fcb5decd775157d61f978c9962fea6e8b7788e0657e263ca",
             "extract_dir": "RetroArch-Win64"
         },
         "32bit": {
             "url": "https://buildbot.libretro.com/stable/1.9.13/windows/x86/RetroArch.7z",
-            "hash": "0b2031a5a56819ef886114218315fbada7660f352ec174ef15cc86ed6c379062",
+            "hash": "a9e91e35e391fc39ac740b1be0d3033ba455a956af36cce3d6ebb1c0f3368cba",
             "extract_dir": "RetroArch-Win32"
         }
     },


### PR DESCRIPTION
Fix hash for 1.9.13 to SHA256 digest. Verified new values against downloads.

Closes #7277