### PR TITLE
openclosedriveeject: new v3 changed executable name

### DIFF
--- a/bucket/openclosedriveeject.json
+++ b/bucket/openclosedriveeject.json
@@ -12,13 +12,13 @@
             "hash": "af0a08db57a19c98599fcb3a3359a42548120488c527406aa9e12be2d5cdf7e9",
             "bin": [
                 [
-                    "OpenCloseDriveEject_x64_p.exe",
+                    "OpenCloseDriveEject_x64.exe",
                     "OpenCloseDriveEject"
                 ]
             ],
             "shortcuts": [
                 [
-                    "OpenCloseDriveEject_x64_p.exe",
+                    "OpenCloseDriveEject_x64.exe",
                     "OpenCloseDriveEject"
                 ]
             ]


### PR DESCRIPTION
Previous v2 version's 64bit exe was "OpenCloseDriveEject_x64_p.exe" and new one is "OpenCloseDriveEject_x64.exe".
When updating, I was getting this error: Can't shim 'OpenCloseDriveEject_x64_p.exe': File doesn't exist.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
