### PR TITLE
interlink: Update to version 52.9.8165, fix checkver

### DIFF
--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -1,16 +1,16 @@
 {
-    "version": "52.9.7899",
+    "version": "52.9.8165",
     "description": "E-mail client",
     "homepage": "https://binaryoutcast.com/projects/interlink/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-52.9.7899.win64.7z",
-            "hash": "adf98d555c46b5ec109ddf3fa5f55e406154864cf24b66c34ee9481d9a2ddba8"
+            "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-52.9.8165.WINNT_x86_64-msvc.7z",
+            "hash": "a4bddbdcf5d8778fbf6e42693e97d8fc30b63e5fd0155a2b1662fd05b67f0668"
         },
         "32bit": {
-            "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-52.9.7899.win32.7z",
-            "hash": "b727f408dec204c219bbad30ec5c0823c770a4fd7fb54d7e94db1eb81c2046d0"
+            "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-52.9.8165.WINNT_x86-msvc.7z",
+            "hash": "284158d25916a7e9cc93015dd3a96db1b6ddcc649051e30e124abb4e306f0735"
         }
     },
     "extract_dir": "interlink",
@@ -22,15 +22,15 @@
     ],
     "checkver": {
         "url": "https://projects.binaryoutcast.com/interlink/releases/latest/",
-        "regex": "interlink-([\\d.]+)\\.win64\\.7z"
+        "regex": "interlink-([\\d.]+)\\.WINNT_x86_64-msvc\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-$version.win64.7z"
+                "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-$version.WINNT_x86_64-msvc.7z"
             },
             "32bit": {
-                "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-$version.win32.7z"
+                "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-$version.WINNT_x86-msvc.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Extras/runs/6448579156?check_suite_focus=true#step:3:229

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
