### PR TITLE
dadroitjsonviewer: Revert to v1.5.2153, fix checkver

### DIFF
--- a/bucket/dadroitjsonviewer.json
+++ b/bucket/dadroitjsonviewer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.2154",
+    "version": "1.5.2153",
     "description": "A JSON viewer that gives a new approach to process JSON Data files.",
     "homepage": "https://dadroit.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dadroit.com/releases/win/Dadroit%20Viewer%201.5%20Build%202154%20x64%20Setup.exe",
-            "hash": "5160559ffa7c67bab3bdc97c4cbf2c6f00b72183fec8ecef367be85ac2077d28"
+            "url": "https://dadroit.com/releases/win/Dadroit%20Viewer%201.5%20Build%202153%20x64%20Setup.exe",
+            "hash": "543d2c2b59e0325846349d72d13f0ab293bdbb54ec4b7bcac365aa3ae5f7ad0c"
         }
     },
     "innosetup": true,
@@ -20,8 +20,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://dadroit.com/release-notes",
-        "regex": "Viewer.{8}([\\d.]+)"
+        "url": "https://dadroit.com/js/app.js",
+        "regex": "Viewer (?<main>[\\d.]+)\\s+Build\\s+(?<build>\\d+)\\s+x64",
+        "replace": "${main}.${build}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Revert to previous version because checkver was picking up macOS only versions from Release Notes page. The issues linked below were because it had autoupdated the link to a 404 HTML page which was a hash mismatch to the exe.

Relates to #8388 #8371 #8347 #8344 #8338 #8336

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
