### PR TITLE
update au.hash in response to Scoop#4619

### DIFF
--- a/bucket/anaconda3.json
+++ b/bucket/anaconda3.json
@@ -53,7 +53,8 @@
             "32bit": {
                 "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86.exe",
                 "hash": {
-                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/"
+                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/",
+                    "regex": "$sha256"
                 }
             }
         }

--- a/bucket/anaconda3.json
+++ b/bucket/anaconda3.json
@@ -53,8 +53,7 @@
             "32bit": {
                 "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86.exe",
                 "hash": {
-                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/",
-                    "regex": "$sha256"
+                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/"
                 }
             }
         }

--- a/bucket/micmute.json
+++ b/bucket/micmute.json
@@ -25,8 +25,7 @@
             }
         },
         "hash": {
-            "url": "$urlNoExt.sha256",
-            "regex": "$sha256"
+            "url": "$urlNoExt.sha256"
         }
     }
 }

--- a/bucket/micmute.json
+++ b/bucket/micmute.json
@@ -25,7 +25,7 @@
             }
         },
         "hash": {
-            "url": "$urlNoExt.sha256"
+            "url": "$baseurl/MicMute.sha256"
         }
     }
 }

--- a/bucket/tinymediamanager.json
+++ b/bucket/tinymediamanager.json
@@ -37,8 +37,7 @@
             "64bit": {
                 "url": "https://release.tinymediamanager.org/v4/dist/tmm_$version_windows-amd64.zip",
                 "hash": {
-                    "url": "$url.sha256",
-                    "regex": "$sha256"
+                    "url": "$url.sha256"
                 }
             }
         }


### PR DESCRIPTION
Since https://github.com/ScoopInstaller/Scoop/pull/4619 is now in `master`, we can simplify these manifests.