### PR TITLE
*mozilla: use $persist_dir instead of $dir in profile path

### DIFF
--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox-esr -CreateProfile \"Scoop-ESR $dir\\profile\"",
+    "post_install": "firefox-esr -CreateProfile \"Scoop-ESR $persist_dir\\profile\"",
     "bin": [
         [
             "firefox.exe",

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox -CreateProfile \"Scoop $dir\\profile\"",
+    "post_install": "firefox -CreateProfile \"Scoop $persist_dir\\profile\"",
     "bin": "firefox.exe",
     "shortcuts": [
         [

--- a/bucket/seamonkey.json
+++ b/bucket/seamonkey.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "seamonkey -CreateProfile \"Scoop $dir\\profile\"",
+    "post_install": "seamonkey -CreateProfile \"Scoop $persist_dir\\profile\"",
     "bin": "seamonkey.exe",
     "shortcuts": [
         [

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "thunderbird -CreateProfile \"Scoop $dir\\profile\"",
+    "post_install": "thunderbird -CreateProfile \"Scoop $persist_dir\\profile\"",
     "bin": "thunderbird.exe",
     "shortcuts": [
         [

--- a/bucket/waterfox-classic.json
+++ b/bucket/waterfox-classic.json
@@ -17,7 +17,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "waterfox-classic -CreateProfile \"Scoop-Classic $dir\\profile\"",
+    "post_install": "waterfox-classic -CreateProfile \"Scoop-Classic $persist_dir\\profile\"",
     "bin": [
         [
             "waterfox.exe",

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -17,7 +17,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "waterfox -CreateProfile \"Scoop $dir\\profile\"",
+    "post_install": "waterfox -CreateProfile \"Scoop $persist_dir\\profile\"",
     "bin": "waterfox.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
use $persist_dir instead of $dir in profile path, then profile path can still be used in other versions after uninstalling the apps. (if it is compatible)

- this change only affects fresh installations.
- for users who have generated a scoop portable profile before this update, you will need to manually edit this file **OR** delete it and reinstall the application to change the profile path, if you want use uninstalled app's profile:
```
$HOME\AppData\Roaming\Mozilla\Firefox\profiles.ini
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
