### PR TITLE
streamlink: Update to version 3.0.1

### DIFF
--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.4.0",
+    "version": "3.0.1",
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",
     "license": "BSD-2-Clause",
@@ -10,8 +10,8 @@
             "ffmpeg-nightly"
         ]
     },
-    "url": "https://github.com/streamlink/streamlink/releases/download/2.4.0/streamlink-2.4.0.exe#/dl.7z",
-    "hash": "660d33229d6ed15bfa63f0862455aaf98cd88721caf06192ec8ec06409fa2688",
+    "url": "https://github.com/streamlink/streamlink/releases/download/3.0.1/streamlink-3.0.1.exe#/dl.7z",
+    "hash": "e83bacdfe2f7892f7b6c9ef39714dd7f47ff07f64e9cd3a2b6b1a5d45af46e41",
     "pre_install": [
         "if (!(Test-Path \"$env:APPDATA\\streamlink\\streamlinkrc\")) {",
         "    info 'Copying default ''streamlinkrc'' to ''%APPDATA%\\streamlink\\streamlinkrc'''",

--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -8,7 +8,8 @@
         "FFmpeg": [
             "ffmpeg",
             "ffmpeg-nightly"
-        ]
+        ],
+        "VLC Player": "extras/vlc"
     },
     "url": "https://github.com/streamlink/streamlink/releases/download/3.0.1/streamlink-3.0.1.exe#/dl.7z",
     "hash": "e83bacdfe2f7892f7b6c9ef39714dd7f47ff07f64e9cd3a2b6b1a5d45af46e41",

--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -3,7 +3,7 @@
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",
     "license": "BSD-2-Clause",
-    "notes": "Streamlink settings can be changed in '%APPDATA%\\streamlink\\streamlinkrc'",
+    "notes": "Streamlink settings can be changed in '%APPDATA%\\streamlink\\config'",
     "suggest": {
         "FFmpeg": [
             "ffmpeg",
@@ -13,6 +13,14 @@
     },
     "url": "https://github.com/streamlink/streamlink/releases/download/3.0.1/streamlink-3.0.1.exe#/dl.7z",
     "hash": "e83bacdfe2f7892f7b6c9ef39714dd7f47ff07f64e9cd3a2b6b1a5d45af46e41",
+    "pre_install": [
+        "if (!(Test-Path \"$env:APPDATA\\streamlink\\config\")) {",
+        "    info 'Copying default ''config'' to ''%APPDATA%\\streamlink\\config'''",
+        "    ensure \"$env:APPDATA\\streamlink\" | Out-Null",
+        "    Copy-Item \"$dir\\`$APPDATA\\streamlink\\config\" \"$env:APPDATA\\streamlink\\config\"",
+        "}",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\ffmpeg\", \"$dir\\uninstall.exe\" -Recurse"
+    ],
     "uninstaller": {
         "script": "if ($purge) { Remove-Item \"$env:APPDATA\\streamlink\" -Recurse}"
     },

--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -12,14 +12,6 @@
     },
     "url": "https://github.com/streamlink/streamlink/releases/download/3.0.1/streamlink-3.0.1.exe#/dl.7z",
     "hash": "e83bacdfe2f7892f7b6c9ef39714dd7f47ff07f64e9cd3a2b6b1a5d45af46e41",
-    "pre_install": [
-        "if (!(Test-Path \"$env:APPDATA\\streamlink\\streamlinkrc\")) {",
-        "    info 'Copying default ''streamlinkrc'' to ''%APPDATA%\\streamlink\\streamlinkrc'''",
-        "    ensure \"$env:APPDATA\\streamlink\" | Out-Null",
-        "    Copy-Item \"$dir\\`$APPDATA\\streamlink\\streamlinkrc\" \"$env:APPDATA\\streamlink\\streamlinkrc\"",
-        "}",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\ffmpeg\", \"$dir\\uninstall.exe\" -Recurse"
-    ],
     "uninstaller": {
         "script": "if ($purge) { Remove-Item \"$env:APPDATA\\streamlink\" -Recurse}"
     },


### PR DESCRIPTION
Update [streamlink](https://streamlink.github.io/) to [3.0.1](https://github.com/streamlink/streamlink/releases/tag/3.0.1). (Previously it was [2.0.4](https://github.com/streamlink/streamlink/releases/tag/2.4.0))

Sorry. This pull request is not an existing issue. If I need to create an issue first, close this pull request.