### PR TITLE
ghidra: Fix exited with error after update

### DIFF
--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -15,7 +15,7 @@
         }
     },
     "post_install": [
-        "    # Copy default Configurations to persisting dir.",
+        "# Copy default Configurations to persisting dir.",
         "if (Test-Path \"$dir\\Ghidra\\Configurations.original\") {",
         "    Copy-Item \"$dir\\Ghidra\\Configurations.original\\*\" \"$persist_dir\\Ghidra\\Configurations\" -Force -Recurse",
         "    Remove-Item \"$dir\\Ghidra\\Configurations.original\" -Force -Recurse | Out-Null",

--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -14,6 +14,13 @@
             "hash": "1ce9bdf2d7f6bdfe5dccd06da828af31bc74acfd800f71ade021d5211e820d5e"
         }
     },
+    "post_install": [
+        "    # Copy default Configurations to persisting dir.",
+        "if (Test-Path \"$dir\\Ghidra\\Configurations.original\") {",
+        "    Copy-Item \"$dir\\Ghidra\\Configurations.original\\*\" \"$persist_dir\\Ghidra\\Configurations\" -Force -Recurse",
+        "    Remove-Item \"$dir\\Ghidra\\Configurations.original\" -Force -Recurse | Out-Null",
+        "}"
+    ],
     "bin": "ghidraRun.bat",
     "shortcuts": [
         [


### PR DESCRIPTION
Multiple modules collided with same name because of the persist dirs. Here is the error message:
```
Exception in thread "main" ghidra.util.exception.AssertException: Multiple modules collided with same name: Public_Release   
$dir\Ghidra\Configurations\Public_Release
$dir\Ghidra\Configurations.original\Public_Release
	at utility.module.ModuleUtilities.findModules(ModuleUtilities.java:162)
	at ghidra.GhidraApplicationLayout.findGhidraModules(GhidraApplicationLayout.java:210)
	at ghidra.GhidraApplicationLayout.<init>(GhidraApplicationLayout.java:70)
	at ghidra.GhidraLauncher.main(GhidraLauncher.java:52)
```