### PR TITLE
pdd: Add version 1.5

### DIFF
--- a/pdd.json
+++ b/pdd.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.5",
+    "description": "Date/time difference calculator and countdown timer. The name 'pdd' stands for Python Date Diff.",
+    "homepage": "https://github.com/jarun/pdd",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://docs.google.com/uc?export=download&id=1yawjwgqpDSKxrAEeluu_HbsbPgJbe-HR#/dl.7z",
+            "hash": "3ed2d0efe7f2afcc00e855ec1653f2f653616ea048e3a94a918eff0c942cbc6d"
+        }
+    },
+    "bin": "pdd.exe",
+    "checkver": "github"
+}

--- a/pdd.json
+++ b/pdd.json
@@ -3,12 +3,24 @@
     "description": "Date/time difference calculator and countdown timer. The name 'pdd' stands for Python Date Diff.",
     "homepage": "https://github.com/jarun/pdd",
     "license": "GPL-3.0-or-later",
-    "architecture": {
-        "64bit": {
-            "url": "https://docs.google.com/uc?export=download&id=1yawjwgqpDSKxrAEeluu_HbsbPgJbe-HR#/dl.7z",
-            "hash": "3ed2d0efe7f2afcc00e855ec1653f2f653616ea048e3a94a918eff0c942cbc6d"
-        }
+    "notes": [
+        "pdd requires dateutil to run properly",
+        "You can install it via pip: pip install python-dateutil"
+    ],
+    "suggest": {
+        "Python": "python"
     },
-    "bin": "pdd.exe",
-    "checkver": "github"
+    "url": "https://github.com/jarun/pdd/archive/refs/tags/v1.5.zip",
+    "hash": "17784abb6772c9cc70ef34e557d0f6ce7c046fad5029d932b94c7846c7f31cb6",
+    "extract_dir": "pdd-1.5",
+    "pre_install": [
+        "Rename-Item \"$dir\\pdd\" \"$dir\\pdd.py\"",
+        "Set-Content \"$dir\\pdd.bat\" \"python `\"%~dp0pdd.py`\" %*\" -Encoding ascii"
+    ],
+    "bin": "pdd.bat",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/jarun/pdd/archive/refs/tags/v$version.zip",
+        "extract_dir": "pdd-$version"
+    }
 }

--- a/pdd.json
+++ b/pdd.json
@@ -12,8 +12,7 @@
     },
     "url": "https://github.com/jarun/pdd/raw/v1.5/pdd#/pdd.py",
     "hash": "298d0b95f37e3cada7d662980e7bc04e9d76a1039df8b6022e1bd6e2f4cb289e",
-    "pre_install": "Set-Content \"$dir\\pdd.bat\" \"python `\"%~dp0pdd.py`\" %*\" -Encoding ascii",
-    "bin": "pdd.bat",
+    "bin": "pdd.py",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/jarun/pdd/raw/v$version/pdd#/pdd.py",

--- a/pdd.json
+++ b/pdd.json
@@ -15,7 +15,7 @@
     "bin": "pdd.py",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/jarun/pdd/raw/v$version/pdd#/pdd.py",
+        "url": "https://raw.githubusercontent.com/jarun/pdd/v$version/pdd#/pdd.py",
         "extract_dir": "pdd-$version"
     }
 }

--- a/pdd.json
+++ b/pdd.json
@@ -15,7 +15,6 @@
     "bin": "pdd.py",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/jarun/pdd/v$version/pdd#/pdd.py",
-        "extract_dir": "pdd-$version"
+        "url": "https://raw.githubusercontent.com/jarun/pdd/v$version/pdd#/pdd.py"
     }
 }

--- a/pdd.json
+++ b/pdd.json
@@ -10,7 +10,7 @@
     "suggest": {
         "Python": "python"
     },
-    "url": "https://github.com/jarun/pdd/raw/v1.5/pdd#/pdd.py",
+    "url": "https://raw.githubusercontent.com/jarun/pdd/v1.5/pdd#/pdd.py",
     "hash": "298d0b95f37e3cada7d662980e7bc04e9d76a1039df8b6022e1bd6e2f4cb289e",
     "bin": "pdd.py",
     "checkver": "github",

--- a/pdd.json
+++ b/pdd.json
@@ -10,17 +10,13 @@
     "suggest": {
         "Python": "python"
     },
-    "url": "https://github.com/jarun/pdd/archive/refs/tags/v1.5.zip",
-    "hash": "17784abb6772c9cc70ef34e557d0f6ce7c046fad5029d932b94c7846c7f31cb6",
-    "extract_dir": "pdd-1.5",
-    "pre_install": [
-        "Rename-Item \"$dir\\pdd\" \"$dir\\pdd.py\"",
-        "Set-Content \"$dir\\pdd.bat\" \"python `\"%~dp0pdd.py`\" %*\" -Encoding ascii"
-    ],
+    "url": "https://github.com/jarun/pdd/raw/v1.5/pdd#/pdd.py",
+    "hash": "298d0b95f37e3cada7d662980e7bc04e9d76a1039df8b6022e1bd6e2f4cb289e",
+    "pre_install": "Set-Content \"$dir\\pdd.bat\" \"python `\"%~dp0pdd.py`\" %*\" -Encoding ascii",
     "bin": "pdd.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/jarun/pdd/archive/refs/tags/v$version.zip",
+        "url": "https://github.com/jarun/pdd/raw/v$version/pdd#/pdd.py",
         "extract_dir": "pdd-$version"
     }
 }


### PR DESCRIPTION
closes #8419

[pdd](https://github.com/jarun/pdd) is a date/time difference calculator and countdown timer. The name 'pdd' stands for Python Date Diff.

**NOTES**:
*~I packed the app into a **standalone exe** so that the app has less depedency and less likely to cause problems. This has to be updated manually, but I think it is fine because the app does not update very often (last update was in October 2020).~
Install .py script instead.
