### PR TITLE
3d-fix-manager: Add version 1.85

### DIFF
--- a/bucket/3d-fix-manager.json
+++ b/bucket/3d-fix-manager.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.85",
+    "description": "Tool for Installing Nvidia 3D Vision Fixes and changing 3D related settings such as 3D depth and convergence while gaming.",
+    "homepage": "http://helixmod.blogspot.com/2017/05/3d-fix-manager.html",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "http://fixmanager.markus-guendert.de/downloads/fix_manager_1.85.zip",
+            "hash": "8c9e56eea7b7e614113772e1633f0c9bf832c819ea2c0ab4bff28d33a15544fc"
+        }
+    },
+    "bin": "3DFixManager.exe",
+    "shortcuts": [
+        [
+            "3DFixManager.exe",
+            "3D Fix Manager"
+        ]
+    ],
+    "persist": [
+        "updateFixes",
+        "3DFixManager.exe.config"
+    ],
+    "checkver": {
+        "url": "http://fixmanager.markus-guendert.de/download.php",
+        "regex": "fix_manager_([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://fixmanager.markus-guendert.de/downloads/fix_manager_$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[3D Fix Manager](http://helixmod.blogspot.com/2017/05/3d-fix-manager.html) is a tool for Installing **Nvidia 3D Vision** Fixes and changing 3D related settings such as 3D depth and convergence while gaming.

**NOTES**:
* Nvidia [removed 3D Vision support](https://www.nvidia.com/en-us/geforce/forums/3d-vision/41/298376) in their driver since version 426.x. This tool can be useful for those who want to use 3D Vision features on newer drivers.
* command-line args is avaiable, see [change notes](http://helixmod.blogspot.com/2017/05/3d-fix-manager.html) for example
> Change Notes Version 1.83 (March 09, 2021):
> ...
> Changed: Added "-window-mode exclusive" launch argument when selecting Unity universal fix in "Fix Profile" tab. Makes sure 3D kicks in on 3D Vision monitors.
* There is a pop-up window on startup says "Do you want to update?". This refers to the game profiles, but not the app itself.
![update](https://user-images.githubusercontent.com/27724471/168434664-557fd77e-afd9-4e73-8cd9-cf453e734699.jpg)
