### PR TITLE
flameshot: Fix "extract_dir"

### DIFF
--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -10,7 +10,7 @@
         "64bit": {
             "url": "https://github.com/flameshot-org/flameshot/releases/download/v0.10.2/flameshot-0.10.2-win64.zip",
             "hash": "47e20f2c6d5c5c9513185d8b2e982a308ebe5eb35d574bf4186db0a7af6a98aa",
-            "extract_dir": "flameshot-0.10.2-win64"
+            "extract_dir": "flameshot-0.10.2-win64/flameshot-0.10.2-win64"
         }
     },
     "pre_install": "Remove-Item \"$dir\\bin\\vc_redi*.exe\"",
@@ -28,7 +28,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/flameshot-org/flameshot/releases/download/v$version/flameshot-$version-win64.zip",
-                "extract_dir": "flameshot-$version-win64"
+                "extract_dir": "flameshot-$version-win64/flameshot-$version-win64"
             }
         },
         "hash": {


### PR DESCRIPTION
Seems like they changed the ZIP archive structure... so add the additional folder path...

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #7355


<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
