### PR TITLE
mumble: Update to version 1.4.230, Add mumble-server

### DIFF
--- a/bucket/mumble-server.json
+++ b/bucket/mumble-server.json
@@ -1,0 +1,47 @@
+{
+    "version": "1.4.230",
+    "description": "Server kit for Mumble, a low-latency and high quality voice chat primarily intended for use while gaming.",
+    "homepage": "https://www.mumble.info/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mumble-voip/mumble/releases/download/v1.4.230/mumble_server-1.4.230.x64.msi",
+            "hash": "b890d54280a7020f44cdca08cae7d9ff6e179e57e4da0a9c62e2feadad646438",
+            "extract_dir": "ProgramFiles64Folder\\Mumble\\server"
+        },
+        "32bit": {
+            "url": "https://github.com/mumble-voip/mumble/releases/download/v1.4.230/mumble_server-1.4.230.x86.msi",
+            "hash": "ac115bf7f53a5e7c7301f911cb45b6972e7bb10ab5113406c4212172ebe68215",
+            "extract_dir": "ProgramFilesFolder\\Mumble\\server"
+        }
+    },
+    "pre_install": [
+        "'murmur.log', 'murmur.sqlite' | ForRach-Object {",
+        "  if(!(Test-Path \"$persist_dir\\$_\")) {New-Item \"$dir\\$_\" -ItemType File | Out-Null}",
+        "}"
+    ],
+    "bin": "mumble-server.exe",
+    "shortcuts": [
+        [
+            "mumble-server.exe",
+            "Mumble"
+        ]
+    ],
+    "persist": [
+        "murmur.log",
+        "murmur.sqlite"
+    ],
+    "checkver": {
+        "github": "https://github.com/mumble-voip/mumble"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mumble-voip/mumble/releases/download/v$version/mumble_server-$version.x64.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/mumble-voip/mumble/releases/download/v$version/mumble_server-$version.x86.msi"
+            }
+        }
+    }
+}

--- a/bucket/mumble.json
+++ b/bucket/mumble.json
@@ -1,44 +1,37 @@
 {
-    "version": "1.3.4",
+    "version": "1.4.230",
     "description": "Low-latency and high quality voice chat primarily intended for use while gaming.",
     "homepage": "https://www.mumble.info/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mumble-voip/mumble/releases/download/1.3.4/mumble-1.3.4.winx64.msi",
-            "hash": "14e58074269ae32d1678738fb66fc9551c2aac2e789439157081886860802e02"
+            "url": "https://github.com/mumble-voip/mumble/releases/download/v1.4.230/mumble_client-1.4.230.x64.msi",
+            "hash": "ac08a69b88442b5f0d5b4566c0241f4a6f12ceff4406b0355fa78ff6630e73f6",
+            "extract_dir": "ProgramFiles64Folder\\Mumble\\client"
         },
         "32bit": {
-            "url": "https://github.com/mumble-voip/mumble/releases/download/1.3.4/mumble-1.3.4.msi",
-            "hash": "eb2f452dccaa60f64409356815f7ee834aa07823f92410eefe3a2628cf90d52e"
+            "url": "https://github.com/mumble-voip/mumble/releases/download/v1.4.230/mumble_client-1.4.230.x86.msi",
+            "hash": "e6392b070c57d9da6e07c8883490eaef16f01bf15a9a976477f9970323fe3954",
+            "extract_dir": "ProgramFilesFolder\\Mumble\\client"
         }
     },
-    "extract_dir": "Mumble",
-    "bin": [
-        "mumble.exe",
-        "murmur.exe"
-    ],
+    "bin": "mumble.exe",
     "shortcuts": [
         [
             "mumble.exe",
             "Mumble"
-        ],
-        [
-            "murmur.exe",
-            "Murmur"
         ]
     ],
-    "persist": "murmur.ini",
     "checkver": {
         "github": "https://github.com/mumble-voip/mumble"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mumble-voip/mumble/releases/download/$version/mumble-$version.winx64.msi"
+                "url": "https://github.com/mumble-voip/mumble/releases/download/v$version/mumble_client-$version.x64.msi"
             },
             "32bit": {
-                "url": "https://github.com/mumble-voip/mumble/releases/download/$version/mumble-$version.msi"
+                "url": "https://github.com/mumble-voip/mumble/releases/download/v$version/mumble_client-$version.x86.msi"
             }
         }
     }


### PR DESCRIPTION
closes #7971

**NOTES**:
* persist is not needed for *client* because config is at `$Env:AppData\Mumble`.
