### PR TITLE
nextcloud: Update to version 3.5.0, fix checkver

### DIFF
--- a/bucket/nextcloud.json
+++ b/bucket/nextcloud.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.4",
+    "version": "3.5.0",
     "description": "Desktop sync client for Nextcloud, a self-hosted productivity platform",
     "homepage": "https://nextcloud.com/",
     "license": "GPL-2.0-or-later",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/nextcloud/desktop/releases/download/v3.4.4/Nextcloud-3.4.4-x64.msi",
-            "hash": "16da441e64121435daad668b4c642063ebab1d07226d26393035d81a572155fc"
+            "url": "https://github.com/nextcloud/desktop/releases/download/v3.5.0/Nextcloud-3.5.0-x64.msi",
+            "hash": "946302e43b9f7d3f5970de4d9b5c89b0b114e3a635a98f5665c977fe1d717b97"
         }
     },
     "extract_dir": "PFiles\\Nextcloud",
@@ -28,7 +28,7 @@
     ],
     "checkver": {
         "url": "https://nextcloud.com/install/",
-        "regex": "Latest stable version: ([\\d.]+)"
+        "regex": "Nextcloud-([\\d.]+)-x64.msi"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to picking pre-release version from website: https://github.com/ScoopInstaller/Extras/runs/6286416461?check_suite_focus=true#step:3:236 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
