### PR TITLE
rtss: Add autoupdate, Update to version 7.3.3

### DIFF
--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -1,6 +1,6 @@
 {
     "##": "Renaming the downloaded zip to 'sourceforge.net.zip' is a hack for the referer header. See dl()-function in \\lib\\install.ps1",
-    "version": "7.3.1",
+    "version": "7.3.3",
     "description": "Framerate monitoring, On-Screen Display and high-performance video capture service provider for other graphics card utilities.",
     "homepage": "https://www.guru3d.com/files-details/rtss-rivatuner-statistics-server-download.html",
     "license": "Freeware",
@@ -8,8 +8,8 @@
         "Visual C++ Redist 2008": "extras/vcredist2008",
         "MSI Afterburner": "extras/msiafterburner"
     },
-    "url": "https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup731Build24485.zip#/sourceforge.net.zip",
-    "hash": "d3d8fb9309723e22ebed67094cdfda63188db4a38426213177507e69e340ee70",
+    "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D.com%5D-RTSS.zip",
+    "hash": "d2df6f2456040e66dc197f5626726d7ecd8870d353253ded147cb6648218322a",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\RTSSSetup*.exe\" -Removal",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Guru3D.com\", \"$dir\\Uninstall*\" -Recurse",

--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -1,5 +1,4 @@
 {
-    "##": "Renaming the downloaded zip to 'sourceforge.net.zip' is a hack for the referer header. See dl()-function in \\lib\\install.ps1",
     "version": "7.3.3",
     "description": "Framerate monitoring, On-Screen Display and high-performance video capture service provider for other graphics card utilities.",
     "homepage": "https://www.guru3d.com/files-details/rtss-rivatuner-statistics-server-download.html",

--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -38,5 +38,8 @@
     "checkver": {
         "url": "https://rtss.guru3d.com/Update.txt",
         "regex": "ProductVersion\\s+=\\s*([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D.com%5D-RTSS.zip"
     }
 }


### PR DESCRIPTION
See https://github.com/ScoopInstaller/Extras/pull/7513
I added an autoupdate section with the given URL, updated the json to use the latest version of RTSS  and tested if everything works which it does.