### PR TITLE
windterm@2.4.1: Fix for changed way of storing profiles by the app

### DIFF
--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -6,6 +6,12 @@
     "suggest": {
         "vcredist2022": "extras/vcredist2022"
     },
+    "notes": [
+        "From version 2.4.0, WindTerm changed the way how the connection profiles are stored.",
+        "During the first run of version 2.4.0 or higher, please, choose the first option for 'profile directory', so the profiles will be stored along the application files.",
+        "Then copy the old profiles directory, stored under 'persist/WindTerm/profiles', over the newly created folder under 'persist/WindTerm/.wind/profiles'. After that you can delete the old 'profiles' directory.",
+        "For details: https://github.com/kingToolbox/WindTerm/releases, section Upgrade."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/kingToolbox/WindTerm/releases/download/2.4.0/WindTerm_2.4.1_Windows_Portable_x86_64.zip",
@@ -24,9 +30,8 @@
         ]
     ],
     "persist": [
+        ".wind",
         "global",
-        "plugins",
-        "profiles",
         "terminal"
     ],
     "checkver": {

--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -6,12 +6,6 @@
     "suggest": {
         "vcredist2022": "extras/vcredist2022"
     },
-    "notes": [
-        "From version 2.4.0, WindTerm changed the way how the connection profiles are stored.",
-        "During the first run of version 2.4.0 or higher, please, choose the first option for 'profile directory', so the profiles will be stored along the application files.",
-        "Then copy the old profiles directory, stored under 'persist/WindTerm/profiles', over the newly created folder under 'persist/WindTerm/.wind/profiles'. After that you can delete the old 'profiles' directory.",
-        "For details: https://github.com/kingToolbox/WindTerm/releases, section Upgrade."
-    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/kingToolbox/WindTerm/releases/download/2.4.0/WindTerm_2.4.1_Windows_Portable_x86_64.zip",
@@ -28,6 +22,14 @@
             "WindTerm.exe",
             "WindTerm"
         ]
+    ],
+    "post_install": [
+        "info '[Portable Mode] Configuring profiles directory...'",
+        "'{ \"path\" : \".\" }' | Set-Content -Path \"$dir\\profiles.config\"",
+        "if (!(Test-Path \"$dir\\.wind\\profiles\") -and (Test-Path \"$persist_dir\\profiles\")) {",
+        "    info '[Portable Mode] Copying existing profiles...'",
+        "    Copy-Item \"$persist_dir\\profiles\" \"$dir\\.wind\" -Recurse",
+        "}"
     ],
     "persist": [
         ".wind"

--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -30,9 +30,7 @@
         ]
     ],
     "persist": [
-        ".wind",
-        "global",
-        "terminal"
+        ".wind"
     ],
     "checkver": {
         "url": "https://github.com/kingToolbox/WindTerm/releases",

--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -32,7 +32,6 @@
         "}"
     ],
     "persist": ".wind",
-        ".wind"
     "checkver": {
         "url": "https://github.com/kingToolbox/WindTerm/releases",
         "regex": "(?<tag>[\\d.]+)\\/WindTerm_([\\d.]+)_Windows_Portable_x86_64.zip"

--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -31,9 +31,8 @@
         "    Copy-Item \"$persist_dir\\profiles\" \"$dir\\.wind\" -Recurse",
         "}"
     ],
-    "persist": [
+    "persist": ".wind",
         ".wind"
-    ],
     "checkver": {
         "url": "https://github.com/kingToolbox/WindTerm/releases",
         "regex": "(?<tag>[\\d.]+)\\/WindTerm_([\\d.]+)_Windows_Portable_x86_64.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Only one persisted folder named '.wind' is defined, notes with suggestion how to configure the app to use profile stored along the application files added.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8409

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
