### PR TITLE
kodi: add version 19.3

### DIFF
--- a/bucket/kodi.json
+++ b/bucket/kodi.json
@@ -1,0 +1,47 @@
+{
+    "version": "19.3",
+    "description": "Open source home theater/media center software and entertainment hub for digital media",
+    "homepage": "https://kodi.tv/",
+    "license": "GPL-2.0-or-later",
+    "suggest": "vcredist2019",
+    "architecture": {
+        "64bit": {
+            "url": "https://mirrors.kodi.tv/releases/windows/win64/kodi-19.3-Matrix-x64.exe#/dl.7z",
+            "hash": "0f75ddfca90fa685b9ae5eb4f6d315b58ad7673d44937a9a399f0c5ea29a3075"
+        },
+        "32bit": {
+            "url": "https://mirrors.kodi.tv/releases/windows/win32/kodi-19.3-Matrix-x86.exe#/dl.7z",
+            "hash": "8915d4a47c27e513b14f09f134c8195edc46e1bcd5fcf3585cb78afc5db96d6f"
+        }
+    },
+    "post_install": [
+        "$unwanted = '$PLUGINSDIR', '$TEMP', 'AppxManifest.xml', 'Uninstall.exe'",
+        "foreach ($object in $unwanted) {",
+        "    Remove-Item \"$dir\\$object\"-Recurse -Force",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "kodi.exe",
+            "Kodi",
+            "-p"
+        ]
+    ],
+    "persist": [
+        "portable_data"
+    ],
+    "checkver": {
+        "url": "https://kodi.tv/download/windows",
+        "regex": "Kodi v(?<version>[\\d.]+) \\((?<name>\\w+)\\)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://mirrors.kodi.tv/releases/windows/win64/kodi-$version-$matchName-x64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://mirrors.kodi.tv/releases/windows/win32/kodi-$version-$matchName-x86.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/kodi.json
+++ b/bucket/kodi.json
@@ -3,7 +3,9 @@
     "description": "Open source home theater/media center software and entertainment hub for digital media",
     "homepage": "https://kodi.tv/",
     "license": "GPL-2.0-or-later",
-    "suggest": "vcredist2019",
+    "suggest": {
+        "Visual C++ Redistributable": "extras/vcredist2019"
+    },
     "architecture": {
         "64bit": {
             "url": "https://mirrors.kodi.tv/releases/windows/win64/kodi-19.3-Matrix-x64.exe#/dl.7z",
@@ -14,12 +16,7 @@
             "hash": "8915d4a47c27e513b14f09f134c8195edc46e1bcd5fcf3585cb78afc5db96d6f"
         }
     },
-    "post_install": [
-        "$unwanted = '$PLUGINSDIR', '$TEMP', 'AppxManifest.xml', 'Uninstall.exe'",
-        "foreach ($object in $unwanted) {",
-        "    Remove-Item \"$dir\\$object\"-Recurse -Force",
-        "}"
-    ],
+    "post_install": "'$PLUGINSDIR', '$TEMP', 'AppxManifest.xml', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
     "shortcuts": [
         [
             "kodi.exe",
@@ -27,9 +24,7 @@
             "-p"
         ]
     ],
-    "persist": [
-        "portable_data"
-    ],
+    "persist": "portable_data",
     "checkver": {
         "url": "https://kodi.tv/download/windows",
         "regex": "Kodi v(?<version>[\\d.]+) \\((?<name>\\w+)\\)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #7164
- Suggests vcredist2019 because it is included in the installer
- Persists `portable_data` and uses `-p` (portable) flag for shortcut as specified in the [wiki](https://kodi.wiki/view/Portable_mode)
- No proper CLI so no shims
- `post_install` removes rubbish left over from installer

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
