### PR TITLE
brackets: Update to version 2.0.1

### DIFF
--- a/bucket/brackets.json
+++ b/bucket/brackets.json
@@ -1,11 +1,16 @@
 {
-    "version": "1.14.2",
+    "version": "2.0.1",
     "description": "A modern, open source text editor that understands web design.",
     "homepage": "http://brackets.io/",
     "license": "MIT",
-    "url": "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.msi",
-    "hash": "5f059e271fe78fefe224e187b6ef559445b1efadd6dca9446a99ca1a53eb4e56",
-    "extract_dir": "Brackets",
+    "url": "https://github.com/brackets-cont/brackets/releases/download/v2.0.1/Brackets.2.0.1ml.exe#/dl.exe",
+    "hash": "edc5da4da36298e4ef752bfbfc72f77f7d778e47c70b73b745afdbf6b5cb313d",
+    "pre_install": [
+        "New-Item \"$dir\\installer\" -ItemType Directory | Out-Null",
+        "Invoke-ExternalCommand \"$dir\\dl.exe\" -ArgumentList \"/extract:`\"$dir\\installer`\"\" | Out-Null",
+        "Expand-MsiArchive \"$dir\\installer\\Brackets.msi\" \"$dir\" | Out-Null",
+        "Remove-Item \"$dir\\installer\",\"$dir\\dl.exe\" -Force -Recurse"
+    ],
     "bin": "brackets.exe",
     "shortcuts": [
         [
@@ -14,10 +19,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/adobe/brackets",
-        "regex": "/releases/tag/release-([\\d.]+)"
+        "github": "https://github.com/brackets-cont/brackets"
     },
     "autoupdate": {
-        "url": "https://github.com/adobe/brackets/releases/download/release-$version/Brackets.Release.$version.msi"
+        "url": "https://github.com/brackets-cont/brackets/releases/download/v$version/Brackets.$versionml.exe#/dl.exe"
     }
 }


### PR DESCRIPTION
closes #8433

**NOTES**:
* Although the repo is called *brackets-cont*, it is the official one. See [homepage](http://brackets.io/) for more info.
* The app is built in 32-bit.
* *persist* is not needed because config/extensions is at `$Env:AppData\Brackets`.
* The "ml" in Brackets.2.0.1**ml**.exe stands for multi language.
* The installer is created using *Advanced Installer*, more info can be found in [exeinfo](https://github.com/ScoopInstaller/Extras/files/8645474/exeinfo.txt) generated by *uniextract*.
 