### PR TITLE
sunshine: Set sunshine_state.json to an empty json

### DIFF
--- a/bucket/sunshine.json
+++ b/bucket/sunshine.json
@@ -17,7 +17,7 @@
         "Set-Content -Path \"$dir\\sunshine.bat\" -Value (@('@echo off', 'pushd %~dp0 && sunshine.exe %* && popd') -join \"`r`n\")",
         "# Create sunshine_state.json if it does not exist",
         "if (!(Test-Path \"$persist_dir\\sunshine_state.json\" -PathType Leaf)) {",
-        "    New-Item -Type File \"$dir\\sunshine_state.json\" | Out-Null",
+        "    Set-Content -Path \"$dir\\sunshine_state.json\" -Value \"{}\"",
         "}"
     ],
     "bin": [


### PR DESCRIPTION
Sunshine fails to write to `sunshine_state.json` when the content is invalid.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
