### PR TITLE
alpinewsl: Add version 3.15.0-0

### DIFF
--- a/bucket/alpinewsl.json
+++ b/bucket/alpinewsl.json
@@ -1,0 +1,60 @@
+{
+    "##": "'rootfs' must be a 'real' directory (at least on Windows 10 RS4)",
+    "version": "3.15.0-0",
+    "description": "Install AlpineWSL as a WSL Instance",
+    "homepage": "https://github.com/yuk7/AlpineWSL",
+    "license": "MIT",
+    "notes": "Even when you are logging in as 'root', some operations (like service command) require Windows administrator privileges",
+    "url": "https://github.com/yuk7/AlpineWSL/releases/download/3.15.0-0/Alpine.zip",
+    "hash": "189575aeee884245c219df00f1943b717d0a669756fb1261b24f5619da2f8cb0",
+    "post_install": [
+        "$installable = $true",
+        "$user = [Security.Principal.WindowsIdentity]::GetCurrent() -as [Security.Principal.WindowsPrincipal]",
+        "$permission = Get-Acl $persist_dir | Select-Object -ExpandProperty Access | Where-Object {",
+        "    ($user.IsInRole($_.IdentityReference)) -and `",
+        "    ($_.FileSystemRights.ToString() -eq 'FullControl') -and `",
+        "    ($_.InheritanceFlags -band 3) -and `",
+        "    ($_.PropagationFlags.ToString() -ne 'NoPropagateInherit')",
+        "}",
+        "if ($null -eq $permission) {",
+        "   warn 'Full Control access to the scoop directory is necessary to install WSL distribution.'",
+        "   warn 'Change directory security and reinstall AlpineWSL.'",
+        "   $installable = $false",
+        "}",
+        "if ($null -eq (Get-Command 'wslconfig' -ErrorAction SilentlyContinue)) {",
+        "    warn 'WSL appears not to be enabled!'",
+        "    warn 'Run ''Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux'''",
+        "    warn 'from an elevated PowerShell. Restart your computer when prompted and reinstall AlpineWSL.'",
+        "    $installable = $false",
+        "}",
+        "$installable = $installable -and !(Invoke-ExternalCommand \"$dir\\Alpine.exe\" 'isregd')",
+        "if ($installable) {",
+        "    warn 'DO NOT KILL THE PROCESS. Installation is still running!'",
+        "    Copy-Item \"$dir\\Alpine.exe\" \"$persist_dir\\data\\Alpine.exe\"",
+        "    $res = Invoke-ExternalCommand \"$persist_dir\\data\\Alpine.exe\" 'install', \"$dir\\rootfs.tar.gz\"",
+        "    Remove-Item \"$persist_dir\\data\\Alpine.exe\" -Force",
+        "    if(!$res) { error 'AlpineWSL installation failed!'; return }",
+        "}",
+        "Remove-Item \"$dir\\rootfs.tar.gz\" -Force"
+    ],
+    "uninstaller": {
+        "script": [
+            "if ($cmd -ne 'uninstall') { return }",
+            "$res = Invoke-ExternalCommand \"$dir\\Alpine.exe\" 'isregd'",
+            "if(!$res) { error 'AlpineWSL is not registered!'; return }",
+            "Invoke-ExternalCommand \"$dir\\Alpine.exe\" 'clean', '-y' | Out-Null"
+        ]
+    },
+    "bin": "Alpine.exe",
+    "shortcuts": [
+        [
+            "Alpine.exe",
+            "Alpine Linux"
+        ]
+    ],
+    "persist": "data",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/yuk7/AlpineWSL/releases/download/$version/Alpine.zip"
+    }
+}

--- a/bucket/alpinewsl.json
+++ b/bucket/alpinewsl.json
@@ -53,8 +53,14 @@
         ]
     ],
     "persist": "data",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/yuk7/AlpineWSL"
+    },
     "autoupdate": {
-        "url": "https://github.com/yuk7/AlpineWSL/releases/download/$version/Alpine.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yuk7/AlpineWSL/releases/download/$version/Alpine.zip"
+            }
+        }
     }
 }

--- a/bucket/alpinewsl.json
+++ b/bucket/alpinewsl.json
@@ -58,10 +58,6 @@
         "regex": "\/releases\/tag\/(?:v|V)?([\\d.]+(-\\d+)?)"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/yuk7/AlpineWSL/releases/download/$version/Alpine.zip"
-            }
-        }
+        "url": "https://github.com/yuk7/AlpineWSL/releases/download/$version/Alpine.zip"
     }
 }

--- a/bucket/alpinewsl.json
+++ b/bucket/alpinewsl.json
@@ -54,7 +54,8 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://github.com/yuk7/AlpineWSL"
+        "url": "https://github.com/yuk7/AlpineWSL/releases/latest",
+        "regex": "\/releases\/tag\/(?:v|V)?([\\d.]+(-\\d+)?)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Add AlpineWSL 3.15.0-0 .

Manifest is directly modified from `ArchWSL`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
