### PR TITLE
xkill: Add version 1.0.0.20141024

### DIFF
--- a/bucket/xkill.json
+++ b/bucket/xkill.json
@@ -4,7 +4,7 @@
     "homepage": "https://bitbucket.org/sta-ger/win-xkill",
     "license": "GPL-3.0-or-later",
     "url": "https://bitbucket.org/sta-ger/win-xkill/downloads/XKill.zip",
-    "hash": "34e5d7f6bd7ff9b770e8bd9afbc9cac1e568e6af9f38ec6e8151fdaabcbc098d",
+    "hash": "8bcfcdef9c7d251bc4efc90064e66e4a799c18f9996f5c3a8780ffefc995e014",
     "shortcuts": [
         [
             "XKill.exe",

--- a/bucket/xkill.json
+++ b/bucket/xkill.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0.20141024",
+    "description": "Display a special cursor as a prompt for the user to select a window to be killed.",
+    "homepage": "https://bitbucket.org/sta-ger/win-xkill",
+    "license": "GPL-3.0-or-later",
+    "url": "https://bitbucket.org/sta-ger/win-xkill/downloads/XKill.zip",
+    "hash": "34e5d7f6bd7ff9b770e8bd9afbc9cac1e568e6af9f38ec6e8151fdaabcbc098d",
+    "shortcuts": [
+        [
+            "XKill.exe",
+            "XKill"
+        ]
+    ]
+}


### PR DESCRIPTION
closes https://github.com/ScoopInstaller/Main/issues/1549
also requested in https://github.com/ScoopInstaller/Main/issues/2399 and https://github.com/ScoopInstaller/Extras/issues/7167

[XKill](https://bitbucket.org/sta-ger/win-xkill) is a tool that works the same as XWindow's *XKill*, which displays a special cursor as a prompt for the user to select a window to be killed.

**NOTES**:
* The app is built in 32-bit.
* *autoupdate* is not needed because last update was in 2014.
* *license* and *version* info can be found in `win-xkill.nuspec` in the source code.