### PR TITLE
crystaldiskinfo: Update download links

### DIFF
--- a/bucket/crystaldiskinfo.json
+++ b/bucket/crystaldiskinfo.json
@@ -3,7 +3,7 @@
     "description": "HDD/SSD utility software which supports S.M.A.R.T and a part of USB-HDD",
     "homepage": "https://osdn.net/projects/crystaldiskinfo/",
     "license": "MIT",
-    "url": "https://osdn.dl.osdn.net/crystaldiskinfo/76657/CrystalDiskInfo8_15_0.zip",
+    "url": "https://free.nchc.org.tw/osdn/crystaldiskinfo/76657/CrystalDiskInfo8_15_0.zip",
     "hash": "bed6b1ab3de241c4b552afdb4cd696c80f41e64732a69aa19c57024213a9cf5f",
     "pre_install": "if (!(Test-Path \"$persist_dir\\DiskInfo.ini\")) { New-Item \"$dir\\DiskInfo.ini\" | Out-Null }",
     "architecture": {
@@ -40,9 +40,9 @@
         "Smart",
         "DiskInfo.ini"
     ],
-    "checkver": "<a href=\"/projects/crystaldiskinfo/releases/(?<release>[\\d]*)\">CrystalDiskInfo ([\\d.]+)</a>",
+    "checkver": "releases/(?<release>\\d+)\">CrystalDiskInfo\\s+([\\w.]+)<",
     "autoupdate": {
-        "url": "https://osdn.dl.osdn.net/crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersion.zip",
+        "url": "https://free.nchc.org.tw/osdn//crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersion.zip",
         "hash": {
             "url": "https://osdn.net/projects/crystaldiskinfo/downloads/$matchRelease/CrystalDiskInfo$underscoreVersion.zip/",
             "regex": "<dd>$sha256</dd>"


### PR DESCRIPTION
This is my attempt at updating the download links to improve the download speeds.

Shortlist of what's modified:

- URL
- Checkver
- Autoupdate

Since I don't comprehend regex and therefore did a copy-paste job hoping that Mark and Info follow the same structure, let's see.

Closes #7922

- [ X ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
