### PR TITLE
android-studio-canary: Add version 2021.2.1.6

### DIFF
--- a/bucket/android-studio-canary.json
+++ b/bucket/android-studio-canary.json
@@ -1,0 +1,36 @@
+{
+    "version": "2021.2.1.6",
+    "description": "The official IDE for Android development, which includes everything you need to build Android apps.",
+    "homepage": "https://developer.android.com/studio/preview",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://developer.android.com/studio/terms.html"
+    },
+    "suggest": {
+        "SDK": [
+            "android-clt",
+            "android-sdk"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.2.1.6/android-studio-2021.2.1.6-windows.zip",
+            "hash": "a5af8dffdbb999d3029921a3c411e2bb504a4a2a17c7ff8e76eaba40f28c3ae9",
+            "shortcuts": [
+                [
+                    "bin\\studio64.exe",
+                    "Android Studio Canary"
+                ]
+            ]
+        }
+    },
+    "extract_dir": "android-studio",
+    "checkver": "android-studio-([\\d.]+)-windows\\.zip",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$version/android-studio-$version-windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Android Studio Canary version https://developer.android.com/studio/preview copied and adapted from android-studio.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
