### PR TITLE
avidemux: add version 2.8.0

### DIFF
--- a/bucket/avidemux.json
+++ b/bucket/avidemux.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.8.0",
+    "description": "Video editor designed for simple cutting, filtering and encoding tasks",
+    "homepage": "http://fixounet.free.fr/avidemux/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mean00/avidemux2/releases/download/2.8.0/avidemux_2.8.0_win64.exe#/dl.7z",
+            "hash": "5b3aeabeaad29b785c76c87536054ad3c98618037e9e43812543cb555405e894"
+        }
+    },
+    "bin": [
+        [
+            "avidemux_cli.exe",
+            "avidemux"
+        ]
+    ],
+    "post_install": "'$PLUGINSDIR', 'uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
+    "shortcuts": [
+        [
+            "avidemux.exe",
+            "Avidemux"
+        ],
+        [
+            "avidemux_jobs.exe",
+            "Avidemux Jobs"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/mean00/avidemux2"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mean00/avidemux2/releases/download/$version/avidemux_$version_win64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #3691 and closes #4775
- Uses GitHub releases for download instead of sourceforge/fosshub, but no hash unfortunately
- CLI added and shortcuts for main program and the Jobs runner

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
