### PR TITLE
wingetui: Add version 1.0

### DIFF
--- a/bucket/wingetui.json
+++ b/bucket/wingetui.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0",
+    "description": "A GUI to manage Winget and Scoop packages",
+    "homepage": "https://github.com/martinet101/WingetUI",
+    "license": "LGPL-2.1-or-later",
+    "suggest": {
+        "vcredist": "extras/vcredist"
+    },
+    "url": "https://github.com/martinet101/WingetUI/releases/download/1.0/WingetUI.Installer.exe",
+    "hash": "0e9c75ae9987ed729a6240378879298924e8c85cbf8d6eb6b5a84b222d475d6b",
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "WingetUI.exe",
+            "WingetUI"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/martinet101/WingetUI/releases/download/$version/WingetUI.Installer.exe",
+        "hash": {
+            "url": "https://github.com/martinet101/WingetUI/releases/tag/$version",
+            "regex": "sha256: <code>$sha256</code>"
+        }
+    }
+}


### PR DESCRIPTION
[wingetui](https://github.com/martinet101/WingetUI) is a GUI to manage Winget and Scoop packages

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Closes https://github.com/ScoopInstaller/Scoop/discussions/4660#discussioncomment-1971483 