### PR TITLE
icecast: Add version 2.4.3

### DIFF
--- a/bucket/icecast.json
+++ b/bucket/icecast.json
@@ -38,8 +38,8 @@
         "script": [
             "# if user uninstalls (but not updates) the app, then uninstall IceCast service",
             "if ($cmd -eq 'uninstall') {",
-            "    sc.exe query IceCast | Out-Null",
-            "    if ($LASTEXITCODE -eq 0) {",
+            "    $service = Get-Service 'IceCast' -ErrorAction SilentlyContinue",
+            "    if ($service) {",
             "        if(!(is_admin)) { error 'Admin right is required to uninstall IceCast service'; break }",
             "        sc.exe delete IceCast",
             "    }",

--- a/bucket/icecast.json
+++ b/bucket/icecast.json
@@ -5,8 +5,14 @@
     "license": "GPL-2.0-only",
     "url": "https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast_win32_2.4.3.exe#/dl.7z",
     "hash": "603bb7c94a9248ac104ef84c3e8472949db8bd3c2fcc4ff7a7a34ee98057efe0",
-    "depends": "nssm",
-    "notes": "Run \"$dir\\install-service.bat\" under Admin to install IceCast as Windows service.",
+    "suggest": {
+        "nssm": "nssm"
+    },
+    "notes": [
+        "To install IceCast as Windows service:",
+        "(1) Install nssm",
+        "(2) Run \"$dir\\install-service.bat\" under Admin"
+    ],
     "pre_install": [
         "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse",
         "'log\\access.log', 'log\\error.log', 'log\\playlist.log' | ForEach-Object {",
@@ -15,12 +21,22 @@
         "Set-Content \"$dir\\icecast-scoop-start.bat\" \"@echo off`r`ncd /d %~dp0`r`nicecast.bat\" -Encoding Ascii"
     ],
     "post_install": [
-        "Set-Content \"$dir\\install-service.bat\"  \"@echo off`r`nnssm install IceCast `\"$dir\\icecast-scoop-start.bat`\"`r`nnet start IceCast\" -Encoding Ascii",
+        "$cont = @(",
+        "    '@echo off'",
+        "    'where nssm >nul'",
+        "    'if %ERRORLEVEL% neq 0 ('",
+        "    '    echo ERROR: cannot find nssm in PATH. Please install nssm before running this script.'",
+        "    '    exit /B'",
+        "    ')'",
+        "    \"nssm install IceCast `\"$dir\\icecast-scoop-start.bat`\"\"",
+        "    'net start IceCast'",
+        ")",
+        "Set-Content \"$dir\\install-service.bat\" ($cont -join \"`r`n\") -Encoding Ascii",
         "Set-Content \"$dir\\uninstall-service.bat\"  \"@echo off`r`nsc delete IceCast\" -Encoding Ascii"
     ],
     "uninstaller": {
         "script": [
-            "# uninstall IceCast service if the user uninstalls the app, but not updates the app",
+            "# if user uninstalls (but not updates) the app, then uninstall IceCast service",
             "if ($cmd -eq 'uninstall') {",
             "    sc.exe query IceCast | Out-Null",
             "    if ($LASTEXITCODE -eq 0) {",

--- a/bucket/icecast.json
+++ b/bucket/icecast.json
@@ -1,0 +1,51 @@
+{
+    "version": "2.4.3",
+    "description": "A streaming media (audio/video) server which supports Ogg (Vorbis and Theora), Opus, WebM and MP3 streams.",
+    "homepage": "https://icecast.org/",
+    "license": "GPL-2.0-only",
+    "url": "https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast_win32_2.4.3.exe#/dl.7z",
+    "hash": "603bb7c94a9248ac104ef84c3e8472949db8bd3c2fcc4ff7a7a34ee98057efe0",
+    "depends": "nssm",
+    "notes": "Run \"$dir\\install-service.bat\" under Admin to install IceCast as Windows service.",
+    "pre_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse",
+        "'log\\access.log', 'log\\error.log', 'log\\playlist.log' | ForEach-Object {",
+        "    if(!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -Force | Out-Null }",
+        "}",
+        "Set-Content \"$dir\\icecast-scoop-start.bat\" \"@echo off`r`ncd /d %~dp0`r`nicecast.bat\" -Encoding Ascii"
+    ],
+    "post_install": [
+        "Set-Content \"$dir\\install-service.bat\"  \"@echo off`r`nnssm install IceCast `\"$dir\\icecast-scoop-start.bat`\"`r`nnet start IceCast\" -Encoding Ascii",
+        "Set-Content \"$dir\\uninstall-service.bat\"  \"@echo off`r`nsc delete IceCast\" -Encoding Ascii"
+    ],
+    "uninstaller": {
+        "script": [
+            "# if user uninstalls (but not updates) the app, then uninstall IceCast service",
+            "if ($cmd -eq 'uninstall') {",
+            "    sc.exe query IceCast | Out-Null",
+            "    if ($LASTEXITCODE -eq 0) {",
+            "        if(!(is_admin)) { error 'Admin right is required to uninstall IceCast service'; break }",
+            "        sc.exe delete IceCast",
+            "    }",
+            "}"
+        ]
+    },
+    "bin": [
+        [
+            "icecast-scoop-start.bat",
+            "icecast"
+        ]
+    ],
+    "persist": [
+        "admin",
+        "log",
+        "icecast.xml"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/xiph/Icecast-Server/tags",
+        "regex": "v([\\d.]+)\""
+    },
+    "autoupdate": {
+        "url": "https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast_win32_$version.exe#/dl.7z"
+    }
+}

--- a/bucket/icecast.json
+++ b/bucket/icecast.json
@@ -20,7 +20,7 @@
     ],
     "uninstaller": {
         "script": [
-            "# if user uninstalls (but not updates) the app, then uninstall IceCast service",
+            "# uninstall IceCast service if the user uninstalls the app, but not updates the app",
             "if ($cmd -eq 'uninstall') {",
             "    sc.exe query IceCast | Out-Null",
             "    if ($LASTEXITCODE -eq 0) {",


### PR DESCRIPTION
closes https://github.com/ScoopInstaller/Extras/issues/8538

[IceCast](https://icecast.org/) is a streaming media (audio/video) server which supports Ogg (Vorbis and Theora), Opus, WebM and MP3 streams.

**NOTES**:
* This package is in *Extras* (rather than *Main*) because of non-standard install methods.

* *IceCast* used to have Windows GUI and Windows service installation, but was removed in 2.3.3.
> https://icecast.org/faq/
What happened to the Windows GUI? I only see a black window with some text.
Icecast used to have a graphical user interface on Windows, but that was deprecated in 2.3.3 as it wasn’t frequently used and hard to maintain. Considering that most of the things the GUI could do now are possible using the Icecast web interface, it’s not needed anymore.
The black window with text you see is the command line running the Icecast server, just keep that window open. When you want to quit Icecast, hit Ctrl+C and confirm that you want to quit.
......
How can I run Icecast as a Service on Windows?
We do not have service capabilities in Icecast anymore, currently. Please see this Wiki page for instruction how to set up Icecast as a service using a third party service manager.

* This packages uses *nssm* instead of `sc.exe create ...` because we are installing a batch file as Windows service. Also this is the recommended method in [the documentation](https://wiki.xiph.org/Icecast_Server/Setup_Windows_Service).