### PR TITLE
notepad2-zifuliu: Add version 4.22.05r4220

### DIFF
--- a/bucket/notepad2-zifuliu.json
+++ b/bucket/notepad2-zifuliu.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.22.05",
+    "version": "4.22.05r4220",
     "description": "Fork of Notepad2, a light-weight Scintilla-based text editor. Featuring syntax highlighting, code folding, auto-completion and API list for about 80 programming languages/documents.",
     "homepage": "https://github.com/zufuliu/notepad2",
     "license": "BSD-3-Clause",
@@ -9,8 +9,8 @@
             "hash": "5ce1218efd2dcb1e151975cb35ae7159f67874ea84bfed6f50ffe9eb3801f42e"
         },
         "32bit": {
-            "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip",
-            "hash": "5ce1218efd2dcb1e151975cb35ae7159f67874ea84bfed6f50ffe9eb3801f42e"
+            "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_Win32_v4.22.05r4220.zip",
+            "hash": "ecc6c274837a3fc1fe23f19a073c6990362d5ea00867229bd465e5d0b348a828"
         }
     },
     "bin": "notepad2.exe",
@@ -28,14 +28,17 @@
         "Notepad2.ini",
         "metapath.ini"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/zufuliu/notepad2",
+        "regex": "Notepad2_en_x64_v([r\\d.]+).zip"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip"
+                "url": "https://github.com/zufuliu/notepad2/releases/download/v$version/Notepad2_en_x64_v$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip"
+                "url": "https://github.com/zufuliu/notepad2/releases/download/v$version/Notepad2_en_Win32_v$version.zip"
             }
         }
     }

--- a/bucket/notepad2-zifuliu.json
+++ b/bucket/notepad2-zifuliu.json
@@ -30,7 +30,7 @@
     ],
     "checkver": {
         "github": "https://github.com/zufuliu/notepad2",
-        "regex": "Notepad2_en_x64_v([r\\d.]+).zip"
+        "regex": "Notepad2_en_x64_v([r\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/notepad2-zifuliu.json
+++ b/bucket/notepad2-zifuliu.json
@@ -1,0 +1,42 @@
+{
+    "version": "4.22.05",
+    "description": "Fork of Notepad2, a light-weight Scintilla-based text editor. Featuring syntax highlighting, code folding, auto-completion and API list for about 80 programming languages/documents.",
+    "homepage": "https://github.com/zufuliu/notepad2",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip",
+            "hash": "5ce1218efd2dcb1e151975cb35ae7159f67874ea84bfed6f50ffe9eb3801f42e"
+        },
+        "32bit": {
+            "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip",
+            "hash": "5ce1218efd2dcb1e151975cb35ae7159f67874ea84bfed6f50ffe9eb3801f42e"
+        }
+    },
+    "bin": "notepad2.exe",
+    "shortcuts": [
+        [
+            "Notepad2.exe",
+            "Notepad2"
+        ],
+        [
+            "metapath.exe",
+            "metapath"
+        ]
+    ],
+    "persist": [
+        "Notepad2.ini",
+        "metapath.ini"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/zufuliu/notepad2/releases/download/v4.22.05r4220/Notepad2_en_x64_v4.22.05r4220.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #8524

[Notepad2-zifuliu](https://github.com/zufuliu/notepad2) is a **maintained fork** of Notepad2, a light-weight Scintilla-based text editor. Featuring syntax highlighting, code folding, auto-completion and API list for about 80 programming languages/documents.

**NOTES**:
* `notepad2.exe` supports **command-line args**. See [documentation: Command-Line Switches](https://github.com/zufuliu/notepad2/wiki/Command-Line-Switches) for examples.