### PR TITLE
waifu2x-snowshell: Add version 2.3

### DIFF
--- a/bucket/waifu2x-snowshell.json
+++ b/bucket/waifu2x-snowshell.json
@@ -1,0 +1,43 @@
+{
+    "version": "2.3",
+    "description": "GUI Shell for waifu2x-caffe, waifu2x-converter-cpp and waifu2x-ncnn-vulkan.",
+    "homepage": "https://github.com/YukihoAA/waifu2x_snowshell",
+    "license": "MIT",
+    "notes": [
+        "Add path to converters in your config file at '$dir\\config.ini' as required.",
+        "Following converters are available: extras/waifu2x-caffe, waifu2x-converter-cpp and waifu2x-ncnn-vulkan."
+    ],
+    "suggest": {
+        "waifu2x-caffe": "extras/waifu2x-caffe",
+        "waifu2x-converter-cpp": "waifu2x-converter-cpp",
+        "waifu2x-ncnn-vulkan": "waifu2x-ncnn-vulkan"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/YukihoAA/waifu2x_snowshell/releases/download/v2.3/waifu2x-snowshell_v2.3.zip",
+            "hash": "5F7BA804C791694FE828E67F3A0933CFBBEB5E25C0159E72AF2E3C9064661D49"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\Lang\")) { New-Item \"$dir\\Lang\" -ItemType Directory | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item \"$dir\\config.ini\" -ItemType File | Out-Null }"
+    ],
+    "persist": [
+        "Lang",
+        "config.ini"
+    ],
+    "shortcuts": [
+        [
+            "waifu2x_snowshell.exe",
+            "waifu2x - Snowshell"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/YukihoAA/waifu2x_snowshell/releases/download/v$version/waifu2x-snowshell_v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Added waifu2x-snowshell version 2.3. 
A simple gui for [extras/waifu2x-caffe](https://github.com/ScoopInstaller/Extras/blob/master/bucket/waifu2x-caffe.json), [waifu2x-converter-cpp](https://github.com/ScoopInstaller/Main/blob/master/bucket/waifu2x-converter-cpp.json) and [waifu2x-ncnn-vulkan](https://github.com/ScoopInstaller/Main/blob/master/bucket/waifu2x-ncnn-vulkan.json)
By default it already comtains `waifu2x-converter-cpp` and `waifu2x-ncnn-vulkan` but they are outdated. User can point towards standalone/up to date version of `waifu2x-converter-cpp` and `waifu2x-ncnn-vulkan` in its config.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
