### PR TITLE
meshlab@2022.02: fix the download link

### DIFF
--- a/bucket/meshlab.json
+++ b/bucket/meshlab.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/cnr-isti-vclab/meshlab/releases/download/MeshLab-2022.02/MeshLab2022.02-windows.zip",
-            "hash": "eb8262c3a34938c2c8b3fcc441900964c2991e9e431d03098eaffd0e5c0a7904"
+            "hash": "1f15ed0bacdd64eb792de3ea1a490340693b659e58d954135878f1feeb305212"
         }
     },
     "pre_install": "Remove-Item \"$dir\\vc_red*\"",

--- a/bucket/meshlab.json
+++ b/bucket/meshlab.json
@@ -22,7 +22,7 @@
     ],
     "checkver": {
         "github": "https://github.com/cnr-isti-vclab/meshlab",
-        "regex": "tag/Meshlab-([\\d.]+)"
+        "regex": "tag/MeshLab-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/meshlab.json
+++ b/bucket/meshlab.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-2022.02/MeshLab2022.02-windows.zip",
+            "url": "https://github.com/cnr-isti-vclab/meshlab/releases/download/MeshLab-2022.02/MeshLab2022.02-windows.zip",
             "hash": "eb8262c3a34938c2c8b3fcc441900964c2991e9e431d03098eaffd0e5c0a7904"
         }
     },
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-$version/MeshLab$version-windows.zip"
+                "url": "https://github.com/cnr-isti-vclab/meshlab/releases/download/MeshLab-$version/MeshLab$version-windows.zip"
             }
         }
     }


### PR DESCRIPTION
Fix the download link: Meshlab -> MeshLab

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
