### PR TITLE
shaderglass: Add version 0.7

### DIFF
--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/mausimus/ShaderGlass/releases/download/v0.7/ShaderGlass-0.7-win-x64.zip",
             "hash": "738c3772283a450e1f2ccf5440ab96cc159bf8ee5e3d51ba4d2a9aeaa602c6fc"
-        }    
+        }
     },
     "bin": "ShaderGlass.exe",
     "shortcuts": [

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -19,6 +19,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-x86_64-v$version.zip"
+        "url": "https://github.com/mausimus/ShaderGlass/releases/download/v$version/ShaderGlass-$version-win-x64.zip"
     }
 }

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.7",
+    "description": "Creates an overlay for running GPU shaders on top of the Windows desktop.",
+    "homepage": "https://github.com/mausimus/ShaderGlass",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/mausimus/ShaderGlass/releases/download/v0.7/ShaderGlass-0.7-win-x64.zip",
+    "hash": "738c3772283a450e1f2ccf5440ab96cc159bf8ee5e3d51ba4d2a9aeaa602c6fc",
+    "bin": [
+        [
+            "ShaderGlass.exe",
+            "shaderglass"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "ShaderGlass.exe",
+            "ShaderGlass"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-x86_64-v$version.zip"
+    }
+}

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -24,7 +24,7 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "x64": {
+            "64bit": {
                 "url": "https://github.com/mausimus/ShaderGlass/releases/download/v$version/ShaderGlass-$version-win-x64.zip"
             }
         }

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -23,6 +23,10 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mausimus/ShaderGlass/releases/download/v$version/ShaderGlass-$version-win-x64.zip"
+        "architecture": {
+            "x64": {
+                "url": "https://github.com/mausimus/ShaderGlass/releases/download/v$version/ShaderGlass-$version-win-x64.zip"
+            }
+        }
     }
 }

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -3,8 +3,12 @@
     "description": "Creates an overlay for running GPU shaders on top of the Windows desktop.",
     "homepage": "https://github.com/mausimus/ShaderGlass",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/mausimus/ShaderGlass/releases/download/v0.7/ShaderGlass-0.7-win-x64.zip",
-    "hash": "738c3772283a450e1f2ccf5440ab96cc159bf8ee5e3d51ba4d2a9aeaa602c6fc",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mausimus/ShaderGlass/releases/download/v0.7/ShaderGlass-0.7-win-x64.zip",
+            "hash": "738c3772283a450e1f2ccf5440ab96cc159bf8ee5e3d51ba4d2a9aeaa602c6fc"
+        }    
+    },
     "bin": [
         [
             "ShaderGlass.exe",

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -9,12 +9,7 @@
             "hash": "738c3772283a450e1f2ccf5440ab96cc159bf8ee5e3d51ba4d2a9aeaa602c6fc"
         }    
     },
-    "bin": [
-        [
-            "ShaderGlass.exe",
-            "shaderglass"
-        ]
-    ],
+    "bin": "ShaderGlass.exe",
     "shortcuts": [
         [
             "ShaderGlass.exe",


### PR DESCRIPTION
Creates an overlay for running GPU shaders on top of the Windows desktop.

- [ X ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
