### PR TITLE
ollydbg: Add version 1.10

### DIFF
--- a/bucket/ollydbg.json
+++ b/bucket/ollydbg.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.10",
+    "description": "Assembler-level analysing debugger for Windows binaries",
+    "homepage": "https://www.ollydbg.de/",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://www.ollydbg.de/download.htm"
+    },
+    "url": "https://www.ollydbg.de/odbg110.zip",
+    "hash": "73b1770f28893dab22196eb58d45ede8ddf5444009960ccc0107d09881a7cd1e",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\ollydbg.ini\")) {New-Item \"$dir\\ollydbg.ini\" | Out-Null}",
+        "Remove-Item \"$dir\\PSAPI.DLL\", \"$dir\\DBGHELP.DLL\""
+    ],
+    "shortcuts": [
+        [
+            "OLLYDBG.EXE",
+            "OllyDbg"
+        ]
+    ],
+    "persist": "ollydbg.ini"
+}


### PR DESCRIPTION
[OllyDbg](https://www.ollydbg.de/) is an assembler-level analysing debugger for Windows binaries.

**NOTES**:
* *pre_install*: `PSAPI.DLL` and `DBGHELP.DLL` are DLLs for Windows APIs. They are not needed as newer versions can be found in `$env:PATH` under Windows 10.
* *checkver* is not needed because the last update was in 2013.