### PR TITLE
trojita: Add version 0.7

### DIFF
--- a/bucket/trojita.json
+++ b/bucket/trojita.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.7",
+    "description": "IMAP e-mail client with lightweight GUI",
+    "homepage": "http://trojita.flaska.net/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://downloads.sourceforge.net/project/trojita/win/Trojita-Setup-0.7.exe#/dl.7z",
+    "hash": "8143493d59de6596ec54760b0752766a61a0d54607f9cc084f0c7d2a199192c6",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Recurse",
+    "shortcuts": [
+        [
+            "trojita.exe",
+            "Trojitá"
+        ]
+    ]
+}


### PR DESCRIPTION
close #4680

[Trojitá](http://trojita.flaska.net/) is a IMAP e-mail client with lightweight GUI.

Notes:
* *checkver/autoupdate* is not needed because the app has not receive any update since 2016.
* *persist* is not needed because config is stored at `$Env:LocalAppData\flaska.net\trojita`

* The app is built in *32-bit*
```
> pelook trojita.exe
loaded "trojita.exe" / 5136851 (0x4E61D3) bytes
signature/type:       PE32 EXE image for i386
image checksum:       0x004F0018 (OK)
machine:              0x014C (i386)
subsystem:            2 (Windows GUI)
minimum os:           4.0 (Win95/NT4)
linkver:              2.25
timestamp:            06/15/2016 10:09:07am (0x57612943)
file alignment:       0x200
section alignment:    0x1000
preferred load base:  0x00400000
code entrypoint:      0x004014C0 -> .text section / file_offset=0xAC0
characteristics:      0x0107 (RELOCS_STRIPPED|EXECUTABLE_IMAGE|LINE_NUMS_STRIPPED|32BIT_MACHINE)
DLL characteristics:  0x0000
debug directory:      <none>
17 PE sections:       .text, .data, .rdata, /4, .bss, .idata, .CRT, .tls, .rsrc, /16, /31, /43, /57, /69, /82, /93, /104
EOF DATA:             FOUND outside PE image at file offset 0x35E600-0x4E61D3 / size=0x187BD3
import modules:       libgcc_s_sjlj-1.dll, KERNEL32.dll, msvcrt.dll, libstdc++-6.dll, zlib1.dll, Qt5Core.dll, Qt5DBus.dll, Qt5Gui.dll, Qt5Network.dll, Qt5Sql.dll, Qt5WebKit.dll, Qt5WebKitWidgets.dll, Qt5Widgets.dll, libtrojita_plugins.dll
```