### PR TITLE
win11dragdroptaskbarfix: add version 2.2.0.0

### DIFF
--- a/bucket/win11dragdroptaskbarfix.json
+++ b/bucket/win11dragdroptaskbarfix.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.2.0.0",
+    "description": "Fixes the missing 'Drag & Drop to the Taskbar' support in Windows 11.",
+    "homepage": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix/releases/download/v.2.2.0.0-release/Windows11DragAndDropToTaskbarFix.exe",
+            "hash": "9306034e67f3a059427d67655e1e5be36d57f3222250cdb41fb86f560cc585b1"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\Windows11DragAndDropToTaskbarFixConfig.txt\")) {",
+        "   New-Item \"$dir\\Windows11DragAndDropToTaskbarFixConfig.txt\" | Out-Null",
+        "   Set-Content -Path \"$dir\\Windows11DragAndDropToTaskbarFixConfig.txt\" -Value \"//Should the program run automatically on system startup? 1 = true, 0 = false.\nAutomaticallyRunThisProgramOnStartup=1\nStartThisProgramAsAdministrator=0\n\n//For more configuration options, please visit: https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix/blob/main/CONFIGURATION.md\" | Out-Null",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "Windows11DragAndDropToTaskbarFix.exe",
+            "Windows 11 Drag & Drop to the Taskbar (Fix)"
+        ]
+    ],
+    "persist": [
+        "Windows11DragAndDropToTaskbarFixConfig.txt"
+    ],
+    "checkver": {
+        "url": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix/releases",
+        "regex": "v.([\\d.]+)-release"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix/releases/download/v.$version-release/Windows11DragAndDropToTaskbarFix.exe"
+            }
+        }
+    }
+}

--- a/bucket/win11dragdroptaskbarfix.json
+++ b/bucket/win11dragdroptaskbarfix.json
@@ -21,9 +21,7 @@
             "Windows 11 Drag & Drop to the Taskbar (Fix)"
         ]
     ],
-    "persist": [
-        "Windows11DragAndDropToTaskbarFixConfig.txt"
-    ],
+    "persist": "Windows11DragAndDropToTaskbarFixConfig.txt",
     "checkver": {
         "url": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix/releases",
         "regex": "v.([\\d.]+)-release"

--- a/bucket/win11dragdroptaskbarfix.json
+++ b/bucket/win11dragdroptaskbarfix.json
@@ -2,7 +2,7 @@
     "version": "2.2.0.0",
     "description": "Fixes the missing 'Drag & Drop to the Taskbar' support in Windows 11.",
     "homepage": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/HerMajestyDrMona/Windows11DragAndDropToTaskbarFix/releases/download/v.2.2.0.0-release/Windows11DragAndDropToTaskbarFix.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #7490
- First try at using persist, is this the simplest way? The program creates a config file but only if you press "Configure..." in its tray menu. So I had to create it in pre_install, hope that's right.
- Also this is the shortest I could make the manifest name without leaving it unreadable/unsearchable.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
