### PR TITLE
compatibility-manager: Add version 1.1.2

### DIFF
--- a/bucket/compatibility-manager.json
+++ b/bucket/compatibility-manager.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.1.2",
+    "description": "A Windows app for bulk editing compatibility settings",
+    "homepage": "https://nbusseneau.github.io/CompatibilityManager/",
+    "license": "MIT",
+    "url": "https://github.com/nbusseneau/CompatibilityManager/releases/download/v1.1.2/CompatibilityManager.v1.1.2.7z",
+    "hash": "c8e890fde904ea633e02df17ae3078c48b3107f936aa03b0b634d3040b9ea245",
+    "extract_dir": "CompatibilityManager",
+    "shortcuts": [
+        [
+            "CompatibilityManager.exe",
+            "CompatibilityManager"
+        ]
+    ],
+    "persist": "CompatibilityManager.exe.config",
+    "checkver": {
+        "github": "https://github.com/nbusseneau/CompatibilityManager"
+    },
+    "autoupdate": {
+        "url": "https://github.com/nbusseneau/CompatibilityManager/releases/download/v$version/CompatibilityManager.v$version.7z"
+    }
+}


### PR DESCRIPTION
A Windows app for bulk editing compatibility settings.

- [ X ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
