### PR TITLE
winrar-helper: add a helper script for scoop

### DIFF
--- a/bucket/winrar-helper.json
+++ b/bucket/winrar-helper.json
@@ -1,0 +1,30 @@
+{
+    "version": "6.02",
+    "description": "A helper script for winrar",
+    "homepage": "https://github.com/ScoopInstaller/Extras/pull/7388#issuecomment-976313692",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://www.win-rar.com/gtb_priv.html?&L=0"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://www.rarlab.com/rar/winrar-x64-602.exe#/dl.7z",
+            "hash": "d41ed4b4de255bee35f93372d023203c9a43694ef88a759ad61b41dfbd0f345d"
+        },
+        "32bit": {
+            "url": "https://www.rarlab.com/rar/wrar602.exe#/dl.7z",
+            "hash": "f3c32238f23c09f989902644df19e0c1156a8ee9aab552e9c39e869e42c5a71f"
+        }
+    },
+    "checkver": "WinRAR and RAR ([\\d.]+) release",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.rarlab.com/rar/winrar-x64-$cleanVersion.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://www.rarlab.com/rar/wrar$cleanVersion.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a winrar helper script as per the suggestion https://github.com/ScoopInstaller/Extras/pull/7388#issuecomment-976313692
- Copied from winrar.json, removed bin/shortcuts/notes, edited description/homepage
- This is required for `scratch` refer #7338 #7388.