### PR TITLE
isocreator: Add version 1.0

### DIFF
--- a/bucket/isocreator.json
+++ b/bucket/isocreator.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0",
+    "description": "Creates ISO images from a given folder or volume.",
+    "homepage": "https://sourceforge.net/projects/iso-creator-cs/",
+    "license": "Public Domain",
+    "url": "https://download.sourceforge.net/project/iso-creator-cs/iso-creator-cs/binary-installer/IsoCreator.msi",
+    "hash": "f01a0a824ddeeb46ade73e2bfc3141a0fee650089a6c4522ab38895d97351634",
+    "shortcuts": [
+        [
+            "IsoCreator.exe",
+            "Iso Creator"
+        ]
+    ]
+}


### PR DESCRIPTION
closes #5364

[ISO Creator](https://sourceforge.net/projects/iso-creator-cs/) is a simple app that creates ISO images from a given folder or volume.

**NOTES**:
* The app is built in 32-bit.
* Version number is not shown in the repo, but can be found in the application.
* *persist* is not needed because the app does not store any config by files or regsitry (tested on a fresh install VM)