### PR TITLE
autohotkey: add version 2.0-beta.3

### DIFF
--- a/bucket/autohotkey2.json
+++ b/bucket/autohotkey2.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0-beta.3",
+    "description": "The ultimate automation scripting language for Windows.",
+    "homepage": "https://www.autohotkey.com/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_2.0-beta.3.zip",
+    "hash": "8f646a06d9b7e84b5f9195a3f114781e036965c216a6cc3e66cef1f83bc660b0",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "autohotkey64.exe",
+                    "autohotkey2"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": [
+                [
+                    "autohotkey32.exe",
+                    "autohotkey2"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "url": "https://www.autohotkey.com/download/2.0/version.txt",
+        "regex": "([\\d.]+[-a-z]*[\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_$version.zip",
+        "hash": {
+            "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_$version.zip.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Adds AutoHotkey v2 beta

I've copied&pasted the main AutoHotkey manifest, updated all the links to version 2 (with a nice bonus of not relying on GitHub) and tested via both installing `2.0-beta.2` and `2.0-beta.3` and autoupdating `2.0-beta.2` manifest to `2.0-beta.3` with checkver

To avoid conflict with v1 I've added a rename rule `AutoHotkey` `32`/`64` `.exe`→`autohotkey2.exe` to install a single executable without installing the original `32`/`64`, so you could have 

- `autohotkey` `32`/`64` `.exe` and `autohotkey.exe` from `autohotkey.json` manifest and
- `autohotkey2.exe` from this manifest,

though I guess in some distant future it should just override the first version and manifests be merged into one. Or maybe not since it's worthwile keeping both versions installed as you'll see scripts using both syntaxes

Closes #7446

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
