### PR TITLE
Wonderpen@2.0.6: Update urls

### DIFF
--- a/bucket/wonderpen.json
+++ b/bucket/wonderpen.json
@@ -1,14 +1,14 @@
 {
-    "homepage": "https://www.atominn.com/en/wonderpen",
+    "homepage": "https://www.tominlab.com/en/wonderpen",
     "description": "Professional writing app with a focused and fluid writing experience.",
     "version": "2.0.6",
     "license": {
         "identifier": "Proprietary",
-        "url": "https://www.atominn.com/term/privacy"
+        "url": "https://www.tominlab.com/en/term/privacy"
     },
     "architecture": {
         "64bit": {
-            "url": "https://file.atominn.net/WonderPen/2.0/WonderPen_win_installer_x64_2.0.6(6186).exe#/dl.7z",
+            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_x64_2.0.6(6186).exe#/dl.7z",
             "hash": "f163cff68af81708bd8e4e84d95a2c9a57dfe38d331035e619ec51f39669b60f",
             "installer": {
                 "script": [
@@ -18,7 +18,7 @@
             }
         },
         "32bit": {
-            "url": "https://file.atominn.net/WonderPen/2.0/WonderPen_win_installer_ia32_2.0.6(6186).exe#/dl.7z",
+            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_ia32_2.0.6(6186).exe#/dl.7z",
             "hash": "84c4e4df77b9b88acb12c7ec8e9d3718e38ac896a704a5499693e0ba2ffb46b1",
             "installer": {
                 "script": [
@@ -35,16 +35,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.atominn.com/wonderpen/download/all",
+        "url": "https://www.tominlab.com/wonderpen/download/all",
         "regex": "([\\d.]+)\\((?<build>[\\d]+)\\)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://file.atominn.net/WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_x64_$version($matchBuild).exe#/dl.7z"
+                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_x64_$version($matchBuild).exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://file.atominn.net/WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_ia32_$version($matchBuild).exe#/dl.7z"
+                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_ia32_$version($matchBuild).exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

The official domain name has been updated from `atominn.com` to `tominlab.com`  and the download links have been updated too.

The new autoupdate url has been tested with `/bin/checkver.ps1`.


