### PR TITLE
cryptomator: Remove Cryptomator.cfg from persist

### DIFF
--- a/bucket/cryptomator.json
+++ b/bucket/cryptomator.json
@@ -22,8 +22,7 @@
         ]
     ],
     "persist": [
-        "data",
-        "app/Cryptomator.cfg"
+        "data"
     ],
     "checkver": {
         "url": "https://github.com/cryptomator/cryptomator/releases",


### PR DESCRIPTION
Currently Cryptomator.cfg is being persisted, which should be altered on every new version from the looks of it.

The script is already updating the Cryptomator.cfg to read from just the ./data dir, and is stored there.

Fixes #7551 