### PR TITLE
jexiftoolgui: Add version 1.10.0.0

### DIFF
--- a/bucket/jexiftoolgui.json
+++ b/bucket/jexiftoolgui.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.10.0.0",
+    "description": "Graphical frontend for ExifTool",
+    "homepage": "https://hvdwolf.github.io/jExifToolGUI/",
+    "license": "GPL-3.0-or-later",
+    "depends": "exiftool",
+    "url": "https://github.com/hvdwolf/jExifToolGUI/releases/download/1.10.0/jExifToolGUI-1.10.0.0-win-x86_64_with-jre.zip",
+    "hash": "e2ebb812779c6e9bb98311ed1d1d8c0478b52166ddc6f1c46ba8080777cd6f8c",
+    "extract_dir": "jExifToolGUI-1.10.0.0-win-x86_64_with-jre",
+    "shortcuts": [
+        [
+            "jExifToolGUI.exe",
+            "jExifToolGUI"
+        ]
+    ],
+    "persist": "logs",
+    "checkver": {
+        "url": "https://github.com/hvdwolf/jExifToolGUI/releases",
+        "regex": "jExifToolGUI-([\\d.]+)-win-x86_64_with-jre\\.zip\""
+    },
+    "autoupdate": {
+        "url": "https://github.com/hvdwolf/jExifToolGUI/releases/download/$matchHead/jExifToolGUI-$version-win-x86_64_with-jre.zip",
+        "extract_dir": "jExifToolGUI-$version-win-x86_64_with-jre"
+    }
+}


### PR DESCRIPTION
closes #8007

[jExifToolGUI](https://hvdwolf.github.io/jExifToolGUI/) is a java/Swing graphical frontend for the command-line tool **ExifTool**.

**NOTES**:
* I chose the binary release with bundled JRE because it is less likely to have environment problems.
* **architecture**: Although the file is named as `win-x86_64`, the executable is built under 32-bit, and can work under 32-bit.
```
>pelook jExifToolGUI.exe
loaded "jExifToolGUI.exe" / 15225974 (0xE85476) bytes
signature/type:       PE32 EXE image for i386
image checksum:       0x00015C90 (MISMATCH / calc=0x00E8E1E8)
machine:              0x014C (i386)
subsystem:            2 (Windows GUI)
minimum os:           4.0 (Win95/NT4)
linkver:              2.26
timestamp:            11/13/2021 04:03:59pm (0x618FE1EF)
```
* **persist**: Besides from `logs`, the config is stored at `$Env:UserProfile\jexiftoolgui_data`.