### PR TITLE
winrar: Update to version 6.10

### DIFF
--- a/bucket/winrar.json
+++ b/bucket/winrar.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.02",
+    "version": "6.10",
     "description": "Powerful archive manager",
     "homepage": "https://rarlab.com/",
     "license": {
@@ -9,12 +9,12 @@
     "notes": "Set up context menu within settings window.",
     "architecture": {
         "64bit": {
-            "url": "https://www.rarlab.com/rar/winrar-x64-602.exe#/dl.7z",
-            "hash": "d41ed4b4de255bee35f93372d023203c9a43694ef88a759ad61b41dfbd0f345d"
+            "url": "https://www.rarlab.com/rar/winrar-x64-610.exe#/dl.7z",
+            "hash": "e0a76fd83d8e283d5136e145245f5eb6ecfdb05e88d115f06d660b65248d5f76"
         },
         "32bit": {
-            "url": "https://www.rarlab.com/rar/wrar602.exe#/dl.7z",
-            "hash": "f3c32238f23c09f989902644df19e0c1156a8ee9aab552e9c39e869e42c5a71f"
+            "url": "https://www.rarlab.com/rar/winrar-x32-610.exe#/dl.7z",
+            "hash": "7ac0ab5bfdb65e98edf874220ec2eadfd5b37761e5d0979cc81ba9b129812ae1"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\rarreg.key\")) { New-Item \"$dir\\rarreg.key\" | Out-Null }",
@@ -37,7 +37,7 @@
                 "url": "https://www.rarlab.com/rar/winrar-x64-$cleanVersion.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://www.rarlab.com/rar/wrar$cleanVersion.exe#/dl.7z"
+                "url": "https://www.rarlab.com/rar/winrar-x32-$cleanVersion.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Fix the download link for 32bit and update to version 6.10

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
