### PR TITLE
jmeter: Add jmeterw.cmd bin

### DIFF
--- a/bucket/jmeter.json
+++ b/bucket/jmeter.json
@@ -8,6 +8,7 @@
     "extract_dir": "apache-jmeter-5.4.3",
     "bin": [
         "bin\\jmeter.bat",
+        "bin\\jmeterw.cmd",
         "bin\\jmeter-n.cmd",
         "bin\\jmeter-n-r.cmd",
         "bin\\jmeter-t.cmd",


### PR DESCRIPTION
The `bin` array is missing one: `jmeterw.bat`
See: https://jmeter.apache.org/usermanual/get-started.html#running

> **jmeterw.cmd**
> &nbsp;&nbsp;&nbsp;&nbsp;run JMeter without the windows shell console (in GUI mode by default)


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
