### PR TITLE
openvpn-connect: Add version 3.3.4.2600

### DIFF
--- a/bucket/openvpn-connect.json
+++ b/bucket/openvpn-connect.json
@@ -19,7 +19,6 @@
         "if($global) {$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath('commonstartmenu'), 'Programs', 'Scoop Apps')}",
         "else {$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath('startmenu'), 'Programs', 'Scoop Apps')}",
         "$exe_dir = (Resolve-Path \"$dir\\..\\$version\").Path",
-        "#Set-Content \"$dir\\OpenVPNConnect.ps1\" \"Start-Process `\"$exe_path`\"\"",
         "$wsShell = New-Object -ComObject WScript.Shell",
         "$wsShell = $wsShell.CreateShortcut(\"$scoop_startmenu_folder\\OpenVPN Connect.lnk\")",
         "$wsShell.TargetPath = \"$exe_dir\\OpenVPNConnect.exe\"",

--- a/bucket/openvpn-connect.json
+++ b/bucket/openvpn-connect.json
@@ -14,13 +14,19 @@
         }
     },
     "extract_dir": "OpenVPN Connect",
-    "bin": "ovpnconnector.exe",
-    "shortcuts": [
-        [
-            "OpenVPNConnect.exe",
-            "OpenVPN Connect"
-        ]
+    "pre_install": [
+        "# OpenVPN Connect cannot work under junctions ('current'), therefore we need to manually create the shortcut",
+        "if($global) {$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath('commonstartmenu'), 'Programs', 'Scoop Apps')}",
+        "else {$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath('startmenu'), 'Programs', 'Scoop Apps')}",
+        "$exe_dir = (Resolve-Path \"$dir\\..\\$version\").Path",
+        "#Set-Content \"$dir\\OpenVPNConnect.ps1\" \"Start-Process `\"$exe_path`\"\"",
+        "$wsShell = New-Object -ComObject WScript.Shell",
+        "$wsShell = $wsShell.CreateShortcut(\"$scoop_startmenu_folder\\OpenVPN Connect.lnk\")",
+        "$wsShell.TargetPath = \"$exe_dir\\OpenVPNConnect.exe\"",
+        "$wsShell.WorkingDirectory = \"$exe_dir\"",
+        "$wsShell.Save()"
     ],
+    "bin": "ovpnconnector.exe",
     "checkver": {
         "url": "https://openvpn.net/vpn-server-resources/openvpn-connect-for-windows-change-log/",
         "regex": "Release notes for ([\\d.]+) \\((\\d+)\\)",

--- a/bucket/openvpn-connect.json
+++ b/bucket/openvpn-connect.json
@@ -16,15 +16,20 @@
     "extract_dir": "OpenVPN Connect",
     "pre_install": [
         "# OpenVPN Connect cannot work under junctions ('current'), therefore we need to manually create the shortcut",
-        "if($global) {$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath('commonstartmenu'), 'Programs', 'Scoop Apps')}",
-        "else {$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath('startmenu'), 'Programs', 'Scoop Apps')}",
-        "$exe_dir = (Resolve-Path \"$dir\\..\\$version\").Path",
+        "$scoop_startmenu_folder = Join-Path $([Environment]::GetFolderPath($(if ($global) {'commonstartmenu'} else {'startmenu'}))) 'Programs' 'Scoop Apps'",
+        "$exe_dir = versiondir 'openvpn-connect' $version",
         "$wsShell = New-Object -ComObject WScript.Shell",
         "$wsShell = $wsShell.CreateShortcut(\"$scoop_startmenu_folder\\OpenVPN Connect.lnk\")",
         "$wsShell.TargetPath = \"$exe_dir\\OpenVPNConnect.exe\"",
         "$wsShell.WorkingDirectory = \"$exe_dir\"",
         "$wsShell.Save()"
     ],
+    "uninstaller": {
+        "script": [
+            "$scoop_startmenu_folder = Join-Path $([Environment]::GetFolderPath($(if ($global) {'commonstartmenu'} else {'startmenu'}))) 'Programs' 'Scoop Apps'",
+            "Remove-Item \"$scoop_startmenu_folder\\OpenVPN Connect.lnk\" -Force"
+        ]
+    },
     "bin": "ovpnconnector.exe",
     "checkver": {
         "url": "https://openvpn.net/vpn-server-resources/openvpn-connect-for-windows-change-log/",
@@ -37,14 +42,14 @@
                 "url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-$version_signed.msi",
                 "hash": {
                     "url": "https://openvpn.net/client-connect-vpn-for-windows/",
-                    "regex": "(?sm)v3-windows\\.msi.*?sha256 signature:\\s*$sha256"
+                    "regex": "(?sm)v3-windows\\.msi.*?$sha256"
                 }
             },
             "32bit": {
                 "url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-$version_signed_x86.msi",
                 "hash": {
                     "url": "https://openvpn.net/client-connect-vpn-for-windows/",
-                    "regex": "(?sm)v3-windows-x86\\.msi.*?sha256 signature:\\s*$sha256"
+                    "regex": "(?sm)v3-windows-x86\\.msi.*?$sha256"
                 }
             }
         }

--- a/bucket/openvpn-connect.json
+++ b/bucket/openvpn-connect.json
@@ -16,7 +16,7 @@
     "extract_dir": "OpenVPN Connect",
     "pre_install": [
         "# OpenVPN Connect cannot work under junctions ('current'), therefore we need to manually create the shortcut",
-        "$scoop_startmenu_folder = Join-Path $([Environment]::GetFolderPath($(if ($global) {'commonstartmenu'} else {'startmenu'}))) 'Programs' 'Scoop Apps'",
+        "$scoop_startmenu_folder = Join-Path $([Environment]::GetFolderPath($(if ($global) {'commonstartmenu'} else {'startmenu'}))) 'Programs\\Scoop Apps'",
         "$exe_dir = versiondir 'openvpn-connect' $version",
         "$wsShell = New-Object -ComObject WScript.Shell",
         "$wsShell = $wsShell.CreateShortcut(\"$scoop_startmenu_folder\\OpenVPN Connect.lnk\")",
@@ -26,7 +26,7 @@
     ],
     "uninstaller": {
         "script": [
-            "$scoop_startmenu_folder = Join-Path $([Environment]::GetFolderPath($(if ($global) {'commonstartmenu'} else {'startmenu'}))) 'Programs' 'Scoop Apps'",
+            "$scoop_startmenu_folder = Join-Path $([Environment]::GetFolderPath($(if ($global) {'commonstartmenu'} else {'startmenu'}))) 'Programs\\Scoop Apps'",
             "Remove-Item \"$scoop_startmenu_folder\\OpenVPN Connect.lnk\" -Force"
         ]
     },

--- a/bucket/openvpn-connect.json
+++ b/bucket/openvpn-connect.json
@@ -1,0 +1,47 @@
+{
+    "version": "3.3.4.2600",
+    "description": "A flexible virtual private network (VPN) solution to secure data communications.",
+    "homepage": "https://openvpn.net",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.3.4.2600_signed.msi",
+            "hash": "98b087af064fe19a1df3053f49a4fa6787ad3f8018d0d74dc170f199b02aafe8"
+        },
+        "32bit": {
+            "url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.3.4.2600_signed_x86.msi",
+            "hash": "cf388f6682d865cd0a01bc79720ec3ead45eb3027fc5a76ae42ffd9c57643da9"
+        }
+    },
+    "extract_dir": "OpenVPN Connect",
+    "bin": "ovpnconnector.exe",
+    "shortcuts": [
+        [
+            "OpenVPNConnect.exe",
+            "OpenVPN Connect"
+        ]
+    ],
+    "checkver": {
+        "url": "https://openvpn.net/vpn-server-resources/openvpn-connect-for-windows-change-log/",
+        "regex": "Release notes for ([\\d.]+) \\((\\d+)\\)",
+        "replace": "${1}.${2}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-$version_signed.msi",
+                "hash": {
+                    "url": "https://openvpn.net/client-connect-vpn-for-windows/",
+                    "regex": "(?sm)v3-windows\\.msi.*?sha256 signature:\\s*$sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://swupdate.openvpn.net/downloads/connect/openvpn-connect-$version_signed_x86.msi",
+                "hash": {
+                    "url": "https://openvpn.net/client-connect-vpn-for-windows/",
+                    "regex": "(?sm)v3-windows-x86\\.msi.*?sha256 signature:\\s*$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
related: #6192

NOTES:

* *persist* is not needed because config is at `$Env:AppData\OpenVPN Connect\`.
* `$dir\snapshot_blob.bin` and `$dir\v8_context_snapshot.bin` is used by the chromium backbone.
* **per_install**: The app cannot work **under junctions**. Therefore we need to manually create the shortcut.
The script is taken from [lib/shortcuts.ps1](https://github.com/ScoopInstaller/Scoop/blob/master/lib/shortcuts.ps1#L30)
If there is a more simple/elegant way to solve the problem, please tell me.