### PR TITLE
laragon: Add version 5.0.0

### DIFF
--- a/bucket/laragon.json
+++ b/bucket/laragon.json
@@ -1,0 +1,26 @@
+{
+    "version": "5.0.0",
+    "description": "Universal development environment for PHP, Node.js, Python, Java, Go, and Ruby.",
+    "homepage": "https://laragon.org/",
+    "license": "MIT",
+    "url": "https://github.com/leokhoa/laragon/releases/download/5.0.0/laragon-portable.zip",
+    "hash": "2db8e0ee4177413bf01bbb3ca6802a49dfaa66446edec30d86122662e1c4c41e",
+    "shortcuts": [
+        [
+            "laragon.exe",
+            "Laragon"
+        ]
+    ],
+    "persist": [
+        "etc",
+        "tmp",
+        "usr",
+        "www"
+    ],
+    "checkver": {
+        "github": "https://github.com/leokhoa/laragon"
+    },
+    "autoupdate": {
+        "url": "https://github.com/leokhoa/laragon/releases/download/$version/laragon-portable.zip"
+    }
+}


### PR DESCRIPTION
closes #5267

[Laragon](https://laragon.org/) is a universal development environment for PHP, Node.js, Python, Java, Go, and Ruby.

**NOTES**:
* The app (and its dependent execuatables, DLLs) are built in **32-bit**.