### PR TITLE
tartube: Add version 2.3.367

### DIFF
--- a/bucket/tartube.json
+++ b/bucket/tartube.json
@@ -1,0 +1,51 @@
+{
+    "version": "2.3.367",
+    "description": "GUI front-end for youtube-dl, partly based on youtube-dl-gui.",
+    "homepage": "https://github.com/axcore/tartube",
+    "license": "GPL-2.0-or-later,Unlicense,LGPL-2.1-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/axcore/tartube/releases/download/v2.3.367/tartube-2.3.367-64bit-portable.zip",
+            "hash": "b9be3fcd2a4f47f10f05489943a2a01ec92f8f7450173d2252bf993ea174047a",
+            "bin": "tartube_portable_64bit.bat",
+            "shortcuts": [
+                [
+                    "tartube_portable_64bit.bat",
+                    "Tartube",
+                    "",
+                    "tartube_icon.ico"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/axcore/tartube/releases/download/v2.3.367/tartube-2.3.367-32bit-portable.zip",
+            "hash": "5c474d50217a4e1f1cc4301382b4c4ffb42b90d5a15fc595b8bfe948a0641456",
+            "bin": "tartube_portable_32bit.bat",
+            "shortcuts": [
+                [
+                    "tartube_portable_32bit.bat",
+                    "Tartube",
+                    "",
+                    "tartube_icon.ico"
+                ]
+            ]
+        }
+    },
+    "extract_dir": "tartube",
+    "persist": [
+        "home\\user\\tartube\\settings.json",
+        "mingw64\\bin",
+        "mingw32\\bin"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/axcore/tartube/releases/download/v$version/tartube-$version-64bit-portable.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/axcore/tartube/releases/download/v$version/tartube-$version-32bit-portable.zip"
+            }
+        }
+    }
+}

--- a/bucket/tartube.json
+++ b/bucket/tartube.json
@@ -7,7 +7,6 @@
         "64bit": {
             "url": "https://github.com/axcore/tartube/releases/download/v2.3.367/tartube-2.3.367-64bit-portable.zip",
             "hash": "b9be3fcd2a4f47f10f05489943a2a01ec92f8f7450173d2252bf993ea174047a",
-            "bin": "tartube_portable_64bit.bat",
             "shortcuts": [
                 [
                     "tartube_portable_64bit.bat",
@@ -20,7 +19,6 @@
         "32bit": {
             "url": "https://github.com/axcore/tartube/releases/download/v2.3.367/tartube-2.3.367-32bit-portable.zip",
             "hash": "5c474d50217a4e1f1cc4301382b4c4ffb42b90d5a15fc595b8bfe948a0641456",
-            "bin": "tartube_portable_32bit.bat",
             "shortcuts": [
                 [
                     "tartube_portable_32bit.bat",


### PR DESCRIPTION
closes #4684
supersedes #4699

[TarTube](https://github.com/axcore/tartube) is a GUI front-end for youtube-dl, partly based on youtube-dl-gui.

**NOTES**:
* **TarTube** has changed their setup method. (different from what we see in #4699. Therefore I think *suggest* is not required in this case.
* Upon first run, will prompt the user the choose **data folder location** (this is stored at `$dir\home\user\tartube\settings.json`). Then, download required softwares (such as `youtube-dl` or `ffmpeg`) and store them in `$dir\mingw64\bin`.