### PR TITLE
snappy-driver-installer: Fix URL and Autoupdate

### DIFF
--- a/bucket/snappy-driver-installer-origin.json
+++ b/bucket/snappy-driver-installer-origin.json
@@ -3,7 +3,7 @@
     "description": "Device drivers installer and updater",
     "homepage": "https://www.snappy-driver-installer.org",
     "license": "GPL-3.0-or-later",
-    "url": "https://snappy-driver-installer.org/downloads/SDIO_1.12.4.744.zip",
+    "url": "https://www.glenn.delahoy.com/downloads/sdio/SDIO_1.12.4.744.zip",
     "hash": "c713d1e9885c27457920816656c152416d1115391ad743bad97f85b4048d455a",
     "extract_dir": "SDIO_1.12.4.744",
     "architecture": {
@@ -49,7 +49,7 @@
         "regex": "SDIO_([\\d.]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://snappy-driver-installer.org/downloads/SDIO_$version.zip",
+        "url": "https://www.glenn.delahoy.com/downloads/sdio/SDIO_$version.zip",
         "extract_dir": "SDIO_$version"
     }
 }


### PR DESCRIPTION
The author is redirecting the downloads to his personal page which resulted in dead links.

This PR updates URL and Autoupdate to reflect this change.

- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
