### PR TITLE
Update firefox.json: v94.0.2

### DIFF
--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -1,16 +1,16 @@
 {
-    "version": "94.0.1",
+    "version": "94.0.2",
     "description": "Popular open source web browser.",
     "homepage": "https://www.mozilla.org/firefox/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/releases/94.0.1/win64/en-US/Firefox%20Setup%2094.0.1.exe#/dl.7z",
-            "hash": "sha512:8923e911b562a65f6bbbbfa3fbf1b5993974509f86c7757328eaaeec417265f15336865dcf70db7f13b43da79f6e8b2a8892330a149d09bb7f661127333c9959"
+            "url": "https://archive.mozilla.org/pub/firefox/releases/94.0.2/win64/en-US/Firefox%20Setup%2094.0.2.exe#/dl.7z",
+            "hash": "sha512:15051bf1886b22aceeda12f02e7aea8777812fb6791e75cb8aeaeab464227fbdce8aac9911ab778baa170bf9a0c110c05d555db56d5eb9e9399abaa9989f9b8d"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/releases/94.0.1/win32/en-US/Firefox%20Setup%2094.0.1.exe#/dl.7z",
-            "hash": "sha512:44208a98eea1f1011295a6527b22549c89ff4a5b843f5e98e876ff8fbe4b89d361967908c700487389020af7196de3fb843611433f5213eff348cdbbb5b40b5e"
+            "url": "https://archive.mozilla.org/pub/firefox/releases/94.0.2/win32/en-US/Firefox%20Setup%2094.0.2.exe#/dl.7z",
+            "hash": "sha512:f2d78782dd3eb00513f52e4745ad45b2bc48e4463eaed4c711392c1729f922e428cd0649bec61b35389c03bd4648ab7d1fb1d1ccdc5497f496478e88f97cc486"
         }
     },
     "extract_dir": "core",

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -23,8 +23,9 @@
     ],
     "persist": "distribution",
     "checkver": {
-        "url": "https://www.mozilla.org/en-US/firefox/notes/",
-        "regex": "<div class=\"c-release-version\">([\\d.]+)</div>"
+        "url": "https://archive.mozilla.org/pub/firefox/candidates/",
+        "regex": "pub/firefox/candidates/([\\d.]+)-candidates",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Updates to version 94.0.2.
- Not fetched by checkver since Mozilla hasn't updated their release notes, but the news broke on the Neowin software page on nov 18th and it was added to the archive page used in the manifest in the evening of nov 19th.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->



<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
