### PR TITLE
twitchtest: Add version 1.52

### DIFF
--- a/bucket/twitchtest.json
+++ b/bucket/twitchtest.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.52",
+    "description": "A lightweight program that performs a bandwidth test for Twitch",
+    "homepage": "https://r1ch.net/projects/twitchtest",
+    "license": "GPL-2.0-only",
+    "suggest": {
+        "Visual C++ Redistributable": "extras/vcredist2022"
+    },
+    "url": "https://r1ch.net/assets/twitchtest/twitchtest-1.52.zip",
+    "hash": "374f1389790255899c27215242c7d73df0c7118dcac390a5227617593ec4b257",
+    "shortcuts": [
+        [
+            "TwitchTest.exe",
+            "TwitchTest"
+        ]
+    ],
+    "checkver": "twitchtest-([\\d.]+)\\.zip",
+    "autoupdate": {
+        "url": "https://r1ch.net/assets/twitchtest/twitchtest-$version.zip"
+    }
+}


### PR DESCRIPTION
[TwitchTest](https://r1ch.net/projects/twitchtest) is a lightweight program that performs a bandwidth test for Twitch.

**NOTES**:

* The app is built in **32-bit**.

* **suggest**: This app requires **VCRedist 2015**. Also, VCRedist 2022 now covers all functions from VC2015-2022.
> https://r1ch.net/projects/twitchtest
TwitchTest will work on all modern versions of Windows. The [Visual Studio 2015 Runtime (vc_redist.x86.exe)](https://www.microsoft.com/en-us/download/details.aspx?id=52685) is required (you'll get a missing VCRUNTIME140.DLL error otherwise). The program will prompt to launch as an administrator since connection quality statistics can only be measured under admin mode.