### PR TITLE
freerapid: Add version 0.9u4

### DIFF
--- a/bucket/freerapid.json
+++ b/bucket/freerapid.json
@@ -16,7 +16,7 @@
     "shortcuts": [
         [
             "frd.exe",
-            "FreeRapid Downloader",
+            "FreeRapid Downloader"
         ]
     ],
     "persist": [

--- a/bucket/freerapid.json
+++ b/bucket/freerapid.json
@@ -15,10 +15,8 @@
     "bin": "frd.jar",
     "shortcuts": [
         [
-            "frd.jar",
+            "frd.exe",
             "FreeRapid Downloader",
-            "",
-            "frd.ico"
         ]
     ],
     "persist": [

--- a/bucket/freerapid.json
+++ b/bucket/freerapid.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.9u4",
+    "description": "A Java downloader that supports downloading from Rapidshare, Youtube, Facebook, Picasa and other file-sharing services.",
+    "homepage": "http://wordrider.net/freerapid/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://wordrider.net/freerapid/faq.html"
+    },
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/freerapid/FreeRapid-0.9u4.zip",
+    "hash": "f26d570b63e9591e438a625f87eee80480b160f077a4d7aae433c8d3e0d20ab9",
+    "suggest": {
+        "JAVA Runtime Environment": "java/openjdk"
+    },
+    "extract_dir": "FreeRapid-0.9u4",
+    "bin": "frd.jar",
+    "shortcuts": [
+        [
+            "frd.jar",
+            "FreeRapid Downloader",
+            "",
+            "frd.ico"
+        ]
+    ],
+    "persist": [
+        "log",
+        "objectdb.conf"
+    ]
+}


### PR DESCRIPTION
* closes https://github.com/ScoopInstaller/Versions/issues/532
* related: #8490

[FreeRapid](http://wordrider.net/freerapid/) is a Java downloader that supports downloading from Rapidshare, Youtube, Facebook, Picasa and other file-sharing services.

**NOTES**:
* **file source**: *FreeRapid* now puts their download behind a **pay-wall**.
In https://github.com/ScoopInstaller/Versions/issues/532, @NatoBoram states that there is a way to fetch files directly from their SVN.

However I don't think we should download from SVN because (1) they may close the access of SVN because of unusual number of connections, etc.  (2) This is some sort of "hacking", which should not be encouraged, especially in an open-source software.

Instead, we can just use the file fetched by `archive.org` before they put the pay-wall, and let users update "legally" through the app itself.

* **bin/shortcuts**: There is `frd.exe` in the file, but it basically calls *javaw* to start `frd.jar` (The app does not have a bundled JRE). I think it is more straightforward to just use `frd.jar` for bin ~and shortcut~.

Also see **$dir\doc\readme.txt**
```
additional parameters for launching are:

java -jar frd.jar [-h -v -d -r -D<property>=<value> -m -p]

options
  -h (--help,-?)      print this message
  -v (--version)      print the version information and exit
  -d (--debug)        print debugging information
  -r (--reset)        reset user properties to default values  
  -m (--minim)        minimize main window on start  
  -Dproperty=value    Passes properties and values to the application (mostly for debug or testing purposes)
  -p (--portable)     configuration files will be stored in the 'config'
                      folder, all file paths will be saved relatively to FRD
                      folder (if possible) - useful for USB FLASH drives

If value of option -D is set 'default' (without ') default value will be used.
```