### PR TITLE
Neovide@0.7.0: current version is outdated. wsl mode does not work in 0.5.0

### DIFF
--- a/bucket/neovide.json
+++ b/bucket/neovide.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.5.0",
+    "version": "0.7.0",
     "description": "A simple GUI for Neovim",
     "homepage": "https://github.com/Kethku/neovide",
     "license": "MIT",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Kethku/neovide/releases/download/0.5.0/neovide.exe",
-            "hash": "fa8453d74b6833e7912c049faa9880544cb629e3e610f1717639c8198a26cd85"
+            "url": "https://github.com/Kethku/neovide/releases/download/0.7.0/neovide.exe",
+            "hash": "8FB6C9EDACB66A0F82E97289386F287D38332DAAF9FFC7ADBDFE6F67F157CAFE"
         }
     },
     "bin": "neovide.exe",


### PR DESCRIPTION
Update neovide to beta 0.7.0 (WSL no longer works in version 0.5.0, 0.7.0 does work)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [✔️] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
