### PR TITLE
fix: persist plugins folder of android-studio

### DIFF
--- a/bucket/android-studio.json
+++ b/bucket/android-studio.json
@@ -25,6 +25,7 @@
         }
     },
     "extract_dir": "android-studio",
+    "persist": "plugins",
     "checkver": "android-studio-([\\d.]+)-windows\\.zip",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Plugins folder should be persisted so any plugin data will not just sit in old version folder of android-studio after update and not carry over to the new version

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8116
<!-- or -->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
