### PR TITLE
XnViewMP: Fix xnview.ini creation and persistence in certain cases

### DIFF
--- a/bucket/xnviewmp.json
+++ b/bucket/xnviewmp.json
@@ -15,8 +15,12 @@
     },
     "extract_dir": "XnViewMP",
     "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\xnview.ini\") -or !(Get-Item \"$persist_dir\\xnview.ini\").Length) {",
-        "   New-Item \"$persist_dir\\xnview.ini\" -ItemType File -Force | Out-Null",
+        "# --- If xnview.ini exists as a folder, then remove it ---",
+        "if (Test-Path \"$persist_dir\\xnview.ini\" -PathType Container) {",
+        "    Remove-Item \"$persist_dir\\xnview.ini\" -Force -Recurse",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\xnview.ini\")) {",
+        "   New-Item \"$dir\\xnview.ini\" -ItemType File | Out-Null",
         "}"
     ],
     "uninstaller": {

--- a/bucket/xnviewmp.json
+++ b/bucket/xnviewmp.json
@@ -14,9 +14,13 @@
         }
     },
     "extract_dir": "XnViewMP",
-    "pre_install": "New-Item \"$persist_dir\\xnview.ini\" -ErrorAction SilentlyContinue",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\xnview.ini\") -or !(Get-Item \"$persist_dir\\xnview.ini\").Length) {",
+        "   New-Item \"$persist_dir\\xnview.ini\" -ItemType File -Force | Out-Null",
+        "}"
+    ],
     "uninstaller": {
-        "script": "Copy-Item \"$dir\\xnview.ini\" \"$persist_dir\\\" -Force"
+        "script": "if ((Test-Path \"$dir\\xnview.ini\") -and !(Get-Item \"$dir\\xnview.ini\").LinkType -and (Test-Path $persist_dir)) { Copy-Item \"$dir\\xnview.ini\" $persist_dir -Force }"
     },
     "bin": "xnviewmp.exe",
     "shortcuts": [

--- a/bucket/xnviewmp.json
+++ b/bucket/xnviewmp.json
@@ -24,7 +24,10 @@
         "}"
     ],
     "uninstaller": {
-        "script": "if ((Test-Path \"$dir\\xnview.ini\") -and !(Get-Item \"$dir\\xnview.ini\").LinkType -and (Test-Path $persist_dir)) { Copy-Item \"$dir\\xnview.ini\" $persist_dir -Force }"
+        "script": [
+            "# Manually copy because Xnview overwrites hardlink with a regular file, which breaks persist",
+            "if ((Test-Path \"$dir\\xnview.ini\") -and !(Get-Item \"$dir\\xnview.ini\").LinkType -and (Test-Path $persist_dir)) { Copy-Item \"$dir\\xnview.ini\" $persist_dir -Force }"
+        ]
     },
     "bin": "xnviewmp.exe",
     "shortcuts": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #7199

Back porting relevant parts from https://github.com/ScoopInstaller/Main/pull/2936

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
