### PR TITLE
kdiff3: Update checkver regex

### DIFF
--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -22,7 +22,7 @@
     ],
     "checkver": {
         "url": "https://download.kde.org/stable/kdiff3/?C=M;O=D",
-        "regex": "(?<file>kdiff3-((?<version>[\\d.]+))-windows[-_]64(-cl)?)\\.exe"
+        "regex": "(?<file>kdiff3-((?<version>[\\d.\\w]+))-windows[-_]64(-cl)?)\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -22,7 +22,7 @@
     ],
     "checkver": {
         "url": "https://download.kde.org/stable/kdiff3/?C=M;O=D",
-        "regex": "(?<file>kdiff3-((?<version>[\\d.\\w]+))-windows[-_]64(-cl)?)\\.exe"
+        "regex": "(?<file>kdiff3-((?<version>[\\d.]+\\w?))-windows[-_]64(-cl)?)\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.9.3",
+    "version": "1.9.4b",
     "description": "Utility for comparing and merging files and directories",
     "homepage": "https://invent.kde.org/sdk/kdiff3",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/kdiff3/kdiff3-1.9.3-windows_64-cl.exe#/dl.7z",
-            "hash": "521974aef1f09a27e8d4d5ed51f2af17d035a58f4b85027556be10de8b2f458f"
+            "url": "https://download.kde.org/stable/kdiff3/kdiff3-1.9.4b-windows-64-cl.exe#/dl.7z",
+            "hash": "81df3f6d306ae1cc6decb3ecb9845e5d4d1e4583f7b0d509d42fe1dcf68cf0a1"
         }
     },
     "pre_install": [

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -1,5 +1,5 @@
 {
-    "version": "91.5.1",
+    "version": "91.6.0",
     "description": "A free email application that’s easy to set up and customize.",
     "homepage": "https://www.thunderbird.net",
     "license": "MPL-2.0",
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.5.1/win64/en-US/Thunderbird%20Setup%2091.5.1.exe#/dl.7z",
-            "hash": "sha512:81784184b7a60cda7cddedaf4c43578e69963c39fbf1f5c6fe23e20a91e68227e1e032381d205377a389226ca1365961bf5c4857d21b5c253fa635a4df8748a1"
+            "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.6.0/win64/en-US/Thunderbird%20Setup%2091.6.0.exe#/dl.7z",
+            "hash": "sha512:42bcdfd5a6289d444c18b7bc058f8e1cd4022c2cac53a12e27e0d0277afa3723fb5979e5dee621b762f0db64f59ee504825f57a36dbc5c117c019ddf2c65a624"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.5.1/win32/en-US/Thunderbird%20Setup%2091.5.1.exe#/dl.7z",
-            "hash": "sha512:3ea7edb4c5cdec20f28047ef07f3b861026602a34a1207b7bc214fe2c64b3790a33e76ffaad4530332c41d02c0bf6d8b67ba7b9e3c9b52754771063adafe5b51"
+            "url": "https://archive.mozilla.org/pub/thunderbird/releases/91.6.0/win32/en-US/Thunderbird%20Setup%2091.6.0.exe#/dl.7z",
+            "hash": "sha512:eb83886f42aa7e8033684ddedff6652a7694fcfbfebcabb6ce589a63cfc8b70a08eb816ebc05de63ecb3de92f3d2007bd79cea5d14a466403bdd7d36334a2e7f"
         }
     },
     "extract_dir": "core",

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.64.0",
+    "version": "1.64.1",
     "description": "Binary releases of VS Code without MS branding/telemetry/licensing.",
     "homepage": "https://github.com/VSCodium/vscodium",
     "license": "MIT",
@@ -9,12 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.64.0/VSCodium-win32-x64-1.64.0.zip",
-            "hash": "d22f87a3115d0da203f191377efd66151dc02ff23d2aef1c5921109b95b7e038"
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.64.1/VSCodium-win32-x64-1.64.1.zip",
+            "hash": "280c3f142a0d7c0e958db6f03abbe224d193a382678805471d59e37be57b4fa4"
         },
         "32bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.64.0/VSCodium-win32-ia32-1.64.0.zip",
-            "hash": "cc3e01cf92a9b310806cb3f88ed36fcf248a1d61dd75a522e8bc1be57cb05860"
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.64.1/VSCodium-win32-ia32-1.64.1.zip",
+            "hash": "1cb409f0ab018dc91d45b82f24c6998e6cd6b19fc38ad742ae0d47dd879788e9"
         }
     },
     "env_add_path": "bin",


### PR DESCRIPTION
Version 1.9.4 has been published as 1.9.4b, thus the checkver regex needs to be updated to match the current version scheme.

See https://invent.kde.org/sdk/kdiff3/-/issues/30 for details.
