### PR TITLE
mathpix: Add version 03.00.0074

### DIFF
--- a/bucket/mathpix.json
+++ b/bucket/mathpix.json
@@ -1,6 +1,6 @@
 {
     "version": "03.00.0074",
-    "description": "A Tool for an Easy and Fast Way to Create Math Equations Using LaTex.",
+    "description": "A tool for an easy and fast way to create math equations using LaTex.",
     "homepage": "https://mathpix.com/",
     "license": {
         "identifier": "Freeware",

--- a/bucket/mathpix.json
+++ b/bucket/mathpix.json
@@ -1,0 +1,22 @@
+{
+    "version": "03.00.0074",
+    "description": "A Tool for an Easy and Fast Way to Create Math Equations Using LaTex.",
+    "homepage": "https://mathpix.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://mathpix.com/terms"
+    },
+    "url": "https://download.mathpix.com/windows/mathpix_snipping_tool_setup.v03.00.0074.exe",
+    "hash": "c17fccdb00f5c337e5bd71e3dc5ab9a02bef5ddd4f34f6a8d2958c876a502bef",
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "mathpix-snipping-tool.exe",
+            "Mathpix Snipping Tool"
+        ]
+    ],
+    "checkver": "mathpix_snipping_tool_setup.v([\\d.]+)\\.exe",
+    "autoupdate": {
+        "url": "https://download.mathpix.com/windows/mathpix_snipping_tool_setup.v$version.exe"
+    }
+}


### PR DESCRIPTION
closes #8367

[Mathpix](https://mathpix.com/) is a tool for an easy and fast way to create math equations using LaTex.

**NOTES**:
* The app (and its dependencies) is built in 32-bit.
* *persist* is not needed because config is at `$Env:LocalAppData\Mathpix\Mathpix Snipping Tool`.