### PR TITLE
Swapped yt-dlg to the maintained fork by @oleksis

### DIFF
--- a/bucket/youtube-dl-gui.json
+++ b/bucket/youtube-dl-gui.json
@@ -3,8 +3,12 @@
     "description": "A cross platform front-end GUI of the popular youtube-dl written in wxPython.",
     "homepage": "https://github.com/oleksis/youtube-dl-gui",
     "license": "Unlicense",
-    "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v1.8.2/yt-dlg.msi",
-    "hash": "720B1B91FD824564842E2B7CE94CF4301823AE8FC95B9A04952CA7EB23C85668",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v1.8.2/yt-dlg.msi",
+            "hash": "720B1B91FD824564842E2B7CE94CF4301823AE8FC95B9A04952CA7EB23C85668"
+        }
+    },
     "extract_dir": "yt-dlg",
     "shortcuts": [
         [
@@ -14,7 +18,10 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/$version/yt-dlg.msi"
-
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/$version/yt-dlg.msi"
+            }
+        }
     }
 }

--- a/bucket/youtube-dl-gui.json
+++ b/bucket/youtube-dl-gui.json
@@ -1,19 +1,20 @@
 {
-    "version": "0.4",
+    "version": "1.8.2",
     "description": "A cross platform front-end GUI of the popular youtube-dl written in wxPython.",
-    "homepage": "https://github.com/MrS0m30n3/youtube-dl-gui",
+    "homepage": "https://github.com/oleksis/youtube-dl-gui",
     "license": "Unlicense",
-    "url": "https://github.com/MrS0m30n3/youtube-dl-gui/releases/download/0.4/youtube-dl-gui-0.4-win-portable.zip",
-    "hash": "5642d1ae53a6dba7a084d997ca76305e40b897e90b1f7a932e08d980ea1a2ba0",
-    "extract_dir": "portable",
+    "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v1.8.2/yt-dlg.msi",
+    "hash": "720B1B91FD824564842E2B7CE94CF4301823AE8FC95B9A04952CA7EB23C85668",
+    "extract_dir": "yt-dlg",
     "shortcuts": [
         [
-            "youtube-dl-gui.exe",
-            "youtube-dl"
+            "yt-dlg.exe",
+            "yt-dlg"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/MrS0m30n3/youtube-dl-gui/releases/download/$version/youtube-dl-gui-$version-win-portable.zip"
+        "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/$version/yt-dlg.msi"
+
     }
 }

--- a/bucket/youtube-dl-gui.json
+++ b/bucket/youtube-dl-gui.json
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/$version/yt-dlg.msi"
+                "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v$version/yt-dlg.msi"
             }
         }
     }


### PR DESCRIPTION
The current youtube-dl-gui release is very out of date, with the last release being from 2017. The maintained fork by @oleksis supports yt-dlp and has a lot more additional features, with the last release being yesterday.