### PR TITLE
Update Inkscape to 1.1.1 and fix autoupdate

### DIFF
--- a/bucket/inkscape.json
+++ b/bucket/inkscape.json
@@ -1,19 +1,20 @@
 {
-    "version": "1.1",
+    "version": "1.1.1",
     "description": "Professional vector graphics editor",
     "homepage": "https://inkscape.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://media.inkscape.org/dl/resources/file/inkscape-1.1-x64.7z",
-            "hash": "0538bc76fb962c7aa99f2f757dfc0bf3eee986e06ec73605e8a62750e3e2ccd2"
+            "url": "https://inkscape.org/ja/gallery/item/29349/inkscape-1.1.1_2021-09-20_3bf5ae0d25-x64.7z",
+            "hash": "e54263167cd0745c5613cd692aadc4b31e2054b69029ab6618982cae64be4d63",
+            "extract_dir": "idir"
         },
         "32bit": {
-            "url": "https://media.inkscape.org/dl/resources/file/inkscape-1.1-x86.7z",
-            "hash": "22ca6feb4f2c130663fd79a5edd7ca8412b9628fa31ab8bef11b68dd85ebcacc"
+            "url": "https://inkscape.org/ja/gallery/item/29417/InkscapePortable_1.1.1.paf.exe#/dl.7z",
+            "hash": "657ea0d03a9b2fe5e2d3259bf7c802c2eb37e7c5a04e83d4005dacec0d508399",
+            "extract_dir": "App\\Inkscape"
         }
     },
-    "extract_dir": "inkscape",
     "bin": [
         "bin\\inkscape.com",
         "bin\\inkview.com"
@@ -26,19 +27,25 @@
     ],
     "checkver": {
         "url": "https://inkscape.org/release",
-        "regex": ">Inkscape\\s+([\\d.]+)</"
+        "script": [
+            "$redirUrl = [System.Net.HttpWebRequest]::Create('https://inkscape.org/release').GetResponse().ResponseUri.AbsoluteUri",
+            "$version = $redirUrl -split '\\/(inkscape-)?' | Select-Object -last 1 -skip 1",
+            "$32bit_dl = Invoke-WebRequest ($redirUrl + '/windows/32-bit/portable-app/dl/') -UseBasicParsing",
+            "$64bit_dl = Invoke-WebRequest ($redirUrl + '/windows/64-bit/compressed-7z/dl/') -UseBasicParsing",
+            "$32bit_url = 'https://inkscape.org' + ($32bit_dl.links | Where-Object href -match '\\.exe$' | Select-Object -first 1 -expand href)",
+            "$64bit_url = 'https://inkscape.org' + ($64bit_dl.links | Where-Object href -match '\\.7z$' | Select-Object -first 1 -expand href)",
+            "Write-Output $version $32bit_url $64bit_url"
+        ],
+        "regex": "(?<version>[\\d.]+)\\s(?<win32biturl>.+)\\s(?<win64biturl>.+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://media.inkscape.org/dl/resources/file/inkscape-$version-x64.7z"
+                "url": "$matchWin64biturl"
             },
             "32bit": {
-                "url": "https://media.inkscape.org/dl/resources/file/inkscape-$version-x86.7z"
+                "url": "$matchWin32biturl#/dl.7z"
             }
-        },
-        "hash": {
-            "url": "https://media.inkscape.org/media/resources/sigs/$basename.sha256"
         }
     }
 }

--- a/bucket/inkscape.json
+++ b/bucket/inkscape.json
@@ -5,12 +5,12 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://inkscape.org/ja/gallery/item/29349/inkscape-1.1.1_2021-09-20_3bf5ae0d25-x64.7z",
+            "url": "https://inkscape.org/en/gallery/item/29349/inkscape-1.1.1_2021-09-20_3bf5ae0d25-x64.7z",
             "hash": "e54263167cd0745c5613cd692aadc4b31e2054b69029ab6618982cae64be4d63",
             "extract_dir": "idir"
         },
         "32bit": {
-            "url": "https://inkscape.org/ja/gallery/item/29417/InkscapePortable_1.1.1.paf.exe#/dl.7z",
+            "url": "https://inkscape.org/en/gallery/item/29417/InkscapePortable_1.1.1.paf.exe#/dl.7z",
             "hash": "657ea0d03a9b2fe5e2d3259bf7c802c2eb37e7c5a04e83d4005dacec0d508399",
             "extract_dir": "App\\Inkscape"
         }
@@ -26,14 +26,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://inkscape.org/release",
         "script": [
-            "$redirUrl = [System.Net.HttpWebRequest]::Create('https://inkscape.org/release').GetResponse().ResponseUri.AbsoluteUri",
+            "$redirUrl = [System.Net.HttpWebRequest]::Create('https://inkscape.org/en/release').GetResponse().ResponseUri.AbsoluteUri",
             "$version = $redirUrl -split '\\/(inkscape-)?' | Select-Object -last 1 -skip 1",
             "$32bit_dl = Invoke-WebRequest ($redirUrl + '/windows/32-bit/portable-app/dl/') -UseBasicParsing",
             "$64bit_dl = Invoke-WebRequest ($redirUrl + '/windows/64-bit/compressed-7z/dl/') -UseBasicParsing",
-            "$32bit_url = 'https://inkscape.org' + ($32bit_dl.links | Where-Object href -match '\\.exe$' | Select-Object -first 1 -expand href)",
-            "$64bit_url = 'https://inkscape.org' + ($64bit_dl.links | Where-Object href -match '\\.7z$' | Select-Object -first 1 -expand href)",
+            "$32bit_url = $32bit_dl.links | Where-Object href -match '\\.exe$' | Select-Object -first 1 -expand href",
+            "$64bit_url = $64bit_dl.links | Where-Object href -match '\\.7z$' | Select-Object -first 1 -expand href",
             "Write-Output $version $32bit_url $64bit_url"
         ],
         "regex": "(?<version>[\\d.]+)\\s(?<win32biturl>.+)\\s(?<win64biturl>.+)"
@@ -41,10 +40,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "$matchWin64biturl"
+                "url": "https://inkscape.org/en$matchWin64biturl"
             },
             "32bit": {
-                "url": "$matchWin32biturl#/dl.7z"
+                "url": "https://inkscape.org/en$matchWin32biturl#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6912

- Updates to version 1.1.1
- Removes hash because it's not provided for compressed releases
- Fixes autoupdate using a script inspired by [Chocolatey's](https://github.com/chocolatey-community/chocolatey-packages/blob/master/automatic/inkscape/update.ps1)
- Changes 32bit from 7z to .paf.exe because compressed release not provided

---

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
