### PR TITLE
kdoc-formatter: Add version 1.4.1

### DIFF
--- a/bucket/kdoc-formatter.json
+++ b/bucket/kdoc-formatter.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.4.1",
+    "description": "Reformats Kotlin KDoc comments, reflowing text and other cleanup",
+    "homepage": "https://github.com/tnorbye/kdoc-formatter",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk",
+            "java/temurin-jdk"
+        ]
+    },
+    "url": "https://github.com/tnorbye/kdoc-formatter/releases/download/v1.4.1/kdoc-formatter-1.4.1.zip",
+    "hash": "6f3bc96fcc6a04a2757ec64d468627978d5ce4241c33247593b2672a6c18d783",
+    "extract_dir": "kdoc-formatter-1.4.1",
+    "bin": "bin\\kdoc-formatter.bat",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/tnorbye/kdoc-formatter/releases/download/v$version/kdoc-formatter-$version.zip",
+        "extract_dir": "kdoc-formatter-$version"
+    }
+}


### PR DESCRIPTION
Add version 1.4.1 of [kdoc-formatter](https://github.com/tnorbye/kdoc-formatter) - Kotlin KDoc auto-format tool

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
