### PR TITLE
qt-creator: Add version 6.0.1

### DIFF
--- a/bucket/qt-creator.json
+++ b/bucket/qt-creator.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0.3",
+    "version": "6.0.1",
     "description": "IDE for development with the Qt framework",
     "homepage": "https://doc.qt.io/qtcreator/index.html",
     "license": "GPL-3.0-only",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.qt.io/official_releases/qtcreator/5.0/5.0.3/installer_source/windows_x64/qtcreator.7z",
-            "hash": "md5:0e0a6bca8ee23496e5b98758445b2a17"
+            "url": "https://download.qt.io/official_releases/qtcreator/6.0/6.0.1/installer_source/windows_x64/qtcreator.7z",
+            "hash": "md5:888a73eef9caa660382ad2aea51d4036"
         },
         "32bit": {
             "url": "https://download.qt.io/official_releases/qtcreator/5.0/5.0.3/installer_source/windows_x86/qtcreator.7z",
-            "hash": "md5:9e9ddb46543c6b7b8413b6f0350ab760"
+            "hash": ""
         }
     },
     "bin": "bin\\qtcreator.exe",
@@ -31,9 +31,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://download.qt.io/official_releases/qtcreator/$majorVersion.$minorVersion/$version/installer_source/windows_x64/qtcreator.7z"
-            },
-            "32bit": {
-                "url": "https://download.qt.io/official_releases/qtcreator/$majorVersion.$minorVersion/$version/installer_source/windows_x86/qtcreator.7z"
             }
         },
         "hash": {

--- a/bucket/qt-creator.json
+++ b/bucket/qt-creator.json
@@ -10,10 +10,6 @@
         "64bit": {
             "url": "https://download.qt.io/official_releases/qtcreator/6.0/6.0.1/installer_source/windows_x64/qtcreator.7z",
             "hash": "md5:888a73eef9caa660382ad2aea51d4036"
-        },
-        "32bit": {
-            "url": "https://download.qt.io/official_releases/qtcreator/5.0/5.0.3/installer_source/windows_x86/qtcreator.7z",
-            "hash": "md5:9e9ddb46543c6b7b8413b6f0350ab760"
         }
     },
     "bin": "bin\\qtcreator.exe",

--- a/bucket/qt-creator.json
+++ b/bucket/qt-creator.json
@@ -13,7 +13,7 @@
         },
         "32bit": {
             "url": "https://download.qt.io/official_releases/qtcreator/5.0/5.0.3/installer_source/windows_x86/qtcreator.7z",
-            "hash": ""
+            "hash": "md5:9e9ddb46543c6b7b8413b6f0350ab760"
         }
     },
     "bin": "bin\\qtcreator.exe",


### PR DESCRIPTION
Latest versions of qt creator do not support x86 so removed the autoupdate

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #7548

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
