### PR TITLE
harmonoid: Update to 0.2.1-hotfix2, support hotfixes

### DIFF
--- a/bucket/harmonoid.json
+++ b/bucket/harmonoid.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.0",
+    "version": "0.2.1-hotfix2",
     "description": "Elegant music app to play & manage music library, lyrics and playlists (with YouTube support).",
     "homepage": "https://github.com/harmonoid/harmonoid",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/harmonoid/harmonoid/releases/download/v0.2.0/harmonoid-windows-exe.zip",
-            "hash": "e064f4a771998fd6805c7bec9f0b1e7a1033e16ac8508a374778693ead3f86fb"
+            "url": "https://github.com/harmonoid/harmonoid/releases/download/v0.2.1-hotfix2/harmonoid-windows-exe.zip",
+            "hash": "d7670f34461629a1e79631fd0f02d2b2217862eff265e6b8a018fccdc3a8ead8"
         }
     },
     "extract_dir": "harmonoid-windows-exe",
@@ -16,7 +16,10 @@
             "Harmonoid"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/harmonoid/harmonoid/releases/",
+        "regex": "tree/v([\\d.]+(?:[-hotfix\\d]+)?)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to download latest version due to '-hotfix' in version name: https://github.com/ScoopInstaller/Extras/runs/5777899107?check_suite_focus=true#step:3:265

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
