### PR TITLE
godot/godot-mono@3.4.2: moved dl location to github

### DIFF
--- a/bucket/godot-mono.json
+++ b/bucket/godot-mono.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/3.4.2/mono/Godot_v3.4.2-stable_mono_win64.zip",
+            "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_mono_win64.zip",
             "hash": "a8929829f7848c45d565fba6ec33a029e152e8a8a17aec445b81dba3ad105ff1"
         },
         "32bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/3.4.2/mono/Godot_v3.4.2-stable_mono_win32.zip",
+            "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_mono_win32.zip",
             "hash": "d54c911927ee875dcf2213e976bb4c11e96278aa5761a265f1288527cd00010c"
         }
     },
@@ -32,10 +32,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$version/mono/Godot_v$version-stable_mono_win64.zip"
+                "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_mono_win64.zip"
             },
             "32bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$version/mono/Godot_v$version-stable_mono_win32.zip"
+                "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_mono_win32.zip"
             }
         }
     }

--- a/bucket/godot-mono.json
+++ b/bucket/godot-mono.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_mono_win64.zip",
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_mono_win64.zip",
             "hash": "a8929829f7848c45d565fba6ec33a029e152e8a8a17aec445b81dba3ad105ff1"
         },
         "32bit": {
-            "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_mono_win32.zip",
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_mono_win32.zip",
             "hash": "d54c911927ee875dcf2213e976bb4c11e96278aa5761a265f1288527cd00010c"
         }
     },

--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/3.4.2/Godot_v3.4.2-stable_win64.exe.zip",
+            "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win64.exe.zip",
             "hash": "7137839e41dae173eb31da86f789fcdf00933250a6d31ed8939e47bfb80d190d"
         },
         "32bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/3.4.2/Godot_v3.4.2-stable_win32.exe.zip",
+            "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win32.exe.zip",
             "hash": "d261f5747ab8c6d5171a63c06020a58670db45299b1d17847e6a44b82ab2c40e"
         }
     },
@@ -28,10 +28,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$version/Godot_v$version-stable_win64.exe.zip"
+                "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win64.exe.zip"
             },
             "32bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$version/Godot_v$version-stable_win32.exe.zip"
+                "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win32.exe.zip"
             }
         }
     }

--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win64.exe.zip",
+            "url":"https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_win64.exe.zip",
             "hash": "7137839e41dae173eb31da86f789fcdf00933250a6d31ed8939e47bfb80d190d"
         },
         "32bit": {
-            "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win32.exe.zip",
+            "url":"https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_win32.exe.zip",
             "hash": "d261f5747ab8c6d5171a63c06020a58670db45299b1d17847e6a44b82ab2c40e"
         }
     },

--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url":"https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_win64.exe.zip",
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_win64.exe.zip",
             "hash": "7137839e41dae173eb31da86f789fcdf00933250a6d31ed8939e47bfb80d190d"
         },
         "32bit": {
-            "url":"https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_win32.exe.zip",
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.2-stable/Godot_v3.4.2-stable_win32.exe.zip",
             "hash": "d261f5747ab8c6d5171a63c06020a58670db45299b1d17847e6a44b82ab2c40e"
         }
     },
@@ -28,10 +28,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win64.exe.zip"
+                "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win64.exe.zip"
             },
             "32bit": {
-                "url":"https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win32.exe.zip"
+                "url": "https://github.com/godotengine/godot/releases/download/$version-stable/Godot_v$version-stable_win32.exe.zip"
             }
         }
     }


### PR DESCRIPTION
godot/godot-mono: moved download location from tuxfamily.org (default dl location for godot engine) to official mirror at github.com (https://github.com/godotengine/godot/releases) for significantly increased download speeds

Closes #6862

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
