### PR TITLE
postman: fix checkver

### DIFF
--- a/bucket/postman.json
+++ b/bucket/postman.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.8.3",
+    "version": "9.9.3",
     "description": "Complete API development environment.",
     "homepage": "https://www.getpostman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/version/9.8.3/windows64#/dl.7z",
-            "hash": "sha1:8a86eeef164398329c4da546999bb2485ba467ef"
+            "url": "https://dl.pstmn.io/download/version/9.9.3/windows64#/dl.7z",
+            "hash": "sha1:253c5a1ff2af46e64ff608e75bea4addd2378a72"
         }
     },
     "pre_install": [
@@ -23,15 +23,15 @@
         ]
     ],
     "checkver": {
-        "url": "https://dl.pstmn.io/changelog?channel=stable&platform=win64",
-        "jsonpath": "$.changelog[0].name"
+        "url": "https://dl.pstmn.io/RELEASES?platform=win64&from=$version",
+        "jsonpath": "$.releases[-1:].name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://dl.pstmn.io/download/version/$version/windows64#/dl.7z",
                 "hash": {
-                    "url": "https://dl.pstmn.io/RELEASES?platform=win64",
+                    "url": "https://dl.pstmn.io/RELEASES?platform=win64&from=$version",
                     "jsonpath": "$.releases[?(@.name=='$version')].files[?(@.filetype=='.exe')].hash"
                 }
             }


### PR DESCRIPTION
The old checkver url (`https://dl.pstmn.io/changelog?channel=stable&platform=win64`) is not working properly anymore, it needs additional parameters to return the correct latest version number. 

Since the added extra parameter is user-associated, it was replaced with the url used in autoupdate (`https://dl.pstmn.io/RELEASES?platform=win64`), which currently works fine. 

Also, add the `from=$version` parameter to reduce the size of the data returned.