### PR TITLE
rancher-desktop: Add version 1.0.1

### DIFF
--- a/bucket/rancher-desktop.json
+++ b/bucket/rancher-desktop.json
@@ -10,7 +10,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.1/Rancher.Desktop.Setup.1.0.1.exe#/dl.7z",
-            "hash": "bdfa295a59cd5c46eb93686e36bc8ad6e60f271ee4844624b12a35bdd3deb07f"
+            "hash": "sha512:200337bfea3b21b0fb9595cb02c885b5e51d9c75a59b16901c2809dbb746b7e111aa642dd8c45e9c80ed1aefd2b806d709666786d2db4d7e5a5057bd405faa77"
         }
     },
     "pre_install": [
@@ -35,7 +35,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v$version/Rancher.Desktop.Setup.$version.exe#/dl.7z",
-                "hash": "$url.sha512sum"
+                "hash": {
+                    "url": "$url.sha512sum"
+                }
             }
         }
     }

--- a/bucket/rancher-desktop.json
+++ b/bucket/rancher-desktop.json
@@ -7,7 +7,7 @@
         "Rancher requires WSL (Windows Subsystem for Linux) to work properly.",
         "To install WSL, run '$dir\\install-wsl.ps1' under Powershell."
     ],
-    "#architecture": {
+    "architecture": {
         "64bit": {
             "url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.1/Rancher.Desktop.Setup.1.0.1.exe#/dl.7z",
             "hash": "bdfa295a59cd5c46eb93686e36bc8ad6e60f271ee4844624b12a35bdd3deb07f"

--- a/bucket/rancher-desktop.json
+++ b/bucket/rancher-desktop.json
@@ -7,7 +7,7 @@
         "Rancher requires WSL (Windows Subsystem for Linux) to work properly.",
         "To install WSL, run '$dir\\install-wsl.ps1' under Powershell."
     ],
-    "architecture": {
+    "#architecture": {
         "64bit": {
             "url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.1/Rancher.Desktop.Setup.1.0.1.exe#/dl.7z",
             "hash": "bdfa295a59cd5c46eb93686e36bc8ad6e60f271ee4844624b12a35bdd3deb07f"

--- a/bucket/rancher-desktop.json
+++ b/bucket/rancher-desktop.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.0.1",
+    "description": "Kubernates container management tool that can build, push, and pull images and run containers.",
+    "homepage": "https://rancherdesktop.io/",
+    "license": "Apache-2.0",
+    "notes": [
+        "Rancher requires WSL (Windows Subsystem for Linux) to work properly.",
+        "To install WSL, run '$dir\\install-wsl.ps1' under Powershell."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.0.1/Rancher.Desktop.Setup.1.0.1.exe#/dl.7z",
+            "hash": "bdfa295a59cd5c46eb93686e36bc8ad6e60f271ee4844624b12a35bdd3deb07f"
+        }
+    },
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal | Out-Null",
+        "Copy-Item \"$dir\\`$PLUGINSDIR\\install-wsl.ps1\" \"$dir\"",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall*.exe\" -Force -Recurse"
+    ],
+    "shortcuts": [
+        [
+            "Rancher Desktop.exe",
+            "Rancher Desktop"
+        ]
+    ],
+    "env_add_path": [
+        "resources\\resources\\win32\\bin",
+        "resources\\resources\\linux\\bin"
+    ],
+    "checkver": {
+        "github": "https://github.com/rancher-sandbox/rancher-desktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v$version/Rancher.Desktop.Setup.$version.exe#/dl.7z",
+                "hash": "$url.sha512sum"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #7973

[Rancher desktop](https://rancherdesktop.io/) is a Kubernates container management tool that can build, push, and pull images and run containers.

**NOTES**:
* persist is not needed because config is at `$Env:LocalAppData\rancher-desktop`.
* **env_add_path**: Some of the binaries is intended to work under WSL (Linux), which cannot be properly shimmed, therefore `env_add_path` is needed here.