### PR TITLE
persist data4

### DIFF
--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -19,7 +19,7 @@
             "RSS Guard"
         ]
     ],
-    "persist": "data",
+    "persist": "data4",
     "checkver": {
         "github": "https://github.com/martinrotter/rssguard",
         "regex": "rssguard-([\\d.]+)-(?<commit>\\w+)-win64\\.7z"


### PR DESCRIPTION
why use `data` not `data4`
![image](https://user-images.githubusercontent.com/36833664/156875850-1f9f4488-c764-449a-9e75-ee812774a715.png)
from `data4`
![image](https://user-images.githubusercontent.com/36833664/156875901-cf7193a7-56c5-4a8d-b5ce-f27b66b9723f.png)
https://github.com/martinrotter/rssguard/blob/master/resources/docs/Documentation.md#userd