### PR TITLE
gephi: Update to version 0.9.3, fix autoupdate

### DIFF
--- a/bucket/gephi.json
+++ b/bucket/gephi.json
@@ -3,22 +3,19 @@
     "description": "Visualization and exploration software for all kinds of graphs and networks",
     "homepage": "https://github.com/gephi/gephi",
     "license": "GPL-3.0-only",
-    "suggest": {
-        "Java 8 only": [
-            "java/oraclejre8",
-            "java/liberica8-jdk"
-        ]
-    },
     "url": "https://github.com/gephi/gephi/releases/download/v0.9.3/gephi-0.9.3-windows-x64.exe",
     "hash": "87e7077eeb283805157e6d826e1b84fed728a4b1431791860daedacadddf9d85",
     "innosetup": true,
     "post_install": [
+        "# When updating from 0.9.2 to 0.9.3, let Gephi use bundled JRE by using new config",
         "$conf_file = \"$dir\\etc\\gephi.conf\"",
+        "$persist_conf = \"$persist_dir\\etc\\gephi.conf\"",
         "$file_contents = Get-Content -path $conf_file -Raw",
-        "if (($file_contents -match \"#jdkhome\") -contains $true) {",
-        "   $replaced = $file_contents -replace \"#jdkhome=`\"\/path\/to\/jdk`\"\", \"jdkhome=`\"$env:JAVA_HOME`\"\"",
-        "   Set-Content -Path $conf_file -Value $replaced",
-        "   Write-Host \"Notes`n-----`nScoop has configured Gephi to run using your current JAVA_HOME - if that is not Java 8, you will need to modify $dir\\etc\\gephi.conf\"",
+        "if (($file_contents -match \"/0.9.2/dev\") -contains $true) {",
+        "   Set-Content -path \"$conf_file.oldjre\" -value $file_contents",
+        "   Get-Content -path \"$conf_file.original\" -Raw | Set-Content -path $persist_conf",
+        "   Remove-Item \"$conf_file.original\"",
+        "   Write-Host \"Notes`n-----`nSince Gephi now bundles its own JRE, your config specifying the location of JAVA_HOME has been moved to $dir\\etc\\gephi.conf.oldjre\"",
         "}"
     ],
     "architecture": {

--- a/bucket/gephi.json
+++ b/bucket/gephi.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.2",
+    "version": "0.9.3",
     "description": "Visualization and exploration software for all kinds of graphs and networks",
     "homepage": "https://github.com/gephi/gephi",
     "license": "GPL-3.0-only",
@@ -9,8 +9,8 @@
             "java/liberica8-jdk"
         ]
     },
-    "url": "https://github.com/gephi/gephi/releases/download/v0.9.2/gephi-0.9.2-windows.exe",
-    "hash": "cc8dbf806baa157fd34876c940bead660c30d160d391c0189826b5fe270678fb",
+    "url": "https://github.com/gephi/gephi/releases/download/v0.9.3/gephi-0.9.3-windows-x64.exe",
+    "hash": "87e7077eeb283805157e6d826e1b84fed728a4b1431791860daedacadddf9d85",
     "innosetup": true,
     "post_install": [
         "$conf_file = \"$dir\\etc\\gephi.conf\"",
@@ -42,6 +42,6 @@
     "persist": "etc\\gephi.conf",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/gephi/gephi/releases/download/v$version/gephi-$version-windows.exe"
+        "url": "https://github.com/gephi/gephi/releases/download/v$version/gephi-$version-windows-x64.exe"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to autoupdate: https://github.com/ScoopInstaller/Extras/runs/5864968342?check_suite_focus=true#step:3:220

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
