### PR TITLE
playnite: Update 9.12 -> 9.14

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -1,10 +1,10 @@
 {
-    "version": "9.12",
+    "version": "9.14",
     "description": "Video game library manager and launcher with support for 3rd party libraries like Steam, GOG, Origin, Battle.net, ...",
     "homepage": "https://playnite.link",
     "license": "MIT",
-    "url": "https://playnite.link/update/stable/9.12/Playnite912.zip",
-    "hash": "44ce7cb0868f5958c3ac75b5ee2db126d2b5f847a01eabcc74227593fde0c1c8",
+    "url": "https://playnite.link/update/stable/9.14/Playnite914.zip",
+    "hash": "262c08661cca97299f5f575e65829731a73996e9f8230102f1b0c1346aa03394",
     "pre_install": "Copy-Item \"$persist_dir\\config.json\" \"$dir\" -ErrorAction 'SilentlyContinue'",
     "uninstaller": {
         "script": "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force"


### PR DESCRIPTION
The download URL for 9.12 is no longer works; is there a reason we're not downloading the GitHub releases?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
