### PR TITLE
php(-nts)-xdebug: Update to version 3.1.2-8.1

### DIFF
--- a/bucket/php-nts-xdebug.json
+++ b/bucket/php-nts-xdebug.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.2-8.0",
+    "version": "3.1.2-8.1",
     "description": "An extension for PHP to assist with debugging and development. (Non-Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
@@ -12,12 +12,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.0-vs16-nts-x86_64.dll#/php_xdebug.dll",
-            "hash": "52b022d50c32ed0379e96675d0b14a21d29076b8bb4a80b47b66e3ddc6c02bc2"
+            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.1-vs16-nts-x86_64.dll#/php_xdebug.dll",
+            "hash": "b5af7ce3aad4dbb3b0f9ec73bac112ea37f3e8a42e2d76ea1d64b8853f1c2477"
         },
         "32bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.0-vs16-nts.dll#/php_xdebug.dll",
-            "hash": "a40df6054f2cbfb5bb2fae1c4186b0289c01f68b467777bf1c543438e7bd962c"
+            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.1-vs16-nts.dll#/php_xdebug.dll",
+            "hash": "2209c94b80fc2d7391b492e5866fb8abaa75347a1c17b7be4b84ed7a30388f8c"
         }
     },
     "post_install": [
@@ -33,21 +33,25 @@
         "}"
     ],
     "checkver": {
-        "url": "https://xdebug.org/download.php",
-        "regex": "php_xdebug-([\\d.]+-8\\.0)-vs16-nts-x86_64\\.dll"
+        "url": "https://xdebug.org/download",
+        "regex": "php_xdebug-([\\d.]+-8\\.1)-vs16-nts-x86_64\\.dll"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts-x86_64.dll#/php_xdebug.dll"
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts-x86_64.dll#/php_xdebug.dll",
+                "hash": {
+                    "url": "https://xdebug.org/download",
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16-nts-x86_64\\.dll"
+                }
             },
             "32bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts.dll#/php_xdebug.dll"
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts.dll#/php_xdebug.dll",
+                "hash": {
+                    "url": "https://xdebug.org/download",
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16-nts\\.dll"
+                }
             }
-        },
-        "hash": {
-            "url": "https://xdebug.org/download.php",
-            "regex": "$sha256\"\\s*href=.*?$basename"
         }
     }
 }

--- a/bucket/php-nts-xdebug.json
+++ b/bucket/php-nts-xdebug.json
@@ -42,14 +42,14 @@
                 "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts-x86_64.dll#/php_xdebug.dll",
                 "hash": {
                     "url": "https://xdebug.org/download",
-                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16-nts-x86_64\\.dll"
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files/php_xdebug-$version-vs16-nts-x86_64\\.dll"
                 }
             },
             "32bit": {
                 "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts.dll#/php_xdebug.dll",
                 "hash": {
                     "url": "https://xdebug.org/download",
-                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16-nts\\.dll"
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files\\/php_xdebug-$version-vs16-nts\\.dll"
                 }
             }
         }

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -41,15 +41,15 @@
             "64bit": {
                 "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll",
                 "hash": {
-                    "url": "https://xdebug.org/download",
-                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16-x86_64\\.dll"
+                    "url": "https://xdebug.org/download.php",
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files\\/php_xdebug-$version-vs16-x86_64\\.dll"
                 }
             },
             "32bit": {
                 "url": "https://xdebug.org/files/php_xdebug-$version-vs16.dll#/php_xdebug.dll",
                 "hash": {
-                    "url": "https://xdebug.org/download",
-                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16\\.dll"
+                    "url": "https://xdebug.org/download.php",
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files\\/php_xdebug-$version-vs16\\.dll"
                 }
             }
         }

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.2-8.0",
+    "version": "3.1.2-8.1",
     "description": "An extension for PHP to assist with debugging and development. (Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
@@ -12,12 +12,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.0-vs16-x86_64.dll#/php_xdebug.dll",
-            "hash": "3a270aadf2b3541db1a298ed389c854f482b4599c00c09ef14737f4b36c37f6e"
+            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.1-vs16-x86_64.dll#/php_xdebug.dll",
+            "hash": "6f3a45d9aebc1c77113fc534e32d6c621091213e4c57b5e637b209347cbc8888"
         },
         "32bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.0-vs16.dll#/php_xdebug.dll",
-            "hash": "487ca0caa0c1b925ae38c829bbfcca271bf50339b73006764587b6eb59ed35fe"
+            "url": "https://xdebug.org/files/php_xdebug-3.1.2-8.1-vs16.dll#/php_xdebug.dll",
+            "hash": "2e73afdf3d34e2983b0fda417f3c7b9f97871b128ab08a7cc9120b69a4bb2d5e"
         }
     },
     "post_install": [
@@ -33,21 +33,25 @@
         "}"
     ],
     "checkver": {
-        "url": "https://xdebug.org/download.php",
-        "regex": "php_xdebug-([\\d.]+-8\\.0)-vs16-x86_64\\.dll"
+        "url": "https://xdebug.org/download",
+        "regex": "php_xdebug-([\\d.]+-8\\.1)-vs16-x86_64\\.dll"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll"
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll",
+                "hash": {
+                    "url": "https://xdebug.org/download",
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16-x86_64\\.dll"
+                }
             },
             "32bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vs16.dll#/php_xdebug.dll"
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16.dll#/php_xdebug.dll",
+                "hash": {
+                    "url": "https://xdebug.org/download",
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href=\"/files/php_xdebug-$version-vs16\\.dll"
+                }
             }
-        },
-        "hash": {
-            "url": "https://xdebug.org/download.php",
-            "regex": "$sha256\"\\s*href=.*?$basename"
         }
     }
 }


### PR DESCRIPTION
As #7526, updates xdebug to PHP8.1, since `php` version goes to 8.1 now.

Except this time from a branch, following feedback provided from @rashil2000, thanks!