### PR TITLE
brave: Use official release and update to version 1.37.116

### DIFF
--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.34.80-80",
+    "version": "1.37.116",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
     "homepage": "https://brave.com",
     "license": {
@@ -8,35 +8,46 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/portapps/brave-portable/releases/download/1.34.80-80/brave-portable-win64-1.34.80-80.7z",
-            "hash": "af917c93469c97a8cc4153e3dd8639406475cee921556d6e513ec552bd43f8e3"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.37.116/brave-v1.37.116-win32-x64.zip",
+            "hash": "6715819203cc103f9a8eef2ec21f746203e7a19a1e04287b92d9d0d6bdf9ac38"
+        },
+        "32bit": {
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.37.116/brave-v1.37.116-win32-ia32.zip",
+            "hash": "537aba02bdaee5fc48c83f9ef5c0520f0d94b1016ee21c58b3051c6778d065f7"
         }
     },
     "bin": [
         [
-            "brave-portable.exe",
-            "brave"
+            "brave.exe",
+            "brave",
+            "--user-data-dir=\"$dir\\User Data\""
         ]
     ],
     "shortcuts": [
         [
-            "brave-portable.exe",
-            "Brave"
+            "brave.exe",
+            "Brave",
+            "--user-data-dir=\"$dir\\User Data\""
         ]
     ],
-    "persist": [
-        "data",
-        "log",
-        "reg"
+    "post_install": [
+        "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$env:LocalAppData\\BraveSoftware\\Brave-Browser\\User Data\")) {",
+        "    info '[Portable Mode]: Copying user data...'",
+        "    Copy-Item \"$env:LocalAppData\\BraveSoftware\\Brave-Browser\\User Data\\*\" \"$dir\\User Data\" -Recurse",
+        "}"
     ],
     "checkver": {
-        "url": "https://github.com/portapps/brave-portable",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+        "url": "https://brave.com/latest/",
+        "regex": "<strong>V([\\d.]+)</strong>"
     },
+    "persist": "User Data",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/portapps/brave-portable/releases/download/$version/brave-portable-win64-$version.7z"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-ia32.zip"
             }
         }
     }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -31,16 +31,20 @@
         ]
     ],
     "post_install": [
+        "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$persist_dir\\data\")) {",
+        "    info '[Portable Mode]: Copying user data from portapps data directory . . .'",
+        "    Copy-Item \"$persist_dir\\data\\*\" \"$dir\\User Data\" -Recurse",
+        "}",
         "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$env:LocalAppData\\BraveSoftware\\Brave-Browser\\User Data\")) {",
-        "    info '[Portable Mode]: Copying user data...'",
+        "    info '[Portable Mode]: Copying user data from local application data directory . . .'",
         "    Copy-Item \"$env:LocalAppData\\BraveSoftware\\Brave-Browser\\User Data\\*\" \"$dir\\User Data\" -Recurse",
         "}"
     ],
+    "persist": "User Data",
     "checkver": {
         "url": "https://brave.com/latest/",
         "regex": "<strong>V([\\d.]+)</strong>"
     },
-    "persist": "User Data",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Use [official GitHub release](https://github.com/brave/brave-browser/releases) and update to [version 1.37.116](https://github.com/brave/brave-browser/releases/tag/v1.37.116)

Relates to #7318
Relates to #7573

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
