### PR TITLE
sdl2: Fix installation script not replacing `@PKG_CONFIG_LIBS_PRIV@`

### DIFF
--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -37,6 +37,7 @@
             "    -replace \"@SDL_LIBS@\",\"-lSDL2\" `",
             "    -replace \"@SDL_STATIC_LIBS@\",\"-lSDL2\" `",
             "    -replace \"@SDL_CFLAGS@\",\"\" `",
+            "    -replace \"@PKGCONFIG_LIBS_PRIV@\",\"\" `",
             ")",
             "",
             "rm -r \"$srcdir\"",


### PR DESCRIPTION
This fixes the compilation errors (file not found) by replacing `@PKG_CONFIG_LIBS_PRIV@` with ` ` (nothing).

Fixes #8126

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
