### PR TITLE
dnspyex: Add version 6.1.9

### DIFF
--- a/bucket/dnspy.json
+++ b/bucket/dnspy.json
@@ -3,6 +3,7 @@
     "description": ".NET debugger and assembly editor",
     "homepage": "https://github.com/0xd4d/dnSpy",
     "license": "GPL-3.0-only",
+    "notes": "dnSpy is not being maintained. We suggest installing 'dnspyex' for latest features and patches.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/0xd4d/dnSpy/releases/download/v6.1.8/dnSpy-net-win64.zip",

--- a/bucket/dnspyex.json
+++ b/bucket/dnspyex.json
@@ -1,0 +1,39 @@
+{
+    "version": "6.1.9",
+    "description": "Continuation of the dnSpy project, a .NET debugger and assembly editor.",
+    "homepage": "https://github.com/dnSpyEx/dnSpy",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v6.1.9/dnSpy-net-win64.zip#/dl.zip_",
+            "hash": "8c01e7fd5c1684cd52dbee6c18d267990f2c1d2f3cfd23d037ea324508ce8e12"
+        },
+        "32bit": {
+            "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v6.1.9/dnSpy-net-win32.zip#/dl.zip_",
+            "hash": "ab881a7dee96478326d7b6c2e27793c9e9b2608ae6befe7a95046d981100132a"
+        }
+    },
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\dl.zip_\" \"$dir\" -Removal | Out-Null",
+        "$archive = Get-ChildItem \"$dir\\*.zip\" | Select -First 1 -ExpandProperty FullName",
+        "Expand-7zipArchive \"$archive\" \"$dir\" -Removal  | Out-Null"
+    ],
+    "bin": "dnSpy.Console.exe",
+    "shortcuts": [
+        [
+            "dnSpy.exe",
+            "dnSpy"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win32.zip"
+            }
+        }
+    }
+}

--- a/bucket/dnspyex.json
+++ b/bucket/dnspyex.json
@@ -29,10 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win64.zip"
+                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win64.zip#/dl.zip_"
             },
             "32bit": {
-                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win32.zip"
+                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win32.zip#/dl.zip_"
             }
         }
     }

--- a/bucket/dnspyex.json
+++ b/bucket/dnspyex.json
@@ -18,10 +18,7 @@
         "$archive = Get-ChildItem \"$dir\\*.zip\" | Select -First 1 -ExpandProperty FullName",
         "Expand-7zipArchive \"$archive\" \"$dir\" -Removal | Out-Null"
     ],
-    "bin": [
-        "dnSpy.Console.exe",
-        "dnSpy.exe"
-    ],
+    "bin": "dnSpy.Console.exe",
     "shortcuts": [
         [
             "dnSpy.exe",

--- a/bucket/dnspyex.json
+++ b/bucket/dnspyex.json
@@ -16,7 +16,7 @@
     "pre_install": [
         "Expand-7zipArchive \"$dir\\dl.zip_\" \"$dir\" -Removal | Out-Null",
         "$archive = Get-ChildItem \"$dir\\*.zip\" | Select -First 1 -ExpandProperty FullName",
-        "Expand-7zipArchive \"$archive\" \"$dir\" -Removal  | Out-Null"
+        "Expand-7zipArchive \"$archive\" \"$dir\" -Removal | Out-Null"
     ],
     "bin": "dnSpy.Console.exe",
     "shortcuts": [

--- a/bucket/dnspyex.json
+++ b/bucket/dnspyex.json
@@ -18,7 +18,10 @@
         "$archive = Get-ChildItem \"$dir\\*.zip\" | Select -First 1 -ExpandProperty FullName",
         "Expand-7zipArchive \"$archive\" \"$dir\" -Removal | Out-Null"
     ],
-    "bin": "dnSpy.Console.exe",
+    "bin": [
+        "dnSpy.Console.exe",
+        "dnSpy.exe"
+    ],
     "shortcuts": [
         [
             "dnSpy.exe",


### PR DESCRIPTION
closes #8544

[dnSpyEx](https://github.com/dnSpyEx/dnSpy) is a continuation of the dnSpy project, a .NET debugger and assembly editor.

**NOTES**:
* *persist* is not needed because config is at `$Env:AppData\dnspy`.