### PR TITLE
Added optional script to update Discord settings to disable automatic…

### DIFF
--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -6,6 +6,7 @@
         "identifier": "Freeware",
         "url": "https://discordapp.com/terms"
     },
+    "notes": "To avoid manifest removal due to internal updates, disable automatic updates by running: '$dir\\disable-auto-update.ps1'",
     "url": "http://dl.discordapp.net/apps/win/Discord-0.0.311-full.nupkg",
     "hash": "sha1:3928a4af8e249184f2d4212bd8c958adc8b2ff4f",
     "extract_dir": "lib\\net45",
@@ -16,6 +17,7 @@
             "Discord"
         ]
     ],
+    "post_install": "Copy-Item -Path \"$bucketsdir\\extras\\scripts\\discord\\disable-auto-update.ps1\" -Destination \"$dir\\\"",
     "checkver": {
         "url": "https://discordapp.com/api/updates/stable/RELEASES",
         "regex": "Discord-([\\d.]+)-full"

--- a/scripts/discord/disable-auto-update.ps1
+++ b/scripts/discord/disable-auto-update.ps1
@@ -1,0 +1,9 @@
+$path = "$Env:appdata/discord/settings.json"
+$settings = Get-Content $path | ConvertFrom-Json
+if (Get-Member -inputobject $settings -name 'SKIP_HOST_UPDATE' -Membertype Properties) {
+    $settings.SKIP_HOST_UPDATE=$True
+}
+else {
+    $settings | Add-Member -MemberType NoteProperty -Name 'SKIP_HOST_UPDATE' -Value $True
+}
+$settings | ConvertTo-Json | Set-Content -Path $path


### PR DESCRIPTION
Closes #6596 

* Added an optional script that can stop Discord from performing automatic updates.
* Referenced a few online packages that do something similar: [NixOS](https://nixos.wiki/wiki/Discord#Discord_wants_latest_version) and [Flathub](https://github.com/flathub/com.discordapp.Discord/blob/master/disable-breaking-updates.py)
* I copy the disable script into the app directory so I can prompt the user to run it given `$dir` since the `"notes"` section of the manifest doesn't permit `$bucketsdir` which would allow me to point directly at the source of the script.