### PR TITLE
yaffplayer: Add version 0.5.7.0

### DIFF
--- a/bucket/yaffplayer.json
+++ b/bucket/yaffplayer.json
@@ -1,0 +1,39 @@
+{
+    "version": "0.5.7.0",
+    "description": "A simple video player based on FFmpeg libraries",
+    "homepage": "https://www.geeks3d.com/yaffplayer/",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.geeks3d.com/dl/get/618#/dl.zip",
+            "hash": "md5:c7d09f08837dc3d49891e317fc8e94bd"
+        }
+    },
+    "extract_dir": "YAFFplayer",
+    "shortcuts": [
+        [
+            "YAFFplayer.exe",
+            "YAFFplayer"
+        ]
+    ],
+    "persist": [
+        "_geexlab_log.txt",
+        "_scene_init_log.txt",
+        "imgui.ini"
+    ],
+    "checkver": {
+        "url": "https://www.geeks3d.com/dl/show/618",
+        "regex": "Version:.*?([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.geeks3d.com/dl/get/618#/dl.zip",
+                "hash": {
+                    "url": "https://www.geeks3d.com/dl/show/618",
+                    "regex": "MD5:.*?$md5"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
close #6335

[YAFFplayer](https://www.geeks3d.com/yaffplayer/) is a simple video player based on FFmpeg libraries.

Notes:
* EULA can be found in `$dir\eula.txt`.
* checkver url (https://www.geeks3d.com/dl/show/618) is consistent, see [web archive](https://web.archive.org/web/20210423072950/https://www.geeks3d.com/dl/show/618) for example.
* The software is built in 64-bit.
```
>pelook yaffplayer.exe
loaded "yaffplayer.exe" / 559616 (0x88A00) bytes
signature/type:       PE64 EXE image for amd64
image checksum:       0x000962BE (OK)
machine:              0x8664 (amd64)
subsystem:            2 (Windows GUI)
minimum os:           6.0 (Vista)
linkver:              Microsoft LINK 14.30
detected toolset(s):  <none>
timestamp:            01/06/2022 10:25:17am (0x61D6C38D)
```


<img src="https://www.geeks3d.com/yaffplayer/gallery/i/yaffplayer-ffmpeg-video-player-geexlab-04.jpg" alt="image" width="700"/>