### PR TITLE
http-downloader@1.0.4.8: Persist "download_history" file

### DIFF
--- a/bucket/http-downloader.json
+++ b/bucket/http-downloader.json
@@ -26,7 +26,8 @@
     ],
     "persist": [
         "incomplete",
-        "http_downloader_settings"
+        "http_downloader_settings",
+        "download_history"
     ],
     "checkver": {
         "url": "https://github.com/erickutcher/httpdownloader/releases",

--- a/bucket/http-downloader.json
+++ b/bucket/http-downloader.json
@@ -15,7 +15,8 @@
     },
     "pre_install": [
         "New-Item \"$dir\\portable\" -Force | Out-Null",
-        "if (!(Test-Path \"$persist_dir\\http_downloader_settings\")) { New-Item \"$dir\\http_downloader_settings\" -Force | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\http_downloader_settings\")) { New-Item \"$dir\\http_downloader_settings\" -Force | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\download_history\")) { New-Item \"$dir\\download_history\" -Force | Out-Null }"
     ],
     "bin": "HTTP_Downloader.exe",
     "shortcuts": [


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Add "download_history" to the list of persisted files.

This file is used to show downloaded files in the downloads list across sessions (an advanced option which is disabled by default). If this file isn't persisted, each new Scoop update of the program will cause the new version to show a blank downloads list. Persisting "download_history" should fix this for those using the feature.