### PR TITLE
ventoy: Add 64-bit architecture, remove broken shim

### DIFF
--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -7,13 +7,24 @@
     "hash": "78886bcfd726b2f7eca8cc9e27f71e03610d68f759680df2f1130159d82c7637",
     "extract_dir": "ventoy-1.0.63",
     "pre_install": "if (!(Test-Path \"$persist_dir\\log.txt\")) { New-Item \"$dir\\log.txt\" | Out-Null }",
-    "bin": "Ventoy2Disk.exe",
-    "shortcuts": [
-        [
-            "Ventoy2Disk.exe",
-            "Ventoy2Disk"
-        ]
-    ],
+    "architecture": {
+        "64bit": {
+            "shortcuts": [
+                [
+                    "altexe\\Ventoy2Disk_X64.exe",
+                    "Ventoy2Disk"
+                ]
+            ]
+        },
+        "32bit": {
+            "shortcuts": [
+                [
+                    "Ventoy2Disk.exe",
+                    "Ventoy2Disk"
+                ]
+            ]
+        }
+    },
     "persist": "log.txt",
     "checkver": {
         "github": "https://github.com/ventoy/Ventoy"


### PR DESCRIPTION
Also removed shim as it didn't work (and this is a GUI application.)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
