### PR TITLE
digital: Add version 0.29

### DIFF
--- a/bucket/digital.json
+++ b/bucket/digital.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.29",
+    "description": "A digital logic designer and circuit simulator",
+    "homepage": "https://github.com/hneemann/Digital",
+    "license": "GPL-3.0-only",
+    "suggest": {
+        "JDK": [
+            "java/opendk",
+            "java/oraclejdk"
+        ]
+    },
+    "url": "https://github.com/hneemann/Digital/releases/download/v0.29/Digital.zip",
+    "hash": "4d61e2776100ddfe3f8638886e5b33e3b99165eefefaf9ba5c9b9fad1f47f3a7",
+    "extract_dir": "Digital",
+    "pre_install": "Set-Content \"$dir\\Digital.bat\" '@start javaw.exe -jar \"%~dp0Digital.jar\" %*' -Encoding Ascii",
+    "shortcuts": [
+        [
+            "Digital.bat",
+            "Digital",
+            "",
+            "Digital.exe"
+        ]
+   ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/hneemann/Digital/releases/download/v$version/Digital.zip"
+    }
+}


### PR DESCRIPTION
I'm not using the exe wrapper because of https://github.com/hneemann/Digital/issues/670.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
