### PR TITLE
rambox-pro: Fix exe name and download link

### DIFF
--- a/bucket/rambox-pro.json
+++ b/bucket/rambox-pro.json
@@ -20,14 +20,14 @@
     "shortcuts": [
         [
             "Rambox.exe",
-            "RamboxPro"
+            "Rambox"
         ]
     ],
     "checkver": {
         "github": "https://github.com/ramboxapp/download"
     },
     "autoupdate": {
-        "url": "https://github.com/ramboxapp/download/releases/download/v$version/RamboxPro-$version-win.exe#/cosi.7z",
+        "url": "https://github.com/ramboxapp/download/releases/download/v$version/Rambox-$version-win-64.exe#/cosi.7z",
         "hash": {
             "url": "$baseurl/latest.yml",
             "regex": "sha512:\\s+$base64"

--- a/bucket/rambox-pro.json
+++ b/bucket/rambox-pro.json
@@ -6,14 +6,16 @@
         "identifier": "Proprietary",
         "url": "https://rambox.pro/#eula"
     },
-    "url": "https://github.com/ramboxapp/download/releases/download/v2.0.0/Rambox-2.0.0-win-x64.exe#/cosi.7z",
-    "hash": "sha512:b0f17be1e9c2963c3a0a0e251b08683b3d57ca042c548b70ad497f53e05e0cc248bf10001f41ca66da5c08a05bcb5a8f78ee43bb01e639dff0c67697d0a662c9",
     "architecture": {
         "64bit": {
-            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+            "url": "https://github.com/ramboxapp/download/releases/download/v2.0.0/Rambox-2.0.0-win-x64.exe#/dl.7z",
+            "hash": "sha512:b0f17be1e9c2963c3a0a0e251b08683b3d57ca042c548b70ad497f53e05e0cc248bf10001f41ca66da5c08a05bcb5a8f78ee43bb01e639dff0c67697d0a662c9"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse",
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse"
+    ],
     "shortcuts": [
         [
             "Rambox.exe",
@@ -24,10 +26,14 @@
         "github": "https://github.com/ramboxapp/download"
     },
     "autoupdate": {
-        "url": "https://github.com/ramboxapp/download/releases/download/v$version/Rambox-$version-win-64.exe#/cosi.7z",
-        "hash": {
-            "url": "$baseurl/latest.yml",
-            "regex": "sha512:\\s+$base64"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ramboxapp/download/releases/download/v$version/Rambox-$version-win-64.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512:\\s+$base64"
+                }
+            }
         }
     }
 }

--- a/bucket/rambox-pro.json
+++ b/bucket/rambox-pro.json
@@ -6,7 +6,7 @@
         "identifier": "Proprietary",
         "url": "https://rambox.pro/#eula"
     },
-    "url": "https://github.com/ramboxapp/download/releases/download/v2.0.0/RamboxPro-2.0.0-win.exe#/cosi.7z",
+    "url": "https://github.com/ramboxapp/download/releases/download/v2.0.0/Rambox-2.0.0-win-x64.exe#/cosi.7z",
     "hash": "sha512:b0f17be1e9c2963c3a0a0e251b08683b3d57ca042c548b70ad497f53e05e0cc248bf10001f41ca66da5c08a05bcb5a8f78ee43bb01e639dff0c67697d0a662c9",
     "architecture": {
         "64bit": {

--- a/bucket/rambox-pro.json
+++ b/bucket/rambox-pro.json
@@ -19,7 +19,7 @@
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse",
     "shortcuts": [
         [
-            "RamboxPro.exe",
+            "Rambox.exe",
             "RamboxPro"
         ]
     ],

--- a/bucket/rambox-pro.json
+++ b/bucket/rambox-pro.json
@@ -11,9 +11,6 @@
     "architecture": {
         "64bit": {
             "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
-        },
-        "32bit": {
-            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\""
         }
     },
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse",


### PR DESCRIPTION
Rambox has dropped the "Pro" from the exe name, and now has added "-x64" to the file-name

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7779

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
