### PR TITLE
gb-studio: Update to version 3.0.2

### DIFF
--- a/bucket/gb-studio.json
+++ b/bucket/gb-studio.json
@@ -1,16 +1,18 @@
 {
-    "version": "1.2.1",
+    "version": "3.0.2",
     "description": "Free and easy to use retro adventure game creator for Game Boy.",
     "homepage": "https://www.gbstudio.dev",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v1.2.1/GB-Studio-Windows-64bit-standalone-1.2.1.zip",
-            "hash": "bf3fa1f3001df566bd2fc682a3c63b767d6da15fa8dd8f0f59180da7a1cab3a4"
+            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v3.0.2/gb-studio-windows-64bit-standalone.zip",
+            "hash": "bfdd4cf656a7aafd65f88965f45613b64776fefa4ae9ba6e5cb43896f18cfaf1",
+            "extract_dir": "GB Studio-win32-x64"
         },
         "32bit": {
-            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v1.2.1/GB-Studio-Windows-32bit-standalone-1.2.1.zip",
-            "hash": "a021996f200385171978a2447cfbb3c432904a660625b7b78b8d2cefdd765c1f"
+            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v3.0.2/gb-studio-windows-32bit-standalone.zip",
+            "hash": "b07905324498390c720a75ef59c5bc5dca232765333f8a6a754f6bd23db8da3e",
+            "extract_dir": "GB Studio-win32-ia32"
         }
     },
     "bin": "gb-studio.exe",
@@ -22,5 +24,17 @@
     ],
     "checkver": {
         "github": "https://github.com/chrismaltby/gb-studio"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/chrismaltby/gb-studio/releases/download/v$version/gb-studio-windows-64bit-standalone.zip",
+                "extract_dir": "GB Studio-win32-x64"
+            },
+            "32bit": {
+                "url": "https://github.com/chrismaltby/gb-studio/releases/download/v$version/gb-studio-windows-32bit-standalone.zip",
+                "extract_dir": "GB Studio-win32-ia32"
+            }
+        }
     }
 }

--- a/bucket/gb-studio.json
+++ b/bucket/gb-studio.json
@@ -15,7 +15,6 @@
             "extract_dir": "GB Studio-win32-ia32"
         }
     },
-    "bin": "gb-studio.exe",
     "shortcuts": [
         [
             "gb-studio.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Manual changes to update to version 3.0.2
- Fixes `autoupdate` section.

Closes #7608

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
