### PR TITLE
SDL2: Remove unnecessary cflags

### DIFF
--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -36,7 +36,7 @@
             "    -replace \"@SDL_RLD_FLAGS@\",\"\" `",
             "    -replace \"@SDL_LIBS@\",\"-lSDL2\" `",
             "    -replace \"@SDL_STATIC_LIBS@\",\"-lSDL2\" `",
-            "    -replace \"@SDL_CFLAGS@\",\"-lpthread -lasound\" `",
+            "    -replace \"@SDL_CFLAGS@\",\"\" `",
             ")",
             "",
             "rm -r \"$srcdir\"",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
They were added in #709 by @tresf as a guess, but as far as I can tell pthread.h & asound.h are not available on windows. And thus caused library not found errors.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #7867

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
