### PR TITLE
sunshine: Properly set working directory to executable path

### DIFF
--- a/bucket/sunshine.json
+++ b/bucket/sunshine.json
@@ -13,7 +13,7 @@
             "hash": "c12904346cdf36a0848b35050f4ce6b45f5dde4c65191f0f00d9c1000d6a1759"
         }
     },
-    "pre_install": "Set-Content -Path \"$dir\\sunshine.bat\" -Value (@('@echo off', 'pushd %~dp0 && sunshine.exe && popd') -join \"`r`n\")",
+    "pre_install": "Set-Content -Path \"$dir\\sunshine.bat\" -Value (@('@echo off', 'pushd %~dp0 && sunshine.exe %* && popd') -join \"`r`n\")",
     "bin": [
         "sunshine.bat",
         "tools\\dxgi-info.exe",

--- a/bucket/sunshine.json
+++ b/bucket/sunshine.json
@@ -20,6 +20,7 @@
         "tools\\audio-info.exe"
     ],
     "persist": [
+        "sunshine_state.json",
         "assets\\sunshine.conf",
         "assets\\apps_windows.json"
     ],

--- a/bucket/sunshine.json
+++ b/bucket/sunshine.json
@@ -13,8 +13,9 @@
             "hash": "c12904346cdf36a0848b35050f4ce6b45f5dde4c65191f0f00d9c1000d6a1759"
         }
     },
+    "pre_install": "Set-Content -Path \"$dir\\sunshine.bat\" -Value (@('@echo off', 'pushd %~dp0 && sunshine.exe && popd') -join \"`r`n\")",
     "bin": [
-        "sunshine.exe",
+        "sunshine.bat",
         "tools\\dxgi-info.exe",
         "tools\\audio-info.exe"
     ],


### PR DESCRIPTION
Fixes https://github.com/SunshineStream/Sunshine/issues/70.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
