### PR TITLE
vesta: Add version 3.5.7

### DIFF
--- a/bucket/vesta.json
+++ b/bucket/vesta.json
@@ -18,6 +18,7 @@
             "extract_dir": "VESTA"
         }
     },
+    "pre_install": "if(!(Test-Path \"$persist_dir\\vesta.ini)) { New-Item \"$dir\\vesta.ini\" | Out-Null }",
     "shortcuts": [
         [
             "vesta.exe",

--- a/bucket/vesta.json
+++ b/bucket/vesta.json
@@ -31,7 +31,7 @@
     ],
     "checkver": {
         "url": "https://jp-minerals.org/vesta/en/changes.html",
-        "regex": "ver. ([\\d.]+)"
+        "regex": "ver\\. ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/vesta.json
+++ b/bucket/vesta.json
@@ -4,7 +4,7 @@
     "homepage": "https://jp-minerals.org/vesta/en/",
     "license": {
         "identifier": "Freeware",
-        "url": "https://jp-minerals.org/vesta/en/download.html#:~:text=WWW%2DMINCRYST-,License%20agreement,-VESTA%20LICENSE%0AVersion"
+        "url": "https://jp-minerals.org/vesta/en/download.html"
     },
     "architecture": {
         "64bit": {
@@ -24,9 +24,7 @@
             "Vesta"
         ]
     ],
-    "persist": [
-        "style"
-    ],
+    "persist": "style",
     "checkver": {
         "url": "https://jp-minerals.org/vesta/en/changes.html",
         "regex": "ver. ([\\d.]+)"

--- a/bucket/vesta.json
+++ b/bucket/vesta.json
@@ -25,7 +25,10 @@
             "Vesta"
         ]
     ],
-    "persist": "style",
+    "persist": [
+        "style",
+        "VESTA.ini"
+    ],
     "checkver": {
         "url": "https://jp-minerals.org/vesta/en/changes.html",
         "regex": "ver. ([\\d.]+)"

--- a/bucket/vesta.json
+++ b/bucket/vesta.json
@@ -1,0 +1,42 @@
+{
+    "version": "3.5.7",
+    "description": "VESTA is a 3D visualization program for structural models, volumetric data such as electron/nuclear densities, and crystal morphologies.",
+    "homepage": "https://jp-minerals.org/vesta/en/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://jp-minerals.org/vesta/en/download.html#:~:text=WWW%2DMINCRYST-,License%20agreement,-VESTA%20LICENSE%0AVersion"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://jp-minerals.org/vesta/archives/3.5.7/VESTA-win64.zip",
+            "hash": "7488ace5ae3a960582e64717a5fbe642f6b4a1e8a715fbd9985f2b836a5e1760",
+            "extract_dir": "VESTA-win64"
+        },
+        "32bit": {
+            "url": "https://jp-minerals.org/vesta/archives/3.5.7/VESTA.zip",
+            "hash": "35c0e7483781398163a5e1472898e4243426691977ca6aee7b4096a41fc10024",
+            "extract_dir": "VESTA"
+        }
+    },
+    "shortcuts": [
+        [
+            "vesta.exe",
+            "Vesta"
+        ]
+    ],
+    "persist": "style",
+    "checkver": {
+        "url": "https://jp-minerals.org/vesta/en/changes.html",
+        "regex": "ver. ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://jp-minerals.org/vesta/archives/$version/VESTA-win64.zip"
+            },
+            "32bit": {
+                "url": "https://jp-minerals.org/vesta/archives/$version/VESTA.zip"
+            }
+        }
+    }
+}

--- a/bucket/vesta.json
+++ b/bucket/vesta.json
@@ -24,7 +24,9 @@
             "Vesta"
         ]
     ],
-    "persist": "style",
+    "persist": [
+        "style"
+    ],
     "checkver": {
         "url": "https://jp-minerals.org/vesta/en/changes.html",
         "regex": "ver. ([\\d.]+)"


### PR DESCRIPTION
> VESTA is a 3D visualization program for structural models, volumetric data such as electron/nuclear densities, and crystal morphologies created and maintained by jp-minerals.org
VESTA is a successor to two 3D visualization programs, VICS and VEND, in the [VENUS (Visualization of Electron/NUclear and Structures) software package](http://fujioizumi.verse.jp/visualization/VENUS.html).


VESTA runs on Windows, Mac OS X, and Linux. It is contributed free of charge for non-commercial users.

More about it can be read [here](https://jp-minerals.org/vesta/en/)


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
