### PR TITLE
lapce: Update to version 0.1.0, switched from wgpu to opengl

### DIFF
--- a/bucket/lapce.json
+++ b/bucket/lapce.json
@@ -1,12 +1,12 @@
 {
-    "homepage": "http://lapce.dev/",
+    "version": "0.1.0",
     "description": "Lightning-fast and Powerful Code Editor written in Rust",
-    "version": "0.0.12",
+    "homepage": "http://lapce.dev/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lapce/lapce/releases/download/v0.0.12/Lapce-windows-portable.zip",
-            "hash": "59cd21e8dfa98c4418482c626d15fb7fd02633c108b677948d0b673e22441719"
+            "url": "https://github.com/lapce/lapce/releases/download/v0.1.0/Lapce-windows-portable.zip",
+            "hash": "4e73e7dd1d5b5fe742a66f10fb2d126b295a8bd4f473eade2582ca968c966e67"
         }
     },
     "bin": "lapce.exe",


### PR DESCRIPTION
Release Notes: https://github.com/lapce/lapce/releases/tag/v0.1.0

#### TL;DR
- switched from WGPU to OpenGL for better compatibility
- subpixel text rendering 
- WSL remote development support
- syntax highlighting for new languages

![image](https://user-images.githubusercontent.com/9583775/168171336-252c8d29-48fe-4090-8ecb-e86a83b4fc89.png)



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
