### PR TITLE
extraterm: Update to version 0.62.0, fix checkver

### DIFF
--- a/bucket/extraterm.json
+++ b/bucket/extraterm.json
@@ -1,28 +1,31 @@
 {
-    "version": "0.59.3",
+    "version": "0.62.0",
     "description": "The swiss army chainsaw of terminal emulators",
     "homepage": "https://extraterm.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sedwards2009/extraterm/releases/download/v0.59.3/extraterm-0.59.3-win32-x64.zip",
-            "hash": "e6316d400519ae934a78b2b9a816096986935c1b41d309d91e56f50770b1a212",
-            "extract_dir": "extraterm-0.59.3-win32-x64"
+            "url": "https://github.com/sedwards2009/extraterm/releases/download/v0.62.0/extratermqt-0.62.0-win32-x64.zip",
+            "hash": "c3a59cd38320e3937cb50ebac027500ddb2a0c38ec2fc567a878c483930b68f8",
+            "extract_dir": "extratermqt-0.62.0-win32-x64"
         }
     },
-    "bin": "extraterm.exe",
+    "bin": "extratermqt.exe",
     "shortcuts": [
         [
-            "extraterm.exe",
+            "extratermqt.exe",
             "Extraterm"
         ]
     ],
-    "checkver": "Extraterm\\s+v([\\d.]+)\\s+released",
+    "checkver": {
+        "url": "https://github.com/sedwards2009/extraterm/releases/",
+        "regex": "Extraterm\\s+v([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sedwards2009/extraterm/releases/download/v$version/extraterm-$version-win32-x64.zip",
-                "extract_dir": "extraterm-$version-win32-x64"
+                "url": "https://github.com/sedwards2009/extraterm/releases/download/v$version/extratermqt-$version-win32-x64.zip",
+                "extract_dir": "extratermqt-$version-win32-x64"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to check for latest version: https://github.com/ScoopInstaller/Extras/runs/6645678794?check_suite_focus=true#step:3:224
- Now built with Qt so `qt` added to file name

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
