### PR TITLE
draw.io: Add au.hash and change homepage

### DIFF
--- a/bucket/draw.io.json
+++ b/bucket/draw.io.json
@@ -1,7 +1,7 @@
 {
     "version": "16.5.1",
     "description": "Professional diagramming",
-    "homepage": "https://www.draw.io",
+    "homepage": "https://www.diagrams.net",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -39,6 +39,10 @@
             "32bit": {
                 "url": "https://github.com/jgraph/drawio-desktop/releases/download/v$version/draw.io-ia32-$version.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "$baseurl/Files-SHA256-Hashes.txt",
+            "regex": "$basename\\s*?$sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

It seems like draw.io Desktop provides hash file, and its homepage has changed too.

BTW, the manifest name `draw.io` is an exception that it uses `.`, should we rename it to `drawio`?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
