### PR TITLE
everything(-lite): Add right-click context menu

### DIFF
--- a/bucket/everything-lite.json
+++ b/bucket/everything-lite.json
@@ -1,25 +1,49 @@
 {
     "version": "1.4.1.1009",
-    "description": "Locate files and folders by name instantly.",
+    "description": "Locate files and folders by name instantly. (lite version, does not contain IPC and ETP/FTP/HTTP servers)",
     "homepage": "https://www.voidtools.com",
     "license": "MIT",
+    "notes": "Run '$dir\\install-context.reg' to add Everything to right-click context menu.",
     "architecture": {
         "64bit": {
-            "url": "https://www.voidtools.com/Everything-1.4.1.1009.x64.Lite.zip",
-            "hash": "3eb524138f87857684801a3daa36a6cb7ff514f0ab139fed3da5e007000faccd"
+            "url": [
+                "https://www.voidtools.com/Everything-1.4.1.1009.x64.Lite.zip",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/install-context.reg",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/uninstall-context.reg"
+            ],
+            "hash": [
+                "3eb524138f87857684801a3daa36a6cb7ff514f0ab139fed3da5e007000faccd",
+                "50241e5e130614e87a160413077db53e44e2b9a6ea5b07fe203766c5826564bc",
+                "971a3011d32793846ea9f7326dc91b942e715f8564fd40a1aa011be65cb52c40"
+            ]
         },
         "32bit": {
-            "url": "https://www.voidtools.com/Everything-1.4.1.1009.x86.Lite.zip",
-            "hash": "259dafc27ec84a67fb1ab48e0eae0f2dc5ff6a6c93f44666a425942ff4da6d1c"
+            "url": [
+                "https://www.voidtools.com/Everything-1.4.1.1009.x86.Lite.zip",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/install-context.reg",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/uninstall-context.reg"
+            ],
+            "hash": [
+                "259dafc27ec84a67fb1ab48e0eae0f2dc5ff6a6c93f44666a425942ff4da6d1c",
+                "50241e5e130614e87a160413077db53e44e2b9a6ea5b07fe203766c5826564bc",
+                "971a3011d32793846ea9f7326dc91b942e715f8564fd40a1aa011be65cb52c40"
+            ]
         }
     },
     "pre_install": [
         "ensure \"$persist_dir\" | Out-Null",
         "if (!(Test-Path \"$persist_dir\\Everything.ini\")) { Invoke-ExternalCommand \"$dir\\Everything.exe\" -Args @('-install-config null') | Out-Null }",
-        "Get-ChildItem \"$persist_dir\\*\" -Include 'Everything.db', 'Bookmarks.csv', 'Everything.ini' | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue"
+        "Get-ChildItem \"$persist_dir\\*\" -Include 'Everything.db', 'Bookmarks.csv', 'Everything.ini' | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue",
+        "$app_path = \"$dir\\Everything.exe\".Replace('\\', '\\\\')",
+        "$reg_content = (Get-Content \"$dir\\install-context.reg\")",
+        "$reg_content = $reg_content.replace('$app_path', $app_path)",
+        "Set-Content \"$dir\\install-context.reg\" $reg_content -Encoding ASCII"
     ],
     "uninstaller": {
-        "script": "Get-ChildItem \"$dir\\*\" -Include 'Everything.ini', 'Everything.db', 'Bookmarks.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
+        "script": [
+            "Get-ChildItem \"$dir\\*\" -Include 'Everything.ini', 'Everything.db', 'Bookmarks.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
+            "reg import \"$dir\\uninstall-context.reg\""
+        ]
     },
     "bin": [
         "Everything.exe",

--- a/bucket/everything.json
+++ b/bucket/everything.json
@@ -3,23 +3,47 @@
     "description": "Locate files and folders by name instantly.",
     "homepage": "https://www.voidtools.com",
     "license": "MIT",
+    "notes": "Run '$dir\\install-context.reg' to add Everything to right-click context menu.",
     "architecture": {
         "64bit": {
-            "url": "https://www.voidtools.com/Everything-1.4.1.1009.x64.zip",
-            "hash": "f61b601acba59d61fb0631a654e48a564db34e279b6f2cc45e20a42ce9d9c466"
+            "url": [
+                "https://www.voidtools.com/Everything-1.4.1.1009.x64.zip",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/install-context.reg",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/uninstall-context.reg"
+            ],
+            "hash": [
+                "f61b601acba59d61fb0631a654e48a564db34e279b6f2cc45e20a42ce9d9c466",
+                "50241e5e130614e87a160413077db53e44e2b9a6ea5b07fe203766c5826564bc",
+                "971a3011d32793846ea9f7326dc91b942e715f8564fd40a1aa011be65cb52c40"
+            ]
         },
         "32bit": {
-            "url": "https://www.voidtools.com/Everything-1.4.1.1009.x86.zip",
-            "hash": "3ada0479c4d55b185a33f7700d7ace8cd85cdceb8ddb610e062cfe04558275ca"
+            "url": [
+                "https://www.voidtools.com/Everything-1.4.1.1009.x86.zip",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/install-context.reg",
+                "https://raw.githubusercontent.com/ScoopInstaller/Extras/master/scripts/everything/uninstall-context.reg"
+            ],
+            "hash": [
+                "3ada0479c4d55b185a33f7700d7ace8cd85cdceb8ddb610e062cfe04558275ca",
+                "50241e5e130614e87a160413077db53e44e2b9a6ea5b07fe203766c5826564bc",
+                "971a3011d32793846ea9f7326dc91b942e715f8564fd40a1aa011be65cb52c40"
+            ]
         }
     },
     "pre_install": [
         "ensure \"$persist_dir\" | Out-Null",
         "if (!(Test-Path \"$persist_dir\\Everything.ini\")) { Invoke-ExternalCommand \"$dir\\Everything.exe\" -Args @('-install-config null') | Out-Null }",
-        "Get-ChildItem \"$persist_dir\\*\" -Include 'Everything.db', 'Bookmarks.csv', 'Everything.ini' | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue"
+        "Get-ChildItem \"$persist_dir\\*\" -Include 'Everything.db', 'Bookmarks.csv', 'Everything.ini' | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue",
+        "$app_path = \"$dir\\Everything.exe\".Replace('\\', '\\\\')",
+        "$reg_content = (Get-Content \"$dir\\install-context.reg\")",
+        "$reg_content = $reg_content.replace('$app_path', $app_path)",
+        "Set-Content \"$dir\\install-context.reg\" $reg_content -Encoding ASCII"
     ],
     "uninstaller": {
-        "script": "Get-ChildItem \"$dir\\*\" -Include 'Everything.ini', 'Everything.db', 'Bookmarks.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
+        "script": [
+            "Get-ChildItem \"$dir\\*\" -Include 'Everything.ini', 'Everything.db', 'Bookmarks.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
+            "reg import \"$dir\\uninstall-context.reg\""
+        ]
     },
     "bin": "Everything.exe",
     "shortcuts": [

--- a/scripts/everything/install-context.reg
+++ b/scripts/everything/install-context.reg
@@ -1,0 +1,23 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything]
+@="search with &Everything"
+"Icon"="$app_path"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything\command]
+@="$app_path -path \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything]
+@="search with &Everything"
+"Icon"="$app_path"
+
+; %v – For verbs that are none implies all. If there is no parameter passed this is the working directory.
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything\command]
+@="$app_path -path \"%V\""
+
+[HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything]
+@="search with &Everything"
+"Icon"="$app_path"
+
+[HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything\command]
+@="$app_path -path \"%1\""

--- a/scripts/everything/uninstall-context.reg
+++ b/scripts/everything/uninstall-context.reg
@@ -1,0 +1,8 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything\command]
+[-HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything]
+[-HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything\command]


### PR DESCRIPTION
This enables user to right-click on folders to search files using **Everything**.

see [extras/grepwin](https://github.com/ScoopInstaller/Extras/blob/master/bucket/grepwin.json) for similar example.

**NOTE**: PR check will fail because the **.reg** files are not merged yet.