### PR TITLE
dumo: hash fix

### DIFF
--- a/bucket/dumo.json
+++ b/bucket/dumo.json
@@ -7,7 +7,7 @@
         "url": "http://www.kcsoftwares.com/legal/ToU.pdf"
     },
     "url": "https://www.kcsoftwares.com/files/dumo.zip",
-    "hash": "198082b2b85a548d3f96523649af5e5371f9225dc7e42c4e3f2c5813ea4de2fa",
+    "hash": "954c48978fbacb2889ca089a449c42db8e32dd2f6db9a598600386541c5fe44f",
     "extract_dir": "dumo",
     "pre_install": "if (!(Test-Path \"$persist_dir\\settings.ini\")) { Set-Content \"$dir\\settings.ini\" '[Settings]', 'AutoUpdate=0' -Encoding Ascii }",
     "bin": "DUMo.exe",


### PR DESCRIPTION
The update to the latest version 2.24.1.119 in 8ed1c45433a1b1dd76d9b2e027da33c12f51b00c did not include the new hash and thus fails to install. 