### PR TITLE
wezterm: also register wezterm-gui.exe

### DIFF
--- a/bucket/wezterm.json
+++ b/bucket/wezterm.json
@@ -10,7 +10,10 @@
         }
     },
     "extract_dir": "WezTerm-windows-20220319-142410-0fcdea07",
-    "bin": "wezterm.exe",
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
     "shortcuts": [
         [
             "wezterm-gui.exe",


### PR DESCRIPTION
This is necessary in order to supply additional configuration options for debugging wezterm on Windows. See https://github.com/wez/wezterm/issues/1576

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
