### PR TITLE
Fix DBeaver version check.

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -1,5 +1,5 @@
 {
-    "version": "21.3.5",
+    "version": "22.0.0",
     "description": "Database tool for developers, SQL programmers, database administrators and analysts",
     "homepage": "https://dbeaver.io",
     "license": "Apache-2.0",
@@ -12,8 +12,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.dbeaver.com/community/21.3.5/dbeaver-ce-21.3.5-win32.win32.x86_64.zip",
-            "hash": "57234e8d1f421e138f7be68ab657ec11e8b2d638c9fdb07fe8c402b8bd2cf7f6"
+            "url": "https://download.dbeaver.com/community/22.0.0/dbeaver-ce-22.0.0-win32.win32.x86_64.zip",
+            "hash": "36b979122ccbcf8b668a34bf9c4e26e2eabd26f0b897d85c6d3d633b48c557db"
         }
     },
     "extract_dir": "dbeaver",
@@ -28,8 +28,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://dbeaver.io/download/",
-        "regex": "Community Edition ([\\d.]+)"
+        "github": "https://github.com/dbeaver/dbeaver"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
With the release of version 22.0 on the 7th, the version check was failing. While the download page lists it as "22.0", the actual version used in file and checksum names was "22.0.0". Switching to use their Github releases page instead gets us the correct result.