### PR TITLE
Update the checkver URL for firefox-beta as no updates were available anymore

### DIFF
--- a/bucket/firefox-beta.json
+++ b/bucket/firefox-beta.json
@@ -1,16 +1,16 @@
 {
-    "version": "94.0b4",
+    "version": "95.0b7",
     "description": "Beta builds of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/beta/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/releases/94.0b4/win64/en-US/Firefox%20Setup%2094.0b4.exe#/dl.7z",
-            "hash": "sha512:d654fed81a817895a7a926ca9495610c2975b33cae969eb41d82d308d9c4552253f23aad1cbb89ba8292b63c6af064503956f7c2ea2de9e11878672d0978bbce"
+            "url": "https://archive.mozilla.org/pub/firefox/releases/95.0b7/win64/en-US/Firefox%20Setup%2095.0b7.exe#/dl.7z",
+            "hash": "sha512:662f68766f6cb4d45e07490b7081f7a5dceb39b044162f4e83d95bf013867002741616d11ccce5fde585148373b8c439fb61ad619a59b1371ad0d56d489e3a90"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/releases/94.0b4/win32/en-US/Firefox%20Setup%2094.0b4.exe#/dl.7z",
-            "hash": "sha512:edf05af3114dfd66e09ec8512e5dbb90270d88ec3ab22753bf76c46ef384bb25a6fc0185d43c456b24627ed095431b787a215c086e4774c95ce7bf1f01445338"
+            "url": "https://archive.mozilla.org/pub/firefox/releases/95.0b7/win32/en-US/Firefox%20Setup%2095.0b7.exe#/dl.7z",
+            "hash": "sha512:1aea515b8baec912f4ddcb58be918cbfaac1b0af52d4b4bd50495d6d0baaab5a37d06fb470cf086844ab95c656545896125ca6a51a3752a2f3e77d39ee547d92"
         }
     },
     "extract_dir": "core",
@@ -28,7 +28,7 @@
     ],
     "persist": "distribution",
     "checkver": {
-        "url": "https://aus5.mozilla.org/update/6/Firefox/60.0/_/WINNT_x86_64-msvc-x64/en-US/beta/_/_/_/_/update.xml",
+        "url": "https://aus5.mozilla.org/update/6/Firefox/93.0/_/WINNT_x86_64-msvc-x64/en-US/beta/_/_/_/_/update.xml",
         "xpath": "/updates/update/patch/@URL",
         "regex": "firefox-([\\db.]+)-"
     },


### PR DESCRIPTION
The firefox-beta version did not update anymore and the checkver URL showed no new builds. This PR should resolve the issue and provide the latest beta version as of now (95.0b7).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #7342
