### PR TITLE
Update Brave Browser version

### DIFF
--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,8 +1,11 @@
 {
     "version": "1.31.87-77",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
-    "homepage": "https://github.com/portapps/brave-portable",
-    "checkver": "github",
+    "homepage": "https://brave.com",
+    "checkver": {
+        "url": "https://github.com/portapps/brave-portable",
+        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+    },
     "license": {
         "identifier": "Freeware,BSD-3-Clause,GPL-3.0-only,...",
         "url": "https://github.com/brave/brave-browser/blob/master/LICENSE"

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -2,10 +2,6 @@
     "version": "1.31.87-77",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
     "homepage": "https://brave.com",
-    "checkver": {
-        "url": "https://github.com/portapps/brave-portable",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
-    },
     "license": {
         "identifier": "Freeware,BSD-3-Clause,GPL-3.0-only,...",
         "url": "https://github.com/brave/brave-browser/blob/master/LICENSE"
@@ -16,6 +12,7 @@
             "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85"
         }
     },
+    "extract_dir": "app",
     "bin": "brave.exe",
     "shortcuts": [
         [
@@ -23,12 +20,15 @@
             "Brave"
         ]
     ],
+    "checkver": {
+        "url": "https://github.com/portapps/brave-portable",
+        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/portapps/brave-portable/releases/download/$version/brave-portable-win64-$version.7z"
             }
         }
-    },
-    "extract_dir": "app"
+    }
 }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -10,7 +10,11 @@
         "identifier": "Freeware,BSD-3-Clause,GPL-3.0-only,...",
         "url": "https://github.com/brave/brave-browser/blob/master/LICENSE"
     },
-    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z",
+    "architecture": {
+        "64bit": {
+	    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z"
+        }
+    }
     "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85",
     "bin": "brave.exe",
     "shortcuts": [
@@ -20,7 +24,11 @@
         ]
     ],
     "autoupdate": {
-        "url": "https://github.com/portapps/brave-portable/releases/download/$version/brave-portable-win64-$version.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/portapps/brave-portable/releases/download/$version/brave-portable-win64-$version.7z"
+            }
+        }
     },
     "extract_dir": "app"
 }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,37 +1,19 @@
 {
-    "version": "1.4.96",
+    "version": "1.31.91",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
     "homepage": "https://brave.com",
     "license": {
         "identifier": "Freeware,BSD-3-Clause,GPL-3.0-only,...",
         "url": "https://github.com/brave/brave-browser/blob/master/LICENSE"
     },
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-x64.exe#/dl.7z",
-            "hash": "d9e7dd4f7597b6cec73dd49a23c52f4da87a8c25ccf837b8c3a8c7a70895606f"
-        },
-        "32bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-ia32.exe#/dl.7z",
-            "hash": "683a5f4e1295cb26acbff648864939e529243e1f6df4451a857aa8c2ed4794fe"
-        }
-    },
-    "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal",
+    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z",
+    "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85",
     "bin": "brave.exe",
+    "extract_dir": "app",
     "shortcuts": [
         [
             "brave.exe",
             "Brave"
         ]
     ],
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave_installer-x64.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave_installer-ia32.exe#/dl.7z"
-            }
-        }
-    }
 }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -15,5 +15,5 @@
             "brave.exe",
             "Brave"
         ]
-    ],
+    ]
 }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -13,9 +13,9 @@
     "architecture": {
         "64bit": {
 	    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z"
+            "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85",
         }
     }
-    "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85",
     "bin": "brave.exe",
     "shortcuts": [
         [

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -12,10 +12,10 @@
     },
     "architecture": {
         "64bit": {
-	    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z"
-            "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85",
+	    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z",
+            "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85"
         }
-    }
+    },
     "bin": "brave.exe",
     "shortcuts": [
         [

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.31.91",
+    "version": "1.31.87",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
     "homepage": "https://brave.com",
     "license": {

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,7 +1,8 @@
 {
-    "version": "1.31.87",
+    "version": "1.31.87-77",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
-    "homepage": "https://brave.com",
+    "homepage": "https://github.com/portapps/brave-portable",
+    "checkver": "github",
     "license": {
         "identifier": "Freeware,BSD-3-Clause,GPL-3.0-only,...",
         "url": "https://github.com/brave/brave-browser/blob/master/LICENSE"
@@ -9,11 +10,14 @@
     "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z",
     "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85",
     "bin": "brave.exe",
-    "extract_dir": "app",
     "shortcuts": [
         [
             "brave.exe",
             "Brave"
         ]
-    ]
+    ],
+    "autoupdate": {
+        "url": "https://github.com/portapps/brave-portable/releases/download/$version/brave-portable-win64-$version.7z"
+    },
+    "extract_dir": "app"
 }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -12,7 +12,7 @@
     },
     "architecture": {
         "64bit": {
-	    "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z",
+            "url": "https://github.com/portapps/brave-portable/releases/download/1.31.87-77/brave-portable-win64-1.31.87-77.7z",
             "hash": "36d2e0dd3b3bebe13cf2633a56990f9dbe78ff476bcd9d2c921567213f36dc85"
         }
     },


### PR DESCRIPTION
Installing `brave` installs a 2 year old version of version where autoupdate is broken which is a potential security risk. Updated Brave to 1.31.87 which is the last version I found that can be installed as portable.