### PR TITLE
lazarus: Don't hardcode path to fpcmkcfg.exe in post-install script

### DIFF
--- a/bucket/lazarus.json
+++ b/bucket/lazarus.json
@@ -18,8 +18,9 @@
     },
     "innosetup": true,
     "post_install": [
-        "$fpcdir = \"$dir\\fpc\\\" + ($fname -replace '.*fpc-([\\d.]+)-.*', '$1')",
-        "& \"$fpcdir\\bin\\x86_64-win64\\fpcmkcfg.exe\" -d \"basepath=$fpcdir\" -o \"$fpcdir\\bin\\x86_64-win64\\fpc.cfg\""
+        "$fpcdir = \"$dir\\fpc\\\" + ($fname -replace '.*fpc-([\\d.]+)-.*', '$1');",
+        "$fpcarch=$(if ($fname -match '.*fpc-([\\d.]+)-win64') {'x86_64-win64'} else {'i386-win32'});",
+        "& \"$fpcdir\\bin\\$fpcarch\\fpcmkcfg.exe\" -d \"basepath=$fpcdir\" -o \"$fpcdir\\bin\\$fpcarch\\fpc.cfg\""
     ],
     "shortcuts": [
         [
@@ -32,7 +33,7 @@
             "--debug"
         ]
     ],
-    "checkver": "lazarus-([\\d.]+)-fpc-(?<fpc>[\\d.]+)-win64\\.exe",
+    "checkver": "lazarus-([\\d.]+)-fpc-(?<fpc>[\\d.]+)-win(64|32)\\.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #7268

Tested on Windows 10.0.19042.1348 with system default PowerShell (5.1.19041 .1320)

<img width="960" alt="Screenshot 2021-11-09 202013" src="https://user-images.githubusercontent.com/59004801/141212551-af95f5c7-97ff-48f9-8c36-fb966a4be0c6.png">

I noticed the updater regex was also 64bit-only and changed it too. Since lazarus updates infrequently, this could only be tested at a PowerShell prompt, like so:

```powershell
$re = "lazarus-([\d.]+)-fpc-(?<fpc>[\d.]+)-win(64|32)\.exe"    
$urlx64 = "https://downloads.sourceforge.net/project/lazarus/Lazarus%20Windows%2064%20bits/Lazarus%202.0.12/lazarus-2.0.12-fpc-3.2.0-win64.exe"
$urlx86 = "https://downloads.sourceforge.net/project/lazarus/Lazarus%20Windows%2032%20bits/Lazarus%202.0.12/lazarus-2.0.12-fpc-3.2.0-win32.exe"
                                                                      
$urlx64 -match $re                                                                                                                   
# ==> True      
$urlx86 -match $re
# ==> True 
```

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
