### PR TITLE
Add GeoGebra version 6.0.676.0

### DIFF
--- a/bucket/geogebra.json
+++ b/bucket/geogebra.json
@@ -1,0 +1,48 @@
+{
+    "version": "6.0.676.0",
+    "description": "A dynamic mathematics software for education that brings together geometry, algebra, spreadsheets, graphing, statistics and calculus.",
+    "homepage": "https://www.geogebra.org/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.geogebra.org/license"
+    },
+    "url": "https://download.geogebra.org/installers/6.0/GeoGebra-Windows-Portable-6-0-676-0.zip",
+    "hash": "ebcc5ee15011885b7275c412c11d5992d3edb96459dd265b422400ed02d29740",
+    "bin": [
+        [
+            "GeoGebra.exe",
+            "geogebra"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "GeoGebra.exe",
+            "GeoGebra"
+        ],
+        [
+            "GeoGebraCalculator.exe",
+            "GeoGebra Calculator"
+        ],
+        [
+            "GeoGebraCAS.exe",
+            "GeoGebra CAS"
+        ],
+        [
+            "GeoGebraGeometry.exe",
+            "GeoGebra Geometry"
+        ],
+        [
+            "GeoGebraGraphing.exe",
+            "GeoGebra Graphing"
+        ]
+    ],
+    "checkver": {
+        "url": "https://download.geogebra.org/installers/6.0/version.txt",
+        "regex": "\\d-(\\d+)-(\\d+)-(\\d+)",
+        "replace": "6.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://download.geogebra.org/installers/$majorVersion.$minorVersion/GeoGebra-Windows-Portable-$dashVersion.zip",
+        "extract_dir": "GeoGebra $version"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Relates to https://github.com/ScoopInstaller/Versions/pull/323#issuecomment-976392477 where we discussed adding the current version of GeoGebra.

One caveat to the manifest - checkver will need to be edited once the next major release arrives (7.0) due to the way it gets the latest version from the website. The website also has "5-0-676-0" as the latest version for the 6.0 release (!!) so my regex should be able to adapt once they fix that (I sent them an email about it).

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
