### PR TITLE
fiji: Add version 20220222-1217

### DIFF
--- a/bucket/fiji.json
+++ b/bucket/fiji.json
@@ -1,0 +1,31 @@
+{
+    "version": "20220222-1217",
+    "description": "ImageJ distribution with many plugins which facilitating scientific image analysis.",
+    "homepage": "https://fiji.sc/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.imagej.net/fiji/archive/20220222-1217/fiji-win64.zip",
+            "hash": "c91f6c3f3ee68d2e74c1a3a565d2f16be936733e2a6e23e127a3c4f14324d59d"
+        }
+    },
+    "extract_dir": "Fiji.app",
+    "shortcuts": [
+        [
+            "ImageJ-win64.exe",
+            "(Fiji Is Just) ImageJ"
+        ]
+    ],
+    "checkver": {
+        "url": "https://downloads.imagej.net/fiji/archive/",
+        "regex": "href=\"(\\d{8}-\\d{4})",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.imagej.net/fiji/archive/$version/fiji-win64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #5813

[Fiji](https://fiji.sc/) is an image processing package — a "batteries-included" distribution of [ImageJ](https://imagej.net/), bundling many plugins which facilitate scientific image analysis.

**NOTES**:
* **checkver**: [Fiji's Github repo](https://github.com/fiji/fiji/tags) provides version names like `2.3.1`. However, from [their download archives](https://downloads.imagej.net/fiji/archive/), we can see there are actually more frequently updates. This will be a problem if we check version *via Github repo* and use `https://downloads.imagej.net/fiji/latest/fiji-win64.zip` as download url.

* shortcut name `(Fiji Is Just) ImageJ` is the window title of the app.

* persist is not needed because config is at `$Env:UserProfile\.imagej`