### PR TITLE
glary-utilities: Add version 5.188

### DIFF
--- a/bucket/glary-utilities.json
+++ b/bucket/glary-utilities.json
@@ -18,9 +18,7 @@
         "Portable\\data",
         "Portable\\skins"
     ],
-    "checkver": {
-        "regex": "([\\d.-]+)</span> for Windows"
-    },
+    "checkver": "([\\d.-]+)</span> for Windows",
     "autoupdate": {
         "url": "https://download.glarysoft.com/guportable.zip"
     }

--- a/bucket/glary-utilities.json
+++ b/bucket/glary-utilities.json
@@ -1,0 +1,27 @@
+{
+    "version": "5.188",
+    "description": "All-in-one utility for cleaning your PC",
+    "homepage": "https://www.glarysoft.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.glarysoft.com/inf/termsofuse/"
+    },
+    "url": "https://download.glarysoft.com/guportable.zip",
+    "hash": "f05d8e54a452bdafb2adfda2b3c42fbf0673f894c51a2ce83445c587b7f6dfc6",
+    "shortcuts": [
+        [
+            "Integrator_Portable.exe",
+            "Glary Utilities"
+        ]
+    ],
+    "persist": [
+        "Portable\\data",
+        "Portable\\skins"
+    ],
+    "checkver": {
+        "regex": "([\\d.-]+)</span> for Windows"
+    },
+    "autoupdate": {
+        "url": "https://download.glarysoft.com/guportable.zip"
+    }
+}


### PR DESCRIPTION
closes #8530

[Glary Utilities](https://www.glarysoft.com/) is an all-in-one utility for cleaning your PC.

**NOTES**:
* There is [an existing manifest](https://github.com/gregwen/grewen-scoop/blob/master/bucket/glary-utilities.json) in a custom bucket for us to refer to.
* The app is built in **32-bit**.
* **bin**: The app does not seem to have command-line args. See [Feedback: I suggest a command line interface](http://feedback.glarysoft.com/forums/203980-general-feedback/suggestions/38308534-i-suggest-a-command-line-interface) for example.
* **license**: I put `Freeware` instead of `Freeware|Proprietary` because the **free** and **pro** version are different apps, see [download page](https://www.glarysoft.com/glary-utilities/download/) for details.