### PR TITLE
dopamine: Update to 2.0.9 & Update checkver

### DIFF
--- a/bucket/dopamine.json
+++ b/bucket/dopamine.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.0.8",
+    "version": "2.0.9",
     "description": "Audio player which tries to make organizing and listening to music as simple and pretty as possible.",
     "homepage": "https://www.digimezzo.com/software/dopamine/",
     "license": "GPL-3.0-only",
-    "url": "https://www.digimezzo.com/content/software/dopamine/Dopamine%202.0.8%20(Release)%20-%20Portable.zip",
-    "hash": "a4a067f15e0e61282fb820f52d938128a9dea3b58235af0c3601df88661e3fb8",
+    "url": "https://www.digimezzo.com/content/software/dopamine/Dopamine%202.0.9%20(Release)%20-%20Portable.zip",
+    "hash": "fd5ec9aa1c6f9a2a21244a65f9d77ef20614422c9ce6df75614ba8edb09c8b08",
     "shortcuts": [
         [
             "Dopamine.exe",
@@ -12,7 +12,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/digimezzo/Dopamine-windows"
+        "url": "https://www.digimezzo.com/content/software/dopamine",
+        "regex": "/Dopamine\\s+([\\d.]+)\\s+\\(Release\\)",
+        "reverse": true
     },
     "autoupdate": {
         "url": "https://www.digimezzo.com/content/software/dopamine/Dopamine%20$version%20(Release)%20-%20Portable.zip"


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

GitHub releases are not updated, but there is a reminder within the software to update. so I found the official website already has the new version installed.

Also try updating checkver to keep up to date with the latest version.