### PR TITLE
transmission: Add CLI, update checkver

### DIFF
--- a/bucket/transmission.json
+++ b/bucket/transmission.json
@@ -21,7 +21,12 @@
         [
             "transmission-qt.exe",
             "transmission"
-        ]
+        ],
+        "transmission-create.exe",
+        "transmission-daemon.exe",
+        "transmission-edit.exe",
+        "transmission-remote.exe",
+        "transmission-show.exe"
     ],
     "shortcuts": [
         [
@@ -30,7 +35,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/transmission/transmission"
+        "url": "https://raw.githubusercontent.com/transmission/transmission.github.io/master/includes/js/constants.js",
+        "regex": "current_version_msi: \"([\\d.]+)\","
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
All of the command line utilities was missing from the manifest.

`checkver`  used Github to check for version change, but that is not reliable, when getting the hash from an external file, as they can update at different times. Change to use to the version time in the file where we get the hash for a more robust update approach.