### PR TITLE
fysty: Add version 20220202-76f785d5

### DIFF
--- a/bucket/fysty.json
+++ b/bucket/fysty.json
@@ -1,0 +1,52 @@
+{
+    "version": "20220202-76f785d5",
+    "description": "A fork of the SSH/Telnet client PuTTY",
+    "homepage": "https://github.com/lalbornoz/FySTY",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lalbornoz/FySTY/releases/download/FySTY-Release-76f785d5/FySTY-Release-76f785d5.zip",
+            "hash": "0f87de7cb30320f7260a25f20e2139416dc9c2417bf35ee306ae135dd81c2f7b"
+        }
+    },
+    "extract_dir": "FySTY-Release-76f785d5",
+    "bin": [
+        "bidi_gettype.exe",
+        "bidi_test.exe",
+        "pageant.exe",
+        "plink.exe",
+        "pscp.exe",
+        "psftp.exe",
+        "psocks.exe",
+        "putty.exe",
+        "puttygen.exe",
+        "puttytel.exe"
+    ],
+    "shortcuts": [
+        [
+            "putty.exe",
+            "PuTTY"
+        ],
+        [
+            "puttygen.exe",
+            "PuttyGen (PuTTY Key Generator)"
+        ],
+        [
+            "pageant.exe",
+            "Pageant (PuTTY authentication agent)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/lalbornoz/FySTY",
+        "regex": "(?sm)datetime=\"(\\d{4})-(\\d{2})-(\\d{2}).*?FySTY-Release-(?<commit>[0-9a-f]{8})\\.zip",
+        "replace": "${1}${2}${3}-${4}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lalbornoz/FySTY/releases/download/FySTY-Release-$matchCommit/FySTY-Release-$matchCommit.zip"
+            }
+        },
+        "extract_dir": "FySTY-Release-$matchCommit"
+    }
+}

--- a/bucket/fysty.json
+++ b/bucket/fysty.json
@@ -44,7 +44,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lalbornoz/FySTY/releases/download/FySTY-Release-$matchCommit/FySTY-Release-$matchSha.zip"
+                "url": "https://github.com/lalbornoz/FySTY/releases/download/FySTY-Release-$matchSha/FySTY-Release-$matchSha.zip"
             }
         },
         "extract_dir": "FySTY-Release-$matchSha"

--- a/bucket/fysty.json
+++ b/bucket/fysty.json
@@ -44,9 +44,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lalbornoz/FySTY/releases/download/FySTY-Release-$matchCommit/FySTY-Release-$matchCommit.zip"
+                "url": "https://github.com/lalbornoz/FySTY/releases/download/FySTY-Release-$matchCommit/FySTY-Release-$matchSha.zip"
             }
         },
-        "extract_dir": "FySTY-Release-$matchCommit"
+        "extract_dir": "FySTY-Release-$matchSha"
     }
 }

--- a/bucket/fysty.json
+++ b/bucket/fysty.json
@@ -37,9 +37,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/lalbornoz/FySTY",
-        "regex": "(?sm)datetime=\"(\\d{4})-(\\d{2})-(\\d{2}).*?FySTY-Release-(?<commit>[0-9a-f]{8})\\.zip",
-        "replace": "${1}${2}${3}-${4}"
+        "github": "https://api.github.com/repos/lalbornoz/FySTY",
+        "regex": "(?s)Release-(?<sha>[0-9a-f]{8}).*?updated_at.*?(\\d{4})-(\\d{2})-(\\d{2})",
+        "replace": "${1}${2}${3}-${sha}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/fysty.json
+++ b/bucket/fysty.json
@@ -1,6 +1,6 @@
 {
     "version": "20220202-76f785d5",
-    "description": "A fork of the SSH/Telnet client PuTTY",
+    "description": "A fork of the SSH/Telnet client PuTTY with new features such as background images, transparent window, clickable URLs and zooming.",
     "homepage": "https://github.com/lalbornoz/FySTY",
     "license": "MIT",
     "architecture": {


### PR DESCRIPTION
closes #8005

[Fysty](https://github.com/lalbornoz/FySTY) is a fork/patch of the SSH and Telnet client **PuTTY**.

**NOTES**:
* The app is built in **64-bit**.
* persist is not needed because config is at `HKCU\SOFTWARE\SimonTatham\PuTTY`.
* **checkver**: I involved **release date** in version because there will be problem checking which one is newer through **commits**. For example, `4c207368` comes after `a2404931`.
* **bin**: Command-line options for `putty.exe`, etc. can be found in [the manual](https://documentation.help/PuTTY/using-general-opts.html). Also see [extras/putty manifest](https://github.com/ScoopInstaller/Extras/blob/master/bucket/putty.json).