### PR TITLE
jetaudio-basic: Add version 8.1.8

### DIFF
--- a/bucket/jetaudio-basic.json
+++ b/bucket/jetaudio-basic.json
@@ -1,0 +1,53 @@
+{
+    "version": "8.1.8",
+    "description": "Music and video organizer",
+    "homepage": "http://www.jetaudio.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://www.jetaudio.com/tos/"
+    },
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/jetaudio/jetaudio-basic-8.1.8.7z",
+    "hash": "3ce4af838ec72432a85a79dc1046bb3907c82a83eb09ef0f8b2375a3d9f92b76",
+    "extract_dir": "JetAudio",
+    "shortcuts": [
+        [
+            "jetAudio.exe",
+            "jetAudio\\jetAudio"
+        ],
+        [
+            "jetAudio.exe",
+            "jetAudio\\jetAudio (Choose Window Configuration)",
+            "/windowmode"
+        ],
+        [
+            "jetCast.exe",
+            "jetAudio\\jetCast"
+        ],
+        [
+            "JetRecorder.exe",
+            "jetAudio\\Audio Mixing Recorder"
+        ],
+        [
+            "JetTrim.exe",
+            "jetAudio\\Audio Trimmer"
+        ],
+        [
+            "JetLyric.exe",
+            "jetAudio\\Lyric Maker"
+        ],
+        [
+            "JetVidCnv.exe",
+            "jetAudio\\Video Converter"
+        ],
+        [
+            "JetVidCopy.exe",
+            "jetAudio\\Video Format Converter to AVI"
+        ]
+    ],
+    "persist": [
+        "Skin",
+        "jetAudio.cfg",
+        "jetCast.cfg",
+        "jetVidcnv.cfg"
+    ]
+}


### PR DESCRIPTION
closes #7127

[jetAudio](http://www.jetaudio.com/) is a music and video organizer.

**NOTES**:
* This is the free version of *jetAudio*. The non-free version is called *jetAudio Plus*.
* The app is built in 32-bit.
* I use `ScoopInstaller/Binary` for download URL because:
    (1) The offcial url for the file (`http://www.jetaudio.com/download/5fc01426-741d-41b8-a120-d890330ec672/jetAudio/JAD8108_BASIC.exe`) requires referer to work properly.
    (2) The installer is made with InstallShield. However the format is not extractable by either *ISX* or *Uniextract*.
    (3) Last update was on December 12, 2015.