### PR TITLE
windterm: Update to version 2.4.1, fix autoupdate

### DIFF
--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "SSH/Sftp/Shell/Telnet/Serial client",
     "homepage": "https://kingtoolbox.github.io/",
     "license": "Apache-2.0",
@@ -8,15 +8,15 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kingToolbox/WindTerm/releases/download/2.4.0/WindTerm_2.4.0_Windows_Portable_x86_64.zip",
-            "hash": "e1aff2ee7164149deb0d8dfeba4d9b0889b9b364ac400ce639a68d86db86ec72"
+            "url": "https://github.com/kingToolbox/WindTerm/releases/download/2.4.0/WindTerm_2.4.1_Windows_Portable_x86_64.zip",
+            "hash": "1614660d42b73a10037c72e725b0a7d86dc7e304fd4d9629fd0fbf9bbf503570"
         },
         "32bit": {
-            "url": "https://github.com/kingToolbox/WindTerm/releases/download/2.4.0/WindTerm_2.4.0_Windows_Portable_x86_32.zip",
-            "hash": "6a2139cf053bb8fd21342a470c0f9a334faec44bbcf60e037c714b2baad22695"
+            "url": "https://github.com/kingToolbox/WindTerm/releases/download/2.4.0/WindTerm_2.4.1_Windows_Portable_x86_32.zip",
+            "hash": "27f4f14f93ada0450bfeecddbec464d0a3532675ff612625d19a965b479d0d93"
         }
     },
-    "extract_dir": "WindTerm_2.4.0",
+    "extract_dir": "WindTerm_2.4.1",
     "shortcuts": [
         [
             "WindTerm.exe",
@@ -30,16 +30,16 @@
         "terminal"
     ],
     "checkver": {
-        "github": "https://github.com/kingToolbox/WindTerm",
-        "regex": "WindTerm_([\\d.]+)_Windows_Portable"
+        "url": "https://github.com/kingToolbox/WindTerm/releases",
+        "regex": "WindTerm_([\\d.]+)_Windows_Portable_x86_64.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$version/WindTerm_$version_Windows_Portable_x86_64.zip"
+                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$majorVersion.$minorVersion.0/WindTerm_$version_Windows_Portable_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$version/WindTerm_$version_Windows_Portable_x86_32.zip"
+                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$majorVersion.$minorVersion.0/WindTerm_$version_Windows_Portable_x86_32.zip"
             }
         },
         "extract_dir": "WindTerm_$version"

--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -31,15 +31,15 @@
     ],
     "checkver": {
         "url": "https://github.com/kingToolbox/WindTerm/releases",
-        "regex": "WindTerm_([\\d.]+)_Windows_Portable_x86_64.zip"
+        "regex": "(?<tag>[\\d.]+)\\/WindTerm_([\\d.]+)_Windows_Portable_x86_64.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$majorVersion.$minorVersion.0/WindTerm_$version_Windows_Portable_x86_64.zip"
+                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$matchTag/WindTerm_$version_Windows_Portable_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$majorVersion.$minorVersion.0/WindTerm_$version_Windows_Portable_x86_32.zip"
+                "url": "https://github.com/kingToolbox/WindTerm/releases/download/$matchTag/WindTerm_$version_Windows_Portable_x86_32.zip"
             }
         },
         "extract_dir": "WindTerm_$version"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator stuck at version 2.4.0 due to using the same GitHub release tag for multiple releases: https://github.com/ScoopInstaller/Extras/runs/6172077668?check_suite_focus=true#step:3:252

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
