### PR TITLE
react-native-debugger: Add version 0.12.1

### DIFF
--- a/bucket/react-native-debugger.json
+++ b/bucket/react-native-debugger.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.12.1",
+    "description": "Standalone app based on official debugger of React Native, and includes React Inspector / Redux DevTools.",
+    "homepage": "https://github.com/jhen0409/react-native-debugger",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jhen0409/react-native-debugger/releases/download/v0.12.1/rn-debugger-windows-x64.zip",
+            "hash": "ca6f754ec29fde66936bec125d864ffcb97a6e480b878b7ef01be67a88062fd5"
+        }
+    },
+    "shortcuts": [
+        [
+            "react-native-debugger.exe",
+            "React Native Debugger"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jhen0409/react-native-debugger/releases/download/v$version/rn-debugger-windows-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #8454

[React Native Debugger](https://github.com/jhen0409/react-native-debugger) is a standalone app based on official debugger of React Native, and includes React Inspector / Redux DevTools.

**NOTES**:
* [The documentation](https://github.com/jhen0409/react-native-debugger/tree/master/docs) has no content about command-line args.
* *persist* is not needed because config is at `$Env:UserProfile\.rndebuggerrc`.