### PR TITLE
chef-workstation: Add version 22.4.861

### DIFF
--- a/bucket/chef-workstation.json
+++ b/bucket/chef-workstation.json
@@ -1,0 +1,38 @@
+{
+    "version": "22.4.861",
+    "description": "Chef Development Kit contains all the tools you need to develop and test your infrastructure, built by the awesome Chef community.",
+    "homepage": "https://www.chef.io",
+    "license": {
+        "identifier": "Proprietary, BSD-2-Clause, MPL-2.0, Apache-2.0, BSD-3-Clause, MIT, Public Domain, OpenSSL, GPL-2.0, GPL-3.0, Zlib, ...",
+        "url": "https://www.chef.io/end-user-license-agreement/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://packages.chef.io/files/stable/chef-workstation/22.4.861/windows/2022/chef-workstation-22.4.861-1-x64.msi",
+            "hash": "53fbd99ae94e5b32deddc1cae1dbb6c3741beb3c0a76c441939dea600730e3d4"
+        }
+    },
+    "extract_dir": "opscode",
+    "pre_install": "Expand-7zipArchive \"$dir\\chef-workstation.zip\" -Removal",
+    "env_add_path": "bin",
+    "shortcuts": [
+        [
+            "components\\chef-workstation-app\\Chef Workstation App.exe",
+            "Chef Workstation"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.chef.io/downloads/tools/workstation",
+        "regex": "/stable/chef-workstation/([\\d.]+)/windows/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://packages.chef.io/files/stable/chef-workstation/$version/windows/2022/chef-workstation-$version-1-x64.msi",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator checkver failing for `chefdk` package: https://github.com/ScoopInstaller/Extras/runs/5954605801?check_suite_focus=true#step:3:210
- This is due to ChefDK reaching End of Life - see https://www.chef.io/downloads/tools/chefdk
- That page says to upgrade to Chef Workstation, which this PR adds. I will make a PR to add a note to `chefdk` afterwards.
- Very similar manifest to `chefdk`, adds `bin` directory to path as that is where the cli programs are stored - plus a shortcut to the gui Chef Desktop

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
