### PR TITLE
uget-integrator@1.0.0: Fix Out-File encoding

### DIFF
--- a/bucket/uget-integrator.json
+++ b/bucket/uget-integrator.json
@@ -18,9 +18,11 @@
         "Set-PersistItem \"com.ugetdm.chrome.json\", \"com.ugetdm.firefox.json\""
     ],
     "post_install": [
-        "if ((scoop prefix uget 6>$null) -and $?) {",
+        "scoop prefix uget 6>$null",
+        "if ($?) {",
+        "    $findExp = \"UGET_COMMAND = \"\"C:\\\\\\\\uGet\\\\\\\\bin\\\\\\\\uget.exe\"\"\"",
         "    $replaceExp = \"UGET_COMMAND = \"\"$(scoop prefix uget)\\bin\\uget.exe\"\"\" -replace \"\\\\\", \"\\\\\"",
-        "    (Get-Content \"$dir\\uget-integrator.py\") -replace \"UGET_COMMAND = \"\"C:\\\\\\\\uGet\\\\\\\\bin\\\\\\\\uget.exe\"\"\", $replaceExp | Out-File \"$dir\\uget-integrator.py\"",
+        "    (Get-Content \"$dir\\uget-integrator.py\") -replace $findExp, $replaceExp | Out-File -Encoding utf8 \"$dir\\uget-integrator.py\"",
         "}"
     ],
     "bin": [


### PR DESCRIPTION
I found that uget-integrator will not work if user run the install command in Windows PowerShell instead of PowerShell Core.
On Windows PowerShell, the default encoding is utf-16le which makes post_install script break the app.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
