### PR TITLE
ghostwriter: Update to version 2.1.2

### DIFF
--- a/bucket/ghostwriter.json
+++ b/bucket/ghostwriter.json
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/michelolvera/vs-ghostwriter/releases/download/$version/ghostwriter_$version_win64_portable.zip"
+                "url": "https://github.com/wereturtle/ghostwriter/releases/download/$version/ghostwriter_$version_win64_portable.zip"
             }
         }
     }

--- a/bucket/ghostwriter.json
+++ b/bucket/ghostwriter.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "Distraction-free Markdown editor",
     "homepage": "https://wereturtle.github.io/ghostwriter/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/michelolvera/vs-ghostwriter/releases/download/win-2.1.1/ghostwriter_x64_portable.7z",
-            "hash": "b6f2e2732fce5cfcdee8699f7a67c484a714ce481cbce65623985ce61d632f00"
+            "url": "https://github.com/wereturtle/ghostwriter/releases/download/2.1.2/ghostwriter_2.1.2_win64_portable.zip",
+            "hash": "a48ca5e45ffc05fc9c6e79ce653e9462db586dc94e010d5ac309a01d2844ffa3"
         }
     },
     "bin": "ghostwriter.exe",
@@ -18,13 +18,13 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://github.com/michelolvera/vs-ghostwriter",
-        "regex": "download/win-([\\d.]+)/"
+        "github": "https://github.com/wereturtle/ghostwriter",
+        "regex": "download/([\\d.]+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/michelolvera/vs-ghostwriter/releases/download/win-$version/ghostwriter_x64_portable.7z"
+                "url": "https://github.com/michelolvera/vs-ghostwriter/releases/download/$version/ghostwriter_$version_win64_portable.zip"
             }
         }
     }

--- a/bucket/ghostwriter.json
+++ b/bucket/ghostwriter.json
@@ -18,8 +18,7 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://github.com/wereturtle/ghostwriter",
-        "regex": "download/([\\d.]+)/"
+        "github": "https://github.com/wereturtle/ghostwriter"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
 # Summary

- The repo is updated: [wereturtle](https://github.com/wereturtle/ghostwriter/releases) has started to provide its own Windows builds again so the current repo will be deprecated.
- Additionally the version is updated to 2.1.2.

 
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
