### PR TITLE
nirlauncher: Update to version 1.23.57 (via nlp2json.py)

### DIFF
--- a/bucket/nirlauncher.json
+++ b/bucket/nirlauncher.json
@@ -122,6 +122,7 @@
                 "NirSoft\\x64\\LSASecretsDump.exe",
                 "NirSoft\\x64\\LSASecretsView.exe",
                 "NirSoft\\MACAddressView.exe",
+                "NirSoft\\MadPassExt.exe",
                 "NirSoft\\mailpv.exe",
                 "NirSoft\\ManageWirelessNetworks.exe",
                 "NirSoft\\x64\\MMCSnapInsView.exe",
@@ -159,6 +160,7 @@
                 "NirSoft\\OpenWithView.exe",
                 "NirSoft\\OperaCacheView.exe",
                 "NirSoft\\OperaPassView.exe",
+                "NirSoft\\x64\\OutlookAccountsView.exe",
                 "NirSoft\\x64\\OutlookAddressBookView.exe",
                 "NirSoft\\x64\\OutlookAttachView.exe",
                 "NirSoft\\x64\\OutlookStatView.exe",
@@ -662,6 +664,10 @@
                     "NirSoft\\MACAddressView - MAC address lookup tool"
                 ],
                 [
+                    "NirSoft\\MadPassExt.exe",
+                    "NirSoft\\MadPassExt - Extract the secret DPAPI password generated for your Microsoft account"
+                ],
+                [
                     "NirSoft\\mailpv.exe",
                     "NirSoft\\Mail PassView - Recovers email passwords"
                 ],
@@ -806,6 +812,10 @@
                     "NirSoft\\OperaPassView - Password recovery tool for Opera Web browser"
                 ],
                 [
+                    "NirSoft\\x64\\OutlookAccountsView.exe",
+                    "NirSoft\\OutlookAccountsView - View POP3, IMAP, SMTP passwords and account settings of Outlook"
+                ],
+                [
                     "NirSoft\\x64\\OutlookAddressBookView.exe",
                     "NirSoft\\OutlookAddressBookView - Displays the details of all recipients stored in the address books of Outlook"
                 ],
@@ -908,10 +918,6 @@
                 [
                     "NirSoft\\x64\\RunAsDate.exe",
                     "NirSoft\\RunAsDate - Run a program with the specified date"
-                ],
-                [
-                    "NirSoft\\x64\\RunFromProcess.exe",
-                    "NirSoft\\RunFromProcess - Run a program from another process that you choose"
                 ],
                 [
                     "NirSoft\\SafariCacheView.exe",
@@ -1309,6 +1315,7 @@
                 "NirSoft\\LSASecretsDump.exe",
                 "NirSoft\\LSASecretsView.exe",
                 "NirSoft\\MACAddressView.exe",
+                "NirSoft\\MadPassExt.exe",
                 "NirSoft\\mailpv.exe",
                 "NirSoft\\ManageWirelessNetworks.exe",
                 "NirSoft\\MMCSnapInsView.exe",
@@ -1346,6 +1353,7 @@
                 "NirSoft\\OpenWithView.exe",
                 "NirSoft\\OperaCacheView.exe",
                 "NirSoft\\OperaPassView.exe",
+                "NirSoft\\OutlookAccountsView.exe",
                 "NirSoft\\OutlookAddressBookView.exe",
                 "NirSoft\\OutlookAttachView.exe",
                 "NirSoft\\OutlookStatView.exe",
@@ -1849,6 +1857,10 @@
                     "NirSoft\\MACAddressView - MAC address lookup tool"
                 ],
                 [
+                    "NirSoft\\MadPassExt.exe",
+                    "NirSoft\\MadPassExt - Extract the secret DPAPI password generated for your Microsoft account"
+                ],
+                [
                     "NirSoft\\mailpv.exe",
                     "NirSoft\\Mail PassView - Recovers email passwords"
                 ],
@@ -1993,6 +2005,10 @@
                     "NirSoft\\OperaPassView - Password recovery tool for Opera Web browser"
                 ],
                 [
+                    "NirSoft\\OutlookAccountsView.exe",
+                    "NirSoft\\OutlookAccountsView - View POP3, IMAP, SMTP passwords and account settings of Outlook"
+                ],
+                [
                     "NirSoft\\OutlookAddressBookView.exe",
                     "NirSoft\\OutlookAddressBookView - Displays the details of all recipients stored in the address books of Outlook"
                 ],
@@ -2095,10 +2111,6 @@
                 [
                     "NirSoft\\RunAsDate.exe",
                     "NirSoft\\RunAsDate - Run a program with the specified date"
-                ],
-                [
-                    "NirSoft\\RunFromProcess.exe",
-                    "NirSoft\\RunFromProcess - Run a program from another process that you choose"
                 ],
                 [
                     "NirSoft\\SafariCacheView.exe",


### PR DESCRIPTION
RunFromProcess.exe was previously identified as a GUI exe. This has been corrected in this release (though the .exe is still actually a GUI app).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
