### PR TITLE
antimicro: Add pre-install for settings INI file

### DIFF
--- a/bucket/antimicro.json
+++ b/bucket/antimicro.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/AntiMicro/antimicro/releases/download/2.23/antimicro-2.23-win32.portable.zip",
     "hash": "5e180198ec6ae56648b0daa3f4e045d5543ca3bbbdd47a2277a2a814a298f74d",
     "extract_dir": "antimicro",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\antimicro_settings.ini\")) { New-Item -ItemType File \"$dir\\antimicro_settings.ini\" | Out-Null }",
     "shortcuts": [
         [
             "antimicro.exe",


### PR DESCRIPTION
Currently the manifest doesn't have a pre-install which makes the supposed INI file end up as a folder in the persist dir.
