### PR TITLE
Update Windows Terminal to v1.12.10732

### DIFF
--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.12.10393.0",
+    "version": "1.12.10732.0",
     "description": "The new Windows Terminal, and the original Windows console host - all in the same place!",
     "homepage": "https://github.com/microsoft/terminal",
     "license": "MIT",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
-    "url": "https://github.com/microsoft/terminal/releases/download/v1.12.10393.0/Microsoft.WindowsTerminal_1.12.10393.0_8wekyb3d8bbwe.msixbundle#/dl.7z",
-    "hash": "23daf0b5a5783d07322b9fee3eef98d45b8d11d4d77f9dbd75a0eb13069592f1",
+    "url": "https://github.com/microsoft/terminal/releases/download/v1.12.10732.0/Microsoft.WindowsTerminal_Win10_1.12.10732.0_8wekyb3d8bbwe.msixbundle#/dl.7z",
+    "hash": "728c84620d6c98d1685f30b000cbe780bd65842655c52313ebc12af5e76e0aef",
     "architecture": {
         "64bit": {
             "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"

--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -36,6 +36,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminal_$version_8wekyb3d8bbwe.msixbundle#/dl.7z"
+        "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminal_Win10_$version_8wekyb3d8bbwe.msixbundle#/dl.7z"
     }
 }


### PR DESCRIPTION
This update to Windows Terminal has a fix for the issue "Element not found" affecting a number of scoop users:
https://github.com/microsoft/terminal/issues/12305

The download URL scheme has changed.
Note that the release notes specify that the Win10 flavor of the URL will work just as well for Win11:

https://github.com/microsoft/terminal/releases/tag/v1.12.10732.0:
> If you install the Windows 10 verison on Windows 11, it will probably automatically upgrade itself to the Windows 11
version. It turns out that it is impossible to have two bundles with the same version number, so it has to be this
way.

