### PR TITLE
sioyek@1.3: updated download url to new naming scheme

### DIFF
--- a/bucket/sioyek.json
+++ b/bucket/sioyek.json
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ahrm/sioyek/releases/download/v1.3.0/sioyek-release-windows-portable.zip",
-            "hash": "0d30d218f86e8d47e409863b3af32b9fcd5c87b4077290efdcb4180eb1aca62f"
+            "url": "https://github.com/ahrm/sioyek/releases/download/v1.3.0/sioyek-windows-portable.zip",
+            "hash": "f6eb5ee4be30ed37c508d19bf4f81ca29e6ea8c7e506bb5793d5a2e94702f4f4"
         }
     },
     "extract_dir": "sioyek-release-windows",
@@ -46,7 +46,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ahrm/sioyek/releases/download/v$version/sioyek-release-windows-portable.zip"
+                "url": "https://github.com/ahrm/sioyek/releases/download/v$version/sioyek-windows-portable.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #8526

In version 1.3.0 the word "release" was removed from the file names of soiyek.

Updated and tested the app manifest. Works for me.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
