### PR TITLE
sk-ssh-agent: Add version 1.4

### DIFF
--- a/bucket/sk-ssh-agent.json
+++ b/bucket/sk-ssh-agent.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.4",
+    "description": "An SSH agent that supports using FIDO/U2F security keys with PuTTY and OpenSSH for Windows.",
+    "homepage": "https://github.com/tetractic/SK-SSH-Agent",
+    "license": "GPL-3.0",
+    "url": "https://github.com/tetractic/SK-SSH-Agent/releases/download/v1.4/SK-SSH-Agent-1.4.zip",
+    "hash": "8a041a9de51385c0d81df830af3e9bc08d605af70f6892c7a023792ab49e8897",
+    "extract_dir": "SK SSH Agent",
+    "checkver": {
+        "github": "https://github.com/tetractic/SK-SSH-Agent"
+    },
+    "autoupdate": {
+        "url": "https://github.com/tetractic/SK-SSH-Agent/releases/download/v$version/SK-SSH-Agent-$version.zip"
+    }
+}


### PR DESCRIPTION
SK SSH Agent is pretty new, but very useful application for Windows. It works as SSH Agent for both putty and openssh and supports  FIDO/U2F security keys for authentication (along with regular keys). No other application on windows can do this (ssh-agent from openssh on Windows 10 works, but require to be started as service, so not usable without admin permissions).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
