### PR TITLE
Add yumi packages

### DIFF
--- a/bucket/yumi-exfat.json
+++ b/bucket/yumi-exfat.json
@@ -8,7 +8,7 @@
     "shortcuts": [
         [
             "YUMI-exFAT.exe",
-            "YUMI2USB - exFAT"
+            "YUMI-exFAT"
         ]
     ],
     "checkver": "YUMI-exFAT-([\\d.]+)\\.exe",

--- a/bucket/yumi-exfat.json
+++ b/bucket/yumi-exfat.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.0.0.0",
+    "description": "Multiboot USB Creator. Supports exFAT format, BIOS and UEFI USB boot.",
+    "homepage": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-exFAT-1.0.0.0.exe#/yumi-exFAT.exe",
+    "hash": "0fff308227aa284a9ba6ce2d8e76b0fb745d7d96b60ca3d4c1e1c9c1b2bcb471",
+    "shortcuts": [
+        [
+            "YUMI-exFAT.exe",
+            "YUMI2USB - exFAT"
+        ]
+    ],
+    "checkver": "YUMI-exFAT-([\\d.]+)\\.exe",
+    "autoupdate": {
+        "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-exFAT-$version.exe#/YUMI-exFAT.exe",
+        "hash": {
+            "url": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
+            "regex": "(?s)$basename.*?$sha256"
+        }
+    }
+}

--- a/bucket/yumi-uefi.json
+++ b/bucket/yumi-uefi.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.0.4.5",
+    "description": "Multiboot USB Creator. Supports FAT32 only. BIOS and UEFI USB booting (Distro dependent).",
+    "homepage": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
+    "license": "GPL-2.0-or-later",
+    "notes": [
+        "You are installing the 'UEFI' version of YUMI",
+        "The new YUMI-exFAT supports exFAT format with 4GB+ files, BIOS and UEFI USB boot.",
+        "To install YUMI-exFAT, Run: scoop install yumi-exfat"
+    ],
+    "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-UEFI-0.0.4.5.exe#/YUMI-UEFI.exe",
+    "hash": "4e0e6a7e74440bde287d896e7b8bddcf4127a80c9f81a10bd03184a4751ce68b",
+    "shortcuts": [
+        [
+            "YUMI-UEFI.exe",
+            "YUMI2USB - UEFI"
+        ]
+    ],
+    "checkver": "YUMI-UEFI-([\\d.]+)\\.exe",
+    "autoupdate": {
+        "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-UEFI-$version.exe#/YUMI-UEFI.exe",
+        "hash": {
+            "url": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
+            "regex": "(?s)$basename.*?$sha256"
+        }
+    }
+}

--- a/bucket/yumi-uefi.json
+++ b/bucket/yumi-uefi.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "YUMI-UEFI.exe",
-            "YUMI2USB - UEFI"
+            "YUMI-UEFI"
         ]
     ],
     "checkver": "YUMI-UEFI-([\\d.]+)\\.exe",

--- a/bucket/yumi.json
+++ b/bucket/yumi.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0.9.4",
+    "description": "Multiboot USB Creator. Supports either NTFS or FAT32 format. BIOS USB boot only.",
+    "homepage": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
+    "license": "GPL-2.0-or-later",
+    "notes": [
+        "You are installing the 'legacy' version of YUMI",
+        "The new YUMI-exFAT supports exFAT format with 4GB+ files, BIOS and UEFI USB boot.",
+        "To install YUMI-exFAT, Run: scoop install yumi-exfat"
+    ],
+    "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-2.0.9.4.exe#/YUMI.exe",
+    "hash": "168a7fd30817e07efecbd1805ff1e8629a62be137b74d0b77958472f0993d134",
+    "shortcuts": [
+        [
+            "YUMI.exe",
+            "YUMI2USB - Legacy"
+        ]
+    ],
+    "checkver": "YUMI-([\\d.]+)\\.exe",
+    "autoupdate": {
+        "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-$version.exe#/YUMI.exe",
+        "hash": {
+            "url": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
+            "regex": "(?s)$basename.*?$sha256"
+        }
+    }
+}

--- a/bucket/yumi.json
+++ b/bucket/yumi.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "YUMI.exe",
-            "YUMI2USB - Legacy"
+            "YUMI-Legacy"
         ]
     ],
     "checkver": "YUMI-([\\d.]+)\\.exe",


### PR DESCRIPTION
closes #7146
closes #7147

[YUMI](https://www.pendrivelinux.com/yumi-multiboot-usb-creator/) is a Multiboot USB Boot Creator.

**NOTES**:
* The apps are all built in 32-bit.
* *license* info can be found in the dialogs of the app.

* The 3 variants of the app are: (https://www.pendrivelinux.com/yumi-multiboot-usb-creator/)
```
NOTE: I know you are probably asking, How can you boot from exFAT USB? A YUMI exFAT USB Boot variant is now available and recommended. It can be used to automatically create an exFAT boot USB. Here are the key differences between the variants:

YUMI exFAT supports exFAT format & 4GB+ files. BIOS and UEFI USB boot.
YUMI Legacy supports either NTFS or Fat32 format. BIOS USB boot only.
YUMI UEFI https://www.pendrivelinux.com/yumi-multiboot-usb-creator/#YUMI-UEFI) supports Fat32 only. BIOS and UEFI USB booting (Distro dependent).
```

* The *legacy* and *uefi* varients are still receiving updates recently (last update of *legacy* was on 30 Jan 2022)

* Although the interface of `yumi.exe` looks like an installer for the app, it is the main program. The app works by copying the files to the newly formatted partition in USB drives.
![](https://www.pendrivelinux.com/wp-content/uploads/YUMI-Multiboot-USB-Creator.png?ezimgfmt=rs:450x350/rscb229/ng:webp/ngcb229)