### PR TITLE
proxifier-portable: Update to version 4.07

### DIFF
--- a/bucket/proxifier-portable.json
+++ b/bucket/proxifier-portable.json
@@ -23,7 +23,7 @@
     ],
     "checkver": {
         "url": "https://www.proxifier.com/download/",
-        "regex": "(?sm)Portable Edition v4.*changelog/win3.html\">([\\d.]+)</a>"
+        "regex": "(?sm)Portable Edition v4.*changelog\">([\\d.]+)</a>"
     },
     "autoupdate": {
         "url": "https://www.proxifier.com/download/ProxifierPE.zip"

--- a/bucket/proxifier-portable.json
+++ b/bucket/proxifier-portable.json
@@ -24,5 +24,8 @@
     "checkver": {
         "url": "https://www.proxifier.com/download/",
         "regex": "(?sm)Portable Edition v4.*changelog/win3.html\">([\\d.]+)</a>"
+    },
+    "autoupdate": {
+        "url": "https://www.proxifier.com/download/ProxifierPE.zip"
     }
 }

--- a/bucket/proxifier-portable.json
+++ b/bucket/proxifier-portable.json
@@ -1,13 +1,13 @@
 {
-    "version": "3.42",
+    "version": "4.07",
     "description": "Allows network applications that do not support working through proxy servers to operate through a SOCKS or HTTPS proxy and chains.",
     "homepage": "https://www.proxifier.com",
     "license": {
         "identifier": "Shareware",
-        "url": "https://www.proxifier.com/docs/win-v3/eula.htm"
+        "url": "https://www.proxifier.com/docs/win-v4/eula.html"
     },
-    "url": "https://www.proxifier.com/download/legacy/ProxifierPE342.zip",
-    "hash": "94b66df9789e811f54d986f3d7f5a509bca9f8e54701b4552565a61696ec35ea",
+    "url": "https://www.proxifier.com/download/ProxifierPE.zip",
+    "hash": "85b7adc5b1f2fd4a44e322abba8f447dca91d76e258e40ff76fee9d354da4737",
     "extract_dir": "Proxifier PE",
     "pre_install": "if (!(Test-Path \"$persist_dir\\Settings.ini\")) { Set-Content \"$dir\\Settings.ini\" '[Settings]', 'UpdateCheck=0' -Encoding Ascii }",
     "bin": "Proxifier.exe",
@@ -23,6 +23,6 @@
     ],
     "checkver": {
         "url": "https://www.proxifier.com/download/",
-        "regex": "(?sm)Portable Edition v3.*changelog/win3.html\">([\\d.]+)</a>"
+        "regex": "(?sm)Portable Edition v4.*changelog/win3.html\">([\\d.]+)</a>"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
proxifier-portable: Update to version 4.07

The latest version of proxifier-portable is 4.07 and in bucket is 3.42. So, I updated it to the latest version.
Closes #7577 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
