### PR TITLE
Fixed Webex checkver regex to match updated website

### DIFF
--- a/bucket/webex.json
+++ b/bucket/webex.json
@@ -1,5 +1,5 @@
 {
-    "version": "42.1.0.21190",
+    "version": "42.2.0.21486",
     "description": "Video and audio conferencing",
     "homepage": "https://www.webex.com/",
     "license": {

--- a/bucket/webex.json
+++ b/bucket/webex.json
@@ -25,7 +25,7 @@
     ],
     "checkver": {
         "url": "https://help.webex.com/article/mqkve8",
-        "regex": "Version:\\s([\\d.]+)"
+        "regex": "Windowsâ€”([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/webex.json
+++ b/bucket/webex.json
@@ -1,5 +1,5 @@
 {
-    "version": "42.2.0.21486",
+    "version": "42.3.0.21576",
     "description": "Video and audio conferencing",
     "homepage": "https://www.webex.com/",
     "license": {
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://binaries.webex.com/WebexTeamsDesktop-Windows-Gold/Webex.msi",
-            "hash": "d859f68a8cc7372877f84552b4a48b1f9dc823f7751c940384ddd7bb9ed51d91"
+            "hash": "e98066412c3c79c8f68330406a7cc246c98ea5419fc3ce41bbb88a2969429694"
         },
         "32bit": {
             "url": "https://binaries.webex.com/WebexTeamsDesktop-Windows-Gold/Webex_x86.msi",
-            "hash": "7fb4a4defdececb64e0f4d8d2b4e2a9ebe873663410f5fc2a7068465684e9955"
+            "hash": "0bc78af8ae53a3c81a6b6bcfb488704941f83f4c48f2f147ee8f96d0a01ea23e"
         }
     },
     "extract_dir": "Cisco Spark",
@@ -25,7 +25,7 @@
     ],
     "checkver": {
         "url": "https://help.webex.com/article/mqkve8",
-        "regex": "Windowsâ€”([\\d.]+)"
+        "regex": ">Windows[^\\d]+([\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Closes #8057

The Webex URL that checkver uses has been updated to change the format of how they present the version from:
`Version: xx.x.x.xxxxx` to `Windows—xx.x.x.xxxxx`.

Note, there is a complication here due to how Scopp downloads the URL and processes the regex, pattern matching on the emdash character is not possible. This is because the UTF-8 website is being interpreted as Windows-1252. So the emdash actually reports as `â€”`. For reference this is a common encoding issue which you can read about [here](https://www.i18nqa.com/debug/utf8-debug.html).

I have not updated the version or hash at this time, I'll leave that for the automated process which should work as normal from now on.
