### PR TITLE
gpxsee: Add version 10.0

### DIFF
--- a/bucket/gpxsee.json
+++ b/bucket/gpxsee.json
@@ -1,0 +1,29 @@
+{
+    "version": "10.0",
+    "description": "GPS log file viewer and analyzer with support for GPX, TCX, KML, FIT, IGC, NMEA, SLF, SML, LOC, GPI, GeoJSON and OziExplorer files",
+    "homepage": "https://www.gpxsee.org/",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/gpxsee/Windows/GPXSee-10.0_x64.exe#/dl.7z",
+            "hash": "sha1:1c8901b65eb1af5b4696f1f01658056ed59f78a7"
+        }
+    },
+    "shortcuts": [
+        [
+            "GPXSee.exe",
+            "GPXSee"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/gpxsee/files/Windows/",
+        "regex": "GPXSee-([0-9.]+)_x64\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/gpxsee/Windows/GPXSee-$version_x64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

As for config persistence, this project is using Qt5 and QSettings to store and manage user preferences. QSettings uses the Windows registry on Windows platforms which I am not able to capture in the manifest. The only other sort of persistence is the tile cache in AppData/Local (also not captured).