### PR TITLE
typora: Fix URLs and hashes

### DIFF
--- a/bucket/typora.json
+++ b/bucket/typora.json
@@ -9,12 +9,12 @@
     "notes": "This package has a 15-day free trial",
     "architecture": {
         "64bit": {
-            "url": "https://typora.io/windows/typora-setup-x64.exe",
-            "hash": "ed37257cfd4143398bfbb16f728a8f915ec35bf8fa2b408f5df715def1fb3177"
+            "url": "https://download.typora.io/windows/typora-setup-x64-1.2.4.exe",
+            "hash": "5faeb8ea810060677cc23372ac8e7e9ff6bf821f35e96bb79c27c3c61a53f64c"
         },
         "32bit": {
-            "url": "https://typora.io/windows/typora-setup-ia32.exe",
-            "hash": "792332afbd284cf015d49cd6593145b00fab2de94bdfabb9458bc55f12406edd"
+            "url": "https://download.typora.io/windows/typora-setup-ia32-1.2.4.exe",
+            "hash": "4f9dae733f3a858c3f65d5b091b3e22593266a45305c344a46cdc2e2f2f91e8a"
         }
     },
     "innosetup": true,
@@ -32,11 +32,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://typora.io/windows/typora-setup-x64.exe"
+                "url": "https://download.typora.io/windows/typora-setup-x64-$version.exe"
             },
             "32bit": {
-                "url": "https://typora.io/windows/typora-setup-ia32.exe"
+                "url": "https://download.typora.io/windows/typora-setup-ia32-$version.exe"
             }
+        },
+        "hash": {
+            "mode": "download"
         }
     }
 }


### PR DESCRIPTION
This PR changes the typora config to use versioned download URLs and also update the hashes automatically via the "download" method (sadly, there are no hashes anywhere).

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
