### PR TITLE
sumatrapdf: Update to version 3.4.2, fix autoupdate

### DIFF
--- a/bucket/sumatrapdf.json
+++ b/bucket/sumatrapdf.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.3.3",
+    "version": "3.4.2",
     "description": "PDF and eBook reader",
     "homepage": "https://www.sumatrapdfreader.org/free-pdf-reader",
     "license": "GPL-3.0-only,BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://www.sumatrapdfreader.org/dl/rel/SumatraPDF-3.3.3-64.zip",
-            "hash": "a4d531e23265a4960ab63ce0217dbafd42647f1b17ee870e599fd267251434ad"
+            "url": "https://www.sumatrapdfreader.org/dl/rel/3.4.2/SumatraPDF-3.4.2-64.zip",
+            "hash": "bcc32276940a43bdba71509efd14bfbdf22397bcf10dea03a685bd9772d65f79"
         },
         "32bit": {
-            "url": "https://www.sumatrapdfreader.org/dl/rel/SumatraPDF-3.3.3.zip",
-            "hash": "13801df7d486bae6d065be8ab65768b3603ce95141dd8a695090ecb034fa2c0a"
+            "url": "https://www.sumatrapdfreader.org/dl/rel/3.4.2/SumatraPDF-3.4.2.zip",
+            "hash": "ad94f65dc87a7215113a702756b68fae2809dcec4e957c258fbc0160bc9e3531"
         }
     },
     "pre_install": [
@@ -39,10 +39,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.sumatrapdfreader.org/dl/rel/SumatraPDF-$version-64.zip"
+                "url": "https://www.sumatrapdfreader.org/dl/rel/$version/SumatraPDF-$version-64.zip"
             },
             "32bit": {
-                "url": "https://www.sumatrapdfreader.org/dl/rel/SumatraPDF-$version.zip"
+                "url": "https://www.sumatrapdfreader.org/dl/rel/$version/SumatraPDF-$version.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in download urls: https://github.com/ScoopInstaller/Extras/runs/6635716977?check_suite_focus=true#step:3:302

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
