### PR TITLE
keepassxc: Update to 2.7.0 and remove 32bit support

### DIFF
--- a/bucket/keepassxc.json
+++ b/bucket/keepassxc.json
@@ -1,18 +1,13 @@
 {
-    "version": "2.6.6",
+    "version": "2.7.0",
     "description": "Community fork of KeePass",
     "homepage": "https://keepassxc.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.6.6/KeePassXC-2.6.6-Win64-Portable.zip",
-            "hash": "45a4cd19f02ad617808aa814fac2ed61b59eff467d8c464d94ba5304d7ccabc0",
-            "extract_dir": "KeePassXC-2.6.6-Win64"
-        },
-        "32bit": {
-            "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.6.6/KeePassXC-2.6.6-Win32-Portable.zip",
-            "hash": "afa03c371d55b113322438c53ec217e6ca1bf750bf72881126b93e23e85f83fb",
-            "extract_dir": "KeePassXC-2.6.6-Win32"
+            "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.7.0/KeePassXC-2.7.0-Win64.zip",
+            "hash": "104574f8e4977792d1b600f89e3abb4cf444bf9b10c9c7c32ad08814b32a5d25",
+            "extract_dir": "KeePassXC-2.7.0-Win64"
         }
     },
     "post_install": "if (Test-Path \"$persist_dir\\keepassxc.ini\") { Move-Item \"$persist_dir\\keepassxc.ini\" \"$dir\\config\" -Force }",
@@ -34,12 +29,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/keepassxreboot/keepassxc/releases/download/$version/KeePassXC-$version-Win64-Portable.zip",
+                "url": "https://github.com/keepassxreboot/keepassxc/releases/download/$version/KeePassXC-$version-Win64.zip",
                 "extract_dir": "KeePassXC-$version-Win64"
-            },
-            "32bit": {
-                "url": "https://github.com/keepassxreboot/keepassxc/releases/download/$version/KeePassXC-$version-Win32-Portable.zip",
-                "extract_dir": "KeePassXC-$version-Win32"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to [Versions#461](https://github.com/ScoopInstaller/Versions/pull/461) and [keepassxc official download page](https://keepassxc.org/download/#windows) 

![image](https://user-images.githubusercontent.com/19755727/159425937-e5ad01b2-888d-4509-a216-73c0d46db260.png)


Keepassxc 32-bit Windows is no longer supported after v2.6.6, please download `keepassxc-legacy` from Version bucket.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
