### PR TITLE
w10privacy: Update to version 3.8.0.2, Fix autoupdate

### DIFF
--- a/bucket/w10privacy.json
+++ b/bucket/w10privacy.json
@@ -1,10 +1,10 @@
 {
     "version": "3.8.0.2",
     "description": "Adjust Windows according to your preferences to improve the performance and privacy of the OS.",
-    "homepage": "https://www.winprivacy.de/english-home",
+    "homepage": "https://www.w10privacy.de/english-home/",
     "license": {
         "identifier": "CC-BY-NC-ND-4.0",
-        "url": "https://www.winprivacy.de/deutsch-start/download"
+        "url": "https://www.w10privacy.de/deutsch-start/download"
     },
     "url": "https://www.w10privacy.de/app/download/12302828636/W10Privacy.zip?t=1653039431",
     "hash": "48ec3dcc922650ea9f88956c1d677da34037ffe5e2ce0c087fa46d41ff6c77ca",
@@ -23,10 +23,10 @@
     ],
     "persist": "W10Privacy.ini",
     "checkver": {
-        "url": "https://www.winprivacy.de/deutsch-start/download",
+        "url": "https://www.w10privacy.de/deutsch-start/download",
         "regex": "(?sm)current version: v\\.([\\d.]+).*href=\"/app/download/(?<randnum>\\d+)/W10Privacy.zip"
     },
     "autoupdate": {
-        "url": "https://www.winprivacy.de/app/download/$matchRandnum/W10Privacy.zip?t=$matchRandnum"
+        "url": "https://www.w10privacy.de/app/download/$matchRandnum/W10Privacy.zip?t=$matchRandnum"
     }
 }

--- a/bucket/w10privacy.json
+++ b/bucket/w10privacy.json
@@ -6,8 +6,8 @@
         "identifier": "CC-BY-NC-ND-4.0",
         "url": "https://www.winprivacy.de/deutsch-start/download"
     },
-    "url": "https://www.winprivacy.de/app/download/12302828636/W10Privacy.zip",
-    "hash": "a14d120e34834e49b7fd399f76fbfbeb400e936b3d8b82d96bfddb047a5ca1d1",
+    "url": "https://www.w10privacy.de/app/download/12302828636/W10Privacy.zip?t=1653039431",
+    "hash": "48ec3dcc922650ea9f88956c1d677da34037ffe5e2ce0c087fa46d41ff6c77ca",
     "installer": {
         "script": [
             "if (-not (Test-Path \"$persist_dir\\W10Privacy.ini\")) { Set-Content \"$dir\\W10Privacy.ini\" '' -Encoding Ascii }",
@@ -27,6 +27,6 @@
         "regex": "(?sm)current version: v\\.([\\d.]+).*href=\"/app/download/(?<randnum>\\d+)/W10Privacy.zip"
     },
     "autoupdate": {
-        "url": "https://www.winprivacy.de/app/download/$matchRandnum/W10Privacy.zip"
+        "url": "https://www.winprivacy.de/app/download/$matchRandnum/W10Privacy.zip?t=$matchRandnum"
     }
 }


### PR DESCRIPTION
This is my attempt to fix:

- The version, which was stuck at 3.8.0.0
- The corresponding hash for the new version; 3.8.0.2
- The Autoupdate section

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
