### PR TITLE
Fix for issue #7902 - godot-mono shim overwrites the one fom the godot package

### DIFF
--- a/bucket/godot-mono.json
+++ b/bucket/godot-mono.json
@@ -14,14 +14,14 @@
         }
     },
     "pre_install": [
-        "(Get-ChildItem \"$dir\\Godot_*\\Godot_*.exe\" | Rename-Item -NewName \"godot.exe\");",
+        "(Get-ChildItem \"$dir\\Godot_*\\Godot_*.exe\" | Rename-Item -NewName \"godot-mono.exe\");",
         "(Get-ChildItem \"$dir\\Godot_*\\*\" | Move-Item -Destination \"$dir\");",
         "Remove-Item \"$dir\\Godot_*\""
     ],
-    "bin": "godot.exe",
+    "bin": "godot-mono.exe",
     "shortcuts": [
         [
-            "godot.exe",
+            "godot-mono.exe",
             "GodotMono"
         ]
     ],


### PR DESCRIPTION
Closes #7902
