### PR TITLE
lunacy: Update to version 8.1.0.0

### DIFF
--- a/bucket/lunacy.json
+++ b/bucket/lunacy.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.1.0",
+    "version": "8.1.0.0",
     "description": "Free Graphic Design Software",
     "homepage": "https://icons8.com/lunacy",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://lun-eu.icons8.com/s/setup/LunacySetup_7.1.0.exe",
-            "hash": "0f71756f14a5fb07a325b43b2e79218568729fe769e06c5599bf481881536824"
+            "url": "https://lun-eu.icons8.com/s/setup/LunacySetup_8.1.0.0.exe",
+            "hash": "22311758abc0ac9d242f8c203d6663bc0c87073932c934863a5feb4f9e6606a5"
         }
     },
     "innosetup": true,
@@ -22,7 +22,7 @@
     ],
     "checkver": {
         "url": "https://docs.icons8.com/release-notes/",
-        "regex": "LunacySetup_([\\d.]+)\\.exe\">here"
+        "regex": "LunacySetup_([\\d.]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
The regex used to find the .exe installer is no longer valid, as the link now says "Installer" instead of "here". So I updated it and ran checkver to update the manifest to the latest release.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
