### PR TITLE
insomnia@2022.2.1: Update checkver regex to find latest version

### DIFF
--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/Kong/insomnia/releases",
-        "regex": "insomnia-([\\d.]+)-f"
+        "regex": "core@([\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/Kong/insomnia/releases",
-        "regex": "core@([\\d.]+)"
+        "regex": "\"core@([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/Kong/insomnia/releases",
-        "regex": "core@([\d.]+)"
+        "regex": "core@([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Scoop is not recognising that there is an update to Insomnia so I am stuck on 2021.7.2. This allows scoop to check for the latest version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
