### PR TITLE
uget-integrator: Add version 1.0.0

### DIFF
--- a/bucket/uget-integrator.json
+++ b/bucket/uget-integrator.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0.0",
+    "description": "Integrate uGet Download Manager with Google Chrome, Chromium, Opera, Vivaldi and Mozilla Firefox",
+    "homepage": "https://github.com/ugetdm/uget-integrator",
+    "license": "GPL-3.0-or-later",
+    "notes": [
+        "Refer to https://github.com/ugetdm/uget-integrator/wiki/Installation#portable-method about how to install uget-integrator.",
+        "Or run install_uget-integrator.cmd directly if you have already installed extras/uget from scoop before uget-integrator."
+    ],
+    "suggest": {
+        "uget": "extras/uget"
+    },
+    "url": "https://github.com/ugetdm/uget-integrator/releases/download/v1.0.0/uget-integrator_win_1.0.0.zip",
+    "hash": "6d25dab25839b6e0d944792e111b55f60aebf6d4980727e3c18636304eed8626",
+    "extract_dir": "uget-integrator",
+    "pre_install": [
+        "function Set-PersistItem { param ( $Path ) foreach ($path in $Path) { if (!(Test-Path \"$persist_dir\\$path\")) { New-Item \"$dir\\$path\" | Out-Null } } }",
+        "Set-PersistItem \"com.ugetdm.chrome.json\", \"com.ugetdm.firefox.json\""
+    ],
+    "post_install": [
+        "if ($(scoop prefix uget) 6>$null && $? ) {",
+        "    $replaceExp = \"UGET_COMMAND = \"\"$(scoop prefix uget)\\bin\\uget.exe\"\"\" -replace \"\\\\\", \"\\\\\"",
+        "    (Get-Content \"$dir\\uget-integrator.py\") -replace \"UGET_COMMAND = \"\"C:\\\\\\\\uGet\\\\\\\\bin\\\\\\\\uget.exe\"\"\", $replaceExp | Out-File \"$dir\\uget-integrator.py\"",
+        "}"
+    ],
+    "bin": [
+        [
+            "add_config.bat",
+            "install_uget-integrator"
+        ]
+    ],
+    "persist": [
+        "com.ugetdm.chrome.json",
+        "com.ugetdm.firefox.json"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ugetdm/uget-integrator/releases/download/v$version/uget-integrator_win_$version.zip"
+    }
+}


### PR DESCRIPTION
[uget-integrator](https://github.com/ugetdm/uget-integrator) is used to integrate uGet with browsers.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
