### PR TITLE
scidavis: Add version 2.7

### DIFF
--- a/bucket/scidavis.json
+++ b/bucket/scidavis.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.7",
+    "description": "Data analysis and visualization program aimed at high-quality plotting of scientific data",
+    "homepage": "http://scidavis.sourceforge.net/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/scidavis/SciDAVis/2/2.7/scidavis.2.7-win-dist.msi",
+            "hash": "sha1:c9e3e6fe9d457de9e86635621e6fdf0dca59efa8"
+        }
+    },
+    "extract_dir": "SciDAVis",
+    "shortcuts": [
+        [
+            "scidavis.exe",
+            "SciDAVis"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/scidavis/",
+        "regex": "scidavis\\.([\\d.]+)-win-dist\\.msi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/scidavis/SciDAVis/$majorVersion/$version/scidavis.$version-win-dist.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #6846

[SciDAVis](http://scidavis.sourceforge.net/) is a aata analysis and visualization program aimed at high-quality plotting of scientific data.

**NOTES**:
* persist is not needed because config is at `HKCU:\SOFTWARE\SciDAVis`
* The program is built in **64-bit**.
```
>pelook scidavis.exe
loaded "scidavis.exe" / 73022283 (0x45A3B4B) bytes
signature/type:       PE64 EXE image for amd64
image checksum:       0x045AD4E3 (OK)
machine:              0x8664 (amd64)
subsystem:            2 (Windows GUI)
minimum os:           4.0 (Win95/NT4)
linkver:              2.37
timestamp:            02/02/2022 04:45:27am (0x61FA0C67)
```