### PR TITLE
adwcleaner: Switch to alt checkver URL

### DIFF
--- a/bucket/adwcleaner.json
+++ b/bucket/adwcleaner.json
@@ -20,8 +20,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://support.malwarebytes.com/hc/en-us/sections/360005837474-Release-History-News",
-        "regex": "Malwarebytes AdwCleaner (\\d[.\\d]+)"
+        "url": "https://toolslib.net/downloads/viewdownload/1-adwcleaner/files/?t=release",
+        "regex": ">([\\d.]+)<\\/td>"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Switch to alt checkver URL because current URL is 403