### PR TITLE
cura: Update to version 5.0.0, fix autoupdate, url, bin

### DIFF
--- a/bucket/cura.json
+++ b/bucket/cura.json
@@ -1,20 +1,20 @@
 {
-    "version": "4.13.1",
+    "version": "5.0.0",
     "description": "Model editing tools for 3D printing",
-    "homepage": "https://ultimaker.com/en/products/ultimaker-cura-software",
+    "homepage": "https://ultimaker.com/software/ultimaker-cura",
     "license": "LGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ultimaker/Cura/releases/download/4.13.1/Ultimaker_Cura-4.13.1-amd64.exe#/dl.7z",
-            "hash": "8de0c18a61a29cac9cbcd5b6d1db1de925f3ea36d67d50e0aabef81d66a91538"
+            "url": "https://github.com/Ultimaker/Cura/releases/download/5.0.0/Ultimaker-Cura-5.0.0-win64.exe#/dl.7z",
+            "hash": "3adc5f24a0ae705a3e302587ed7950f05d6f2c60834fce13fa69c2aef3a8da62"
         }
     },
     "pre_install": "Remove-Item \"$dir\\Uninstall*\", \"$dir\\`$*\", \"$dir\\vcredist_*.exe\" -Recurse",
-    "bin": "CuraCLI.exe",
+    "bin": "CuraEngine.exe",
     "shortcuts": [
         [
-            "Cura.exe",
-            "Cura"
+            "Ultimaker-Cura.exe",
+            "Ultimaker Cura"
         ]
     ],
     "checkver": {
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker_Cura-$version-amd64.exe#/dl.7z"
+                "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker-Cura-$version-win64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Extras/runs/6485627258?check_suite_focus=true#step:3:214

- Updated URL, CLI location, and shortcut location
- Fixed autoupdate

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
