### PR TITLE
imageglass: fix warning on start, fix hash extraction, add 32bit

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -40,8 +40,8 @@
             "64bit": {
                 "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x64.zip",
                 "hash": {
-                    "url": "https://imageglass.org/download",
-                    "regex": "(?sm)Download portable x64 version.*?$sha1"
+                    "url": "https://github.com/d2phap/ImageGlass/releases",
+                    "regex": "ImageGlass_[\\d.]+_x64.zip</td>\\n<td><code>$sha1"
                 },
                 "extract_dir": "ImageGlass_$version_x64"
             }

--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -13,7 +13,7 @@
     },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\igconfig.xml\")) {",
-        "    Add-Content \"$dir\\igconfig.xml\" '<ImageGlass><Configuration><Info/><Content><Item key=\"AutoUpdate\" value=\"0\" /></Content></Configuration></ImageGlass>' -Encoding Ascii",
+        "    Add-Content \"$dir\\igconfig.xml\" '<ImageGlass><Configuration><Info description=\"ImageGlass Configuration file\" version=\"7.5\" /><Info/><Content><Item key=\"AutoUpdate\" value=\"0\" /></Content></Configuration></ImageGlass>' -Encoding Ascii",
         "}"
     ],
     "bin": [

--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -9,6 +9,11 @@
             "url": "https://github.com/d2phap/ImageGlass/releases/download/8.5.1.22/ImageGlass_8.5.1.22_x64.zip",
             "hash": "sha1:a04de0d9a833c562e2871a1834dabc204d1c76ca",
             "extract_dir": "ImageGlass_8.5.1.22_x64"
+        },
+        "32bit": {
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.5.1.22/ImageGlass_8.5.1.22_x86.zip",
+            "hash": "sha1:3c9a00bc5c169251021d942f578987d606a43110",
+            "extract_dir": "ImageGlass_8.5.1.22_x86"
         }
     },
     "pre_install": [
@@ -44,6 +49,14 @@
                     "regex": "ImageGlass_[\\d.]+_x64.zip</td>\\n<td><code>$sha1"
                 },
                 "extract_dir": "ImageGlass_$version_x64"
+            },
+            "32bit": {
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x86.zip",
+                "hash": {
+                    "url": "https://github.com/d2phap/ImageGlass/releases",
+                    "regex": "ImageGlass_[\\d.]+_x86.zip</td>\\n<td><code>$sha1"
+                },
+                "extract_dir": "ImageGlass_$version_x86"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Currently, when opening ImageGlass for the first time, users get the following warning message box:
```
---------------------------
ImageGlass
---------------------------
Some settings are not compatible with your ImageGlass 8.5.1.22. It's recommended to update them before continuing.


- Click Yes to learn about the changes.

- Click No to launch ImageGlass with default settings.
---------------------------
Yes   No   
---------------------------
```
It seems in version 7.5 (released January 2020!!) there was a change to the base structure of its XML config file `igconfig.xml`. For more info see this page: https://imageglass.org/docs/app-configs. With this fix, there is no warning and the first-time setup appears straight away, as normal.

While fixing this, I also noticed & fixed a failing autoupdate hash extraction and a missing 32bit architecture.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
