### PR TITLE
teamviewer@15.25.8: update version string

### DIFF
--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -1,5 +1,5 @@
 {
-    "version": "15.25.8",
+    "version": "15.27.3",
     "description": "Remote control, desktop sharing, online meetings, web conferencing and file transfer between computers",
     "homepage": "https://www.teamviewer.com",
     "license": {

--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -17,8 +17,8 @@
     ],
     "persist": "teamviewer.ini",
     "checkver": {
-        "url": "https://www.teamviewer.com/en/download/windows/",
-        "regex": "<p>Current version:\\s*([\\d.]+)\\s*<\\/p>"
+        "url": "https://community.teamviewer.com/English/categories/change-logs-en",
+        "regex": "\\[Windows\\] v([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://download.teamviewer.com/download/version_$majorVersionx/TeamViewerPortable.zip"

--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -18,7 +18,7 @@
     "persist": "teamviewer.ini",
     "checkver": {
         "url": "https://www.teamviewer.com/en/download/windows/",
-        "regex": "Current version:\\s*([\\d.]+)\\s*</"
+        "regex": "<p>Current version:\\s*([\\d.]+)\\s*<\\/p>"
     },
     "autoupdate": {
         "url": "https://download.teamviewer.com/download/version_$majorVersionx/TeamViewerPortable.zip"


### PR DESCRIPTION
The version string was updated. The hash was right.
If the version string is old and you are already on that version, the update will not be triggered.

Closes #8097 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
