### PR TITLE
Fix extract_dir for FreeCad package.

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -31,6 +31,6 @@
             "url": "$url-SHA256.txt",
             "regex": "SHA256: $sha256"
         },
-        "extract_dir": "FreeCAD-$version.$matchBuild-WIN-x64-portable"
+        "extract_dir": "FreeCAD-$version-WIN-x64-portable"
     }
 }

--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -9,7 +9,7 @@
             "hash": "b457a6ca8f65b643461ab22cdad6535df558f9745edc40e4e7a78c3501bd0b58"
         }
     },
-    "extract_dir": "FreeCAD-0.19.3.6530e36-WIN-x64-portable",
+    "extract_dir": "FreeCAD-0.19.3-WIN-x64-portable",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Wrong extract directory for FreeCad package.
