### PR TITLE
FastCopy: update to 4.0.2

### DIFF
--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -18,8 +18,8 @@
             "installer": {
                 "script": [
                     "Start-Process \"$dir\\$fname\" '/EXTRACT64' -Wait",
-                    "Get-ChildItem \"$dir\\FastCopy${version}_x64\" | Move-Item -Destination \"$dir\"",
-                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy${version}_x64\""
+                    "Get-ChildItem \"$dir\\FastCopy$version_x64\" | Move-Item -Destination \"$dir\"",
+                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy$version_x64\""
                 ]
             }
         },
@@ -47,6 +47,6 @@
     "persist": "FastCopy2.ini",
     "checkver": "FastCopy ver ([\\d.]+)",
     "autoupdate": {
-        "url": "https://fastcopy.jp/archive/FastCopy${version}_installer.exe"
+        "url": "https://fastcopy.jp/archive/FastCopy$version_installer.exe"
     }
 }

--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -27,8 +27,8 @@
             "installer": {
                 "script": [
                     "Start-Process \"$dir\\$fname\" '/EXTRACT32' -Wait",
-                    "Get-ChildItem \"$dir\\FastCopy${version}\" | Move-Item -Destination \"$dir\"",
-                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy${version}\""
+                    "Get-ChildItem \"$dir\\FastCopy$version\" | Move-Item -Destination \"$dir\"",
+                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy$version\""
                 ]
             }
         }

--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -18,8 +18,9 @@
             "installer": {
                 "script": [
                     "Start-Process \"$dir\\$fname\" '/EXTRACT64' -Wait",
-                    "Get-ChildItem \"$dir\\FastCopy$version_x64\" | Move-Item -Destination \"$dir\"",
-                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy$version_x64\""
+                    "$extract_dir = Get-ChildItem -Path $dir -Filter 'FastCopy*' -Directory",
+                    "Get-ChildItem $extract_dir | Move-Item -Destination $dir",
+                    "Remove-Item \"$dir\\$fname\", $extract_dir"
                 ]
             }
         },
@@ -27,8 +28,9 @@
             "installer": {
                 "script": [
                     "Start-Process \"$dir\\$fname\" '/EXTRACT32' -Wait",
-                    "Get-ChildItem \"$dir\\FastCopy$version\" | Move-Item -Destination \"$dir\"",
-                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy$version\""
+                    "$extract_dir = Get-ChildItem -Path $dir -Filter 'FastCopy*' -Directory",
+                    "Get-ChildItem $extract_dir | Move-Item -Destination $dir",
+                    "Remove-Item \"$dir\\$fname\", $extract_dir"
                 ]
             }
         }

--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -44,10 +44,7 @@
             "FastCopy Manual"
         ]
     ],
-    "persist": [
-        "FastCopy2.ini",
-        "Log"
-    ],
+    "persist": "FastCopy2.ini",
     "checkver": "FastCopy ver ([\\d.]+)",
     "autoupdate": {
         "url": "https://fastcopy.jp/archive/FastCopy${version}_installer.exe"

--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -1,18 +1,38 @@
 {
-    "version": "3.92",
+    "version": "4.0.2",
     "description": "The Fastest copy/backup software.",
     "homepage": "https://fastcopy.jp",
     "license": {
         "identifier": "Freeware",
         "url": "https://fastcopy.jp/help/fastcopy_eng.htm#license"
     },
-    "url": "https://fastcopy.jp/archive/FastCopy392.zip",
-    "hash": "04ef1db25c903a3d97a6f72a9b0652155393f273f288d4e39918230971c774ec",
+    "url": "https://fastcopy.jp/archive/FastCopy4.0.2_installer.exe",
+    "hash": "c1a61cc5337a2fe8442548e2e9d59ecbcb890d1c3c99cde74b553a050397c69a",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\FastCopy2.ini\")) {",
         "   Set-Content \"$dir\\FastCopy2.ini\" '[main]' -Encoding ASCII",
         "}"
     ],
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": [
+                    "Start-Process \"$dir\\$fname\" '/EXTRACT64' -Wait",
+                    "Get-ChildItem \"$dir\\FastCopy${version}_x64\" | Move-Item -Destination \"$dir\"",
+                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy${version}_x64\""
+                ]
+            }
+        },
+        "32bit": {
+            "installer": {
+                "script": [
+                    "Start-Process \"$dir\\$fname\" '/EXTRACT32' -Wait",
+                    "Get-ChildItem \"$dir\\FastCopy${version}\" | Move-Item -Destination \"$dir\"",
+                    "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy${version}\""
+                ]
+            }
+        }
+    },
     "bin": "FastCopy.exe",
     "shortcuts": [
         [
@@ -30,6 +50,6 @@
     ],
     "checkver": "FastCopy ver ([\\d.]+)",
     "autoupdate": {
-        "url": "https://fastcopy.jp/archive/FastCopy$cleanVersion.zip"
+        "url": "https://fastcopy.jp/archive/FastCopy${version}_installer.exe"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

FastCopy is updated with a major version bump (v4). It introduces exciting features such as a command line app. It also no longer releasing a zip archive for download. Instead, there is a installer with "extraction" option. So we need to change the script a bit.

Here is my attempt. I tested locally without problem. One small question: when the manifest has "installer/script" specified, the installer file is always kept? Anyways, I explicitly remove `$dir\$fname` at the end.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
