### PR TITLE
altsnap: Add version 1.51

### DIFF
--- a/bucket/altdrag.json
+++ b/bucket/altdrag.json
@@ -3,6 +3,10 @@
     "description": "Easily drag windows when pressing the Alt key",
     "homepage": "https://stefansundin.github.io/altdrag/",
     "license": "GPL-3.0-or-later",
+    "notes": [
+        "AltDrag has not been updated since 2015. It may not work as intended under latest Windows versions.",
+        "We suggest installing 'extras/altsnap', a maintained fork of AltDrag, for better experience."
+    ],
     "url": "https://github.com/stefansundin/altdrag/releases/download/v1.1/AltDrag-1.1.zip",
     "hash": "5e1cf4fd8bfbdeca672cd53141019471b344317c81fdefe1ae9cb3f96183bdf9",
     "extract_dir": "AltDrag",
@@ -17,11 +21,5 @@
             "AltDrag"
         ]
     ],
-    "persist": "AltDrag.ini",
-    "checkver": {
-        "github": "https://github.com/stefansundin/altdrag"
-    },
-    "autoupdate": {
-        "url": "https://github.com/stefansundin/altdrag/releases/download/v$version/AltDrag-$version.zip"
-    }
+    "persist": "AltDrag.ini"
 }

--- a/bucket/altsnap.json
+++ b/bucket/altsnap.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.51",
+    "description": "Easily drag windows when pressing the Alt key (maintained continuation of Stefan Sundin's AltDrag)",
+    "homepage": "https://github.com/RamonUnch/AltSnap",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/RamonUnch/AltSnap/releases/download/1.51/AltSnap1.51bin_x64.zip",
+            "hash": "a807229cb5dd365a40b8cca3461abbca7465e1f23d3509b976e3ea63232e3a2b"
+        },
+        "32bit": {
+            "url": "https://github.com/RamonUnch/AltSnap/releases/download/1.51/AltSnap1.51bin.zip",
+            "hash": "33180befff1072c39e18e71a35c45b0575334c8b3d839d7ecd2cc56bed9d97ba"
+        }
+    },
+    "shortcuts": [
+        [
+            "AltSnap.exe",
+            "AltSnap"
+        ]
+    ],
+    "persist": "AltSnap.ini",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/RamonUnch/AltSnap/releases/download/$version/AltSnap$versionbin_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/RamonUnch/AltSnap/releases/download/$version/AltSnap$versionbin.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
supersedes #6395
closes #6398

* [AltSnap](https://github.com/RamonUnch/AltSnap) is maintained continuation of Stefan Sundin's **AltDrag**, an app that enables dragging windows when pressing the Alt key.

* remove autoupdate and add notes in `altdrag`. I keep the package (instead of deleting it) so that old `altdrag` users can find the new maintained app.