### PR TITLE
uivonim: Add version 0.29.0

### DIFF
--- a/bucket/uivonim.json
+++ b/bucket/uivonim.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.29.0",
+    "description": "Fork of Veonim, a GUI frontend of Neovim that leverages latest Neovim features (floating windows, builtin LSP, Lua) without reliance on VSCode extensions.",
+    "homepage": "https://github.com/smolck/uivonim",
+    "license": "AGPL-3.0-or-later",
+    "suggest": {
+        "neovim": "neovim"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/smolck/uivonim/releases/download/v0.29.0/uivonim-0.29.0-win.zip",
+            "hash": "c5e4d2847cc5f3317e2cb6bc7f49db41cc639e07365768d4caacd6505492bdfc"
+        }
+    },
+    "shortcuts": [
+        [
+            "uivonim.exe",
+            "Uivonim"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/smolck/uivonim/releases/download/v$version/uivonim-$version-win.zip"
+            }
+        }
+    }
+}

--- a/bucket/uivonim.json
+++ b/bucket/uivonim.json
@@ -12,6 +12,7 @@
             "hash": "c5e4d2847cc5f3317e2cb6bc7f49db41cc639e07365768d4caacd6505492bdfc"
         }
     },
+    "bin": "uivonim.exe",
     "shortcuts": [
         [
             "uivonim.exe",


### PR DESCRIPTION
[Uivonim](https://github.com/smolck/uivonim) is a maintained fork of **Veonim** (`extras/veonim`, deprecated), a GUI frontend for Neovim.

**NOTES**:
* *persist* is not needed because config is at `$Env:AppData\uivonim`.