### PR TITLE
JMkvpropedit: Add version 1.5.2

### DIFF
--- a/bucket/jmkvpropedit.json
+++ b/bucket/jmkvpropedit.json
@@ -2,7 +2,8 @@
     "version": "1.5.2",
     "description": "A batch GUI for mkvpropedit (part of MKVToolNix) written in Java",
     "homepage": "https://github.com/BrunoReX/jmkvpropedit",
-    "license": "BSD 2-Clause \"Simplified\" License",
+    "license": "BSD-2-Clause",
+
     "suggest": {
         "JDK": [
             "java/openjdk",

--- a/bucket/jmkvpropedit.json
+++ b/bucket/jmkvpropedit.json
@@ -3,7 +3,6 @@
     "description": "A batch GUI for mkvpropedit (part of MKVToolNix) written in Java",
     "homepage": "https://github.com/BrunoReX/jmkvpropedit",
     "license": "BSD-2-Clause",
-
     "suggest": {
         "JDK": [
             "java/openjdk",

--- a/bucket/jmkvpropedit.json
+++ b/bucket/jmkvpropedit.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.5.2",
+    "description": "A batch GUI for mkvpropedit (part of MKVToolNix) written in Java",
+    "homepage": "https://github.com/BrunoReX/jmkvpropedit",
+    "license": "BSD 2-Clause \"Simplified\" License",
+    "suggest": {
+        "JDK": [
+            "java/openjdk",
+            "java/temurinjdk"
+        ]
+    },
+    "url": "https://github.com/BrunoReX/jmkvpropedit/releases/download/v1.5.2/jmkvpropedit-v1.5.2.zip",
+    "hash": "1a3998ee7ad343852b0f8e669278b03a88d546a7335dec166cead96c33fc27b9",
+    "pre_install": "$manifest.persist | ForEach-Object { if (-not (Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null } }",
+    "shortcuts": [
+        [
+            "JMkvpropedit.exe",
+            "JMkvpropedit"
+        ]
+    ],
+    "persist": "JMkvpropedit.ini",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/BrunoReX/jmkvpropedit/releases/download/v$version/jmkvpropedit-v$version.zip"
+    }
+}


### PR DESCRIPTION
JMkvpropedit is a batch GUI for mkvpropedit (part of MKVToolNix) written in Java.
Requires Java 8 or newer.

Source and downloads at:
https://github.com/BrunoReX/jmkvpropedit

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
