### PR TITLE
Added context menu items for Beyond Compare

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -6,6 +6,7 @@
         "identifier": "Shareware",
         "url": "https://www.scootersoftware.com/index.php?zz=kb_licensev4"
     },
+    "notes": "Add Beyond Compare as a context menu option by running: '$dir\\install-context.reg'",
     "architecture": {
         "64bit": {
             "url": "https://www.scootersoftware.com/BCompare-4.4.1.26165_x64.msi",
@@ -27,6 +28,20 @@
             "BCClipboard.exe",
             "Clipboard Compare"
         ]
+    ],
+    "post_install": [
+        "$dir_escaped = \"$dir\".Replace('\\', '\\\\')",
+        "\"install-context-$architecture\", \"uninstall-context\" | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\beyondcompare\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\beyondcompare\\$_.reg\"",
+        "    $content = $content.Replace('$install_dir', $dir_escaped)",
+        "    if ($global) {",
+        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    $outfile_no_arch = $_.Replace(\"-$architecture\", \"\")",
+        "    $content | Set-Content -Path \"$dir\\$outfile_no_arch.reg\"",
+        "  }",
+        "}"
     ],
     "checkver": {
         "url": "https://www.scootersoftware.com/download.php?zz=kb_dl4_winalternate",

--- a/scripts/beyondcompare/install-context-32bit.reg
+++ b/scripts/beyondcompare/install-context-32bit.reg
@@ -1,0 +1,23 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$install_dir\\BCShellEx.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"="Beyond Compare 4 Shell Extension"

--- a/scripts/beyondcompare/install-context-64bit.reg
+++ b/scripts/beyondcompare/install-context-64bit.reg
@@ -1,0 +1,30 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$install_dir\\BCShellEx64.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$install_dir\\BCShellEx.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"="Beyond Compare 4 Shell Extension"

--- a/scripts/beyondcompare/uninstall-context.reg
+++ b/scripts/beyondcompare/uninstall-context.reg
@@ -1,0 +1,12 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+[-HKEY_CURRENT_USER\Software\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+
+[-HKEY_CURRENT_USER\Software\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"=-


### PR DESCRIPTION
Closes #1645 

* Added new reg files to associate Beyond Compare with the Windows explorer context menu based on content from the Beyond Compare support [website](https://www.scootersoftware.com/support.php?zz=kb_shellex).
* Modified installer script to notify the user about the new post install step and customize the reg file based on Scoop settings. 