### PR TITLE
Corrected Brackets App Manifest

### DIFF
--- a/bucket/brackets.json
+++ b/bucket/brackets.json
@@ -11,10 +11,10 @@
         "Expand-MsiArchive \"$dir\\installer\\Brackets.msi\" \"$dir\" | Out-Null",
         "Remove-Item \"$dir\\installer\",\"$dir\\dl.exe\" -Force -Recurse"
     ],
-    "bin": "brackets.exe",
+    "bin": "APPDIR\\brackets.exe",
     "shortcuts": [
         [
-            "brackets.exe",
+            "APPDIR\\brackets.exe",
             "Brackets"
         ]
     ],


### PR DESCRIPTION
Brackets installs in folder called `APPDIR`. Hence shims and shortcuts should be directed there.
Before it was directed directly to install directory hence caused problems.

![image](https://user-images.githubusercontent.com/79869936/167289259-68f6e596-92e1-4549-82b2-675240377f7f.png)

**The Directory View**
![explorer_lnRtAPaVMs](https://user-images.githubusercontent.com/79869936/167289460-c2359ac1-7503-4629-ac01-e967ae399fda.gif)

The `install.json` and `manifest.json` were created after me testing the changed version out.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #8435

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
