### PR TITLE
silex-desktop: add hash extraction

### DIFF
--- a/bucket/silex-desktop.json
+++ b/bucket/silex-desktop.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/silexlabs/silex-desktop/releases/download/v2.7.27/silex-desktop-Setup-2.7.27.exe#/dl.7z",
-            "hash": "bb7b1c9cebf0c1f5f20ea75892b363980cc6e0ea2c6305ea72d15bfad1a024ab"
+            "hash": "sha512:0e442e9a824e0bd2e159cb4ef6bab3ed7161cdd002f1224cb0dd12afed1c4ea194d23e39b63390df5df69567f169c2214a9797e31a1830b6571f02d63a378da2"
         }
     },
     "pre_install": [
@@ -24,7 +24,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/silexlabs/silex-desktop/releases/download/v$version/silex-desktop-Setup-$version.exe#/dl.7z"
+                "url": "https://github.com/silexlabs/silex-desktop/releases/download/v$version/silex-desktop-Setup-$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512:\\s+$base64"
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to #7765
- @rashil2000 I searched the repo for other manifests using `latest.yml` and discovered you could use `$base64` in the regex

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
