### PR TITLE
discord: Update to version 1.0.9004

### DIFF
--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.0.311",
+    "version": "1.0.9004",
     "description": "Free Voice and Text Chat",
     "homepage": "https://discordapp.com/",
     "license": {
@@ -7,9 +7,17 @@
         "url": "https://discordapp.com/terms"
     },
     "notes": "To avoid manifest removal due to internal updates, disable automatic updates by running: '$dir\\disable-auto-update.ps1'",
-    "url": "http://dl.discordapp.net/apps/win/Discord-0.0.311-full.nupkg",
-    "hash": "sha1:3928a4af8e249184f2d4212bd8c958adc8b2ff4f",
-    "extract_dir": "lib\\net45",
+    "url": "https://dl.discordapp.net/distro/app/stable/win/x86/1.0.9004/DiscordSetup.exe#/dl.7z",
+    "hash": "5edc53181d1300141e42bc756a7188949f3ce6bbebcafe80cd8e326deec21eae",
+    "extract_to": "_temp",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\_temp\\Discord-$version-full.nupkg\" \"$dir\\_temp\"",
+            "Move-Item \"$dir\\_temp\\lib\\net45\\*\" \"$dir\" -Force",
+            "Remove-Item \"$dir\\_temp\" -Force -Recurse"
+        ]
+    },
+    "post_install": "Copy-Item -Path \"$bucketsdir\\extras\\scripts\\discord\\disable-auto-update.ps1\" -Destination \"$dir\\\"",
     "bin": "Discord.exe",
     "shortcuts": [
         [
@@ -17,15 +25,12 @@
             "Discord"
         ]
     ],
-    "post_install": "Copy-Item -Path \"$bucketsdir\\extras\\scripts\\discord\\disable-auto-update.ps1\" -Destination \"$dir\\\"",
     "checkver": {
-        "url": "https://discordapp.com/api/updates/stable/RELEASES",
-        "regex": "Discord-([\\d.]+)-full"
+        "url": "https://discord.com/api/updates/distributions/app/manifests/latest?arch=x86&channel=stable&platform=win",
+        "json_path": "$.full.url",
+        "regex": "x86\\/([\\d.]+)\\/full\\.distro"
     },
     "autoupdate": {
-        "url": "http://dl.discordapp.net/apps/win/Discord-$version-full.nupkg",
-        "hash": {
-            "url": "https://discordapp.com/api/updates/stable/RELEASES"
-        }
+        "url": "https://dl.discordapp.net/distro/app/stable/win/x86/$version/DiscordSetup.exe#/dl.7z"
     }
 }

--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -27,7 +27,7 @@
     ],
     "checkver": {
         "url": "https://discord.com/api/updates/distributions/app/manifests/latest?arch=x86&channel=stable&platform=win",
-        "json_path": "$.full.url",
+        "jsonpath": "$.full.url",
         "regex": "x86\\/([\\d.]+)\\/full\\.distro"
     },
     "autoupdate": {


### PR DESCRIPTION
Closes #8051

I used Fiddler to capture network traffic to see what URL the updater was pinging to get the new version. The old checkver URL still exists, but has become out of date. From downloading the installer from the website manually I was able to find the new download URL scheme, then substitute in the correct version.

Checkver now uses jsonpath to grab the updater's URL then regex to extract the version from there. There is a version field array within the JSON I wanted to use but I couldn't figure out whether jsonpath lets me concat 3 elements to build up the version, so instead I went with regex parsing the URL. Note that URLs uses in this json are for the updater, we don't use them.

The install now requires two unzip operations, the first unpacks the DiscordSetup.exe file to reveal the inner .nupkg. From there I use an installer script to unpack that package and move the payload we need into the correct location (I used blisk.json as a reference, please correct me if there is a better way).

I also re-ordered post_install to match the master order specified in the contribution guide.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
