### PR TITLE
Improvement for Firefox(-ESR), Thunderbird and SeaMonkey

### DIFF
--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -14,6 +14,7 @@
         }
     },
     "extract_dir": "core",
+    "post_install": "firefox-esr -CreateProfile \"Scoop-ESR $dir\\profile\"",
     "bin": [
         [
             "firefox.exe",
@@ -24,9 +25,17 @@
         [
             "firefox.exe",
             "Firefox ESR"
+        ],
+        [
+            "firefox.exe",
+            "Firefox ESR Profile Manager",
+            "-P"
         ]
     ],
-    "persist": "distribution",
+    "persist": [
+        "distribution",
+        "profile"
+    ],
     "checkver": {
         "url": "https://aus5.mozilla.org/update/6/Firefox/78.0/_/WINNT_x86_64-msvc-x64/en-US/esr/_/_/_/_/update.xml",
         "xpath": "/updates/update/@appVersion"

--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -3,6 +3,12 @@
     "description": "Extended Support Release of Firefox: the popular open source web browser",
     "homepage": "https://www.mozilla.org/en-US/firefox/organizations/",
     "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop-ESR' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Firefox ESR Profile Manager', choose 'Scoop-ESR' then click 'Start Firefox'.",
+        "  - Visit 'about:profiles' page in Firefox ESR to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://archive.mozilla.org/pub/firefox/releases/91.5.0esr/win64/en-US/Firefox%20Setup%2091.5.0esr.exe#/dl.7z",

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -14,14 +14,23 @@
         }
     },
     "extract_dir": "core",
+    "post_install": "firefox -CreateProfile \"Scoop $dir\\profile\"",
     "bin": "firefox.exe",
     "shortcuts": [
         [
             "firefox.exe",
             "Firefox"
+        ],
+        [
+            "firefox.exe",
+            "Firefox Profile Manager",
+            "-P"
         ]
     ],
-    "persist": "distribution",
+    "persist": [
+        "distribution",
+        "profile"
+    ],
     "checkver": {
         "url": "https://archive.mozilla.org/pub/firefox/candidates/",
         "regex": "pub/firefox/candidates/([\\d.]+)-candidates",

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -3,6 +3,12 @@
     "description": "Popular open source web browser.",
     "homepage": "https://www.mozilla.org/firefox/",
     "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Firefox Profile Manager', choose 'Scoop' then click 'Start Firefox'.",
+        "  - Visit 'about:profiles' page in Firefox to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://archive.mozilla.org/pub/firefox/releases/96.0.3/win64/en-US/Firefox%20Setup%2096.0.3.exe#/dl.7z",

--- a/bucket/seamonkey.json
+++ b/bucket/seamonkey.json
@@ -3,6 +3,12 @@
     "description": "All-in-one application suite capable of web browsing, advanced e-mail, newsgroup, feed client, IRC chat and HTML editing.",
     "homepage": "https://www.seamonkey-project.org",
     "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'SeaMonkey Profile Manager', choose 'Scoop' then click 'Start SeaMonkey'.",
+        "  - Visit 'about:profiles' page in SeaMonkey to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://archive.mozilla.org/pub/seamonkey/releases/2.53.10.2/win64/en-US/seamonkey-2.53.10.2.en-US.win64.installer.exe#/dl.7z",
@@ -14,11 +20,17 @@
         }
     },
     "extract_dir": "core",
+    "post_install": "seamonkey -CreateProfile \"Scoop $dir\\profile\"",
     "bin": "seamonkey.exe",
     "shortcuts": [
         [
             "seamonkey.exe",
             "SeaMonkey"
+        ],
+        [
+            "seamonkey.exe",
+            "SeaMonkey Profile Manager",
+            "-P"
         ]
     ],
     "checkver": ">SeaMonkey\\s+([\\d.]+)</",

--- a/bucket/seamonkey.json
+++ b/bucket/seamonkey.json
@@ -33,6 +33,7 @@
             "-P"
         ]
     ],
+    "persist": "profile",
     "checkver": ">SeaMonkey\\s+([\\d.]+)</",
     "autoupdate": {
         "architecture": {

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -3,6 +3,12 @@
     "description": "A free email application that’s easy to set up and customize.",
     "homepage": "https://www.thunderbird.net",
     "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Thunderbird Profile Manager', choose 'Scoop' then click 'Start Thunderbird'.",
+        "  - Visit 'about:profiles' page in Thunderbird to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-and-remove-thunderbird-profiles"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.5.1/win64/en-US/Thunderbird%20Setup%2091.5.1.exe#/dl.7z",

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -14,13 +14,20 @@
         }
     },
     "extract_dir": "core",
+    "post_install": "thunderbird -CreateProfile \"Scoop $dir\\profile\"",
     "bin": "thunderbird.exe",
     "shortcuts": [
         [
             "thunderbird.exe",
             "Thunderbird"
+        ],
+        [
+            "thunderbird.exe",
+            "Thunderbird Profile Manager",
+            "-P"
         ]
     ],
+    "persist": "profile",
     "checkver": {
         "url": "https://www.thunderbird.net/thunderbird/all/",
         "regex": "thunderbird/([\\d.]+)/"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/ScoopInstaller/Extras/issues/7841 https://github.com/ScoopInstaller/Extras/issues/7827 https://github.com/ScoopInstaller/Extras/issues/7742 https://github.com/ScoopInstaller/Extras/issues/7773 https://github.com/ScoopInstaller/Extras/issues/6854 https://github.com/ScoopInstaller/Extras/issues/4935 https://github.com/ScoopInstaller/Extras/issues/4377 https://github.com/ScoopInstaller/Extras/issues/3531 https://github.com/ScoopInstaller/Extras/issues/7713 and more.

- Create Profile and point to `$dir\profile`

|App|Profile Name|Path|
|-|-|-|
|firefox|Scoop|$dir\profile (\<Scoop>\persist\firefox\profile)|
|firefox-esr|Scoop-ESR|$dir\profile (\<Scoop>\persist\firefox-esr\profile)|
|thunderbird|Scoop|$dir\profile (\<Scoop>\persist\thunderbird\profile)|
|seamonkey|Scoop|$dir\profile (\<Scoop>\persist\seamonkey\profile)|

- Create shortcut for Profile Manager
  - Easier migration/management for people who have installed them before using Scoop
  - Users can run it to find the profile data persisted by Scoop
  - Will not affect previous profiles and it's settings

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
