### PR TITLE
opencv: add version 4.5.5

### DIFF
--- a/bucket/opencv.json
+++ b/bucket/opencv.json
@@ -1,0 +1,32 @@
+{
+    "version": "4.5.5",
+    "description": "Open Source Computer Vision Library",
+    "homepage": "https://opencv.org/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-vc14_vc15.exe#/dl.7z",
+            "hash": "cac31973cd1c59bfe9dc926acbde815553d23662ea355e0414b5e50d8f8aa5a8"
+        }
+    },
+    "extract_dir": "opencv",
+    "env_set": {
+        "OPENCV_DIR": "$dir\\build\\x64\\vc15"
+    },
+    "env_add_path": "$dir\\build\\x64\\vc15\\bin",
+    "checkver": {
+        "url": "https://opencv.org/releases/",
+        "regex": "\\*\\s</span>OpenCV &#8211; ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/opencv/opencv/releases/download/$version/opencv-$version-vc14_vc15.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/opencv/opencv/releases",
+                    "regex": "$sha256\\sopencv-$version-vc14_vc15.exe"
+                }
+            }
+        }
+    }
+}

--- a/bucket/opencv.json
+++ b/bucket/opencv.json
@@ -9,7 +9,7 @@
             "hash": "cac31973cd1c59bfe9dc926acbde815553d23662ea355e0414b5e50d8f8aa5a8"
         }
     },
-    "extract_dir": "opencv",
+    "extract_dir": "opencv\\build",
     "env_set": {
         "OPENCV_DIR": "$dir\\build\\x64\\vc15"
     },

--- a/bucket/opencv.json
+++ b/bucket/opencv.json
@@ -11,9 +11,9 @@
     },
     "extract_dir": "opencv\\build",
     "env_set": {
-        "OPENCV_DIR": "$dir\\build\\x64\\vc15"
+        "OPENCV_DIR": "$dir\\x64\\vc14"
     },
-    "env_add_path": "$dir\\build\\x64\\vc15\\bin",
+    "env_add_path": "x64\\vc14\\bin",
     "checkver": {
         "url": "https://opencv.org/releases/",
         "regex": "\\*\\s</span>OpenCV &#8211; ([\\d.]+)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7701

Based on docs here https://docs.opencv.org/4.5.5/d3/d52/tutorial_windows_install.html#tutorial_windows_install_path:
- Adds `OPENCV_DIR` to env variables
- Adds bin folder to path
- Assumes use of Visual Studio 2017 (or higher?) (I think that's what `vc15` is...), should we add another manifest in Extras/Versions for `vc14`?

- Could @honwhy check that the above is what you would expect from an installation? And do you also need another manifest for the 3.x version of OpenCV?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
