### PR TITLE
imageglass: Update to version 8.3.11.21

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -1,14 +1,14 @@
 {
-    "version": "8.2.6.6",
+    "version": "8.3.11.21",
     "description": "A lightweight, versatile image viewer",
     "homepage": "https://imageglass.org",
     "license": "GPL-3.0-only",
     "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.xml'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.2.6.6/ImageGlass_8.2.6.6_x64.zip",
-            "hash": "sha1:e06c8e33db158b9b2d5ef67f9dcf89388f201cc3",
-            "extract_dir": "ImageGlass_8.2.6.6_x64"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.3.11.21/ImageGlass_8.3.11.21_x64.zip",
+            "hash": "sha1:2d149661e7dd5928267c3a0d19be383084b478ed",
+            "extract_dir": "ImageGlass_8.3.11.21_x64"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Used `checkver.ps1` ​from [autoupdate guide](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate) to update imageglass

Fixes: #7412