### PR TITLE
mozregression-gui: Add version 4.0.18

### DIFF
--- a/bucket/mozregression-gui.json
+++ b/bucket/mozregression-gui.json
@@ -1,0 +1,21 @@
+{
+    "version": "4.0.18",
+    "description": "Regression range finder for Firefox and other Mozilla products. Helps determining a changeset range corresponding to when a problem was introduced.",
+    "homepage": "https://mozilla.github.io/mozregression/",
+    "license": "MPL-2.0",
+    "url": "https://github.com/mozilla/mozregression/releases/download/4.0.18/mozregression-gui.exe#/dl.7z",
+    "hash": "395731f80997b556197ad922869ed890836610b7de5c96905aa9e757ef8acec0",
+    "pre_install": "Remove-Item \"$dir\\uninstall.exe\"",
+    "shortcuts": [
+        [
+            "mozregression-gui.exe",
+            "Mozregression GUI"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/mozilla/mozregression"
+    },
+    "autoupdate": {
+        "url": "https://github.com/mozilla/mozregression/releases/download/$version/mozregression-gui.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
closes #5625

[Mozregression](https://mozilla.github.io/mozregression/) is a tool **developed by Mozilla**. It is a regression range finder for Firefox and other Mozilla products, which helps determining a changeset range corresponding to when a problem was introduced.

**NOTES**:
* The app (and its dependent DLLs) are built in **32-bit**.
* Persist is not needed because config, firefox images, test datasets, etc. are stored at `$Env:UserProfile\.mozilla\mozregression`.