### PR TITLE
win-gpg-agent: Add additional persist files

### DIFF
--- a/bucket/win-gpg-agent.json
+++ b/bucket/win-gpg-agent.json
@@ -36,7 +36,11 @@
         "  ) -join '' | Set-Content \"$dir\\agent-gui.conf\" -Encoding ASCII",
         "}"
     ],
-    "persist": "agent-gui.conf",
+    "persist": [
+        "agent-gui.conf",
+        "pinentry.conf",
+        "sorelay.conf"
+    ],
     "shortcuts": [
         [
             "agent-gui.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

From https://github.com/rupor-github/win-gpg-agent/releases/tag/v1.6.2:
> Make sure all config files are persisted and not only `agent-gui.conf`.

@rupor-github It would be helpful if you contributed the change here upstream as well.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
