### PR TITLE
whynotwin11: Add version 2.4.3.1

### DIFF
--- a/bucket/whynotwin11.json
+++ b/bucket/whynotwin11.json
@@ -1,0 +1,33 @@
+{
+    "version": "2.4.3.1",
+    "description": "Detection Script to help identify why your PC isn't Windows 11 Release Ready.",
+    "homepage": "https://github.com/rcmaehl/WhyNotWin11",
+    "license": "LGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rcmaehl/WhyNotWin11/releases/download/2.4.3.1/WhyNotWin11.exe",
+            "hash": "fea2f47f057fbd827d44b063458da4629fd4d5db123d84051842d792be0e0aac"
+        },
+        "32bit": {
+            "url": "https://github.com/rcmaehl/WhyNotWin11/releases/download/2.4.3.1/WhyNotWin11_x86.exe#/WhyNotWin11.exe",
+            "hash": "388ab182080cedd5c89f399c0247533887032e9c833ccde5726b84b0718d139c"
+        }
+    },
+    "shortcuts": [
+        [
+            "WhyNotWin11.exe",
+            "WhyNotWin11"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rcmaehl/WhyNotWin11/releases/download/$version/WhyNotWin11.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/rcmaehl/WhyNotWin11/releases/download/$version/WhyNotWin11_x86.exe#/WhyNotWin11.exe"
+            }
+        }
+    }
+}

--- a/bucket/whynotwin11.json
+++ b/bucket/whynotwin11.json
@@ -1,6 +1,7 @@
 {
     "version": "2.4.3.1",
-    "description": "Detection Script to help identify why your PC isn't Windows 11 Release Ready.",
+    "description": "Help identify why your PC isn't Windows 11 Ready.",
+
     "homepage": "https://github.com/rcmaehl/WhyNotWin11",
     "license": "LGPL-3.0-only",
     "architecture": {


### PR DESCRIPTION
Created a manifest for [WhyNotWin11](https://github.com/rcmaehl/WhyNotWin11)

This is a helpful utility to figure out **exactly** why your computer can't update to windows 11.

There is no need for `perist`, as this program keeps its data in `$Env:LocalAppData\WhyNotWin11`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
