### PR TITLE
kdenlive: Update to version 22.04.0-1, fix checkver

### DIFF
--- a/bucket/kdenlive.json
+++ b/bucket/kdenlive.json
@@ -1,15 +1,15 @@
 {
-    "version": "21.12.3",
+    "version": "22.04.0-1",
     "description": "Video editing software based on the MLT Framework, KDE and Qt",
     "homepage": "https://kdenlive.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/kdenlive/21.12/windows/kdenlive-21.12.3_standalone.exe#/dl.7z",
-            "hash": "95d9cfad1807099c1a5a23722393e43b4b29565d45229f155c46796df9949710"
+            "url": "https://download.kde.org/stable/kdenlive/22.04/windows/kdenlive-22.04.0-1_standalone.exe#/dl.7z",
+            "hash": "7087bf5a42e6279004fa0ec7addb4f1b3796146ef3a3897bd17af97e37abd30f"
         }
     },
-    "extract_dir": "kdenlive-21.12.3_standalone",
+    "extract_dir": "kdenlive-22.04.0-1_standalone",
     "bin": "bin\\kdenlive.exe",
     "shortcuts": [
         [
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://kdenlive.org/en/download/",
-        "regex": "kdenlive-([\\d.]+)_standalone\\.exe"
+        "regex": "kdenlive-([\\d.\\-]+)_standalone\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to hyphen in version: https://github.com/ScoopInstaller/Extras/runs/6263781836?check_suite_focus=true#step:3:224

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
