### PR TITLE
potplayer: Add 'module' folder to persist

### DIFF
--- a/bucket/potplayer.json
+++ b/bucket/potplayer.json
@@ -58,6 +58,7 @@
         "Extention",
         "IconPack",
         "Logos",
+        "Module",
         "Playlist",
         "Skins",
         "UrlList",


### PR DESCRIPTION
Added Module Directory to persist.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #6544
<!-- or -->
Relates to #XXXX

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
