### PR TITLE
cdex: Add version 2.24

### DIFF
--- a/bucket/cdex.json
+++ b/bucket/cdex.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.24",
+    "description": "Open-source Digital Audio CD Extractor",
+    "homepage": "https://cdex.mu/",
+    "license": "GPL-3.0-or-later",
+    "url": "http://mirror.cdex.mu/CDex-2.24.exe#/dl.7z_",
+    "hash": "49f8e02b42034e69d6f03fc105c79e2a077e9902ad9cf426afbeb62524062e67",
+    "pre_install": [
+        "# Exclude $PLUGINSDIR and $0 first because Antivirus softwares (e.g. Avira, PC-Cillin) detects these files as ADwares.",
+        "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\" -Overwrite Skip -Switches '-x!$*' | Out-Null",
+        "Remove-Item \"$dir\\vc_redist.x86.exe\", \"$dir\\uninstall.exe\""
+    ],
+    "shortcuts": [
+        [
+            "CDex.exe",
+            "CDex"
+        ]
+    ],
+    "checkver": {
+        "url": "https://cdex.mu/download",
+        "regex": "CDex ([\\d.]+)</a>"
+    },
+    "autoupdate": {
+        "url": "http://mirror.cdex.mu/CDex-2.24.exe#/dl.7z_",
+        "hash": {
+            "url": "https://cdex.mu/download",
+            "regex": "(?sm)$basename.*?$sha256"
+        }
+    }
+}

--- a/bucket/cdex.json
+++ b/bucket/cdex.json
@@ -15,16 +15,5 @@
             "CDex.exe",
             "CDex"
         ]
-    ],
-    "checkver": {
-        "url": "https://cdex.mu/download",
-        "regex": "CDex ([\\d.]+)</a>"
-    },
-    "autoupdate": {
-        "url": "http://mirror.cdex.mu/CDex-2.24.exe#/dl.7z_",
-        "hash": {
-            "url": "https://cdex.mu/download",
-            "regex": "(?sm)$basename.*?$sha256"
-        }
-    }
+    ]
 }


### PR DESCRIPTION
closes #5481

[CDex](https://cdex.mu/) is an open-source digital audio CD extractor.

**NOTES**:
* The app is built in 32-bit.
* *persist* is not needed because config is at `$Env:AppData\CDex`