### PR TITLE
bulk-crap-uninstaller: Update to version 5.3, Fix autoupdate

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,10 +1,10 @@
 {
-    "version": "5.2",
+    "version": "5.3",
     "description": "Bulk program uninstaller with advanced automation",
     "homepage": "https://www.bcuninstaller.com/",
     "license": "Apache-2.0",
-    "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html/BCUninstaller_5.2_portable.7z",
-    "hash": "fa734878b6a230b67fdc95196057a28afd027be8d09caeea412f86a446dfd693",
+    "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html?dwl=BCUninstaller_5.3_portable.zip",
+    "hash": "494ca88f25a50d1768a76f753e8a98fec9cd686f75beb9280938cd48dfa8eaf8",
     "architecture": {
         "64bit": {
             "extract_dir": "win-x64"
@@ -21,11 +21,11 @@
         "script": "Copy-Item \"$dir\\BCUninstaller.settings\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force"
     },
     "bin": [
-        "BCUninstaller.exe",
         "BCU-console.exe",
-        "StoreAppHelper.exe",
-        "SteamHelper.exe",
+        "BCUninstaller.exe",
         "OculusHelper.exe",
+        "SteamHelper.exe",
+        "StoreAppHelper.exe",
         "UninstallerAutomatizer.exe"
     ],
     "shortcuts": [
@@ -38,6 +38,6 @@
         "github": "https://github.com/Klocman/Bulk-Crap-Uninstaller"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html/BCUninstaller_$version_portable.7z"
+        "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html?dwl=BCUninstaller_$version_portable.zip"
     }
 }


### PR DESCRIPTION
The URL has changed slightly, as well as using ZIP format instead of 7z.

Updates URL and Autoupdate, as well as making the Bin section alphabetical.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
