### PR TITLE
pixelorama: Fix 0.10 extract_dir

### DIFF
--- a/bucket/pixelorama.json
+++ b/bucket/pixelorama.json
@@ -6,11 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Orama-Interactive/Pixelorama/releases/download/v0.10/Pixelorama.Windows-64bit.zip",
-            "hash": "66e163f634f57497a25347a23738f6336bcb9bd7cb8da9d3766c2953b1b4f670"
+            "hash": "66e163f634f57497a25347a23738f6336bcb9bd7cb8da9d3766c2953b1b4f670",
+            "extract_dir": "windows-64bit"
         },
         "32bit": {
             "url": "https://github.com/Orama-Interactive/Pixelorama/releases/download/v0.10/Pixelorama.Windows-32bit.zip",
-            "hash": "9f6885d4edb8340bbee46a99c7d566203530804b92b02b07e3f976366a2c7e29"
+            "hash": "9f6885d4edb8340bbee46a99c7d566203530804b92b02b07e3f976366a2c7e29",
+            "extract_dir": "windows-32bit"
         }
     },
     "bin": "Pixelorama.exe",


### PR DESCRIPTION
Pixelorama seemingly changed their release format in version 0.10

This commit fixes the `extract_dir`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
