### PR TITLE
dxwnd: Add version 2.05.78

### DIFF
--- a/bucket/dxwnd.json
+++ b/bucket/dxwnd.json
@@ -14,7 +14,8 @@
     ],
     "persist": [
         "dxwnd.ini",
-        "vcda\\winmm.ini"
+        "vcda\\winmm.ini",
+        "alt.dll"
     ],
     "env_add_path": "vcda",
     "checkver": {

--- a/bucket/dxwnd.json
+++ b/bucket/dxwnd.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.05.78",
+    "description": "Window hooker to run fullscreen programs in window and much more.",
+    "homepage": "https://sourceforge.net/projects/dxwnd/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://downloads.sourceforge.net/project/dxwnd/Latest%20build/v2_05_78_fx2_build.rar",
+    "hash": "sha1:724198f403bae6e8f15986aa221d60b042ce3425",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\dxwnd.ini\")) { New-Item \"$dir\\dxwnd.ini\" | Out-Null }",
+    "shortcuts": [
+        [
+            "dxwnd.exe",
+            "DxWnd"
+        ]
+    ],
+    "persist": [
+        "dxwnd.ini",
+        "vcda\\winmm.ini"
+    ],
+    "env_add_path": "vcda",
+    "checkver": {
+        "url": "https://sourceforge.net/projects/dxwnd/files/",
+        "regex": "v(\\d+)_(\\d+)_(\\d+)_fx2_build.rar",
+        "replace": "${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/dxwnd/Latest%20build/v$underscoreVersion_fx2_build.rar"
+    }
+}
+


### PR DESCRIPTION
supersedes #5015. (see old PR for more details)

**dxwnd** is Window hooker to run fullscreen programs in window and much more.

NOTES:

* Based on the content of `$dir\tweaks.ini`, I don't think this needs to be persisted.
```
[FixD3DWindowFrame]
help="Tries to prevent D3D from rendering on the whole window surface including the window border. It activates a small trick that cause the program to render to a child modal surface within the main window borders."
[NoD3DWindowMove]
help="Do not try to update the window position and size on D3D rendering. In some cases, the window may be movable but the rendering area does not move with it. In this case, avoid moving the window at all. It is an experimental feature and doesn't always work."
```

* `$dir\vcda\readme.txt` says:
```
copy to the target program folder these file
	winmm.dll 
	winmm.ini 
copy there also these files from DxWnd folder
	dxwplay.dll
	libogg.dll
	libvorbis.dll
	libvorbisfile.dll
```

However, `dxwplay.dll` etc. are already in `$dir`. (I think the help text is not keep to date)
Also, it says copy `winmm.dll` and `winmm.ini` to target program folder, but pratically we can just add them to PATH.
