### PR TITLE
fix: Don't run Excavator in forks

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Excavate
+      if: github.repository == ‘ScoopInstaller/#xtras’
       uses: ScoopInstaller/GithubActions@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Excavate
-      if: github.repository == ‘ScoopInstaller/#xtras’
+      if: github.repository == ‘ScoopInstaller/Extras’
       uses: ScoopInstaller/GithubActions@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

I can't freshen my fork from upstream via GitHub, see
https://github.com/rasa/scoop-extras/pull/1

Users can also turn off actions in their fork, but by then, their fork has already diverged. And they may want some actions.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
