### PR TITLE
barrier: add version 2.4.0

### DIFF
--- a/bucket/barrier.json
+++ b/bucket/barrier.json
@@ -1,0 +1,31 @@
+{
+    "version": "2.4.0",
+    "description": "Open-source KVM software",
+    "homepage": "https://github.com/debauchee/barrier",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/debauchee/barrier/releases/download/v2.4.0/BarrierSetup-2.4.0-release.exe",
+            "hash": "7e66b7b4d13312e607edd06f8ea38f3c9b09b3e8aea2b55250c00b25f9892885"
+        }
+    },
+    "innosetup": true,
+    "bin": [
+        "barrierc.exe",
+        "barriers.exe"
+    ],
+    "shortcuts": [
+        [
+            "barrier.exe",
+            "Barrier"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/debauchee/barrier/releases/download/v$version/BarrierSetup-$version-release.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #7166
- Nothing to persist as config stored in registry at `Computer\HKEY_CURRENT_USER\Software\Debauchee\Barrier`
- `bin`s are CLI versions of the Client and Server parts of Barrier

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
