### PR TITLE
youtube-dl-gui@1.8.2: Fix decompress error

### DIFF
--- a/bucket/youtube-dl-gui.json
+++ b/bucket/youtube-dl-gui.json
@@ -5,11 +5,19 @@
     "license": "Unlicense",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v1.8.2/yt-dlg.msi",
+            "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v1.8.2/yt-dlg.msi#/dl.ism",
             "hash": "720B1B91FD824564842E2B7CE94CF4301823AE8FC95B9A04952CA7EB23C85668"
         }
     },
-    "extract_dir": "yt-dlg",
+    "pre_install": [
+        "$_args = @{",
+        "    'Path' = \"$dir\\$fname\"",
+        "    'DestinationPath' = \"$dir\"",
+        "    'Removal' = $true",
+        "}",
+        "if (get_config 'MSIEXTRACT_USE_LESSMSI' $true) { $_args.Add('ExtractDir', 'APPDIR\\yt-dlg') } else { $_args.Add('ExtractDir', 'yt-dlg') }",
+        "Expand-MsiArchive @_args"
+    ],
     "shortcuts": [
         [
             "yt-dlg.exe",
@@ -20,7 +28,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v$version/yt-dlg.msi"
+                "url": "https://github.com/oleksis/youtube-dl-gui/releases/download/v$version/yt-dlg.msi#/dl.ism"
             }
         }
     }


### PR DESCRIPTION
close https://github.com/ScoopInstaller/Extras/issues/7494

```powershell
PS C:\Users\HUMOR> scoop config MSIEXTRACT_USE_LESSMSI false
'MSIEXTRACT_USE_LESSMSI' has been set to 'false'
PS C:\Users\HUMOR> scoop install youtube-dl-gui
Installing 'youtube-dl-gui' (1.8.2) [64bit]
Loading yt-dlg.msi from cache
Checking hash of yt-dlg.msi ... ok.
Running pre-install script...
Linking ~\scoop\apps\youtube-dl-gui\current => ~\scoop\apps\youtube-dl-gui\1.8.2
Creating shortcut for yt-dlg (yt-dlg.exe)
'youtube-dl-gui' (1.8.2) was installed successfully!
PS C:\Users\HUMOR> scoop config MSIEXTRACT_USE_LESSMSI true
'MSIEXTRACT_USE_LESSMSI' has been set to 'true'
PS C:\Users\HUMOR> scoop uninstall youtube-dl-gui
Uninstalling 'youtube-dl-gui' (1.8.2).
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\yt-dlg.lnk
Unlinking ~\scoop\apps\youtube-dl-gui\current
'youtube-dl-gui' was uninstalled.
PS C:\Users\HUMOR> scoop install youtube-dl-gui
Installing 'youtube-dl-gui' (1.8.2) [64bit]
Loading yt-dlg.msi from cache
Checking hash of yt-dlg.msi ... ok.
Running pre-install script...
Linking ~\scoop\apps\youtube-dl-gui\current => ~\scoop\apps\youtube-dl-gui\1.8.2
Creating shortcut for yt-dlg (yt-dlg.exe)
'youtube-dl-gui' (1.8.2) was installed successfully!
```