### PR TITLE
fclones: Update to v0.25.0, fix autoupdate

### DIFF
--- a/bucket/fclones.json
+++ b/bucket/fclones.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.24.0",
+    "version": "0.25.0",
     "description": "Efficient duplicate file finder",
     "homepage": "https://github.com/pkolaczk/fclones",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/pkolaczk/fclones/releases/download/v0.24.0/fclones-0.24.0-win.x86_64.zip",
-            "hash": "0781504ab93b45d32b707eb94b7f0e0954d184c538c60c38952f951208895754"
+            "url": "https://github.com/pkolaczk/fclones/releases/download/v0.25.0/fclones-0.25.0-windows.x86_64.zip",
+            "hash": "ddc7a2bf1aa7ab109f7a877135926841aa81dce4facd7f740dd331b6a4223572"
         }
     },
     "bin": "fclones.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/pkolaczk/fclones/releases/download/v$version/fclones-$version-win.x86_64.zip"
+                "url": "https://github.com/pkolaczk/fclones/releases/download/v$version/fclones-$version-windows.x86_64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update (`win` --> `windows`): https://github.com/ScoopInstaller/Extras/runs/6722644998?check_suite_focus=true#step:3:232

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
