### PR TITLE
praat: Update to version 6.2.12, fix autoupdate

### DIFF
--- a/bucket/praat.json
+++ b/bucket/praat.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.2.11",
+    "version": "6.2.12",
     "description": "The scientific analysis of speech in phonetics",
     "homepage": "http://www.fon.hum.uva.nl/praat/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/praat/praat/releases/download/6.2.11/praat6211_win64.zip",
-            "hash": "49d5fcf7eb1790c14bc1ef206814de428ef3b7d9cc589ae71c927b7139af486f"
+            "url": "https://github.com/praat/praat/releases/download/v6.2.12/praat6212_win64.zip",
+            "hash": "371884642d4143da71d316fb6e5a5da65705b8be31db94b5d53709018038d446"
         },
         "32bit": {
-            "url": "https://github.com/praat/praat/releases/download/6.2.11/praat6211_win32.zip",
-            "hash": "8b00fbf09ab16346cfd6f7ca35dc3e2c02b826ccce323bb80babdb3de3076448"
+            "url": "https://github.com/praat/praat/releases/download/v6.2.12/praat6212_win32.zip",
+            "hash": "63dc4d309e630603ce51e217a33ad0f69cac81b0e122ce993769690e1a2385b0"
         }
     },
     "bin": "Praat.exe",
@@ -26,10 +26,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/praat/praat/releases/download/$version/praat$cleanVersion_win64.zip"
+                "url": "https://github.com/praat/praat/releases/download/v$version/praat$cleanVersion_win64.zip"
             },
             "32bit": {
-                "url": "https://github.com/praat/praat/releases/download/$version/praat$cleanVersion_win32.zip"
+                "url": "https://github.com/praat/praat/releases/download/v$version/praat$cleanVersion_win32.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Extras/runs/6084782217?check_suite_focus=true#step:3:265

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
