### PR TITLE
qtemu: Fix JSONpath error in checkver

### DIFF
--- a/bucket/qtemu.json
+++ b/bucket/qtemu.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://gitlab.com/api/v4/projects/10442008/releases",
-        "jp": "$.tag_name",
+        "jp": "$.[0].tag_name",
         "regex": "([\\d.-]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator error `Property 'tag_name' not valid on JArray.`: https://github.com/ScoopInstaller/Extras/runs/6003978022?check_suite_focus=true#step:3:245

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
