### PR TITLE
abricotine: Update to version 1.1.3, fix pre_install

### DIFF
--- a/bucket/abricotine.json
+++ b/bucket/abricotine.json
@@ -1,15 +1,15 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.3",
     "description": "Markdown editor with inline preview",
     "homepage": "https://abricotine.brrd.fr",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brrd/abricotine/releases/download/1.0.0/abricotine-setup-win32-x64.exe#/dl.7z",
-            "hash": "b393bcccd29ce7a2b97dfc54c7168ceb5b8d76689b85c316363f140907f30ff2",
+            "url": "https://github.com/brrd/abricotine/releases/download/v1.1.3/Abricotine-Setup-1.1.3.exe#/dl.7z",
+            "hash": "82ae3cb7ac8f29cdb9cbf76cdb80b6e9f25f5cf072b1e531d9978c6890e30289",
             "pre_install": [
-                "Get-ChildItem \"$dir\" -Exclude '*full.nupkg' | Remove-Item -Recurse",
-                "Expand-7zipArchive \"$dir\\abricotine-$version-full.nupkg\" -ExtractDir 'lib\\net45' -Removal"
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
+                "Remove-Item \"$dir\\`$*\" -Recurse"
             ]
         }
     },
@@ -26,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brrd/abricotine/releases/download/$version/abricotine-setup-win32-x64.exe#/dl.7z"
+                "url": "https://github.com/brrd/abricotine/releases/download/v$version/Abricotine-Setup-$version.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Extras/runs/6569648276?check_suite_focus=true#step:3:200

Fixed the pre_install script, now setup exe contains app in a 7zip file

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
