### PR TITLE
onionshare: Update to version 2.5, Add autoupdate

### DIFF
--- a/bucket/onionshare.json
+++ b/bucket/onionshare.json
@@ -1,26 +1,27 @@
 {
-    "version": "2.2",
+    "version": "2.5",
     "description": "Securely and anonymously send and receive files.",
     "homepage": "https://onionshare.org/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/micahflee/onionshare/releases/download/v2.2/onionshare-2.2-setup.exe#/dl.7z",
-    "hash": "0ca64f3001d9bcee3c9be7b2e9c5b2ef61e93b63cddc6f328726280d1540df35",
-    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force",
+    "url": "https://github.com/onionshare/onionshare/releases/download/v2.5/OnionShare-2.5.msi",
+    "hash": "db4b49f03ac2b0ba590db1e6965ac9f1e108ed10a1ffb07043a7a581e5975f53",
+    "extract_dir": "OnionShare",
     "bin": [
         [
-            "onionshare-gui.exe",
+            "onionshare-cli.exe",
             "onionshare"
         ]
     ],
     "shortcuts": [
         [
-            "onionshare-gui.exe",
-            "OnionShare",
-            "",
-            "onionshare.ico"
+            "onionshare.exe",
+            "OnionShare"
         ]
     ],
     "checkver": {
         "github": "https://github.com/micahflee/onionshare"
+    },
+    "autoupdate": {
+        "url": "https://github.com/onionshare/onionshare/releases/download/v$version/OnionShare-$version.msi"
     }
 }


### PR DESCRIPTION
* closes #6198
* *persist* is not needed because config is at `$AppData\OnionShare`.