### PR TITLE
manifold|-viewer: Update to 9.0.176.3-r2, fix checkver

### DIFF
--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -1,13 +1,13 @@
 {
-    "version": "9.0.176.3",
+    "version": "9.0.176.3-r2",
     "description": "File viewer for Manifold - a parallel GIS, ETL, data science and DBMS tool",
     "homepage": "https://manifold.net/",
     "license": "Freeware",
     "suggest": {
         "Microsoft Visual C++ Redistributable 2017": "extras/vcredist2022"
     },
-    "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-9.0.176.3-x64.zip",
-    "hash": "de2c920137bbe71ed10fae96c08d2caccdb3d4ebcbad444a9a56dfa1a23da363",
+    "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-9.0.176.3-r2-x64.zip",
+    "hash": "9835068cc0ebe31762423efc6aac949c066b3a99ebb79e2f5310178283866270",
     "extract_dir": "manifold-viewer-9.0.176.3-x64",
     "architecture": {
         "64bit": {
@@ -31,11 +31,11 @@
     },
     "checkver": {
         "url": "https://manifold.net/updates/download_viewer.shtml",
-        "regex": "https://manifoldgis.com/updates/working/manifold-viewer-([\\d.]+)-x64.zip"
+        "regex": "https://manifoldgis.com/updates/working/manifold-viewer-([\\d.\\-r]+)-x64.zip"
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-$version-x64.zip",
-        "extract_dir": "manifold-viewer-$version-x64",
+        "extract_dir": "manifold-viewer-$matchHead.$buildVersion-x64",
         "hash": {
             "url": "https://manifold.net/updates/download_viewer.shtml",
             "regex": "$basename.*?$sha256"

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -1,13 +1,13 @@
 {
-    "version": "9.0.176.3",
+    "version": "9.0.176.3-r2",
     "description": "Parallel GIS, ETL, data science and DBMS tool",
     "homepage": "https://manifold.net/",
     "license": "Proprietary",
     "suggest": {
         "Microsoft Visual C++ Redistributable 2017": "extras/vcredist2022"
     },
-    "url": "https://www.manifoldgis.com/updates/working/manifold-9.0.176.3-x64.zip",
-    "hash": "4199f61a83dbbc65ba1e352e1456c7ac3927ef06f5704b3f8f6ce1842bd2faf0",
+    "url": "https://www.manifoldgis.com/updates/working/manifold-9.0.176.3-r2-x64.zip",
+    "hash": "3262262ce5c809b49bb696dd1b96c6bbcb414cc07ebe898a51fe44c126e71edb",
     "extract_dir": "manifold-9.0.176.3-x64",
     "architecture": {
         "64bit": {
@@ -31,11 +31,11 @@
     },
     "checkver": {
         "url": "https://manifold.net/updates/download_9.shtml",
-        "regex": "https://manifoldgis.com/updates/working/manifold-([\\d.]+)-x64.zip"
+        "regex": "https://manifoldgis.com/updates/working/manifold-([\\d.\\-r]+)-x64.zip"
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-$version-x64.zip",
-        "extract_dir": "manifold-$version-x64",
+        "extract_dir": "manifold-$matchHead.$buildVersion-x64",
         "hash": {
             "url": "https://manifold.net/updates/download_9.shtml",
             "regex": "$basename.*?$sha256"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to update due to `-r2` in version: https://github.com/ScoopInstaller/Extras/runs/6254370286?check_suite_focus=true#step:3:225
- Update extract_dir to use version number without `-r2`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
