### PR TITLE
rxrepl@1.5: Fix URL

### DIFF
--- a/bucket/rxrepl.json
+++ b/bucket/rxrepl.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://hastebin.com/raw/adajilisey"
     },
-    "url": "https://sites.google.com/site/regexreplace/home/rxrepl.zip?attredirects=0",
+    "url": "https://drive.google.com/uc?id=1reCUlV4He6ZDqX8GgJtuFsegc557PgDi&export=download",
     "hash": "c0d8523addafa2fb5e89440e9b5262ce80c84fa9e87ca82d7b3cc23ad10c1e1b",
     "bin": "rxrepl.exe"
 }

--- a/bucket/rxrepl.json
+++ b/bucket/rxrepl.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://hastebin.com/raw/adajilisey"
     },
-    "url": "https://drive.google.com/uc?id=1reCUlV4He6ZDqX8GgJtuFsegc557PgDi&export=download",
+    "url": "https://drive.google.com/uc?id=1reCUlV4He6ZDqX8GgJtuFsegc557PgDi&export=download#/dl.zip",
     "hash": "c0d8523addafa2fb5e89440e9b5262ce80c84fa9e87ca82d7b3cc23ad10c1e1b",
     "bin": "rxrepl.exe"
 }


### PR DESCRIPTION
Files for Google Sites are now hosted on Google Drive. So, "https://drive.google.com/uc?id=1reCUlV4He6ZDqX8GgJtuFsegc557PgDi&export=download" instead of "https://sites.google.com/site/regexreplace/home/rxrepl.zip?attredirects=0". Everything else seems the same.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
