### PR TITLE
Speedtest GUI: Add version 1.10.163

### DIFF
--- a/bucket/speedtest.json
+++ b/bucket/speedtest.json
@@ -1,5 +1,4 @@
 {
-    "##": "Autoupdate has not been added as the url will remain same.",
     "version": "1.10.163",
     "description": "Internet Speedtest for Windows GUI",
     "homepage": "https://www.speedtest.net/apps/windows",
@@ -25,5 +24,15 @@
             "Speed Test"
         ]
     ],
-    "checkver": "<span class=\"u-note\">v([\\d.]+)</span>"
+    "checkver": "<span class=\"u-note\">v([\\d.]+)</span>",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://install.speedtest.net/app/windows/latest/speedtestbyookla_x64.msi"
+            },
+            "32bit": {
+                "url": "https://install.speedtest.net/app/windows/latest/speedtestbyookla_x86.msi"
+            }
+        }
+    }
 }

--- a/bucket/speedtest.json
+++ b/bucket/speedtest.json
@@ -1,6 +1,6 @@
 {
     "version": "1.10.163",
-    "description": "Internet Speedtest for Windows GUI",
+    "description": "Internet Speedtest GUI for Windows",
     "homepage": "https://www.speedtest.net/apps/windows",
     "license": {
         "identifier": "Freeware",

--- a/bucket/speedtest.json
+++ b/bucket/speedtest.json
@@ -1,0 +1,32 @@
+{
+    "##": "Autoupdate has not been added as the url will remain same.",
+    "version": "1.10.163",
+    "description": "Internet Speedtest for Windows GUI",
+    "homepage": "https://www.speedtest.net/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.speedtest.net/about/eula"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://install.speedtest.net/app/windows/latest/speedtestbyookla_x64.msi",
+            "hash": "0c4fc9e11056dbc5ac3fec66f8cbfb5dea9a327fef3cbea878c347b70d89df30",
+            "extract_dir": "ProgramFiles64Folder\\Speedtest"
+        },
+        "32bit": {
+            "url": "https://install.speedtest.net/app/windows/latest/speedtestbyookla_x86.msi",
+            "hash": "934a5ed894432fadc07b7cca9ed1bdc0b67f970e19d1e6e209ba35162fc9227b",
+            "extract_dir": "ProgramFilesFolder\\Speedtest"
+        }
+    },
+    "shortcuts": [
+        [
+            "Speedtest.exe",
+            "Speed Test"
+        ]
+    ],
+    "checkver": {
+        "url": "https://speedtest.net/apps/windows/",
+        "regex": "<span class=\"u-note\">v([\\d.]+)</span>"
+    }
+}

--- a/bucket/speedtest.json
+++ b/bucket/speedtest.json
@@ -2,7 +2,7 @@
     "##": "Autoupdate has not been added as the url will remain same.",
     "version": "1.10.163",
     "description": "Internet Speedtest for Windows GUI",
-    "homepage": "https://www.speedtest.net/",
+    "homepage": "https://www.speedtest.net/apps/windows",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.speedtest.net/about/eula"
@@ -25,8 +25,5 @@
             "Speed Test"
         ]
     ],
-    "checkver": {
-        "url": "https://speedtest.net/apps/windows/",
-        "regex": "<span class=\"u-note\">v([\\d.]+)</span>"
-    }
+    "checkver": "<span class=\"u-note\">v([\\d.]+)</span>"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Added Speedtest GUI.
Homepage is https://speedtest.net/
This can be done online only but some people prefer the app.

I have not added the autoupdate part as the url remains same even after new version is released.
The checkver contains html elements as the regex part was not detecting things properly.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7136

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
