### PR TITLE
Fix Wireshark autoupdate and update version to 3.6.0

### DIFF
--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.10",
+    "version": "3.6.0",
     "description": "A network protocol analyzer that lets you see what’s happening on your network at a microscopic level.",
     "homepage": "https://www.wireshark.org/",
     "license": "GPL-2.0-or-later",
@@ -11,8 +11,8 @@
     "suggest": {
         "Nmap (includes Npcap)": "nmap"
     },
-    "url": "https://1.eu.dl.wireshark.org/win32/all-versions/WiresharkPortable_3.4.10.paf.exe#/dl.7z",
-    "hash": "85f2382b854be81ee7bc3deedaab41214e60e17a83c25822d4e5831c1d88e379",
+    "url": "https://1.eu.dl.wireshark.org/win32/all-versions/WiresharkPortable32_3.6.0.paf.exe#/dl.7z",
+    "hash": "0dbeaa8d882dc50a839c5c33cea2cffce1f606d5ff38999d5186d1e89ac0ee0e",
     "bin": [
         "App\\Wireshark\\capinfos.exe",
         "App\\Wireshark\\captype.exe",
@@ -25,13 +25,13 @@
         "App\\Wireshark\\text2pcap.exe",
         "App\\Wireshark\\tshark.exe",
         [
-            "WiresharkPortable.exe",
+            "WiresharkPortable32.exe",
             "Wireshark"
         ]
     ],
     "shortcuts": [
         [
-            "WiresharkPortable.exe",
+            "WiresharkPortable32.exe",
             "Wireshark"
         ]
     ],
@@ -41,7 +41,7 @@
         "regex": "Version ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://1.eu.dl.wireshark.org/win32/all-versions/WiresharkPortable_$version.paf.exe#/dl.7z",
+        "url": "https://1.eu.dl.wireshark.org/win32/all-versions/WiresharkPortable32_$version.paf.exe#/dl.7z",
         "hash": {
             "url": "https://www.wireshark.org/download/SIGNATURES-$version.txt",
             "regex": "SHA256\\($basename\\)=$sha256"


### PR DESCRIPTION
The autoupdate functionality in the Wireshark manifest is broken due to a filename change which now include "32" suffix to the  downloadable file.
This PR fixes the manifest and updates Wireshark to the latest version.