### PR TITLE
gcloud: Use 7zip 19.00 helper for extraction

### DIFF
--- a/bucket/gcloud.json
+++ b/bucket/gcloud.json
@@ -4,17 +4,22 @@
     "homepage": "https://cloud.google.com/sdk/",
     "license": "Proprietary",
     "notes": "To initialize Cloud SDK, you will need to run: 'gcloud init'",
+    "depends": "7zip19.00-helper",
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-380.0.0-windows-x86_64-bundled-python.zip",
+            "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-380.0.0-windows-x86_64-bundled-python.zip#/dl.zip_",
             "hash": "cc044bcd09985ec433fa8557b7c0cfa29def8bb9d891e4b8c1f9d53c687e9ab8"
         },
         "32bit": {
-            "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-380.0.0-windows-x86-bundled-python.zip",
+            "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-380.0.0-windows-x86-bundled-python.zip#/dl.zip_",
             "hash": "4b214fa1dade2badb8ec5e5150186ecbb1b6fe6c07b2e748aedfca1e64bbff6a"
         }
     },
-    "extract_dir": "google-cloud-sdk",
+    "pre_install": [
+        "Invoke-ExternalCommand 7z1900-helper -ArgumentList @('x', '-bso0', \"`\"$dir\\dl.zip_`\"\", \"`\"-o$dir`\"\") | Out-Null",
+        "Move-Item \"$dir\\google-cloud-sdk\\*\" \"$dir\\\" | Out-Null",
+        "Remove-Item \"$dir\\google-cloud-sdk\", \"$dir\\dl.zip_\" -Force -Recurse"
+    ],
     "bin": [
         "bin\\gcloud.cmd",
         "bin\\gsutil.cmd",
@@ -29,10 +34,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$version-windows-x86_64-bundled-python.zip"
+                "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$version-windows-x86_64-bundled-python.zip#/dl.zip_"
             },
             "32bit": {
-                "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$version-windows-x86-bundled-python.zip"
+                "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$version-windows-x86-bundled-python.zip#/dl.zip_"
             }
         }
     }


### PR DESCRIPTION
This fixes the extraction error mentioned in https://github.com/ScoopInstaller/Scoop/issues/4647 by using **7-Zip 19.00 helper package** to extract files.

Related Issues:
* https://github.com/ScoopInstaller/Extras/issues/8298
* https://github.com/ScoopInstaller/Scoop/issues/4647

Notes:
* I changed the name(`bin`) of the helper to `7z1900-helper`, because the dot (`.`) in the file name will cause Start-Process to fail.