### PR TITLE
gimp: Remove persisted folders

### DIFF
--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -57,10 +57,6 @@
             "GIMP"
         ]
     ],
-    "persist": [
-        "etc\\gimp",
-        "share\\gimp"
-    ],
     "checkver": {
         "url": "https://www.gimp.org/downloads/",
         "regex": "gimp-(?<version>[\\d.]+)-setup(?<build>-\\d)?\\.exe",


### PR DESCRIPTION
GIMP 2.10 stores settings in %APPDATA%\GIMP, not in the "etc\gimp" and "share\gimp" folders. Scoop persists these folders, but user settings will never be stored in them. They merely hold the standard brushes, patterns, etc. They needn't and shouldn't be persisted.

The change presented in this PR should not break any existing user's install since GIMP will have been storing all their settings already in %APPDATA%.

I am hoping that GIMP one day offers a proper [portable ZIP archive](https://gitlab.gnome.org/GNOME/gimp/-/issues/2861) so that this rather inelegant manifest can be simplified...