### PR TITLE
universal-mediacreationtool: Add version 2022.03.20

### DIFF
--- a/bucket/universal-mediacreationtool.json
+++ b/bucket/universal-mediacreationtool.json
@@ -6,7 +6,6 @@
     "url": "https://codeload.github.com/AveYo/MediaCreationTool.bat/zip/refs/heads/main#/dl.zip",
     "hash": "086040615636459b49043d8c44df72cf61725e2184bc6ba87334b64ce8cf6847",
     "extract_dir": "MediaCreationTool.bat-main",
-    "bin": "MediaCreationTool.bat",
     "shortcuts": [
         [
             "MediaCreationTool.bat",

--- a/bucket/universal-mediacreationtool.json
+++ b/bucket/universal-mediacreationtool.json
@@ -1,0 +1,23 @@
+{
+    "version": "2022.03.20",
+    "description": "Universal MediaCreationTool. Wrapper for all Windows 10/11 versions from 1507 to 21H1 with business (Enterprise) edition support",
+    "homepage": "https://github.com/AveYo/MediaCreationTool.bat",
+    "license": "MIT",
+    "url": "https://codeload.github.com/AveYo/MediaCreationTool.bat/zip/refs/heads/main#/dl.zip",
+    "hash": "086040615636459b49043d8c44df72cf61725e2184bc6ba87334b64ce8cf6847",
+    "extract_dir": "MediaCreationTool.bat-main",
+    "bin": "MediaCreationTool.bat",
+    "shortcuts": [
+        [
+            "MediaCreationTool.bat",
+            "Universal MediaCreationTool"
+        ]
+    ],
+    "checkver": {
+        "regex": "(\\d{4}\\.\\d{2}\\.\\d{2})\\:",
+        "reverse": true
+    },
+    "autoupdate": {
+        "url": "https://codeload.github.com/AveYo/MediaCreationTool.bat/zip/refs/heads/main#/dl.zip"
+    }
+}


### PR DESCRIPTION
closes #8532

[Universal MediaCreationTool](https://github.com/AveYo/MediaCreationTool.bat) is a wrapper for all Windows 10/11 versions from 1507 to 21H1 with business (Enterprise) edition support. Named after **MediaCreationTool** ([extras/mediacreationtool](https://github.com/ScoopInstaller/Extras/blob/master/bucket/mediacreationtool.json)).

**NOTES**:
* There is an [existing manifest](https://github.com/ACooper81/scoop-apps/blob/master/bucket/UniversalMediaCreationTool-Portable.json) in a custom bucket.

* This manifest downloads the whole repo (instead of just `MediaCreationTool.bat`) so that [bypass11](https://github.com/AveYo/MediaCreationTool.bat/tree/main/bypass11) can also be included. *Universal MediaCreationTool* does not depend on *bypass11* to work, but it can be useful in some situations.

