### PR TITLE
LibreWolf: Update to 98.0 and fix autoupdate

### DIFF
--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -1,12 +1,12 @@
 {
-    "version": "97.0.1",
+    "version": "98.0",
     "description": "A fork of Firefox, focused on privacy, security and freedom.",
     "homepage": "https://librewolf.net/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/104340b6af08248415936de2c1c94757/librewolf-97.0.1.en-US.win64.zip",
-            "hash": "5952366f1437ec79fa34a45a918e2db88864d1bd3f67bc9c2f0204e1228cbf05"
+            "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/90d15e27ba473d2beb0da8b9bf9033d7/librewolf-98.0.en-US.win64-portable.zip",
+            "hash": "765069e8259d9acf4e5d0828d6e85870ecca23f998d48bfe37ddb0417fc52934"
         }
     },
     "pre_install": [
@@ -23,18 +23,18 @@
     "shortcuts": [
         [
             "librewolf-portable.exe",
-            "Librewolf"
+            "LibreWolf"
         ]
     ],
     "persist": "Profiles",
     "checkver": {
         "url": "https://gitlab.com/api/v4/projects/13852981/releases",
-        "regex": "/uploads/(?<randidzip>[a-z0-9]+)/librewolf-([\\d.]+)\\.en-US\\.win64\\.zip.*?/uploads/(?<randidsha>[a-z0-9]+)/sha256sums\\.txt"
+        "regex": "/uploads/(?<randidzip>[a-z0-9]+)/librewolf-([\\d.]+)\\.en-US\\.win64-portable\\.zip.*?/uploads/(?<randidsha>[a-z0-9]+)/sha256sums\\.txt"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/$matchRandidzip/librewolf-$version.en-US.win64.zip",
+                "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/$matchRandidzip/librewolf-$version.en-US.win64-portable.zip",
                 "hash": {
                     "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/$matchRandidsha/sha256sums.txt"
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Devs decided to change the name of the portable zip, fun

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
