### PR TITLE
rstudio: Use 'RStudio' as shortcut name

### DIFF
--- a/bucket/rstudio.json
+++ b/bucket/rstudio.json
@@ -25,7 +25,7 @@
     "shortcuts": [
         [
             "bin\\rstudio.exe",
-            "R Studio"
+            "RStudio"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Official name is `RStudio`, no whitespace.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
