### PR TITLE
hydrus-network: update to 470b

### DIFF
--- a/bucket/hydrus-network.json
+++ b/bucket/hydrus-network.json
@@ -33,7 +33,8 @@
     ],
     "persist": "db",
     "checkver": {
-        "github": "https://github.com/hydrusnetwork/hydrus"
+        "url": "https://github.com/hydrusnetwork/hydrus/releases/latest",
+        "re": "v(?<version>[\\d\\w.]+)/Hydrus.Network.(?<version>[\\d\\w.]+).-.Windows.-.Extract.only.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/hydrus-network.json
+++ b/bucket/hydrus-network.json
@@ -34,7 +34,7 @@
     "persist": "db",
     "checkver": {
         "url": "https://github.com/hydrusnetwork/hydrus/releases/latest",
-        "re": "v(?<version>[\\d\\w.]+)/Hydrus.Network.(?<version>[\\d\\w.]+).-.Windows.-.Extract.only.zip"
+        "regex": "/Hydrus\\.Network\\.([\\w]+)\\.-\\.Windows\\.-\\.Extract"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/hydrus-network.json
+++ b/bucket/hydrus-network.json
@@ -1,12 +1,12 @@
 {
-    "version": "469",
+    "version": "470b",
     "description": "A personal booru-style media tagger",
     "homepage": "https://hydrusnetwork.github.io/hydrus/",
     "license": "WTFPL",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hydrusnetwork/hydrus/releases/download/v469/Hydrus.Network.469.-.Windows.-.Extract.only.zip",
-            "hash": "ebf4936205aef8e205276f32da999c0cff375c4bee9aa580d9e9c1d965669a8e"
+            "url": "https://github.com/hydrusnetwork/hydrus/releases/download/v470b/Hydrus.Network.470b.-.Windows.-.Extract.only.zip",
+            "hash": "ab65a5a819d2c327ed5dcda5b5f49824b166bbb0fb60dd638ecdb463c7062216"
         }
     },
     "extract_dir": "Hydrus Network",


### PR DESCRIPTION
The normal autoupdate with '.\bin\checkver.ps1 hydrus-network -u' failed for version 470.
Stating the version explicitly '.\bin\checkver.ps1 hydrus-network -u -v "470b"' worked.
Looks like the script did not recognize v470b as a valid git version tag and tried to download the already removed release for v470 instead.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
