### PR TITLE
touchcursor: Add version 1.7.1

### DIFF
--- a/bucket/touchcursor.json
+++ b/bucket/touchcursor.json
@@ -1,6 +1,6 @@
 {
     "version": "1.7.1",
-    "description": "TouchCursor lets you use the home keys as cursor keys – in all Windows programs – keeping your fingers in the best position for fast typing.",
+    "description": "Lets you use the home keys as cursor keys.",
     "homepage": "https://martin-stone.github.io/touchcursor/",
     "license": "GPL-3.0-only",
     "url": "https://github.com/martin-stone/touchcursor/releases/download/v1.7.1/TouchCursor-1.7.1.zip",
@@ -12,12 +12,5 @@
             "touchcursor.exe",
             "touchcursor"
         ]
-    ],
-    "checkver": {
-        "url": "https://martin-stone.github.io/touchcursor/",
-        "regex": "Version ([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "https://github.com/martin-stone/touchcursor/releases/download/v$version/TouchCursor-$version.zip"
-    }
+    ]
 }

--- a/bucket/touchcursor.json
+++ b/bucket/touchcursor.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.7.1",
+    "description": "TouchCursor lets you use the home keys as cursor keys – in all Windows programs – keeping your fingers in the best position for fast typing.",
+    "homepage": "https://martin-stone.github.io/touchcursor/",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/martin-stone/touchcursor/releases/download/v1.7.1/TouchCursor-1.7.1.zip",
+    "hash": "3c4a4361d8f32f3b594a3021c5159d1efe670310126ce99ed8d07d4e8b9c4e77",
+    "extract_dir": "TouchCursor",
+    "bin": "touchcursor.exe",
+    "shortcuts": [
+        [
+            "touchcursor.exe",
+            "touchcursor"
+        ]
+    ],
+    "checkver": {
+        "url": "https://martin-stone.github.io/touchcursor/",
+        "regex": "Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/martin-stone/touchcursor/releases/download/v$version/TouchCursor-$version.zip"
+    }
+}


### PR DESCRIPTION
[Touchcursor](https://martin-stone.github.io/touchcursor) is a hidden gem for windows programming productivity.

> **TouchCursor** lets you use the home keys as cursor keys – in all Windows programs – keeping your fingers in the best position for fast typing. It's free and open-source.

Let me know if you see something to change.