### PR TITLE
Cuetools: Update to version 2.1.9

### DIFF
--- a/bucket/cuetools.json
+++ b/bucket/cuetools.json
@@ -2,18 +2,19 @@
     "version": "2.1.9",
     "description": "A suite of tools for lossless audio/CUE sheet format conversion and verification.",
     "homepage": "http://cue.tools/wiki/Main_Page",
-    "license": "Public Domain",
+    "license": "GPL-2.0-or-later",
     "suggest": {
         "vcredist": "extras/vcredist2008"
     },
-    "url": "https://github.com/gchudov/cuetools.net/releases/download/v2.1.9/CUETools_2.1.9.zip",
-    "hash": "sha512:944f097cbe21dcaf6f824ffb8fddf9f31949107b86aafe7a25e330ec4659cd7a597c4e1c6cf74c5d517b6dc5528a3ee72a58282c4a0b12190127d67cbd0c1dce",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gchudov/cuetools.net/releases/download/v2.1.9/CUETools_2.1.9.zip",
+            "hash": "28b065547d779cfca1cf33f9548c3aaccba6bf2bac3f973feba789088d2a6cce"
+        }
+    },
     "extract_dir": "CUETools_2.1.9",
     "post_install": "Remove-Item \"$dir\\user_profiles_enabled\"",
-    "bin": [
-        "CUERipper.exe",
-        "CUETools.exe"
-    ],
+    "bin": "CUETools.Ripper.Console.exe",
     "shortcuts": [
         [
             "CUERipper.exe",
@@ -28,12 +29,15 @@
         "CUE Tools\\settings.txt",
         "CUERipper\\settings.txt"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/gchudov/cuetools.net"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/gchudov/cuetools.net/releases/download/v$version/CUETools_$version.zip"
             }
-        }
+        },
+        "extract_dir": "CUETools_$version"
     }
 }

--- a/bucket/cuetools.json
+++ b/bucket/cuetools.json
@@ -28,7 +28,7 @@
         "CUE Tools\\settings.txt",
         "CUERipper\\settings.txt"
     ],
-    "checkver": "https://github.com/gchudov/cuetools.net/releases/",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/cuetools.json
+++ b/bucket/cuetools.json
@@ -1,14 +1,14 @@
 {
-    "version": "2.1.6",
+    "version": "2.1.9",
     "description": "A suite of tools for lossless audio/CUE sheet format conversion and verification.",
     "homepage": "http://cue.tools/wiki/Main_Page",
     "license": "Public Domain",
     "suggest": {
         "vcredist": "extras/vcredist2008"
     },
-    "url": "http://www.cuetools.net/install/CUETools_2.1.6.zip",
-    "hash": "sha512:27f74d40852cf18091ece091b00bbc18ab177b1814ee922ef98a35158591705bdeb5bdc27e3aa926e6a6523dd59ea9cee90c121eb58c0cd01851c69f0c058712",
-    "extract_dir": "CUETools_2.1.6",
+    "url": "https://github.com/gchudov/cuetools.net/releases/download/v2.1.9/CUETools_2.1.9.zip",
+    "hash": "sha512:944f097cbe21dcaf6f824ffb8fddf9f31949107b86aafe7a25e330ec4659cd7a597c4e1c6cf74c5d517b6dc5528a3ee72a58282c4a0b12190127d67cbd0c1dce",
+    "extract_dir": "CUETools_2.1.9",
     "post_install": "Remove-Item \"$dir\\user_profiles_enabled\"",
     "bin": [
         "CUERipper.exe",

--- a/bucket/cuetools.json
+++ b/bucket/cuetools.json
@@ -27,5 +27,13 @@
     "persist": [
         "CUE Tools\\settings.txt",
         "CUERipper\\settings.txt"
-    ]
+    ],
+    "checkver": "https://github.com/gchudov/cuetools.net/releases/",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gchudov/cuetools.net/releases/download/v$version/CUETools_$version.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Bump to Version 2.1.9, download location changed to github as per http://cue.tools/wiki/CUETools_Download#Download

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
