### PR TITLE
FastCopy: switch wait mechanism

### DIFF
--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -17,7 +17,8 @@
         "64bit": {
             "installer": {
                 "script": [
-                    "Start-Process \"$dir\\$fname\" '/EXTRACT64' -Wait",
+                    "& \"$dir\\$fname\" /EXTRACT64",
+                    "Start-Sleep 5",
                     "$extract_dir = Get-ChildItem -Path $dir -Filter 'FastCopy*' -Directory",
                     "Get-ChildItem $extract_dir | Move-Item -Destination $dir",
                     "Remove-Item \"$dir\\$fname\", $extract_dir"
@@ -27,7 +28,8 @@
         "32bit": {
             "installer": {
                 "script": [
-                    "Start-Process \"$dir\\$fname\" '/EXTRACT32' -Wait",
+                    "& \"$dir\\$fname\" /EXTRACT32",
+                    "Start-Sleep 5",
                     "$extract_dir = Get-ChildItem -Path $dir -Filter 'FastCopy*' -Directory",
                     "Get-ChildItem $extract_dir | Move-Item -Destination $dir",
                     "Remove-Item \"$dir\\$fname\", $extract_dir"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7829
<!-- or -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Looks like `Start-Process -Wait` does not work reliably across all PowerShell versions. It seems the FastCopy installer process exits too early for the extraction option.

So let's try simple ol' sleep approach. Hope the 5 seconds is long enough for everyone.