### PR TITLE
mpc-hc-fork: Update to 1.9.21.2, fix checkver

### DIFF
--- a/bucket/mpc-hc-fork.json
+++ b/bucket/mpc-hc-fork.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.9.20",
+    "version": "1.9.21.2",
     "description": "An extremely light-weight, open source media player for Windows.",
     "homepage": "https://github.com/clsid2/mpc-hc",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/clsid2/mpc-hc/releases/download/1.9.20/MPC-HC.1.9.20.x64.zip",
-            "hash": "f71fa3d491c1be9e03709c1565b8871cfdc7152961ad297ef0d1b2e1445a54d6",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/1.9.21/MPC-HC.1.9.21.2.x64.zip",
+            "hash": "1ae2faf728ef3d94be7691fb0d463218966e43ee647c64c641dffbdd4aad018f",
             "bin": [
                 [
                     "mpc-hc64.exe",
@@ -21,8 +21,8 @@
             ]
         },
         "32bit": {
-            "url": "https://github.com/clsid2/mpc-hc/releases/download/1.9.20/MPC-HC.1.9.20.x86.zip",
-            "hash": "023b53d27825206581dd4093d69b1e52f0ae3e8c4a9a1f432ce8dd4ff3e4a2db",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/1.9.21/MPC-HC.1.9.21.2.x86.zip",
+            "hash": "101ff589aaa70b0c53c1d6e58fc64adf259edb9291722f6ca42c4c738947fa62",
             "bin": "mpc-hc.exe",
             "shortcuts": [
                 [
@@ -42,14 +42,17 @@
         "mpc-hc.ini",
         "default.mpcpl"
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/clsid2/mpc-hc/releases",
+        "regex": "(?<tag>[\\d.]+)\\/MPC-HC.([\\d.]+).x64.exe"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/clsid2/mpc-hc/releases/download/$version/MPC-HC.$version.x64.zip"
+                "url": "https://github.com/clsid2/mpc-hc/releases/download/$matchTag/MPC-HC.$version.x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/clsid2/mpc-hc/releases/download/$version/MPC-HC.$version.x86.zip"
+                "url": "https://github.com/clsid2/mpc-hc/releases/download/$matchTag/MPC-HC.$version.x86.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to update due to reusing the releases tag for multiple further releases: https://github.com/ScoopInstaller/Extras/runs/6224966985?check_suite_focus=true#step:3:231
- Similar method for checkver as https://github.com/ScoopInstaller/Extras/pull/8392

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
