### PR TITLE
clash-mini: Add version 0.1.6

### DIFF
--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -1,0 +1,39 @@
+{
+    "version": "0.1.6",
+    "description": "A simple GUI for Clash.",
+    "homepage": "https://github.com/MetaCubeX/Clash.Mini",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.1.6/Clash.Mini_v0.1.6_x64.7z",
+            "hash": ""
+        },
+        "32bit": {
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.1.6/Clash.Mini_v0.1.6_x86.7z",
+            "hash": ""
+        }
+    },
+    "bin": "Clash.Mini.exe",
+    "shortcuts": [
+        [
+            "Clash.Mini.exe",
+            "Clash.Mini"
+        ]
+    ],
+    "persist": [
+        ".cm",
+        ".core"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "64bit": {
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x64.7z"
+        },
+        "32bit": {
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x86.7z"
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -35,7 +35,8 @@
             }
         },
         "hash": {
-            "url": "$url.sha256"
+            "url": "$url.sha256",
+            "regex": "([\\S]+)"
         }
     }
 }

--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -13,7 +13,6 @@
             "hash": "c14ce8714e268d6249a3eca49fe7f0f363efbff74644c66da544ded438be3345"
         }
     },
-    "bin": "Clash.Mini.exe",
     "shortcuts": [
         [
             "Clash.Mini.exe",

--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.1.6/Clash.Mini_v0.1.6_x64.7z",
-            "hash": ""
+            "hash": "716848db574808c38937669d74e868269281b86b03946cc7698405062c66dd63"
         },
         "32bit": {
             "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.1.6/Clash.Mini_v0.1.6_x86.7z",
-            "hash": ""
+            "hash": "c14ce8714e268d6249a3eca49fe7f0f363efbff74644c66da544ded438be3345"
         }
     },
     "bin": "Clash.Mini.exe",
@@ -26,11 +26,13 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "64bit": {
-            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x64.7z"
-        },
-        "32bit": {
-            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x86.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x64.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x86.7z"
+            }
         },
         "hash": {
             "url": "$url.sha256"


### PR DESCRIPTION
[Clash.Mini](https://github.com/MetaCubeX/Clash.Mini) a simple GUI for [Clash](https://github.com/Dreamacro/clash).

Closes #7920

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
