### PR TITLE
onecommander: Fix license URL and checkver and persist templates

### DIFF
--- a/bucket/onecommander.json
+++ b/bucket/onecommander.json
@@ -1,10 +1,10 @@
 {
     "version": "3.4.12.0",
-    "description": "A file manager with improved functionality, re-imagined user interface and experience of navigating filesystem and manipulating files.",
+    "description": "A modern dual-pane file manager with tabs, columns view, built-in preview, editable themes, and more.",
     "homepage": "https://onecommander.com/",
     "license": {
         "identifier": "Freeware",
-        "url": "http://www.onecommand.com/terms-of-use"
+        "url": "https://onecommander.com/license.txt"
     },
     "url": "https://onecommander.com/OneCommander3.4.12.0.zip",
     "hash": "73fd10b5ec22501247353f8988647faa39329bd71aad585fa6ff522a2f97d3c6",
@@ -16,11 +16,11 @@
     ],
     "persist": [
         "Settings",
-        "Logs"
+        "Logs",
+        "Templates"
     ],
     "checkver": {
-        "url": "https://onecommander.com/",
-        "regex": "Download ([\\d.]+)"
+        "url": "https://onecommander.com/version.txt"
     },
     "autoupdate": {
         "url": "https://onecommander.com/OneCommander$version.zip"

--- a/bucket/onecommander.json
+++ b/bucket/onecommander.json
@@ -16,11 +16,12 @@
     ],
     "persist": [
         "Settings",
-        "Logs",
-        "Templates"
+        "Templates",
+        "Logs"
     ],
     "checkver": {
-        "url": "https://onecommander.com/version.txt"
+        "url": "https://onecommander.com/version.txt",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
         "url": "https://onecommander.com/OneCommander$version.zip"


### PR DESCRIPTION
Fixed license url, description, added Templates in persist, version checking improvement

Closes #7627