### PR TITLE
banana-cake-pop: Update to version 1.0.0-preview.18 and fix checkver

### DIFF
--- a/bucket/banana-cake-pop.json
+++ b/bucket/banana-cake-pop.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.0.0-preview.14",
+    "version": "1.0.0-preview.18",
     "description": "GraphQL IDE",
     "homepage": "https://chillicream.com/docs/bananacakepop",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.14.exe#/dl.7z",
-            "hash": "e3de34389bcf3b164730031ebf7223bb06b4b76dac4f2e12da73326aec1de778",
+            "url": "https://download.chillicream.com/bananacakepop/BananaCakePop-1.0.0-preview.18-win-x64.exe#/dl.7z",
+            "hash": "9b6c94dd792e8f1a8fc2235a649451fab88e4f8cb7b0edadb456b84f113c00c6",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\"",
                 "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninst*\" -Recurse"
@@ -19,11 +19,14 @@
             "Banana Cake Pop"
         ]
     ],
-    "checkver": "BananaCakePop-([\\w.-]+)\\.exe",
+    "checkver": {
+        "url": "https://github.com/ChilliCream/hotchocolate/blob/main/website/src/docs/bananacakepop/index.md",
+        "regex": "BananaCakePop-([\\w.-]+)-win-x64\\.exe"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.chillicream.com/bananacakepop/BananaCakePop-$version.exe#/dl.7z"
+                "url": "https://download.chillicream.com/bananacakepop/BananaCakePop-$version-win-x64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Excavator for this manifest return error code 301, so I also changed the checkver URL to the source code of the webpage in github
```
banana-cake-pop: The remote server returned an error: (301) Moved Permanently.
URL https://chillicream.com/docs/bananacakepop is not valid
```
