### PR TITLE
opentrack: Update to version 2022.2.0, fix autoupdate

### DIFF
--- a/bucket/opentrack.json
+++ b/bucket/opentrack.json
@@ -1,10 +1,10 @@
 {
-    "version": "2022.1.1",
+    "version": "2022.2.0",
     "description": "Tracks user's head movements and relaying the information to games and flight simulation software.",
     "homepage": "https://github.com/opentrack/opentrack",
     "license": "ISC",
-    "url": "https://github.com/opentrack/opentrack/releases/download/opentrack-2022.1.1/opentrack-2022.1.1-win32-portable.7z",
-    "hash": "690af92d80f83316b087a0da9280fda3a8207d94a4b1f51cfa0ea358e855f42b",
+    "url": "https://github.com/opentrack/opentrack/releases/download/opentrack-2022.2.0/opentrack-2022.2.0-portable.7z",
+    "hash": "4d4082d42db5a3dbb9f29c512e9fa80db571d1ec9ef0bb001569a1591d760599",
     "extract_dir": "install",
     "bin": "opentrack.exe",
     "shortcuts": [
@@ -29,6 +29,6 @@
         "regex": "tag/opentrack-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/opentrack/opentrack/releases/download/opentrack-$version/opentrack-$version-win32-portable.7z"
+        "url": "https://github.com/opentrack/opentrack/releases/download/opentrack-$version/opentrack-$version-portable.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Extras/runs/6448579156?check_suite_focus=true#step:3:248

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
