### PR TITLE
office-tool-plus: Add version 8.3.10.7

### DIFF
--- a/bucket/office-tool-plus.json
+++ b/bucket/office-tool-plus.json
@@ -17,6 +17,9 @@
     },
     "autoupdate": {
         "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_with_runtime_v$version.7z",
-        "hash": "$basename.*?$sha256"
+        "hash": {
+            "url": "https://github.com/YerongAI/Office-Tool/releases/latest",
+            "regex": "(?s)$basename.*?$sha256"
+        }
     }
 }

--- a/bucket/office-tool-plus.json
+++ b/bucket/office-tool-plus.json
@@ -1,0 +1,22 @@
+{
+    "version": "8.3.10.7",
+    "description": "A powerful and useful tool for Office deployments",
+    "homepage": "https://otp.landian.vip/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/YerongAI/Office-Tool/releases/download/v8.3.10.7/Office_Tool_with_runtime_v8.3.10.7.7z",
+    "hash": "757ac90af36ef1e92501429172a7670b884c1472be4eab99d42eb34de5a712a0",
+    "extract_dir": "Office Tool",
+    "shortcuts": [
+        [
+            "Office Tool Plus.exe",
+            "Office Tool Plus"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/YerongAI/Office-Tool"
+    },
+    "autoupdate": {
+        "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_with_runtime_v$version.7z",
+        "hash": "$basename.*?$sha256"
+    }
+}


### PR DESCRIPTION
[office-tool-plus](https://github.com/YerongAI/Office-Tool) is a powerful and useful tool for Office deployments.

According to Sandboxie, it store its configuration in registry.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
