### PR TITLE
gcc-arm-none-eabi: suggest 32bit python27 (fixes #8361)

### DIFF
--- a/bucket/gcc-arm-none-eabi.json
+++ b/bucket/gcc-arm-none-eabi.json
@@ -3,6 +3,14 @@
     "description": "Pre-built GNU Toolchain for the Arm Architecture",
     "homepage": "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain",
     "license": "GPL-3.0-only",
+    "notes": [
+        "For GDB support, a 32bit Python 2.7 install is required"
+    ],
+    "suggest": {
+        "arm-none-eabi-gdb": [
+            "versions/python27"
+        ]
+    },
     "url": "https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-mingw-w64-i686-arm-none-eabi.zip",
     "hash": "sha256:585156432d73c9c2c8b4742e342564a75d47886d90ac821f88d2b564c33e6766",
     "extract_dir": "gcc-arm-11.2-2022.02-mingw-w64-i686-arm-none-eabi",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8361


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
