### PR TITLE
amazon-workspaces@4.0.6.2415: update version and fix checkver logic

### DIFF
--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -30,6 +30,10 @@
         "regex": "title>Version ([\\d.]+)</"
     },
     "autoupdate": {
-        "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"
+            }
+        }
     }
 }

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -6,8 +6,12 @@
         "identifier": "Proprietary",
         "url": "https://clients.amazonworkspaces.com/app-terms.html"
     },
-    "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
-    "hash": "47033f2ef12a4117254d82f8a8da58cee20ee752b2a3fb25a053da89b7556030",
+    "architecture": {
+        "64bit": {
+            "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
+            "hash": "47033f2ef12a4117254d82f8a8da58cee20ee752b2a3fb25a053da89b7556030"
+        }
+    },
     "extract_dir": "[ApplicationFolderName]",
     "pre_install": [
         "# Disable the autoupdate of amazon-workspaces client",

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.10.2252",
+    "version": "4.0.6.2415",
     "description": "Client for Amazon workspaces service",
     "homepage": "https://clients.amazonworkspaces.com",
     "license": {
@@ -7,7 +7,7 @@
         "url": "https://clients.amazonworkspaces.com/app-terms.html"
     },
     "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
-    "hash": "d3c61efad452738dd61dba3967a81e9270f5311335a218b5f6b0b8b9d990d2e2",
+    "hash": "47033f2ef12a4117254d82f8a8da58cee20ee752b2a3fb25a053da89b7556030",
     "extract_dir": "[ApplicationFolderName]",
     "pre_install": [
         "# Disable the autoupdate of amazon-workspaces client",
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/dub/windows/WorkSpacesAppCast.xml",
+        "url": "https://s3.amazonaws.com/workspaces-client-updates/prod/global/windows/WorkSpacesAppCastx64.xml",
         "regex": "title>Version ([\\d.]+)</"
     },
     "autoupdate": {


### PR DESCRIPTION
The amazon-workspaces version check was validating the version by pinging the [winsparkle](https://github.com/vslavik/winsparkle) appcast config file for the x86 version. The 32-bit version is no longer updated by Amazon, so to make scoop work properly, the url had to be updated to point to the x64 version.

The [documentation](https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-ag.pdf#%5B%7B%22num%22%3A183%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C72%2C152.414%2Cnull%5D) references the x86 url only so I had to decompile the `workspaces.dll` file to find the correct filename. 

``` csharp
public string GetAppcastFileName()
{
	if (Environment.Is64BitOperatingSystem)
	{
		return "WorkSpacesAppCastx64.xml";
	}
	return "WorkSpacesAppCast.xml";
}
```
The download url is composed out of:
`https://s3.amazonaws.com/workspaces-client-updates/<environment>/<region>/<platform>/WorkSpacesAppCastx64.xml`

Combining this information makes the new url for 64-bit only: 
https://s3.amazonaws.com/workspaces-client-updates/prod/global/windows/WorkSpacesAppCastx64.xml

For reference, the download url for the outdated 32-bit version of amazon workspaces client is:
https://d2td7dqidlhjx7.cloudfront.net/prod/pdt/windows/x86/Amazon+WorkSpaces.msi


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
