### PR TITLE
camo-studio: Add version 1.1.6.7135

### DIFF
--- a/bucket/camo-studio.json
+++ b/bucket/camo-studio.json
@@ -6,8 +6,12 @@
         "identifier": "Freeware",
         "url": "https://reincubate.com/terms-conditions/#terms-eula"
     },
-    "url": "https://reincubate.com/res/labs/camo/camo-windows-latest.msi",
-    "hash": "21a16894868a918f44c3938011951f842d5730962298edd275cf30d292274c80",
+    "architecture": {
+        "64bit": {
+            "url": "https://reincubate.com/res/labs/camo/camo-windows-latest.msi",
+            "hash": "21a16894868a918f44c3938011951f842d5730962298edd275cf30d292274c80"
+        }
+    },
     "extract_dir": "Camo Studio",
     "shortcuts": [
         [
@@ -20,6 +24,10 @@
         "regex": "Camo ([\\d.]+) released"
     },
     "autoupdate": {
-        "url": "https://reincubate.com/res/labs/camo/camo-windows-latest.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://reincubate.com/res/labs/camo/camo-windows-latest.msi"
+            }
+        }
     }
 }

--- a/bucket/camo-studio.json
+++ b/bucket/camo-studio.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.1.6.7135",
+    "description": "Use your phone as a webcam",
+    "homepage": "https://reincubate.com/camo",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://reincubate.com/terms-conditions/#terms-eula"
+    },
+    "url": "https://reincubate.com/res/labs/camo/camo-windows-latest.msi",
+    "hash": "21a16894868a918f44c3938011951f842d5730962298edd275cf30d292274c80",
+    "extract_dir": "Camo Studio",
+    "shortcuts": [
+        [
+            "CamoStudio.exe",
+            "Camo Studio"
+        ]
+    ],
+    "checkver": {
+        "url": "https://reincubate.com/support/camo/release-notes/?platform=windows",
+        "regex": "Camo ([\\d.]+) released"
+    },
+    "autoupdate": {
+        "url": "https://reincubate.com/res/labs/camo/camo-windows-latest.msi"
+    }
+}


### PR DESCRIPTION
Closes #8325 

Adds Camo Studio app used as a bridge to allow phones to become Windows recognized webcams.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
