### PR TITLE
Telegram@v3.7.3: Changed links to github

### DIFF
--- a/bucket/telegram.json
+++ b/bucket/telegram.json
@@ -5,11 +5,11 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://updates.tdesktop.com/tx64/tportable-x64.3.7.3.zip",
+            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v3.7.3/tportable-x64.3.7.3.zip",
             "hash": "f09f36ab14a9bed46db5d362642d9c5eca56bd8c826683904399c681c26b34b8"
         },
         "32bit": {
-            "url": "https://updates.tdesktop.com/tsetup/tportable.3.7.3.zip",
+            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v3.7.3/tportable.3.7.3.zip",
             "hash": "79531214762cb1b50721ad68156ea9dd9f67d1a929727b128c97eb0c201834b3"
         }
     },
@@ -29,10 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://updates.tdesktop.com/tx64/tportable-x64.$version.zip"
+                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable-x64.$version.zip"
             },
             "32bit": {
-                "url": "https://updates.tdesktop.com/tsetup/tportable.$version.zip"
+                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable.$version.zip"
             }
         }
     }


### PR DESCRIPTION
Changed download links and autoupdate links from tdesktop.com to github. This is to resolve issue #7002.
> Telegram has anti-DDoS measurement, even if Telegram itself isn't blocked by your country or region. It might halt your telegram install or updates.
To fix this is simply access the web site: https://desktop.telegram.org/
Click the link to "Portable version" download: https://desktop.telegram.org/
Then lets your IP indexed on their whitelist database. It will downloads the portable version on your web browser, you can cancel it, then rerun the telegram update (or install),

Hence this measure. Not a major change, but github is always better.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7002 

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
