### PR TITLE
winrar: Add 'helper' package

### DIFF
--- a/bucket/winrar-helper.json
+++ b/bucket/winrar-helper.json
@@ -1,0 +1,32 @@
+{
+    "version": "6.02",
+    "description": "WinRAR helper package (only used for extracting installers such as NSIS)",
+    "homepage": "https://rarlab.com/",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://www.win-rar.com/gtb_priv.html?&L=0"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://www.rarlab.com/rar/winrar-x64-602.exe#/dl.7z",
+            "hash": "d41ed4b4de255bee35f93372d023203c9a43694ef88a759ad61b41dfbd0f345d"
+        },
+        "32bit": {
+            "url": "https://www.rarlab.com/rar/wrar602.exe#/dl.7z",
+            "hash": "f3c32238f23c09f989902644df19e0c1156a8ee9aab552e9c39e869e42c5a71f"
+        }
+    },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\rarreg.key\")) { New-Item \"$dir\\rarreg.key\" | Out-Null }",
+    "persist": "rarreg.key",
+    "checkver": "WinRAR and RAR ([\\d.]+) release",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.rarlab.com/rar/winrar-x64-$cleanVersion.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://www.rarlab.com/rar/wrar$cleanVersion.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Will be used in #7388. (as a workaround for the extraction failure mentioned in #7338)

This adds an **WinRAR** "helper" package, which is identical to `winrar` package, but without bin/shortcut.

This is an alternative to `"depends:extras/winrar"`, as it can avoid some confusing situations for end-users.
Most people have their WinRAR installed through other means. If we silently install another WinRAR without asking the user, people may complain about it.
(Why there are 2 WinRARs? Why my WinRAR suddenly turn into English rather than my localized version?)

With this helper package, we can extract the files using *WinRAR* without affecting the users, and always keep this "helper" WinRAR updated.