### PR TITLE
vieas: Change all download URLs to https

### DIFF
--- a/bucket/vieas.json
+++ b/bucket/vieas.json
@@ -1,15 +1,15 @@
 {
     "version": "5.4.6.0",
     "description": "An image viewer and converter with combination of two window forms.",
-    "homepage": "http://www.vieas.com/en/software/vieas.html",
+    "homepage": "https://www.vieas.com/en/software/vieas.html",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "http://www.vieas.com/software/dl/Vieas5460_64.zip",
+            "url": "https://www.vieas.com/software/dl/Vieas5460_64.zip",
             "hash": "0bddd11fbf873dbaa6b66dfa8a0f03a950ef1c4f7235a7a2687e072dd6f17d89"
         },
         "32bit": {
-            "url": "http://www.vieas.com/software/dl/Vieas5460_32.zip",
+            "url": "https://www.vieas.com/software/dl/Vieas5460_32.zip",
             "hash": "15c8cd8aff2500b0942e0b4eda7ce4a0e02f037d6b5e8bfdeedb807adfcde668"
         }
     },
@@ -22,16 +22,16 @@
         ]
     ],
     "checkver": {
-        "url": "http://www.vieas.com/en/software/vie_his.html",
+        "url": "https://www.vieas.com/en/software/vie_his.html",
         "regex": "Version ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.vieas.com/software/dl/Vieas$cleanVersion_64.zip"
+                "url": "https://www.vieas.com/software/dl/Vieas$cleanVersion_64.zip"
             },
             "32bit": {
-                "url": "http://www.vieas.com/software/dl/Vieas$cleanVersion_32.zip"
+                "url": "https://www.vieas.com/software/dl/Vieas$cleanVersion_32.zip"
             }
         }
     }


### PR DESCRIPTION
HTTP status code 307, and scoop cannot redirect url. 
 