### PR TITLE
watchman: Add version 2022.05.16.00

### DIFF
--- a/bucket/watchman.json
+++ b/bucket/watchman.json
@@ -1,0 +1,32 @@
+{
+    "version": "2022.05.16.00",
+    "description": "A file watching service by Facebook",
+    "homepage": "https://facebook.github.io/watchman/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/facebook/watchman/releases/download/v2022.05.16.00/watchman-v2022.05.16.00-windows.zip",
+            "hash": "8f118958283acf2b431dcd54f86f26a87a347954bcc1b3ada4380d0bc39e0405",
+            "extract_dir": "watchman-v2022.05.16.00-windows"
+        }
+    },
+    "bin": [
+        "bin\\watchman-diag.exe",
+        "bin\\watchman-make.exe",
+        "bin\\watchman-replicate-subscription.exe",
+        "bin\\watchman-wait.exe",
+        "bin\\watchman.exe",
+        "bin\\watchmanctl.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/facebook/watchman"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/facebook/watchman/releases/download/v$version/watchman-v$version-windows.zip",
+                "extract_dir": "watchman-v$version-windows"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[watchman](https://facebook.github.io/watchman/) is a file watching service by Facebook.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
