### PR TITLE
uget@2.2.3: Fix checkver, autoupdate

### DIFF
--- a/bucket/uget.json
+++ b/bucket/uget.json
@@ -6,10 +6,6 @@
     "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.2/uget-2.2.2-win32%2Bgtk3.7z",
     "hash": "sha1:22d54d9f63be15228c21d06444e0a2c22b4e2578",
     "pre_install": "Move-Item \"$dir\\uget-portable-mode\" \"$dir\\bin\"",
-    "persist": [
-        "config",
-        "share\\locale"
-    ],
     "post_install": [
         "if (!(Test-Path \"$dir\\config\\uGet\") -and (Test-Path \"$env:LocalAppData\\uGet\")) {",
         "    Copy-Item \"$env:LocalAppData\\uGet\" \"$dir\\config\" -Recurse",
@@ -22,11 +18,15 @@
             "uGet"
         ]
     ],
+    "persist": [
+        "config",
+        "share\\locale"
+    ],
     "checkver": {
         "url": "https://sourceforge.net/projects/urlget/rss?path=/uget%20%28stable%29",
-        "regex": "/uget-([\\d.]+)-win32\\+gtk3\\.7z"
+        "regex": "/([\\d.]+)/uget-([\\d.-]+)-win32\\+gtk3\\.7z"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/$version/uget-$version-win32%2Bgtk3.7z"
+        "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/$version/uget-$match2-win32%2Bgtk3.7z"
     }
 }

--- a/bucket/uget.json
+++ b/bucket/uget.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "Open source download manager.",
     "homepage": "https://ugetdm.com/",
     "license": "LGPL-2.1-only",
-    "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.2/uget-2.2.2-win32%2Bgtk3.7z",
-    "hash": "sha1:22d54d9f63be15228c21d06444e0a2c22b4e2578",
+    "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.3/uget-2.2.3-2-win32%2Bgtk3.7z",
+    "hash": "sha1:f8b77a669bf46b372c5595530802e20bc76ce2c2",
     "pre_install": "Move-Item \"$dir\\uget-portable-mode\" \"$dir\\bin\"",
     "post_install": [
         "if (!(Test-Path \"$dir\\config\\uGet\") -and (Test-Path \"$env:LocalAppData\\uGet\")) {",


### PR DESCRIPTION
uget is currently 2.2.3 https://sourceforge.net/projects/urlget/files/uget%20%28stable%29/

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
