### PR TITLE
lite-xl: Add version 2.0.3

### DIFF
--- a/bucket/lite-xl.json
+++ b/bucket/lite-xl.json
@@ -1,6 +1,6 @@
 {
     "version": "2.0.3",
-    "description": "A lightweight text editor written in Lua",
+    "description": "A lightweight text editor written in Lua, adapted from lite.",
     "homepage": "https://lite-xl.github.io",
     "license": "MIT",
     "architecture": {

--- a/bucket/lite-xl.json
+++ b/bucket/lite-xl.json
@@ -1,0 +1,37 @@
+{
+    "version": "2.0.3",
+    "description": "A lightweight text editor written in Lua",
+    "homepage": "https://lite-xl.github.io",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lite-xl/lite-xl/releases/download/v2.0.3/lite-xl-windows-x86_64.zip",
+            "hash": "d76fb97760c06a75c433734d68a0fb5970c4a148acfb66648f0943d4a0a95471"
+        },
+        "32bit": {
+            "url": "https://github.com/lite-xl/lite-xl/releases/download/v2.0.3/lite-xl-windows-x86.zip",
+            "hash": "3f0e62793120c29c71d5b3d5f5b394fc9d897ce7cb3a99d5b54e028e14a879f0"
+        }
+    },
+    "extract_dir": "lite-xl",
+    "bin": "lite-xl.exe",
+    "shortcuts": [
+        [
+            "lite-xl.exe",
+            "Lite XL"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/lite-xl/lite-xl"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lite-xl/lite-xl/releases/download/v$version/lite-xl-windows-x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/lite-xl/lite-xl/releases/download/v$version/lite-xl-windows-x86.zip"
+            }
+        }
+    }
+}

--- a/bucket/lite.json
+++ b/bucket/lite.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.11",
+    "description": "A lightweight text editor written in Lua.",
+    "homepage": "https://github.com/rxi/lite",
+    "license": "MIT",
+    "url": "https://github.com/rxi/lite/releases/download/v1.11/lite.zip",
+    "hash": "da3701cf6985bc493cb11b37556325551c7ce8606f5502ff3f15199039835eef",
+    "bin": "lite.exe",
+    "shortcuts": [
+        [
+            "lite.exe",
+            "Lite"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/rxi/lite/releases/download/v$version/lite.zip"
+    }
+}

--- a/bucket/lite.json
+++ b/bucket/lite.json
@@ -3,8 +3,12 @@
     "description": "A lightweight text editor written in Lua.",
     "homepage": "https://github.com/rxi/lite",
     "license": "MIT",
-    "url": "https://github.com/rxi/lite/releases/download/v1.11/lite.zip",
-    "hash": "da3701cf6985bc493cb11b37556325551c7ce8606f5502ff3f15199039835eef",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rxi/lite/releases/download/v1.11/lite.zip",
+            "hash": "da3701cf6985bc493cb11b37556325551c7ce8606f5502ff3f15199039835eef"
+        }
+    },
     "bin": "lite.exe",
     "shortcuts": [
         [
@@ -12,8 +16,13 @@
             "Lite"
         ]
     ],
+    "persist": "data",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/rxi/lite/releases/download/v$version/lite.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rxi/lite/releases/download/v$version/lite.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
Homepage:

- Lite: https://github.com/rxi/lite
- Lite XL: https://lite-xl.github.io

Lite's last release is 1.11, and has stopped development from July, 2020, so there is Lite XL, an enhanced version of Lite.

Closes #4494

Supercedes #4612