### PR TITLE
sysinternals: fix disk2vhd in 64-bit architecture  installation

### DIFF
--- a/bucket/sysinternals.json
+++ b/bucket/sysinternals.json
@@ -59,7 +59,11 @@
                 "ctrl2cap.exe",
                 "Dbgview.exe",
                 "Desktops.exe",
-                "disk2vhd.exe",
+                [
+                    "disk2vhd64.exe",
+                    "disk2vhd"
+                ],
+                "disk2vhd64.exe",
                 [
                     "diskext64.exe",
                     "diskext"
@@ -330,7 +334,7 @@
                     "/accepteula"
                 ],
                 [
-                    "Disk2vhd.exe",
+                    "Disk2vhd64.exe",
                     "SysInternals/Disk2vhd - Create VHD files from online disk",
                     "/accepteula"
                 ],


### PR DESCRIPTION
Closes #7431 