### PR TITLE
gammy: Remove autoupdate, fix pre_install, url

### DIFF
--- a/bucket/gammy.json
+++ b/bucket/gammy.json
@@ -1,10 +1,10 @@
 {
     "version": "0.9.64",
     "description": "Adaptive screen brightness tool",
-    "homepage": "https://getgammy.com",
+    "homepage": "https://github.com/Fushko/gammy",
     "license": "GPL-3.0-only",
     "suggest": {
-        "Microsoft Visual C++ Redistributable 2017": "extras/vcredist2022"
+        "Microsoft Visual C++ Redistributable": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {
@@ -15,7 +15,7 @@
     "extract_dir": "gammy_v0.9.64",
     "pre_install": [
         "if (Test-Path \"$persist_dir\\gammysettings.cfg\") {",
-        "    warn 'Application's configuration was renamed and changed. Previous configuration will not work'",
+        "    warn \"Application's configuration was renamed and changed. Previous configuration will not work\"",
         "    Rename-Item \"$persist_dir\\gammysettings.cfg\" 'gammysettings.cfg.old'",
         "}"
     ],
@@ -26,17 +26,5 @@
             "Gammy"
         ]
     ],
-    "persist": "gammyconf.txt",
-    "checkver": {
-        "url": "https://getgammy.com/downloads.html",
-        "regex": "/gammy_v([\\d.]+)\\.zip"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/Fushko/gammy/releases/download/v$version/gammy_v$version.zip"
-            }
-        },
-        "extract_dir": "gammy_v$version"
-    }
+    "persist": "gammyconf.txt"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator checkver not working due to website being down - the project has been archived on GitHub and 0.9.64 is the final release: https://github.com/ScoopInstaller/Extras/runs/5954605801?check_suite_focus=true#step:3:245
- Fixes pre_install not working due to unescaped apostrophe
- Update URL to archived GitHub repo rather than dead website

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
