### PR TITLE
powertoys: Fix installer.script and add au.hash

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -12,13 +12,9 @@
     },
     "installer": {
         "script": [
-            "$_pwd_ = $pwd",
-            "Set-Location $dir",
-            "$_exe_ = Get-ChildItem PowerToys*.exe",
-            "Start-Process $_exe_ --extract_msi -Wait; Set-Location $_pwd_",
-            "$_msi_ = Get-ChildItem -Path $dir\\PowerToys*.msi",
-            "Expand-MsiArchive $_msi_ $dir -ExtractDir 'PowerToys'",
-            "Remove-Item $_exe_, $_msi_ -Force"
+            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\.tmp\"",
+            "Expand-MsiArchive \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup-$version-x64.msi\" \"$dir\" -ExtractDir 'PowerToys'",
+            "Remove-Item \"$dir\\.tmp\", \"$dir\\$fname\" -Force -Recurse"
         ]
     },
     "shortcuts": [
@@ -31,7 +27,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe"
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe",
+                "hash": {
+                    "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
+                    "regex": ">$sha256<"
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

PowerToys changes its installer in recent version and make current script stop working.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

It is indeed a WIX installer, I'll finish the installer PR as soon as possible.

Relates to https://github.com/ScoopInstaller/Scoop/pull/3502

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
