### PR TITLE
libreoffice: Fix autoupdate

### DIFF
--- a/bucket/libreoffice.json
+++ b/bucket/libreoffice.json
@@ -56,7 +56,7 @@
         "regex": ">([\\d.]+)/<"
     },
     "autoupdate": {
-        "url": "http://download.documentfoundation.org/libreoffice/portable/$version/LibreOfficePortable_$version_MultilingualStandard.paf.exe#/dl.7z",
+        "url": "https://download.documentfoundation.org/libreoffice/portable/$version/LibreOfficePortable_$version_MultilingualStandard.paf.exe#/dl.7z",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/libreoffice.json
+++ b/bucket/libreoffice.json
@@ -56,7 +56,7 @@
         "regex": ">([\\d.]+)/<"
     },
     "autoupdate": {
-        "url": "http://download.documentfoundation.org/libreoffice/portable/$version/LibreOfficePortable_$version_MultilingualStandard.paf.exe",
+        "url": "http://download.documentfoundation.org/libreoffice/portable/$version/LibreOfficePortable_$version_MultilingualStandard.paf.exe#/dl.7z",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/libreoffice.json
+++ b/bucket/libreoffice.json
@@ -1,13 +1,13 @@
 {
-    "version": "7.2.5",
+    "version": "7.3.1",
     "description": "Powerful office suite",
     "homepage": "https://libreoffice.org/",
     "license": "MPL-2.0",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
-    "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/7.2.5.2/portable/LibreOfficePortable_7.2.5_MultilingualStandard.paf.exe#/dl.7z",
-    "hash": "6eda6e3fc9196f3b75be32b389f855e2467b7367a5212869555c991714a89b90",
+    "url": "http://download.documentfoundation.org/libreoffice/portable/7.3.1/LibreOfficePortable_7.3.1_MultilingualStandard.paf.exe#/dl.7z",
+    "hash": "68dcab2a22718385ef148c80c7b84a02778ace224723c577a18d7424635f3cbd",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\Data\\settings\")) {",
         "    New-Item \"$dir\\Data\\settings\\LibreOfficePortableSettings.ini\" -Value \"[LibreOfficePortableSettings]`nInvalidPackageWarningShown=$version.0\" -Force | Out-Null",

--- a/bucket/libreoffice.json
+++ b/bucket/libreoffice.json
@@ -56,7 +56,7 @@
         "regex": ">([\\d.]+)/<"
     },
     "autoupdate": {
-        "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/$version.2/portable/LibreOfficePortable_$version_MultilingualStandard.paf.exe#/dl.7z",
+        "url": "http://download.documentfoundation.org/libreoffice/portable/$version/LibreOfficePortable_$version_MultilingualStandard.paf.exe",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
The "url" in "autoupdate" was wrong. I had repaired it.

### Bug Report

**Package Name:** [libreoffice](https://github.com/ScoopInstaller/Extras/blob/4d38cbf2f8d45aaf3e6d21d76b82d11f44288ff9/bucket/libreoffice.json)

### Current Behaviour

Did not update the latest version.

### Expected Behaviour

The libreoffice had updated to [7.2.6 or 7.3.1](https://www.libreoffice.org/download/download/?lang=zh-CN&version=7.2.6&pk_campaign=update), but the manifest still stayed in 7.2.5.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
