### PR TITLE
bt (Browser Tamer): Add version 2.1

### DIFF
--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -17,6 +17,14 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.aloneguid.uk/projects/bt/bin/latest.txt"
+        "url": "https://www.aloneguid.uk/projects/bt/bin/latest.txt",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.aloneguid.uk/projects/bt/bin/bt-$version.zip"
+            }
+        }
     }
-  }
+}

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -1,0 +1,14 @@
+{
+    "version": "2.1",
+    "description": "Opens required browser based on configuration",
+    "homepage": "https://www.aloneguid.uk/projects/bt/",
+    "url": "https://www.aloneguid.uk/projects/bt/bin/bt-2.1.zip",
+    "bin": "bt.exe",
+    "hash": "cdf9827246daffc999ce476728a3ef578c00399054b1b6618d3b0fa7dfc41f23",
+    "shortcuts": [
+        [
+            "bt.exe",
+            "Browser Tamer"
+        ]
+    ]
+  }

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -2,9 +2,14 @@
     "version": "2.1",
     "description": "Opens required browser based on configuration",
     "homepage": "https://www.aloneguid.uk/projects/bt/",
-    "url": "https://www.aloneguid.uk/projects/bt/bin/bt-2.1.zip",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.aloneguid.uk/projects/bt/bin/bt-2.1.zip",
+            "hash": "cdf9827246daffc999ce476728a3ef578c00399054b1b6618d3b0fa7dfc41f23"
+        }
+    },
     "bin": "bt.exe",
-    "hash": "cdf9827246daffc999ce476728a3ef578c00399054b1b6618d3b0fa7dfc41f23",
     "shortcuts": [
         [
             "bt.exe",

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -15,5 +15,8 @@
             "bt.exe",
             "Browser Tamer"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://www.aloneguid.uk/projects/bt/bin/latest.txt"
+    }
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Makes [Browser Tamer](https://www.aloneguid.uk/projects/bt/) available via scoop extras.

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
