### PR TITLE
discord@1.0.9004-11: version update and switch to portable version

### DIFF
--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.9004-11",
+    "version": "1.0.9004-10",
     "description": "Free Voice and Text Chat",
     "homepage": "https://discordapp.com/",
     "license": {
@@ -8,12 +8,6 @@
     },
     "url": "https://github.com/portapps/discord-portable/releases/download/1.0.9004-11/discord-portable-win32-1.0.9004-11.7z",
     "hash": "670691395ba0bd2ac59e5cbaa1af72cbdae91bd44ed5ec69f922d1547b8078af",
-    "bin": [
-        [
-            "discord-portable.exe",
-            "Discord"
-        ]
-    ],
     "shortcuts": [
         [
             "discord-portable.exe",
@@ -31,7 +25,7 @@
     "autoupdate": {
         "url": "https://github.com/portapps/discord-portable/releases/download/$version/discord-portable-win32-$version.7z",
         "hash": {
-            "url": "https://github.com/portapps/discord-portable/releases/download/$version/checksums.txt"
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.9004-10",
+    "version": "1.0.9004-11",
     "description": "Free Voice and Text Chat",
     "homepage": "https://discordapp.com/",
     "license": {

--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,31 +1,37 @@
 {
-    "version": "0.0.311",
+    "version": "1.0.9004-11",
     "description": "Free Voice and Text Chat",
     "homepage": "https://discordapp.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://discordapp.com/terms"
     },
-    "notes": "To avoid manifest removal due to internal updates, disable automatic updates by running: '$dir\\disable-auto-update.ps1'",
-    "url": "http://dl.discordapp.net/apps/win/Discord-0.0.311-full.nupkg",
-    "hash": "sha1:3928a4af8e249184f2d4212bd8c958adc8b2ff4f",
-    "extract_dir": "lib\\net45",
-    "bin": "Discord.exe",
-    "shortcuts": [
+    "url": "https://github.com/portapps/discord-portable/releases/download/1.0.9004-11/discord-portable-win32-1.0.9004-11.7z",
+    "hash": "670691395ba0bd2ac59e5cbaa1af72cbdae91bd44ed5ec69f922d1547b8078af",
+    "bin": [
         [
-            "Discord.exe",
+            "discord-portable.exe",
             "Discord"
         ]
     ],
-    "post_install": "Copy-Item -Path \"$bucketsdir\\extras\\scripts\\discord\\disable-auto-update.ps1\" -Destination \"$dir\\\"",
+    "shortcuts": [
+        [
+            "discord-portable.exe",
+            "Discord"
+        ]
+    ],
+    "persist": [
+        "data",
+        "log"
+    ],
     "checkver": {
-        "url": "https://discordapp.com/api/updates/stable/RELEASES",
-        "regex": "Discord-([\\d.]+)-full"
+        "url": "https://github.com/portapps/discord-portable",
+        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
     },
     "autoupdate": {
-        "url": "http://dl.discordapp.net/apps/win/Discord-$version-full.nupkg",
+        "url": "https://github.com/portapps/discord-portable/releases/download/$version/discord-portable-win32-$version.7z",
         "hash": {
-            "url": "https://discordapp.com/api/updates/stable/RELEASES"
+            "url": "https://github.com/portapps/discord-portable/releases/download/$version/checksums.txt"
         }
     }
 }

--- a/scripts/discord/disable-auto-update.ps1
+++ b/scripts/discord/disable-auto-update.ps1
@@ -1,9 +1,0 @@
-$path = "$Env:appdata/discord/settings.json"
-$settings = Get-Content $path | ConvertFrom-Json
-if (Get-Member -inputobject $settings -name 'SKIP_HOST_UPDATE' -Membertype Properties) {
-    $settings.SKIP_HOST_UPDATE=$True
-}
-else {
-    $settings | Add-Member -MemberType NoteProperty -Name 'SKIP_HOST_UPDATE' -Value $True
-}
-$settings | ConvertTo-Json | Set-Content -Path $path


### PR DESCRIPTION
Closes #8051

Switch Discord over to the portable version maintained by portapps. This version deals with the complexities of keeping Discord from auto updating itself and also redirects its data nicely. This also brings us up-to-date as our manifest version is quite old.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
