### PR TITLE
Wonderpen: Update to 2.0.8

### DIFF
--- a/bucket/wonderpen.json
+++ b/bucket/wonderpen.json
@@ -1,13 +1,13 @@
 {
     "homepage": "https://www.tominlab.com/en/wonderpen",
     "description": "Professional writing app with a focused and fluid writing experience.",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.tominlab.com/en/term/privacy"
     },
-    "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_x64_2.0.7(6208).exe#/dl.7z",
-    "hash": "0ab34b1ee20b5baf30e60142580c3c1c4437045dbfda139e54d17ba9e96a239e",
+    "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_2.0.8(6212).exe#/dl.7z",
+    "hash": "701e883ae4e1f6038caf6fac7d31988bf7e551d2fa81ab0ed495093d1f55fd39",
     "architecture": {
         "64bit": {
             "installer": {
@@ -37,6 +37,6 @@
         "regex": "([\\d.]+)\\((?<build>[\\d]+)\\)"
     },
     "autoupdate": {
-        "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_x64_$version($matchBuild).exe#/dl.7z"
+        "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_$version($matchBuild).exe#/dl.7z"
     }
 }

--- a/bucket/wonderpen.json
+++ b/bucket/wonderpen.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.tominlab.com/en/wonderpen",
     "description": "Professional writing app with a focused and fluid writing experience.",
-    "version": "2.0.8",
+    "version": "2.0.7",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.tominlab.com/en/term/privacy"
     },
+    "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_x64_2.0.7(6208).exe#/dl.7z",
+    "hash": "0ab34b1ee20b5baf30e60142580c3c1c4437045dbfda139e54d17ba9e96a239e",
     "architecture": {
         "64bit": {
-            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_2.0.8(6212).exe#/dl.7z",
-            "hash": "701e883ae4e1f6038caf6fac7d31988bf7e551d2fa81ab0ed495093d1f55fd39",
             "installer": {
                 "script": [
                     "Expand-7ZipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
@@ -18,8 +18,6 @@
             }
         },
         "32bit": {
-            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_2.0.8(6212).exe#/dl.7z",
-            "hash": "701e883ae4e1f6038caf6fac7d31988bf7e551d2fa81ab0ed495093d1f55fd39",
             "installer": {
                 "script": [
                     "Expand-7ZipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\" -Removal",
@@ -35,17 +33,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.tominlab.com/wonderpen/downloads/all",
+        "url": "https://www.tominlab.com/wonderpen/download/all",
         "regex": "([\\d.]+)\\((?<build>[\\d]+)\\)"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_$version($matchBuild).exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_$version($matchBuild).exe#/dl.7z"
-            }
-        }
+        "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_x64_$version($matchBuild).exe#/dl.7z"
     }
 }

--- a/bucket/wonderpen.json
+++ b/bucket/wonderpen.json
@@ -33,7 +33,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.tominlab.com/wonderpen/download/all",
+        "url": "https://www.tominlab.com/wonderpen/downloads/all",
         "regex": "([\\d.]+)\\((?<build>[\\d]+)\\)"
     },
     "autoupdate": {

--- a/bucket/wonderpen.json
+++ b/bucket/wonderpen.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.tominlab.com/en/wonderpen",
     "description": "Professional writing app with a focused and fluid writing experience.",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.tominlab.com/en/term/privacy"
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_x64_2.0.7(6208).exe#/dl.7z",
-            "hash": "0ab34b1ee20b5baf30e60142580c3c1c4437045dbfda139e54d17ba9e96a239e",
+            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_2.0.8(6212).exe#/dl.7z",
+            "hash": "701e883ae4e1f6038caf6fac7d31988bf7e551d2fa81ab0ed495093d1f55fd39",
             "installer": {
                 "script": [
                     "Expand-7ZipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
@@ -18,8 +18,8 @@
             }
         },
         "32bit": {
-            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_ia32_2.0.7(6208).exe#/dl.7z",
-            "hash": "f36d4cbfd6298ca6257a7e7eaa33785d91b6d0577dfbbbd5a06cd626b88ca591",
+            "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/2.0/WonderPen_win_installer_2.0.8(6212).exe#/dl.7z",
+            "hash": "701e883ae4e1f6038caf6fac7d31988bf7e551d2fa81ab0ed495093d1f55fd39",
             "installer": {
                 "script": [
                     "Expand-7ZipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\" -Removal",
@@ -35,16 +35,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.tominlab.com/wonderpen/download/all",
+        "url": "https://www.tominlab.com/wonderpen/downloads/all",
         "regex": "([\\d.]+)\\((?<build>[\\d]+)\\)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_x64_$version($matchBuild).exe#/dl.7z"
+                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_$version($matchBuild).exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_ia32_$version($matchBuild).exe#/dl.7z"
+                "url": "https://www.tominlab.com/to/get-file/cdn?file=WonderPen/$majorVersion.$minorVersion/WonderPen_win_installer_$version($matchBuild).exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

The official 32-bit separate installation package is cancelled by the developer and now updated to a two-in-one installation package.

Also the url for checkver has been updated.