### PR TITLE
shutter-encoder: Add version 15.9

### DIFF
--- a/bucket/shutter-encoder.json
+++ b/bucket/shutter-encoder.json
@@ -1,0 +1,32 @@
+{
+    "version": "15.9",
+    "description": "Multimedia file converter",
+    "homepage": "https://www.shutterencoder.com/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.shutterencoder.com/Shutter%20Encoder%2015.9%20Windows%2064bits.zip",
+            "hash": "3f5b56a776d3be13e295d7e8dc1d60b6cdb68d67edbd975220d7bccda21989d4",
+            "extract_dir": "Shutter Encoder 15.9 Windows 64bits"
+        }
+    },
+    "shortcuts": [
+        [
+            "Shutter Encoder.exe",
+            "Shutter Encoder"
+        ]
+    ],
+    "persist": "settings.xml",
+    "checkver": {
+        "url": "https://www.shutterencoder.com/en/",
+        "regex": "Shutter Encoder ([\\d.]+) Windows 64bits\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.shutterencoder.com/Shutter%20Encoder%20$version%20Windows%2064bits.zip",
+                "extract_dir": "Shutter Encoder $version Windows 64bits"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #7102

[Shutter Encoder](https://www.shutterencoder.com/) is a multimedia file converter.

**NOTES**:
* Only 64-bit binary is available for this app.