### PR TITLE
tsip: Add version 0.2.06

### DIFF
--- a/bucket/tsip.json
+++ b/bucket/tsip.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.2.06",
+    "description": "SIP softphone software",
+    "license": "BSD-3-Clause",
+    "homepage": "http://tomeko.net/software/SIPclient/",
+    "url": "https://github.com/tomek-o/tSIP/releases/download/v0.2.06/tSIP_0_2_06_bin.zip",
+    "hash": "f0dc405b8a58efd78e009c45296259c27d289f30dd8775369986505b0d1100b1",
+    "extract_dir": "tSIP_0_2_06_bin",
+    "pre_install": [
+        "'tSIP.json', 'tSIP.log', 'tSIP_buttons.json', 'tSIP_history.json' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "tSIP.exe",
+            "tSIP"
+        ]
+    ],
+    "persist": [
+        "certificates",
+        "modules",
+        "phone",
+        "recordings",
+        "tSIP.json",
+        "tSIP.log",
+        "tSIP_buttons.json",
+        "tSIP_history.json"
+    ],
+    "checkver": {
+        "github": "https://github.com/tomek-o/tSIP"
+    },
+    "autoupdate": {
+        "url": "https://github.com/tomek-o/tSIP/releases/download/v$version/tSIP_$underscoreVersion_bin.zip",
+        "extract_dir": "tSIP_$underscoreVersion_bin"
+    }
+}


### PR DESCRIPTION
closes #5363

[tSIP](http://tomeko.net/software/SIPclient/) is a small, portable SIP softphone for Windows based on [re/rem/baresip](https://github.com/baresip/).

**NOTES**:
* The app is built in 32-bit.