### PR TITLE
webcopy: Remove 'Link Checker' and 'URI Tester'

### DIFF
--- a/bucket/webcopy.json
+++ b/bucket/webcopy.json
@@ -34,14 +34,6 @@
         [
             "cyowcopy.exe",
             "WebCopy"
-        ],
-        [
-            "lnkchkgui.exe",
-            "Link Checker"
-        ],
-        [
-            "uritest.exe",
-            "URI Tester"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7797

In [Upcoming Changes](https://www.cyotek.com/cyotek-webcopy/upcoming-changes):

> Removed
> - The Link Checker (GUI and CLI), URI Tester and XPath Tester tools have been removed from distribution due to lack of use

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
