### PR TITLE
Create autohdr.json: For Codectory's AutoHDR project

### DIFF
--- a/bucket/autohdr.json
+++ b/bucket/autohdr.json
@@ -13,6 +13,7 @@
             "hash": "745ffd001d189b6d701647d76b2fef9318561eb83b4153035bf90cea2b36bb4a"
         }
     },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\UserSettings.json\")) { New-Item -ItemType File \"$dir\\UserSettings.json\" | Out-Null }", 
     "bin": "AutoHDR.exe",
     "shortcuts": [
         [
@@ -30,5 +31,6 @@
                 "url": "https://github.com/Codectory/AutoHDR/releases/download/$version/Release_AutoHDR_$version_x86.zip"
             }
         }
-    }
+    },
+    "persist": "UserSettings.json"
 }

--- a/bucket/autohdr.json
+++ b/bucket/autohdr.json
@@ -14,7 +14,6 @@
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\UserSettings.json\")) { New-Item -ItemType File \"$dir\\UserSettings.json\" | Out-Null }", 
-    "bin": "AutoHDR.exe",
     "shortcuts": [
         [
             "AutoHDR.exe",

--- a/bucket/autohdr.json
+++ b/bucket/autohdr.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "https://github.com/Codectory/AutoHDR",
-    "description": "Create profiles for your displays and apps to automatically switch the resolution, refresh rate and HDR state according to the app you're using",
     "version": "1.7.19",
-    "license": "https://github.com/Codectory/AutoHDR/blob/main/LICENSE",
+    "description": "Create profiles for your displays and apps to automatically switch the resolution, refresh rate and HDR state according to the app you're using",
+    "homepage": "https://github.com/Codectory/AutoHDR",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Codectory/AutoHDR/releases/download/1.7.19/Release_AutoHDR_1.7.19_x64.zip",

--- a/bucket/autohdr.json
+++ b/bucket/autohdr.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://github.com/Codectory/AutoHDR",
+    "description": "Create profiles for your displays and apps to automatically switch the resolution, refresh rate and HDR state according to the app you're using",
+    "version": "1.7.19",
+    "license": "https://github.com/Codectory/AutoHDR/blob/main/LICENSE",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Codectory/AutoHDR/releases/download/1.7.19/Release_AutoHDR_1.7.19_x64.zip",
+            "hash": "13211a6cb0b6cc42754728cb991686582c5e6e5810e1af983bfd500c74681e96"
+        },
+        "32bit": {
+            "url": "https://github.com/Codectory/AutoHDR/releases/download/1.7.19/Release_AutoHDR_1.7.19_x86.zip",
+            "hash": "745ffd001d189b6d701647d76b2fef9318561eb83b4153035bf90cea2b36bb4a"
+        }
+    },
+    "bin": "AutoHDR.exe",
+    "shortcuts": [
+        [
+            "AutoHDR.exe",
+            "AutoHDR"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Codectory/AutoHDR/releases/download/$version/Release_AutoHDR_$version_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Codectory/AutoHDR/releases/download/$version/Release_AutoHDR_$version_x86.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a manifest for the project AutoHDR by Codectory [here](https://github.com/Codectory/AutoHDR).

I wanted to create a pre-install section to persist UserSettings.json as a hardlink, but I didn't manage to do it by taking inspiration from [flycast.json](https://github.com/Calinou/scoop-games/blob/master/bucket/flycast.json) in the Scoop Games bucket and do something similar to:  

"pre_install": "if (!(Test-Path \"$persist_dir\\UserSettings.json\")) New-Item -ItemType File \"$dir\\UserSettings.json\" | Out-Null",

It's just throwing errors - so someone who knows better is most welcome to figure that one out with me.

Apart from that it should work just fine.