### PR TITLE
fatty: Add version 20210122

### DIFF
--- a/bucket/fatty.json
+++ b/bucket/fatty.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.6",
+    "description": "Cygwin Terminal emulator with tabs",
+    "homepage": "https://github.com/juho-p/fatty",
+    "license": "GPL-3.0-or-later",
+    "depends": "cygwin",
+    "architecture": {
+        "64bit": {
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/fatty/fatty_v1.6.7z",
+            "hash": "5f442b6b47399c9012d0eb2dff511e80778b20f3fff8f37a135fdc3db5be867f"
+        }
+    },
+    "pre_install": [
+        "$forward_slash_dir = $dir.ToString().replace('\\', '/')",
+        "Set-Content \"$dir\\fatty.bat\" \"cygwin -c `\"$forward_slash_dir/fatty`\" -\" -Encoding ascii | Out-Null"
+    ],
+    "bin": "fatty.bat",
+    "shortcuts": [
+        [
+            "fatty.bat",
+            "FaTTY"
+        ]
+    ]
+}

--- a/bucket/fatty.json
+++ b/bucket/fatty.json
@@ -3,6 +3,7 @@
     "description": "Cygwin Terminal emulator with tabs",
     "homepage": "https://github.com/juho-p/fatty",
     "license": "GPL-3.0-or-later",
+    "notes": "To create a new tab in FaTTY, press Ctrl-Shift-T",
     "depends": "cygwin",
     "architecture": {
         "64bit": {

--- a/bucket/fatty.json
+++ b/bucket/fatty.json
@@ -18,7 +18,9 @@
     "shortcuts": [
         [
             "fatty.bat",
-            "FaTTY"
+            "FaTTY",
+            "",
+            "fatty.exe"
         ]
     ]
 }

--- a/bucket/fatty.json
+++ b/bucket/fatty.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.6",
+    "version": "20210122",
     "description": "Cygwin Terminal emulator with tabs",
     "homepage": "https://github.com/juho-p/fatty",
     "license": "GPL-3.0-or-later",
@@ -7,8 +7,8 @@
     "depends": "cygwin",
     "architecture": {
         "64bit": {
-            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/fatty/fatty_v1.6.7z",
-            "hash": "5f442b6b47399c9012d0eb2dff511e80778b20f3fff8f37a135fdc3db5be867f"
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/fatty/fatty-20210122.7z",
+            "hash": "f734895ac27ae482b03c5e17c662ba459a1b5906c5f8a062273cf85c48360a1f"
         }
     },
     "pre_install": [


### PR DESCRIPTION
close #4932

[FaTTY](https://github.com/juho-p/fatty) is a Cygwin Terminal emulator **with tabs**.

Notes:
* FaTTY has not received any updates since ~2016~ Jan 2021. Therefore I think we can just compile from source, and stick with this version.
* The binary is compiled with Cygwin version 2.915 and the following packages:
![cyg](https://user-images.githubusercontent.com/27724471/149373821-3bb8c6a5-eeea-40bf-af62-81d868c566c8.jpg)


Screenshots:
![](https://camo.githubusercontent.com/0c2942f0f91a522fb28d7d0816bbaae8afa1b1a6336d6448c66dc20404d1075f/687474703a2f2f692e696d6775722e636f6d2f5a4d7076634e482e706e67)