### PR TITLE
ultravnc: Add version 1.3.6.0

### DIFF
--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -27,16 +27,16 @@
     ],
     "checkver": {
         "url": "https://uvnc.com/downloads/ultravnc/",
-        "re": "/downloads/ultravnc/([\\d]+)-ultravnc-([\\d]+)-([\\d]+)-([\\d]+)-([\\d]+)\\.html",
-        "replace": "${2}.${3}.${4}.${5}"
+        "re": "/downloads/ultravnc/(?<filenum>[\\d]+)-ultravnc-(?<major>[\\d]+)-(?<minor>[\\d]+)-(?<patch>[\\d]+)-(?<revision>[\\d]+)\\.html",
+        "replace": "${major}.${minor}.${patch}.${revision}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip"
+                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchFilenum-ultravnc-$matchMajor-$matchMinor-$matchPatch$matchRevision-bin-zip.html?Itemid=0#/dl.zip"
             },
             "32bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip"
+                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchFilenum-ultravnc-$matchMajor-$matchMinor-$matchPatch$matchRevision-bin-zip.html?Itemid=0#/dl.zip"
             }
         }
     }

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -43,13 +43,6 @@
         "regex": "(?<version>[\\d.]+)\\s(?<dlquerypath>.+)"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchDlquerypath#/dl.zip"
-            },
-            "32bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchDlquerypath#/dl.zip"
-            }
-        }
+        "url": "https://uvnc.com/component/jdownloads/send/0-/$matchDlquerypath#/dl.zip"
     }
 }

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -27,7 +27,7 @@
     ],
     "checkver": {
         "url": "https://uvnc.com/downloads/ultravnc/",
-        "re": "/downloads/ultravnc/([\\d])-ultravnc-([\\d])-([\\d])-([\\d])-([\\d])\\.html",
+        "re": "/downloads/ultravnc/([\\d]+)-ultravnc-([\\d]+)-([\\d]+)-([\\d]+)-([\\d]+)\\.html",
         "replace": "${2}.${3}.${4}.${5}"
     },
     "autoupdate": {

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -2,7 +2,7 @@
     "version": "1.3.6.0",
     "description": "UltraVNC Server and Viewer can display the screen of one computer (Server) on the screen of another (Viewer).",
     "homepage": "https://uvnc.com",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://uvnc.com/component/jdownloads/send/0-/420-ultravnc-1-3-60-bin-zip.html?Itemid=0#/dl.zip",

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -1,0 +1,45 @@
+{
+    "version": "1.3.6.0",
+    "description": "UltraVNC Server and Viewer can display the screen of one computer (Server) on the screen of another (Viewer).",
+    "homepage": "https://uvnc.com",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://uvnc.com/component/jdownloads/send/0-/420-ultravnc-1-3-60-bin-zip.html?Itemid=0#/dl.zip",
+            "hash": "c2c36c1b088ebe06d7bc6f6b4bef603f051a33350a628ff46e20e4beb2f906f2",
+            "extract_dir": "x64"
+        },
+        "32bit": {
+            "url": "https://uvnc.com/component/jdownloads/send/0-/420-ultravnc-1-3-60-bin-zip.html?Itemid=0#/dl.zip",
+            "hash": "c2c36c1b088ebe06d7bc6f6b4bef603f051a33350a628ff46e20e4beb2f906f2",
+            "extract_dir": "x86"
+        }
+    },
+    "shortcuts": [
+        [
+            "vncviewer.exe",
+            "VNC Viewer"
+        ],
+        [
+            "winvnc.exe",
+            "WinVNC"
+        ]
+    ],
+    "checkver": {
+        "url": "https://uvnc.com/downloads/ultravnc/",
+        "re": "/downloads/ultravnc/([\\d.]+)-ultravnc-([\\d])-([\\d])-([\\d])-([\\d])\\.html",
+        "replace": "${2}.${3}.${4}.${5}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip",
+                "extract_dir": "x64"
+            },
+            "32bit": {
+                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip",
+                "extract_dir": "x86"
+            }
+        }
+    }
+}

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -27,7 +27,7 @@
     ],
     "checkver": {
         "url": "https://uvnc.com/downloads/ultravnc/",
-        "re": "/downloads/ultravnc/([\\d.]+)-ultravnc-([\\d])-([\\d])-([\\d])-([\\d])\\.html",
+        "re": "/downloads/ultravnc/([\\d])-ultravnc-([\\d])-([\\d])-([\\d])-([\\d])\\.html",
         "replace": "${2}.${3}.${4}.${5}"
     },
     "autoupdate": {

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -33,8 +33,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip",
-                "extract_dir": "x64"
+                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip"
             },
             "32bit": {
                 "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip",

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -26,17 +26,27 @@
         ]
     ],
     "checkver": {
-        "url": "https://uvnc.com/downloads/ultravnc/",
-        "re": "/downloads/ultravnc/(?<filenum>[\\d]+)-ultravnc-(?<major>[\\d]+)-(?<minor>[\\d]+)-(?<patch>[\\d]+)-(?<revision>[\\d]+)\\.html",
-        "replace": "${major}.${minor}.${patch}.${revision}"
+        "script": [
+            "$uvnc_release_resp = Invoke-WebRequest -Uri 'https://uvnc.com/downloads/ultravnc.html'",
+            "$uvnc_release_page = $uvnc_release_resp.Links | Where-Object href -match '/downloads/ultravnc/(\\d+)' | Select-Object -first 1 -expand href",
+            "$uvnc_artifact_url = 'https://uvnc.com' + $uvnc_release_page",
+            "$uvnc_artifact_resp = Invoke-WebRequest -Uri $uvnc_artifact_url",
+            "$uvnc_artifact_summary_url = $uvnc_artifact_resp.Links | Where-Object href -match '/(\\d+)-ultravnc-(\\d+)-(\\d+)-(\\d)(\\d)-bin-zip.html' | Select-Object -first 1 -expand href",
+            "$version = $matches[2] + '.' + $matches[3] + '.' + $matches[4] + '.' + $matches[5]",
+            "$artifact_version = $matches[2] + '-' + $matches[3] + '-' + $matches[4] + $matches[5]",
+            "$filenum = $matches[1]",
+            "$download_path = $filenum + '-ultravnc-' + $artifact_version + '-bin-zip.html?Itemid=0'",
+            "Write-Output $version $download_path"
+        ],
+        "regex": "(?<version>[\\d.]+)\\s(?<dlquerypath>.+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchFilenum-ultravnc-$matchMajor-$matchMinor-$matchPatch$matchRevision-bin-zip.html?Itemid=0#/dl.zip"
+                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchDlquerypath#/dl.zip"
             },
             "32bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchFilenum-ultravnc-$matchMajor-$matchMinor-$matchPatch$matchRevision-bin-zip.html?Itemid=0#/dl.zip"
+                "url": "https://uvnc.com/component/jdownloads/send/0-/$matchDlquerypath#/dl.zip"
             }
         }
     }

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -15,6 +15,10 @@
             "extract_dir": "x86"
         }
     },
+    "bin": [
+        "vncviewer.exe",
+        "winvnc.exe"
+    ],
     "shortcuts": [
         [
             "vncviewer.exe",

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -3,15 +3,13 @@
     "description": "UltraVNC Server and Viewer can display the screen of one computer (Server) on the screen of another (Viewer).",
     "homepage": "https://uvnc.com",
     "license": "GPL-3.0-or-later",
+    "url": "https://uvnc.com/component/jdownloads/send/0-/420-ultravnc-1-3-60-bin-zip.html?Itemid=0#/dl.zip",
+    "hash": "c2c36c1b088ebe06d7bc6f6b4bef603f051a33350a628ff46e20e4beb2f906f2",
     "architecture": {
         "64bit": {
-            "url": "https://uvnc.com/component/jdownloads/send/0-/420-ultravnc-1-3-60-bin-zip.html?Itemid=0#/dl.zip",
-            "hash": "c2c36c1b088ebe06d7bc6f6b4bef603f051a33350a628ff46e20e4beb2f906f2",
             "extract_dir": "x64"
         },
         "32bit": {
-            "url": "https://uvnc.com/component/jdownloads/send/0-/420-ultravnc-1-3-60-bin-zip.html?Itemid=0#/dl.zip",
-            "hash": "c2c36c1b088ebe06d7bc6f6b4bef603f051a33350a628ff46e20e4beb2f906f2",
             "extract_dir": "x86"
         }
     },

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -36,8 +36,7 @@
                 "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip"
             },
             "32bit": {
-                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip",
-                "extract_dir": "x86"
+                "url": "https://uvnc.com/component/jdownloads/send/0-/${1}-ultravnc-${2}-${3}-${4}${5}-bin-zip.html?Itemid=0#/dl.zip"
             }
         }
     }


### PR DESCRIPTION
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This adds UltraVNC.

*UltraVNC Server and Viewer are a powerful, easy to use, free software that can display the screen of
one computer (Server) on the screen of another (Viewer). The program allows the viewer to use their mouse
and keyboard to control the Server Computer remotely.
UltraVNC is a VNC application that is tailored towards Windows PCs, with several features not found
in other VNC products.*

Closes #7560 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
