### PR TITLE
Autoclicker: Add version 1.0.0.2

### DIFF
--- a/bucket/autoclicker.json
+++ b/bucket/autoclicker.json
@@ -5,12 +5,12 @@
     "license": "CC-BY-NC-2.0",
     "url": "https://sourceforge.net/projects/orphamielautoclicker/files/AutoClicker.exe",
     "hash": "sha1:1751d9389adb1e7187afa4938a3559e58739dce6",
-    "pre_install": "$manifest.persist | ForEach-Object { if (-not (Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -Force -ItemType \"file\" | Out-Null } }",	
+    "pre_install": "$manifest.persist | ForEach-Object { if (-not (Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -Force -ItemType \"file\" | Out-Null } }",
     "shortcuts": [
         [
             "AutoClicker.exe",
             "AutoClicker"
         ]
     ],
-	"persist": "ACLib\\ACA_conf.ini"
+    "persist": "ACLib\\ACA_conf.ini"
 }

--- a/bucket/autoclicker.json
+++ b/bucket/autoclicker.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0.2",
+    "description": "A full-fledged autoclicker with two modes of autoclicking, at your dynamic cursor location or at a prespecified location",
+    "homepage": "https://sourceforge.net/projects/orphamielautoclicker/",
+    "license": "CC-BY-NC-2.0",
+    "url": "https://sourceforge.net/projects/orphamielautoclicker/files/AutoClicker.exe",
+    "hash": "sha1:1751d9389adb1e7187afa4938a3559e58739dce6",
+    "pre_install": "$manifest.persist | ForEach-Object { if (-not (Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -Force -ItemType \"file\" | Out-Null } }",	
+    "shortcuts": [
+        [
+            "AutoClicker.exe",
+            "AutoClicker"
+        ]
+    ],
+	"persist": "ACLib\\ACA_conf.ini"
+}


### PR DESCRIPTION
Created a manifest for [Autoclicker ](https://sourceforge.net/projects/orphamielautoclicker/)
A full-fledged autoclicker with two modes of autoclicking, at your dynamic cursor location or at a prespecified location. The maximum amounts of clicked can also be set (or left as infinite).

Judging by weekly downloads, I'm surprised no one suggested it already:
https://sourceforge.net/projects/orphamielautoclicker/files/stats/timeline

Unsure if autoupdate is needed. What do you think?
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
