### PR TITLE
trafficmonitor@1.83: persist plugins

### DIFF
--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -26,7 +26,6 @@
         "if (!(Test-Path \"$persist_dir\\global_cfg.ini\")) { Set-Content \"$dir\\global_cfg.ini\" @('[config]', 'portable_mode = true') -Encoding Ascii }",
         "if (!(Test-Path \"$persist_dir\\history_traffic.dat\")) { New-Item \"$dir\\history_traffic.dat\" | Out-Null }"
     ],
-    "bin": "TrafficMonitor.exe",
     "shortcuts": [
         [
             "TrafficMonitor.exe",

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -18,7 +18,7 @@
         "    # Portable migration",
         "if (!(Test-Path \"$persist_dir\") -and (Test-Path \"$env:APPDATA\\TrafficMonitor\\config.ini\")) {",
         "    ensure \"$persist_dir\" | Out-Null",
-        "    Copy-Item \"$env:APPDATA\\TrafficMonitor\\*\" \"$persist_dir\"",
+        "    Copy-Item -Recurse \"$env:APPDATA\\TrafficMonitor\\*\" \"$persist_dir\"",
         "    Rename-Item \"$env:APPDATA\\TrafficMonitor\" 'TrafficMonitor.old'",
         "}",
         "",
@@ -36,7 +36,8 @@
     "persist": [
         "config.ini",
         "global_cfg.ini",
-        "history_traffic.dat"
+        "history_traffic.dat",
+        "plugins"
     ],
     "checkver": {
         "github": "https://github.com/zhongyang219/TrafficMonitor"


### PR DESCRIPTION

Need to persist `plugins`  folder since TrafficMonitor v1.82 has added plugins system.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
