### PR TITLE
7ztm: Add version 2.1.1

### DIFF
--- a/bucket/7ztm.json
+++ b/bucket/7ztm.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.1.1",
+    "description": "Theme manager for 7-Zip",
+    "homepage": "http://www.7ztm.de/",
+    "license": "Freeware",
+    "url": [
+        "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.7z#/main.7z",
+        "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.1_hotfix.7z#/hotfix.7z"
+    ],
+    "hash": [
+        "d1bb8aa1b5f49c39c606604964fe616009b4598c4f3c02e6fff808fa9d4da15e",
+        "09eb32ccfed696ec2030dd87779ac03a1233897c7ef83e5c7f81f1f696b811e0"
+    ],
+    "shortcuts": [["7zTM.exe", "7-Zip Theme Manager"]],
+    "checkver": "7zTM ([\\d.]+)"
+}

--- a/bucket/7ztm.json
+++ b/bucket/7ztm.json
@@ -2,7 +2,10 @@
     "version": "2.1.1",
     "description": "Theme manager for 7-Zip",
     "homepage": "http://www.7ztm.de/",
-    "license": "Freeware",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://www.7ztm.de/index.php?cat=01_English&page=01_FAQ"
+    },
     "url": [
         "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.7z#/main.7z",
         "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.1_hotfix.7z#/hotfix.7z"

--- a/bucket/7ztm.json
+++ b/bucket/7ztm.json
@@ -11,6 +11,11 @@
         "d1bb8aa1b5f49c39c606604964fe616009b4598c4f3c02e6fff808fa9d4da15e",
         "09eb32ccfed696ec2030dd87779ac03a1233897c7ef83e5c7f81f1f696b811e0"
     ],
-    "shortcuts": [["7zTM.exe", "7-Zip Theme Manager"]],
+    "shortcuts": [
+        [
+            "7zTM.exe",
+            "7-Zip Theme Manager"
+        ]
+    ],
     "checkver": "7zTM ([\\d.]+)"
 }

--- a/bucket/7ztm.json
+++ b/bucket/7ztm.json
@@ -19,6 +19,5 @@
             "7zTM.exe",
             "7-Zip Theme Manager"
         ]
-    ],
-    "checkver": "7zTM ([\\d.]+)"
+    ]
 }


### PR DESCRIPTION
[7zTM](http://www.7ztm.de/) is a theme manager for 7-Zip.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
