### PR TITLE
qimgv and qimgv-video: Update to version 1.0.2 (x64 only)

### DIFF
--- a/bucket/qimgv-video.json
+++ b/bucket/qimgv-video.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.9.1",
+    "version": "1.0.2",
     "description": "Fast, configurable and easy to use image viewer with video support",
     "homepage": "https://github.com/easymodo/qimgv",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/easymodo/qimgv/releases/download/v0.9.1/qimgv-x64_0.9.1-video.zip",
-            "hash": "26c679a572159b5e405b213c6ea433a8a284fa9d7b79ae90bb3763bd04efd59d"
+            "url": "https://github.com/easymodo/qimgv/releases/download/v1.0.2/qimgv-x64_1.0.2-video.zip",
+            "hash": "5476268f5f237fbb4dbd840ac626dc63f54007ab6d79a130e31dafeba35142ed"
         },
         "32bit": {
             "url": "https://github.com/easymodo/qimgv/releases/download/v0.9.1/qimgv_0.9.1-video.zip",

--- a/bucket/qimgv.json
+++ b/bucket/qimgv.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.9.1",
+    "version": "1.0.2",
     "description": "Qt5 image viewer",
     "homepage": "https://github.com/easymodo/qimgv",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/easymodo/qimgv/releases/download/v0.9.1/qimgv-x64_0.9.1.zip",
-            "hash": "86f111717b727b62289ed257eddb33609fb07572b1c4dcd3efa7f847769cd1b1"
+            "url": "https://github.com/easymodo/qimgv/releases/download/v1.0.2/qimgv-x64_1.0.2.zip",
+            "hash": "17600bcde1f3c5b2bc7fdbabe0f1679c16bdf9ff4b34656826faa2d768344135"
         },
         "32bit": {
             "url": "https://github.com/easymodo/qimgv/releases/download/v0.9.1/qimgv_0.9.1.zip",


### PR DESCRIPTION
Used `checkver.ps1` ​from [autoupdate guide](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate) to update qimgv and qimgv-video

### Additional context/output

As I mentioned in the issue, the dev doesn't host 32bit versions for the new versions (though mentions he'll post them later), so `checkver.ps1` auto-update fails on the full manifest since it fails to download 32bit versions for hash generation
I've left the 32-bit version as is (old `0.9.1`), only updated the 64-bit version

Fixes: #7415

