### PR TITLE
bat2exe: Add version 2.0

### DIFF
--- a/bucket/bat2exe.json
+++ b/bucket/bat2exe.json
@@ -1,21 +1,29 @@
 {
-  "version": "2.0",
-  "description": "A simple application which converts any windows batch file to a fully working executable .exe with an icon of your choice.",
-  "homepage": "https://github.com/islamadel/bat2exe",
-  "license": "Unknown",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/islamadel/bat2exe/archive/refs/tags/2.0.tar.gz",
-      "hash": "C5D3E4D6EB667F0E781ADE713A11FAD3C277702D718D2D44D2BABC99493DE30E",
-      "extract_dir": "bat2exe-2.0\\upload"
+    "version": "2.0",
+    "description": "A simple application which converts any windows batch file to a fully working executable .exe with an icon of your choice.",
+    "homepage": "https://bat2exe.net",
+    "license": "Unknown",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/islamadel/bat2exe/releases/download/2.0/bat2exe.exe",
+            "hash": "a80c25d09bfc8bc4affb8e394a7254574b7e7e39404404775382f005e6a067c6"
+        }
+    },
+    "bin": "bat2exe.exe",
+    "shortcuts": [
+        [
+            "bat2exe.exe",
+            "BAT 2 EXE"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/islamadel/bat2exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/islamadel/bat2exe/releases/download/$version/bat2exe.exe"
+            }
+        }
     }
-  },
-  "bin": "bat2exe.exe",
-  "shortcuts": [
-    [
-      "bat2exe.exe",
-      "BAT 2 EXE"
-    ]
-  ],
-  "checkver": "github"
 }

--- a/bucket/bat2exe.json
+++ b/bucket/bat2exe.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "description": "A simple application which converts any windows batch file to a fully working executable .exe with an icon of your choice.",
     "homepage": "https://bat2exe.net",
-    "license": "Unknown",
+    "license": "Freeware",
     "architecture": {
         "64bit": {
             "url": "https://github.com/islamadel/bat2exe/releases/download/2.0/bat2exe.exe",

--- a/bucket/bat2exe.json
+++ b/bucket/bat2exe.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0",
+  "description": "A simple application which converts any windows batch file to a fully working executable .exe with an icon of your choice.",
+  "homepage": "https://github.com/islamadel/bat2exe",
+  "license": "Unknown",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/islamadel/bat2exe/archive/refs/tags/2.0.tar.gz",
+      "hash": "C5D3E4D6EB667F0E781ADE713A11FAD3C277702D718D2D44D2BABC99493DE30E",
+      "extract_dir": "bat2exe-2.0\\upload"
+    }
+  },
+  "bin": "bat2exe.exe",
+  "shortcuts": [
+    [
+      "bat2exe.exe",
+      "BAT 2 EXE"
+    ]
+  ],
+  "checkver": "github"
+}


### PR DESCRIPTION
Makes [bat2exe](https://www.bat2exe.net/) ([github](https://github.com/islamadel/bat2exe)) available via scoop extras