### PR TITLE
Eget: Add version 1.0.1

### DIFF
--- a/bucket/eget.json
+++ b/bucket/eget.json
@@ -2,22 +2,31 @@
     "version": "1.0.1",
     "description": "Easily install prebuilt binaries from GitHub.",
     "homepage": "https://github.com/zyedidia/eget",
-    "license": {
-        "identifier": "MIT",
-        "url": "https://github.com/zyedidia/eget/blob/master/LICENSE"
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip#/dl.7z",
+            "hash": "b5242376d6fbf253a4854839548312bd101bc81deca8da26b22f1e4f987dcce3",
+            "extract_dir": "eget-1.0.1-windows_386"
+        },
+        "64bit": {
+            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_amd64.zip#/dl.7z",
+            "hash": "c07aa2c534571ec214e46665a08f94ae4ac89acaff6abbe1ee09e50c476dc746",
+            "extract_dir": "eget-1.0.1-windows_amd64"
+        }
     },
-    "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip",
-    "hash": "b5242376d6fbf253a4854839548312bd101bc81deca8da26b22f1e4f987dcce3",
-    "pre_install": [
-        "Copy-Item -Path $dir\\eget-$version-windows_386\\* -Destination $dir -Force -Recurse | Out-Null",
-        "Remove-Item -Path $dir\\eget-$version-windows_386\\* -Force -Recurse | Out-Null",
-        "Remove-Item -Path $dir\\eget-$version-windows_386 -Force -Recurse | Out-Null"
-    ],
     "bin": "eget.exe",
-    "checkver": {
-        "github": "https://github.com/zyedidia/eget"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip"
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip#/dl.7z",
+                "extract_dir": "eget-$version-windows_386"
+            },
+            "64bit": {
+                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_amd64.zip#/dl.7z",
+                "extract_dir": "eget-$version-windows_amd64"
+            }
+        }
     }
 }

--- a/bucket/eget.json
+++ b/bucket/eget.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip#/dl.7z",
+            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip",
             "hash": "b5242376d6fbf253a4854839548312bd101bc81deca8da26b22f1e4f987dcce3",
             "extract_dir": "eget-1.0.1-windows_386"
         },
         "64bit": {
-            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_amd64.zip#/dl.7z",
+            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_amd64.zip",
             "hash": "c07aa2c534571ec214e46665a08f94ae4ac89acaff6abbe1ee09e50c476dc746",
             "extract_dir": "eget-1.0.1-windows_amd64"
         }
@@ -20,11 +20,11 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip#/dl.7z",
+                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip",
                 "extract_dir": "eget-$version-windows_386"
             },
             "64bit": {
-                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_amd64.zip#/dl.7z",
+                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_amd64.zip",
                 "extract_dir": "eget-$version-windows_amd64"
             }
         }

--- a/bucket/eget.json
+++ b/bucket/eget.json
@@ -4,28 +4,28 @@
     "homepage": "https://github.com/zyedidia/eget",
     "license": "MIT",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip",
-            "hash": "b5242376d6fbf253a4854839548312bd101bc81deca8da26b22f1e4f987dcce3",
-            "extract_dir": "eget-1.0.1-windows_386"
-        },
         "64bit": {
             "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_amd64.zip",
             "hash": "c07aa2c534571ec214e46665a08f94ae4ac89acaff6abbe1ee09e50c476dc746",
             "extract_dir": "eget-1.0.1-windows_amd64"
+        },
+        "32bit": {
+            "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip",
+            "hash": "b5242376d6fbf253a4854839548312bd101bc81deca8da26b22f1e4f987dcce3",
+            "extract_dir": "eget-1.0.1-windows_386"
         }
     },
     "bin": "eget.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip",
-                "extract_dir": "eget-$version-windows_386"
-            },
             "64bit": {
                 "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_amd64.zip",
                 "extract_dir": "eget-$version-windows_amd64"
+            },
+            "32bit": {
+                "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip",
+                "extract_dir": "eget-$version-windows_386"
             }
         }
     }

--- a/bucket/eget.json
+++ b/bucket/eget.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.1",
+    "description": "Easily install prebuilt binaries from GitHub.",
+    "homepage": "https://github.com/zyedidia/eget",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/zyedidia/eget/blob/master/LICENSE"
+    },
+    "url": "https://github.com/zyedidia/eget/releases/download/v1.0.1/eget-1.0.1-windows_386.zip",
+    "hash": "b5242376d6fbf253a4854839548312bd101bc81deca8da26b22f1e4f987dcce3",
+    "pre_install": [
+        "Copy-Item -Path $dir\\eget-$version-windows_386\\* -Destination $dir -Force -Recurse | Out-Null",
+        "Remove-Item -Path $dir\\eget-$version-windows_386\\* -Force -Recurse | Out-Null",
+        "Remove-Item -Path $dir\\eget-$version-windows_386 -Force -Recurse | Out-Null"
+    ],
+    "bin": "eget.exe",
+    "checkver": {
+        "github": "https://github.com/zyedidia/eget"
+    },
+    "autoupdate": {
+        "url": "https://github.com/zyedidia/eget/releases/download/v$version/eget-$version-windows_386.zip"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
> Eget is the best way to easily get pre-built binaries for your favorite tools. It downloads and extracts pre-built binaries from releases on GitHub.

This is what it does. More information can be found on https://github.com/zyedidia/eget
It is licensed under MIT License.

Its FAQ page is https://github.com/zyedidia/eget#faq
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8521 

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
