### PR TITLE
flat-assembler: Update to version 1.73.30, add license URL

### DIFF
--- a/bucket/flat-assembler.json
+++ b/bucket/flat-assembler.json
@@ -1,10 +1,13 @@
 {
-    "version": "1.73.29",
+    "version": "1.73.30",
     "description": "Open source assembly language compiler",
     "homepage": "https://flatassembler.net/",
-    "license": "Unknown",
-    "url": "https://flatassembler.net/fasmw17329.zip",
-    "hash": "6995d164069dd45d45a8228440935ef38e444a35d700af7a339c67b3d5c67d23",
+    "license": {
+        "identifier": "Unknown",
+        "url": "https://github.com/tgrysztar/fasm/blob/master/LICENSE.TXT"
+    },
+    "url": "https://flatassembler.net/fasmw17330.zip",
+    "hash": "0570454a4f93baf68bab4ad2a7a5e25eb86f1df62fa57dd6942842426c94286a",
     "pre_install": "if (!(Test-Path \"$persist_dir\\FASMW.INI\")) { New-Item \"$dir\\FASMW.INI\" | Out-Null }",
     "bin": [
         "FASM.EXE",

--- a/bucket/flat-assembler.json
+++ b/bucket/flat-assembler.json
@@ -3,7 +3,7 @@
     "description": "Open source assembly language compiler",
     "homepage": "https://flatassembler.net/",
     "license": {
-        "identifier": "Unknown",
+        "identifier": "Freeware",
         "url": "https://github.com/tgrysztar/fasm/blob/master/LICENSE.TXT"
     },
     "url": "https://flatassembler.net/fasmw17330.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator issue 'URL is not valid', checkver works okay locally... https://github.com/ScoopInstaller/Extras/runs/5777899107?check_suite_focus=true#step:3:230

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
