### PR TITLE
listary@6.0.9.25: Use installer instead of portable zip

### DIFF
--- a/bucket/listary.json
+++ b/bucket/listary.json
@@ -1,12 +1,11 @@
 {
-    "version": "6.0.9",
+    "version": "6.0.9.25",
     "description": "A revolutionary search utility.",
     "homepage": "https://www.listary.com",
     "license": "Shareware",
-    "url": "https://www.listary.com/download/ListaryPortable.zip?version=6.0.9#/ListaryPortable.zip",
-    "hash": "f39573e56fa98940e62ca8bb2115e424119cb13dea805b4e101de22324d0366f",
-    "extract_dir": "ListaryPortable",
-    "persist": "UserData",
+    "url": "https://www.listary.com/download/Listary.exe?version=6.0.9.25#/dl.exe",
+    "hash": "eed097d25bc653454fcf0b2896582d0a4d83c71a36b6b2acfbd171b970b9f5c8",
+    "innosetup": true,
     "shortcuts": [
         [
             "Listary.exe",
@@ -15,9 +14,9 @@
     ],
     "checkver": {
         "url": "https://www.listary.com/download",
-        "regex": "v([\\d.]+)"
+        "regex": "<h2>([\\d.]+) \\([\\d/]+\\)</h2>"
     },
     "autoupdate": {
-        "url": "https://www.listary.com/download/ListaryPortable.zip?version=$version#/ListaryPortable.zip"
+        "url": "https://www.listary.com/download/Listary.exe?version=$version#/dl.exe"
     }
 }


### PR DESCRIPTION
fixes #8557

* [Listary](https://www.listary.com/download) doesn't seem to provide portable ZIP version anymore, which is causing installation to fail.

* The config data of the **installer** version is at `$Env:AppData\Listary\UserProfile`. However I cannot find the portable version to compare the difference. Therefore, I cannot be sure if copying the data from `$persist_dir\UserData` to `$Env:AppData` is safe. The config data of the two versions may be incompatible.