### PR TITLE
another-redis-desktop-manager: add version 1.5.2

### DIFF
--- a/bucket/another-redis-desktop-manager.json
+++ b/bucket/another-redis-desktop-manager.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.5.2",
+    "description": "A faster, better and more stable Redis desktop manager",
+    "homepage": "https://github.com/qishibo/AnotherRedisDesktopManager",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.5.2/Another-Redis-Desktop-Manager.1.5.2.exe#/dl.7z",
+            "hash": "472459dc07bf6bf8222e8930b0091f9dee909b8a44a3c86db2446447eb7adbec"
+        }
+    },
+    "pre_install": [
+        "Expand-7ZipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
+        "'$PLUGINSDIR', 'Uninstall*.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }"
+    ],
+    "shortcuts": [
+        [
+            "Another Redis Desktop Manager.exe",
+            "Another Redis Desktop Manager"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v$version/Another-Redis-Desktop-Manager.$version.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/another-redis-desktop-manager.json
+++ b/bucket/another-redis-desktop-manager.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.5.2/Another-Redis-Desktop-Manager.1.5.2.exe#/dl.7z",
-            "hash": "472459dc07bf6bf8222e8930b0091f9dee909b8a44a3c86db2446447eb7adbec"
+            "hash": "sha512:588c5fe828475d68a5e25a40ece6ffb8812cb081602a4450b2d1ea79f6a6b42990516de4fed4dabdda8310fdc10a42e1110e1439dea60c287f663197691b178a"
         }
     },
     "pre_install": [

--- a/bucket/another-redis-desktop-manager.json
+++ b/bucket/another-redis-desktop-manager.json
@@ -23,7 +23,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v$version/Another-Redis-Desktop-Manager.$version.exe#/dl.7z"
+                "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v$version/Another-Redis-Desktop-Manager.$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512:\\s+$base64"
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #7982
- Nothing to persist as settings saved in `AppData\Roaming\another-redis-desktop-manager`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
