### PR TITLE
dangerzone: Add version 0.3.1

### DIFF
--- a/bucket/dangerzone.json
+++ b/bucket/dangerzone.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.3.1",
+    "description": "Take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF.",
+    "homepage": "https://dangerzone.rocks/",
+    "license": "MIT",
+    "notes": [
+        "DangerZone requires Docker Desktop to run.",
+        "You can download it from: https://www.docker.com/products/docker-desktop/"
+    ],
+    "url": "https://github.com/firstlookmedia/dangerzone/releases/download/v0.3.1/Dangerzone-0.3.1.msi",
+    "hash": "68f813f8af0666e19117d8a31bff94a0044fbddfc0c281840a945c6416018c5d",
+    "extract_dir": "Dangerzone",
+    "bin": "dangerzone-cli.exe",
+    "shortcuts": [
+        [
+            "dangerzone.exe",
+            "DangerZone"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/firstlookmedia/dangerzone"
+    },
+    "autoupdate": {
+        "url": "https://github.com/firstlookmedia/dangerzone/releases/download/v$version/Dangerzone-$version.msi"
+    }
+}


### PR DESCRIPTION
closes #8319

[DangerZone](https://dangerzone.rocks/) is an app that take potentially dangerous PDFs, office documents, or images and convert them to a safe PDF.

**NOTES**:
* *DangerZone* requires **Docker desktop** to run (will prompt user on startup). **Docker desktop** is currently not avaiable on Scoop because it needs to install services. I will work on that later.
* The app (and its dependencies) is built in 32-bit.
* *persist* is not needed because config is at `$Env:LocalAppData\DangerZone`.
