### PR TITLE
ds4windows: Remove bin

### DIFF
--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -34,7 +34,6 @@
         "}",
         "if (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }"
     ],
-    "bin": "DS4Windows.exe",
     "shortcuts": [
         [
             "DS4Windows.exe",


### PR DESCRIPTION
DS4Windows does not have a command-line interface. Thus, it should not be added to `bin`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
