### PR TITLE
advanced-ip-scanner: Add version 2.5.3850

### DIFF
--- a/bucket/advanced-ip-scanner.json
+++ b/bucket/advanced-ip-scanner.json
@@ -1,0 +1,37 @@
+{
+    "version": "2.5.3850",
+    "description": "Network scanner that can analyse LAN, show network devices, and provide remote control via RDP and Radmin.",
+    "homepage": "https://www.advanced-ip-scanner.com/",
+    "license": "Freeware",
+    "url": "https://download.advanced-ip-scanner.com/download/files/Advanced_IP_Scanner_2.5.3850.exe#/dl.7z",
+    "hash": "87bfb05057f215659cc801750118900145f8a22fa93ac4c6e1bfd81aa98b0a55",
+    "pre_install": [
+        "New-Item \"$dir\\platforms\", \"$dir\\printsupport\" -ItemType Directory | Out-Null",
+        "Move-Item \"$dir\\qwindows.dll\" \"$dir\\platforms\\qwindows.dll\"",
+        "Move-Item \"$dir\\windowsprintersupport.dll\" \"$dir\\printsupport\\windowsprintersupport.dll\"",
+        "if(Test-Path \"$persist_dir\") {Copy-Item \"$persist_dir\\*\" \"$dir\\\"}"
+    ],
+    "uninstaller": {
+        "script": [
+            "ensure \"$persist_dir\" | Out-Null",
+            "Copy-Item \"$dir\\advanced_ip_scanner_*.bin\" \"$persist_dir\\\""
+        ]
+    },
+    "bin": [
+        "advanced_ip_scanner_console.exe",
+        [
+            "advanced_ip_scanner_console.exe",
+            "advanced_ip_scanner"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "advanced_ip_scanner.exe",
+            "Advanced IP Scanner"
+        ]
+    ],
+    "checkver": "Advanced_IP_Scanner_([\\d.]+)\\.exe",
+    "autoupdate": {
+        "url": "https://download.advanced-ip-scanner.com/download/files/Advanced_IP_Scanner_$version.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
close #7100

[Advanced IP Scanner](https://www.advanced-ip-scanner.com/) is a network scanner that can analyse LAN, show network devices, and provide remote control via RDP and Radmin.

Notes:
* **license**: EULA can be found in the dialog of the installer.
* 7-zip did not put `qwindows.dll` and `windowsprintersupport.dll` in the right directory. Therefore need to be fixed in *pre_install*.
* **persist**: Advanced IP Scanner uses **binary files** to store its settings, therefore manual persist is needed.
* The **.msi** files under `$dir` is for user to install *Radmin* when needed.
![install](https://user-images.githubusercontent.com/27724471/148503751-c8addae6-58ff-47d3-b77e-841a7e70976e.jpg)
