### PR TITLE
inkscape, ultravnc, xmind: Change checkver conflicted variable

### DIFF
--- a/bucket/inkscape.json
+++ b/bucket/inkscape.json
@@ -28,12 +28,12 @@
     "checkver": {
         "script": [
             "$redirUrl = [System.Net.HttpWebRequest]::Create('https://inkscape.org/en/release').GetResponse().ResponseUri.AbsoluteUri",
-            "$ver = $redirUrl -split '\\/(inkscape-)?' | Select-Object -last 1 -skip 1",
+            "$scriptver = $redirUrl -split '\\/(inkscape-)?' | Select-Object -last 1 -skip 1",
             "$32bit_dl = Invoke-WebRequest ($redirUrl + '/windows/32-bit/portable-app/dl/') -UseBasicParsing",
             "$64bit_dl = Invoke-WebRequest ($redirUrl + '/windows/64-bit/compressed-7z/dl/') -UseBasicParsing",
             "$32bit_url = $32bit_dl.links | Where-Object href -match '\\.exe$' | Select-Object -first 1 -expand href",
             "$64bit_url = $64bit_dl.links | Where-Object href -match '\\.7z$' | Select-Object -first 1 -expand href",
-            "Write-Output $ver $32bit_url $64bit_url"
+            "Write-Output $scriptver $32bit_url $64bit_url"
         ],
         "regex": "(?<version>[\\d.]+)\\s(?<win32biturl>.+)\\s(?<win64biturl>.+)"
     },

--- a/bucket/inkscape.json
+++ b/bucket/inkscape.json
@@ -28,12 +28,12 @@
     "checkver": {
         "script": [
             "$redirUrl = [System.Net.HttpWebRequest]::Create('https://inkscape.org/en/release').GetResponse().ResponseUri.AbsoluteUri",
-            "$version = $redirUrl -split '\\/(inkscape-)?' | Select-Object -last 1 -skip 1",
+            "$ver = $redirUrl -split '\\/(inkscape-)?' | Select-Object -last 1 -skip 1",
             "$32bit_dl = Invoke-WebRequest ($redirUrl + '/windows/32-bit/portable-app/dl/') -UseBasicParsing",
             "$64bit_dl = Invoke-WebRequest ($redirUrl + '/windows/64-bit/compressed-7z/dl/') -UseBasicParsing",
             "$32bit_url = $32bit_dl.links | Where-Object href -match '\\.exe$' | Select-Object -first 1 -expand href",
             "$64bit_url = $64bit_dl.links | Where-Object href -match '\\.7z$' | Select-Object -first 1 -expand href",
-            "Write-Output $version $32bit_url $64bit_url"
+            "Write-Output $ver $32bit_url $64bit_url"
         ],
         "regex": "(?<version>[\\d.]+)\\s(?<win32biturl>.+)\\s(?<win64biturl>.+)"
     },

--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -34,11 +34,11 @@
             "$uvnc_artifact_url = 'https://uvnc.com' + $uvnc_release_page",
             "$uvnc_artifact_resp = Invoke-WebRequest -Uri $uvnc_artifact_url",
             "$uvnc_artifact_summary_url = $uvnc_artifact_resp.Links | Where-Object href -match '/(\\d+)-ultravnc-(\\d+)-(\\d+)-(\\d)(\\d)-bin-zip.html' | Select-Object -first 1 -expand href",
-            "$version = $matches[2] + '.' + $matches[3] + '.' + $matches[4] + '.' + $matches[5]",
+            "$scriptver = $matches[2] + '.' + $matches[3] + '.' + $matches[4] + '.' + $matches[5]",
             "$artifact_version = $matches[2] + '-' + $matches[3] + '-' + $matches[4] + $matches[5]",
             "$filenum = $matches[1]",
             "$download_path = $filenum + '-ultravnc-' + $artifact_version + '-bin-zip.html?Itemid=0'",
-            "Write-Output $version $download_path"
+            "Write-Output $scriptver $download_path"
         ],
         "regex": "(?<version>[\\d.]+)\\s(?<dlquerypath>.+)"
     },

--- a/bucket/xmind.json
+++ b/bucket/xmind.json
@@ -33,8 +33,8 @@
         "script": [
             "$path_64bit = [System.Net.HttpWebRequest]::Create('https://www.xmind.net/zen/download/win64/').GetResponse().ResponseUri.LocalPath.TrimStart('/')",
             "$path_32bit = [System.Net.HttpWebRequest]::Create('https://www.xmind.net/zen/download/win32/').GetResponse().ResponseUri.LocalPath.TrimStart('/')",
-            "$version = $path_64bit -Replace '.*64bit-([\\d.]+)-\\d+\\.exe$', '$1'",
-            "Write-Output $version $path_32bit $path_64bit"
+            "$scriptver = $path_64bit -Replace '.*64bit-([\\d.]+)-\\d+\\.exe$', '$1'",
+            "Write-Output $scriptver $path_32bit $path_64bit"
         ],
         "regex": "(?<version>[\\d.]+)\\s(?<path32bit>.+)\\s(?<path64bit>.+)"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/ScoopInstaller/GithubActions/issues/3
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Context:
> I think it's from `inkscape` checkver. it's using `$version` variable and the value is 1.1.1

Ok so this is the problem. changed it in dummy repo[^1], and then run the github action[^2], it's working[^3].

[^1]: https://github.com/LazyGeniusMan/Scoop-Test/commit/b249b7ba19186cf9da6a86beb0e79a3848fd54fa
[^2]: https://github.com/LazyGeniusMan/Scoop-Test/actions/runs/1645606185
[^3]: https://github.com/LazyGeniusMan/Scoop-Test/commits/master