### PR TITLE
musicplayer2@2.74: Update persist files

### DIFF
--- a/bucket/musicplayer2.json
+++ b/bucket/musicplayer2.json
@@ -21,12 +21,13 @@
             "MusicPlayer2"
         ]
     ],
-    "pre_install": "'recent_path.dat', 'song_data.dat', 'config.ini' | ForEach-Object { if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File -Force | Out-Null } }",
+    "pre_install": "'recent_path.dat', 'song_data.dat', 'config.ini', 'global_cfg.ini' | ForEach-Object { if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File -Force | Out-Null } }",
     "persist": [
         "playlist",
         "recent_path.dat",
         "song_data.dat",
-        "config.ini"
+        "config.ini",
+        "global_cfg.ini"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

New version added `global_cfg.ini`. Keep it empty and persistent and when Musicplayer2 is started for the first time, it will automatically write portable parameters in it.

