### PR TITLE
linqpad: Update to 7.1.4

### DIFF
--- a/bucket/linqpad.json
+++ b/bucket/linqpad.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.15.12",
+    "version": "7.1.4",
     "description": "The .NET programmer’s playground",
     "homepage": "https://www.linqpad.net",
     "license": {
@@ -9,61 +9,113 @@
     "suggest": {
         ".Net SDK": "dotnet-sdk"
     },
-    "url": "http://download.linqpad.net/public/LINQPad6.zip",
-    "hash": "94cfd97b53595cb3f3d1ec9369c890d0fc76e5b7045480c1422c92cda61e79a6",
-    "pre_install": [
-        "$major = $version -split '\\.' | Select-Object -First 1",
-        "Get-ChildItem \"$dir\" 'l*.exe' | ForEach-Object {",
-        "         # $1 is needed to not remove character",
-        "    $newName = $_.Basename -replace \"([^8])$major\", '$1'",
-        "    Rename-Item $_.Fullname ($newName + $_.Extension)",
-        "}"
-    ],
+    "url": "https://linqpad.azureedge.net/public/LINQPad7.zip",
+    "hash": "faadb098c2efc8873e451fa94ece0c8de6084de001ddbb8792c203cc92fd2bba",
     "architecture": {
         "64bit": {
             "bin": [
-                "lprun.exe",
-                "linqpad.exe",
-                "lprun-x86.exe",
-                "linqpad-x86.exe"
+                [
+                    "LPRun7-x64.exe",
+                    "lprun"
+                ],
+                [
+                    "LINQPad7-x64.exe",
+                    "linqpad"
+                ],
+                [
+                    "LPRun7-x86.exe",
+                    "lprun-x86"
+                ],
+                [
+                    "LINQPad7-x86.exe",
+                    "linqpad-x86"
+                ]
             ],
             "shortcuts": [
                 [
-                    "linqpad.exe",
-                    "LINQPad"
+                    "LINQPad7-x64.exe",
+                    "LINQPad 7"
                 ],
                 [
-                    "linqpad-x86.exe",
-                    "LINQPad x86"
+                    "LINQPad7-x86.exe",
+                    "LINQPad 7 (x86)"
                 ]
             ]
         },
         "32bit": {
             "bin": [
-                "lprun-x86.exe",
-                "linqpad-x86.exe",
                 [
-                    "lprun-x86.exe",
+                    "LPRun7-x86.exe",
                     "lprun"
                 ],
                 [
-                    "linqpad-x86.exe",
+                    "LINQPad7-x86.exe",
                     "linqpad"
                 ]
             ],
             "shortcuts": [
                 [
-                    "linqpad-x86.exe",
-                    "LINQPad"
+                    "LINQPad7-x86.exe",
+                    "LINQPad 7"
                 ]
             ]
         }
     },
     "checkver": {
         "url": "https://www.linqpad.net/Download.aspx",
-        "regex": ">(6\\.[\\d.]+)"
+        "regex": "Version\">([\\d.]+)<"
     },
     "autoupdate": {
-        "url": "http://download.linqpad.net/public/LINQPad$majorVersion.zip"
+        "url": "https://linqpad.azureedge.net/public/LINQPad$majorVersion.zip",
+        "architecture": {
+            "64bit": {
+                "bin": [
+                    [
+                        "LPRun$majorVersion-x64.exe",
+                        "lprun"
+                    ],
+                    [
+                        "LINQPad$majorVersion-x64.exe",
+                        "linqpad"
+                    ],
+                    [
+                        "LPRun$majorVersion-x86.exe",
+                        "lprun-x86"
+                    ],
+                    [
+                        "LINQPad$majorVersion-x86.exe",
+                        "linqpad-x86"
+                    ]
+                ],
+                "shortcuts": [
+                    [
+                        "LINQPad$majorVersion-x64.exe",
+                        "LINQPad $majorVersion"
+                    ],
+                    [
+                        "LINQPad$majorVersion-x86.exe",
+                        "LINQPad $majorVersion (x86)"
+                    ]
+                ]
+            },
+            "32bit": {
+                "bin": [
+                    [
+                        "LPRun$majorVersion-x86.exe",
+                        "lprun"
+                    ],
+                    [
+                        "LINQPad$majorVersion-x86.exe",
+                        "linqpad"
+                    ]
+                ],
+                "shortcuts": [
+                    [
+                        "LINQPad$majorVersion-x86.exe",
+                        "LINQPad $majorVersion"
+                    ]
+                ]
+            }
+        }
     }
 }


### PR DESCRIPTION
`autoupdate` will be valid in scoop core's new autoupdate feature.