### PR TITLE
aircrack-ng: Add version 1.6

### DIFF
--- a/bucket/aircrack-ng.json
+++ b/bucket/aircrack-ng.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.6",
+    "description": "A suite of tools to assess WiFi network security",
+    "homepage": "https://www.aircrack-ng.org/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.aircrack-ng.org/aircrack-ng-1.6-win.zip",
+            "hash": "sha1:ede4ac13ad04e9ec10b973460b36c92ce97829af"
+        }
+    },
+    "extract_dir": "aircrack-ng-1.6-win",
+    "pre_install": "if(!(Test-Path \"$persist_dir\\bin\\debug.log\")) {New-Item \"$dir\\bin\\debug.log\" | Out-Null}",
+    "shortcuts": [
+        [
+            "bin\\Aircrack-ng GUI.exe",
+            "Aircrack-ng GUI"
+        ]
+    ],
+    "env_add_path": "bin",
+    "persist": "bin\\debug.log",
+    "checkver": {
+        "url": "https://www.aircrack-ng.org/downloads.html",
+        "regex": "aircrack-ng-([\\d.]+)-win\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.aircrack-ng.org/aircrack-ng-$version-win.zip",
+                "hash": {
+                    "url": "https://www.aircrack-ng.org/downloads.html",
+                    "regex": "(?sm)aircrack-ng-[\\d.]+-win\\.zip.*?$sha1"
+                }
+            }
+        },
+        "extract_dir": "aircrack-ng-$version-win"
+    }
+}


### PR DESCRIPTION
closes #7990

[Aircrack-ng](https://www.aircrack-ng.org/) is a suite of tools to assess WiFi network security.

**NOTES**:
* The binary is built in **64-bit**.