### PR TITLE
 losslesscut: Update to version 3.44.0

### DIFF
--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.43.0",
+    "version": "3.44.0",
     "description": "Lossless trimming tool for video and audio files",
     "homepage": "https://github.com/mifi/lossless-cut",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mifi/lossless-cut/releases/download/v3.43.0/LosslessCut-win.exe#/dl.7z",
-            "hash": "4fc16dec21fd3a11827bb1ee37887378363a5958919faa80375a92ffabdc4515",
+            "url": "https://github.com/mifi/lossless-cut/releases/download/v3.44.0/LosslessCut-win-x64.exe#/dl.7z",
+            "hash": "6e8128e8574a45442e39debf4abd87ab58800799a02b528f1ce9bb43f356698c",
             "installer": {
                 "script": [
                     "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -26,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-win.exe#/dl.7z"
+                "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-win-x64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Losslesscut releases have slightly different names than the last release so github actions auto-update didn't pick it up.
This PR addresses the filename change.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
