### PR TITLE
modernflyouts: Add version 0.9.3.0

### DIFF
--- a/bucket/modernflyouts.json
+++ b/bucket/modernflyouts.json
@@ -28,11 +28,11 @@
         ]
     ],
     "checkver": {
+        "##": "Github release tag (e.g. 0.9.3) != full version (e.g. 0.9.3.0), which can cause error during extraction, thus 'regex' is needed.",
         "github": "https://github.com/ModernFlyouts-Community/ModernFlyouts",
-        "regex": "(\\w+)\\.ModernFlyouts_(?<version>[\\d.]+)(\\w+)\\.Msixbundle",
-        "replace": "${version}"
+        "regex": "ModernFlyouts_([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/ModernFlyouts-Community/ModernFlyouts/releases/download/$matchHead/$match1.ModernFlyouts_$version$match2.Msixbundle#/dl.7z"
+        "url": "https://github.com/ModernFlyouts-Community/ModernFlyouts/releases/download/$matchHead/32669SamG.ModernFlyouts_$version_neutral___pcy8vm99wrpcg.Msixbundle#/dl.7z"
     }
 }

--- a/bucket/modernflyouts.json
+++ b/bucket/modernflyouts.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.9.3.0",
+    "description": "A replacement for the built-in audio flyout UI, with a Modern Fluent Design.",
+    "homepage": "https://modernflyouts-community.github.io/",
+    "license": "MIT",
+    "url": "https://github.com/ModernFlyouts-Community/ModernFlyouts/releases/download/0.9.3/32669SamG.ModernFlyouts_0.9.3.0_neutral___pcy8vm99wrpcg.Msixbundle#/dl.7z",
+    "hash": "c91b2903945709fb598aef5d8205dee96fa1a2ce7ade3f033517cfc5777a1e33",
+    "architecture": {
+        "64bit": {
+            "pre_install": [
+                "$file = \"ModernFlyouts.Package_$($version)_x64.msix\"",
+                "Remove-Item \"$dir\\*\" -Exclude $file -Recurse",
+                "Expand-7zipArchive \"$dir\\$file\" -Removal | Out-Null"
+            ]
+        },
+        "32bit": {
+            "pre_install": [
+                "$file = \"ModernFlyouts.Package_$($version)_x86.msix\"",
+                "Remove-Item \"$dir\\*\" -Exclude $file -Recurse",
+                "Expand-7zipArchive \"$dir\\$file\" -Removal | Out-Null"
+            ]
+        }
+    },
+    "shortcuts": [
+        [
+            "ModernFlyouts.exe",
+            "ModernFlyouts"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ModernFlyouts-Community/ModernFlyouts",
+        "regex": "(\\w+)\\.ModernFlyouts_(?<version>[\\d.]+)(\\w+)\\.Msixbundle",
+        "replace": "${version}"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ModernFlyouts-Community/ModernFlyouts/releases/download/$matchHead/$match1.ModernFlyouts_$version$match2.Msixbundle#/dl.7z"
+    }
+}

--- a/bucket/modernflyouts.json
+++ b/bucket/modernflyouts.json
@@ -1,4 +1,5 @@
 {
+    "##": "Github release tag (e.g. 0.9.3) != full version (e.g. 0.9.3.0), which can cause error during extraction, thus 'checkver->regex' is needed.",
     "version": "0.9.3.0",
     "description": "A replacement for the built-in audio flyout UI, with a Modern Fluent Design.",
     "homepage": "https://modernflyouts-community.github.io/",
@@ -28,7 +29,6 @@
         ]
     ],
     "checkver": {
-        "##": "Github release tag (e.g. 0.9.3) != full version (e.g. 0.9.3.0), which can cause error during extraction, thus 'regex' is needed.",
         "github": "https://github.com/ModernFlyouts-Community/ModernFlyouts",
         "regex": "ModernFlyouts_([\\d.]+)"
     },


### PR DESCRIPTION
close #3142

[ModernFlyouts](https://github.com/ModernFlyouts-Community/ModernFlyouts) is a replacement for the built-in audio flyout UI, with a Modern Fluent Design.

Notes:
* *persist* is not needed because config file is at `$Env:LocalAppData\ModernFlyouts_Community`.
* ~*autoupdate* cannot work properly without `"replace": "${version}"` in *checkver*.~ This is probably a bug in Scoop core. 
**UPDATE**: The problem no longer happens in this manifest.
It happens when the 2nd matchgroup is named as *version*. (e.g. `"regex": "(\\w+)\\.ModernFlyouts_(?<version>[\\d.]+)(\\w+)\\.Msixbundle"`)
*checkver* will be fine, but in *autoupdate*, $version becomes an empty string.

Screenshots:

![](https://user-images.githubusercontent.com/63704247/128132478-6ab74bd0-3d2f-4f92-af6c-a505b4d5f1fe.png)