### PR TITLE
gephi: add version 0.9.2

### DIFF
--- a/bucket/gephi.json
+++ b/bucket/gephi.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.9.2",
+    "description": "Visualization and exploration software for all kinds of graphs and networks",
+    "homepage": "https://github.com/gephi/gephi",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/gephi/gephi/releases/download/v0.9.2/gephi-0.9.2-windows.exe",
+    "hash": "cc8dbf806baa157fd34876c940bead660c30d160d391c0189826b5fe270678fb",
+    "innosetup": true,
+    "architecture": {
+        "64bit": {
+            "shortcuts": [
+                [
+                    "bin\\gephi64.exe",
+                    "Gephi"
+                ]
+            ]
+        },
+        "32bit": {
+            "shortcuts": [
+                [
+                    "bin\\gephi.exe",
+                    "Gephi"
+                ]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/gephi/gephi/releases/download/v$version/gephi-$version-windows.exe"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #7794
- Nothing to persist as config stored in `C:\Users\username\AppData\Roaming\.gephi`
- Caveat: requires Java 1.8 to be installed - does NOT detect Java installed using any manifest in the Java bucket nor does it accept any higher Java version, should this be added as a note?
- Java issue would probably be fixed by https://github.com/ScoopInstaller/Java/issues/119 as at the moment Java manifests only add `JAVA_HOME` environment variable

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
