### PR TITLE
kdeconnect: Add version 21.12.0-835

### DIFF
--- a/bucket/kdeconnect.json
+++ b/bucket/kdeconnect.json
@@ -1,0 +1,40 @@
+{
+    "version": "21.12.0-835",
+    "description": "Communications and data transfer between devices over local networks",
+    "homepage": "https://kdeconnect.kde.org/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://binary-factory.kde.org/view/Windows%2064-bit/job/kdeconnect-kde_Release_win64/lastSuccessfulBuild/artifact/kdeconnect-kde-21.12.0-835-windows-msvc2019_64-cl.7z",
+            "hash": "8c3f37c3ef459a5cc5148afe4400392f4482d643e731199a6880bd5470c2eb47"
+        }
+    },
+    "bin": [
+        "bin\\kdeconnect-cli.exe",
+        [
+            "bin\\kdeconnect-cli.exe",
+            "kdeconnect"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bin\\kdeconnect-app.exe",
+            "KDEConnect"
+        ]
+    ],
+    "checkver": {
+        "url": "https://binary-factory.kde.org/view/Windows%2064-bit/job/kdeconnect-kde_Release_win64/",
+        "regex": "kdeconnect-kde-([\\d.-]+)-windows-msvc(?<vc>\\d+)_64-cl\\.7z</a>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://binary-factory.kde.org/view/Windows%2064-bit/job/kdeconnect-kde_Release_win64/lastSuccessfulBuild/artifact/kdeconnect-kde-$version-windows-msvc$matchVc_64-cl.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256",
+            "regex": "$sha256"
+        }
+    }
+}


### PR DESCRIPTION
close #7110

**KDEConnect** ([homepage](https://kdeconnect.kde.org/)) ([Wikipedia](https://en.wikipedia.org/wiki/KDE_Connect)) is a multi-platform application developed by **KDE**, which facilitates wireless communications and data transfer between devices over local networks.

NOTES:
* **persist** is not needed because config file is stored at `$Env:LocalAppData\kdeconnect\config`