### PR TITLE
winsetupfromusb: Add version 1.10

### DIFF
--- a/bucket/winsetupfromusb.json
+++ b/bucket/winsetupfromusb.json
@@ -1,0 +1,39 @@
+{
+    "version": "1.10",
+    "description": "Creating multi-boot USB for Windows/Linux installations.",
+    "homepage": "http://www.winsetupfromusb.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://www.winsetupfromusb.com/faq/"
+    },
+    "url": "http://downloads.winsetupfromusb.com/WinSetupFromUSB-1-10.exe#/dl.7z",
+    "hash": "f1f2db8cc6e02a8c7abd3e91a7aad23d1f3730eb16763b9041e73a55b817a7eb",
+    "extract_dir": "WinSetupFromUSB-1-10",
+    "pre_install": [
+        "if (!(Test-Path \"$dir\\WinSetupFromUSB.log\")) {New-Item \"$dir\\WinSetupFromUSB.log\" | Out-Null}",
+        "$dashVersion = $version.Replace('.', '-')",
+        "$64bit_exe = \"$dir\\WinSetupFromUSB_$($dashVersion)_x64.exe\"",
+        "$32bit_exe = \"$dir\\WinSetupFromUSB_$($dashVersion).exe\"",
+        "if($architecture -eq '64bit') {",
+        "    Rename-Item $64bit_exe 'WinSetupFromUSB.exe'",
+        "    Remove-Item $32bit_exe",
+        "} else {",
+        "    Rename-Item $32bit_exe 'WinSetupFromUSB.exe'",
+        "    Remove-Item $32bit_exe",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "WinSetupFromUSB.exe",
+            "WinSetupFromUSB"
+        ]
+    ],
+    "checkver": {
+        "url": "http://www.winsetupfromusb.com/downloads/",
+        "regex": "WinSetupFromUSB\\s([\\d.]+)\\.exe"
+    },
+    "autoupdate": {
+        "url": "http://downloads.winsetupfromusb.com/WinSetupFromUSB-$dashVersion.exe#/dl.7z",
+        "extract_dir": "WinSetupFromUSB-$dashVersion"
+    }
+}

--- a/bucket/winsetupfromusb.json
+++ b/bucket/winsetupfromusb.json
@@ -1,6 +1,6 @@
 {
     "version": "1.10",
-    "description": "Creating multi-boot USB for Windows/Linux installations.",
+    "description": "Create multi-boot USB for Windows/Linux installations.",
     "homepage": "http://www.winsetupfromusb.com/",
     "license": {
         "identifier": "Freeware",

--- a/bucket/winsetupfromusb.json
+++ b/bucket/winsetupfromusb.json
@@ -19,7 +19,7 @@
         "    Remove-Item $32bit_exe",
         "} else {",
         "    Rename-Item $32bit_exe 'WinSetupFromUSB.exe'",
-        "    Remove-Item $32bit_exe",
+        "    Remove-Item $64bit_exe",
         "}"
     ],
     "shortcuts": [


### PR DESCRIPTION
[WinSetupFromUsb](http://www.winsetupfromusb.com/) is a tool that can create multi-boot USB for Windows/Linux installations.

**NOTES**:
* The site does not support HTTPS.
* license info can be found on the [FAQ page](http://www.winsetupfromusb.com/faq/)
```
12. Is the program free and may it be freely redistributed?
Program is free for personal and commercial use and can be freely redistributed as long as the licenses of the tools included are not violated and there is clear link to [this](http://www.winsetupfromusb.com/) page or the home [page @ msfn forum](https://www.msfn.org/board/topic/120444-how-to-install-windows-from-usb-winsetupfromusb-with-gui/) if it is hosted elsewhere.

The program may not be sold or included in commercial products without written consent from its author.
```