### PR TITLE
impregnate: Add version 1.2.2

### DIFF
--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -1,28 +1,18 @@
 {
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "A standalone installer for Cumcord, a Discord client modification that allows you to interface with Discord's internals via plugins.",
     "homepage": "https://github.com/Cumcord/Impregnate",
     "license": "MIT",
     "suggest": {
-        "discord": [
-            "discord",
-            "discord-ptb",
-            "discord-canary"
-        ]
+        "Discord": "extras/discord"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
-            "hash": "ae00db169c649428da2bc7baea1acaaa0290c95fb1de9852f3cb9c63a5e4b337"
+            "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.3/impregnate.exe",
+            "hash": "138cde1b90549f94a1f81adac82f765b1addc6208bebc750e210c36ea8516745"
         }
     },
-    "bin": "impregnate.exe",
-    "shortcuts": [
-        [
-            "impregnate.exe",
-            "Impregnate"
-        ]
-    ],
+    "shortcuts": [["impregnate.exe", "Impregnate"]],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -12,7 +12,12 @@
             "hash": "138cde1b90549f94a1f81adac82f765b1addc6208bebc750e210c36ea8516745"
         }
     },
-    "shortcuts": [["impregnate.exe", "Impregnate"]],
+    "shortcuts": [
+        [
+            "impregnate.exe",
+            "Impregnate"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -1,6 +1,6 @@
 {
     "version": "1.2.2",
-    "description": "A standalone installer for Cumcord.",
+    "description": "A standalone installer for Cumcord, a Discord client modification that allows you to interface with Discord's internals via plugins.",
     "homepage": "https://github.com/Cumcord/Impregnate",
     "license": "MIT",
     "architecture": {

--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -3,6 +3,13 @@
     "description": "A standalone installer for Cumcord, a Discord client modification that allows you to interface with Discord's internals via plugins.",
     "homepage": "https://github.com/Cumcord/Impregnate",
     "license": "MIT",
+    "suggest": {
+        "discord": [
+            "discord",
+            "discord-ptb",
+            "discord-canary"
+        ]
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",

--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -1,22 +1,31 @@
 {
-    "version": "1.2.2",
-    "description": "A standalone installer for Cumcord.",
-    "homepage": "https://github.com/Cumcord/Impregnate",
-    "license": "Apache-2.0",
-    "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
-    "hash": "AE00DB169C649428DA2BC7BAEA1ACAAA0290C95FB1DE9852F3CB9C63A5E4B337",
-    "bin": "impregnate.exe",
-    "shortcuts": [
-        [
-            "impregnate.exe",
-            "Impregnate"
-        ]
-    ],
-    "checkver": {
-        "url": "https://github.com/Cumcord/Impregnate/releases/latest",
-        "regex": "v(\\d\\.\\d+\\.\\d+),"
-    },
-    "autoupdate": {
-        "url": "https://github.com/Cumcord/Impregnate/releases/download/$version/impregnate.exe"
+  "version": "1.2.2",
+  "description": "A standalone installer for Cumcord.",
+  "homepage": "https://github.com/Cumcord/Impregnate",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
+      "hash": "AE00DB169C649428DA2BC7BAEA1ACAAA0290C95FB1DE9852F3CB9C63A5E4B337"
     }
+  },
+  "bin": "impregnate.exe",
+  "shortcuts": [
+    [
+      "impregnate.exe",
+      "Impregnate"
+    ]
+  ],
+  "checkver": {
+    "url": "https://github.com/Cumcord/Impregnate/releases/latest",
+    "regex": "v(\\d\\.\\d+\\.\\d+),"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
+        "hash": "AE00DB169C649428DA2BC7BAEA1ACAAA0290C95FB1DE9852F3CB9C63A5E4B337"
+      }
+    }
+  }
 }

--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -1,31 +1,27 @@
 {
-  "version": "1.2.2",
-  "description": "A standalone installer for Cumcord.",
-  "homepage": "https://github.com/Cumcord/Impregnate",
-  "license": "Apache-2.0",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
-      "hash": "AE00DB169C649428DA2BC7BAEA1ACAAA0290C95FB1DE9852F3CB9C63A5E4B337"
-    }
-  },
-  "bin": "impregnate.exe",
-  "shortcuts": [
-    [
-      "impregnate.exe",
-      "Impregnate"
-    ]
-  ],
-  "checkver": {
-    "url": "https://github.com/Cumcord/Impregnate/releases/latest",
-    "regex": "v(\\d\\.\\d+\\.\\d+),"
-  },
-  "autoupdate": {
+    "version": "1.2.2",
+    "description": "A standalone installer for Cumcord.",
+    "homepage": "https://github.com/Cumcord/Impregnate",
+    "license": "MIT",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
-        "hash": "AE00DB169C649428DA2BC7BAEA1ACAAA0290C95FB1DE9852F3CB9C63A5E4B337"
-      }
+        "64bit": {
+            "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
+            "hash": "ae00db169c649428da2bc7baea1acaaa0290c95fb1de9852f3cb9c63a5e4b337"
+        }
+    },
+    "bin": "impregnate.exe",
+    "shortcuts": [
+        [
+            "impregnate.exe",
+            "Impregnate"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Cumcord/Impregnate/releases/download/v$version/impregnate.exe"
+            }
+        }
     }
-  }
 }

--- a/bucket/impregnate.json
+++ b/bucket/impregnate.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.2.2",
+    "description": "A standalone installer for Cumcord.",
+    "homepage": "https://github.com/Cumcord/Impregnate",
+    "license": "Apache-2.0",
+    "url": "https://github.com/Cumcord/Impregnate/releases/download/v1.2.2/impregnate.exe",
+    "hash": "AE00DB169C649428DA2BC7BAEA1ACAAA0290C95FB1DE9852F3CB9C63A5E4B337",
+    "bin": "impregnate.exe",
+    "shortcuts": [
+        [
+            "impregnate.exe",
+            "Impregnate"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/Cumcord/Impregnate/releases/latest",
+        "regex": "v(\\d\\.\\d+\\.\\d+),"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Cumcord/Impregnate/releases/download/$version/impregnate.exe"
+    }
+}


### PR DESCRIPTION
This pull request adds Impregnate (https://github.com/Cumcord/Impregnate), the installer for Cumcord (https://cumcord.com/).

Closes #7290