### PR TITLE
*mozilla: Allow appending of Additional items

### DIFF
--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -25,7 +25,8 @@
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
-        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "bin": [
         [

--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -20,7 +20,12 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox-esr -CreateProfile \"Scoop-ESR $persist_dir\\profile\"",
+    "post_install": [
+        "firefox-esr -CreateProfile \"Scoop-ESR $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+    ],
     "bin": [
         [
             "firefox.exe",

--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -24,6 +24,7 @@
         "firefox-esr -CreateProfile \"Scoop-ESR $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": [

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -20,7 +20,12 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox -CreateProfile \"Scoop $persist_dir\\profile\"",
+    "post_install": [
+        "firefox -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+    ],
     "bin": "firefox.exe",
     "shortcuts": [
         [

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -25,7 +25,8 @@
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
-        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "bin": "firefox.exe",
     "shortcuts": [

--- a/bucket/firefox.json
+++ b/bucket/firefox.json
@@ -24,6 +24,7 @@
         "firefox -CreateProfile \"Scoop $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": "firefox.exe",

--- a/bucket/seamonkey.json
+++ b/bucket/seamonkey.json
@@ -20,7 +20,12 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "seamonkey -CreateProfile \"Scoop $persist_dir\\profile\"",
+    "post_install": [
+        "seamonkey -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+    ],
     "bin": "seamonkey.exe",
     "shortcuts": [
         [

--- a/bucket/seamonkey.json
+++ b/bucket/seamonkey.json
@@ -24,6 +24,7 @@
         "seamonkey -CreateProfile \"Scoop $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": "seamonkey.exe",

--- a/bucket/seamonkey.json
+++ b/bucket/seamonkey.json
@@ -25,7 +25,8 @@
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
-        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "bin": "seamonkey.exe",
     "shortcuts": [

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -24,6 +24,7 @@
         "thunderbird -CreateProfile \"Scoop $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": "thunderbird.exe",

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -25,7 +25,8 @@
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
-        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "bin": "thunderbird.exe",
     "shortcuts": [

--- a/bucket/thunderbird.json
+++ b/bucket/thunderbird.json
@@ -20,7 +20,12 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "thunderbird -CreateProfile \"Scoop $persist_dir\\profile\"",
+    "post_install": [
+        "thunderbird -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+    ],
     "bin": "thunderbird.exe",
     "shortcuts": [
         [

--- a/bucket/waterfox-classic.json
+++ b/bucket/waterfox-classic.json
@@ -22,7 +22,8 @@
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
-        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "bin": [
         [

--- a/bucket/waterfox-classic.json
+++ b/bucket/waterfox-classic.json
@@ -17,7 +17,12 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "waterfox-classic -CreateProfile \"Scoop-Classic $persist_dir\\profile\"",
+    "post_install": [
+        "waterfox-classic -CreateProfile \"Scoop-Classic $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+    ],
     "bin": [
         [
             "waterfox.exe",

--- a/bucket/waterfox-classic.json
+++ b/bucket/waterfox-classic.json
@@ -21,6 +21,7 @@
         "waterfox-classic -CreateProfile \"Scoop-Classic $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": [

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -22,7 +22,8 @@
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
-        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "bin": "waterfox.exe",
     "shortcuts": [

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -17,7 +17,12 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "waterfox -CreateProfile \"Scoop $persist_dir\\profile\"",
+    "post_install": [
+        "waterfox -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
+    ],
     "bin": "waterfox.exe",
     "shortcuts": [
         [

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -21,6 +21,7 @@
         "waterfox -CreateProfile \"Scoop $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": "waterfox.exe",


### PR DESCRIPTION

USAGE:
Create a directory named **addition** in app's persist directory (e.g. ~\scoop\persist\firefox\addition), and put files/configs/etc. into the directory. 

Items of **addition** directory will be copied to app root directory by install script every install/update.

---

Any items that overwrite the original files are **NOT RECOMMENDED**.

see also: https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig

Closes #8016

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
