### PR TITLE
upx-easy-gui: Add version 2.1

### DIFF
--- a/bucket/upx-easy-gui.json
+++ b/bucket/upx-easy-gui.json
@@ -1,0 +1,20 @@
+{
+    "##": "Not suggesting 'upx' here because this upx-easy-gui contains bundled UPX.",
+    "version": "2.1",
+    "description": "A graphical user interface (GUI) for UPX EXE Compressor",
+    "homepage": "https://www.novirusthanks.org/products/upx-easy-gui/",
+    "license": "Freeware",
+    "url": "https://downloads.novirusthanks.org/files/portables/upx_easy_gui_portable.zip",
+    "hash": "4bc0700eca5abded37f3dfecbe4ea63e376ed614f53ece42817732f097778f48",
+    "extract_dir": "PORTABLE",
+    "shortcuts": [
+        [
+            "UPXEasyGUI.exe",
+            "UPX Easy GUI"
+        ]
+    ],
+    "checkver": "UPX Easy GUI v([\\d.]+)</h1>",
+    "autoupdate": {
+        "url": "https://downloads.novirusthanks.org/files/portables/upx_easy_gui_portable.zip"
+    }
+}


### PR DESCRIPTION
* closes #5207

**[UPX Easy GUI](https://www.novirusthanks.org/products/upx-easy-gui/)** is a graphical user interface (GUI) for UPX EXE Compressor (`main/upx`).

**NOTES**:
* The app is built in **32-bit**.
* Not suggesting `upx` here because this upx-easy-gui contains bundled UPX.
* *license* info can be found in [EULA.txt](https://github.com/ScoopInstaller/Extras/files/8831243/EULA.txt) in the archive.
