### PR TITLE
freac: Update to version 1.1.6, fix autoupdate

### DIFF
--- a/bucket/freac.json
+++ b/bucket/freac.json
@@ -1,18 +1,18 @@
 {
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "Audio converter and CD ripper with support for various popular formats and encoders",
     "homepage": "https://www.freac.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/enzo1982/freac/releases/download/v1.1.5/freac-1.1.5-windows-x64.zip",
-            "hash": "46fdc6b17035687d0335698017acf25fc9d8c2c9764763c62c82046a7fcef1aa",
-            "extract_dir": "freac-1.1.5-x64"
+            "url": "https://github.com/enzo1982/freac/releases/download/v1.1.6/freac-1.1.6-windows-x64.zip",
+            "hash": "1b9af77be45efbbefa6f97e7d38e76a46f0eab66e98754b6b49de75d28dcfd2f",
+            "extract_dir": "freac-1.1.6-x64"
         },
         "32bit": {
-            "url": "https://github.com/enzo1982/freac/releases/download/v1.1.5/freac-1.1.5-windows.zip",
-            "hash": "22aa7ee6e2de1cc61001d63f5472250dc3c6b5026130e7e330b7ba658129d9bc",
-            "extract_dir": "freac-1.1.5"
+            "url": "https://github.com/enzo1982/freac/releases/download/v1.1.6/freac-1.1.6-windows-i686.zip",
+            "hash": "1093bf498128b4a87abc3c728d2589b5abbaf224f1e9bd0ef46e6c1a245bb810",
+            "extract_dir": "freac-1.1.6"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\freac.xml\")) { New-Item \"$dir\\freac.xml\" | Out-Null }",
@@ -40,7 +40,7 @@
                 "extract_dir": "freac-$version-x64"
             },
             "32bit": {
-                "url": "https://github.com/enzo1982/freac/releases/download/v$version/freac-$version-windows.zip",
+                "url": "https://github.com/enzo1982/freac/releases/download/v$version/freac-$version-windows-i686.zip",
                 "extract_dir": "freac-$version"
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator out of date: https://github.com/ScoopInstaller/Extras/runs/5777899107?check_suite_focus=true#step:3:246

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
