### PR TITLE
playnite: Persist Extensions folder

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -24,6 +24,7 @@
     "persist": [
         "browsercache",
         "cache",
+        "Extensions",
         "ExtensionsData",
         "library"
     ],


### PR DESCRIPTION
Closes #7463
Relates to #4919, #5088, #5093

----

The issue raised by @Ash258 (https://github.com/ScoopInstaller/Extras/pull/5093#pullrequestreview-528583580) is no longer valid, as Playnite now has a fully working built-in extension update mechanism and UI.