### PR TITLE
goldendict@1.5.0-RC2-372-gc3ff15f: make goldendict portable

### DIFF
--- a/bucket/goldendict.json
+++ b/bucket/goldendict.json
@@ -13,6 +13,10 @@
             "GoldenDict"
         ]
     ],
+    "persist": [
+        "portable",
+        "content"
+    ],
     "checkver": {
         "url": "https://sourceforge.net/p/goldendict/activity/feed",
         "regex": "GoldenDict-([\\w.-]+)_\\(QT_486\\)\\.7z"


### PR DESCRIPTION
According to goldendict>help>03_Portable_Mode, goldendict can be made portable if a folder named portable is under its dirertory, in which case the dictionaries must be stored within the program.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
