### PR TITLE
ImageGlass: fix URL and SHA1 and regex

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -6,14 +6,14 @@
     "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.xml'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.6.6.6/ImageGlass_8.6.6.6_x64.zip",
-            "hash": "sha1:a04de0d9a833c562e2871a1834dabc204d1c76ca",
-            "extract_dir": "ImageGlass_8.6.6.6_x64"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.6.6.6/ImageGlass_Kobe_8.6.6.6_x64.zip",
+            "hash": "sha1:8EE32EC15D2135E3A69BA4916D01908BC450CCE5",
+            "extract_dir": "ImageGlass_Kobe_8.6.6.6_x64"
         },
         "32bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.6.6.6/ImageGlass_8.6.6.6_x86.zip",
-            "hash": "sha1:3c9a00bc5c169251021d942f578987d606a43110",
-            "extract_dir": "ImageGlass_8.6.6.6_x86"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.6.6.6/ImageGlass_Kobe_8.6.6.6_x86.zip",
+            "hash": "sha1:2299838ABDB05411C2F231B429AF61E2C0135537",
+            "extract_dir": "ImageGlass_Kobe_8.6.6.6_x86"
         }
     },
     "pre_install": [
@@ -43,20 +43,20 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x64.zip",
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_Kobe_$version_x64.zip",
                 "hash": {
                     "url": "https://github.com/d2phap/ImageGlass/releases",
-                    "regex": "ImageGlass_[\\d.]+_x64.zip</td>\\n<td><code>$sha1"
+                    "regex": "ImageGlass_Kobe_[\\d.]+_x64.zip</td>\\n<td><code>$sha1"
                 },
-                "extract_dir": "ImageGlass_$version_x64"
+                "extract_dir": "ImageGlass_Kobe_$version_x64"
             },
             "32bit": {
-                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x86.zip",
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_Kobe_$version_x86.zip",
                 "hash": {
                     "url": "https://github.com/d2phap/ImageGlass/releases",
-                    "regex": "ImageGlass_[\\d.]+_x86.zip</td>\\n<td><code>$sha1"
+                    "regex": "ImageGlass_Kobe_[\\d.]+_x86.zip</td>\\n<td><code>$sha1"
                 },
-                "extract_dir": "ImageGlass_$version_x86"
+                "extract_dir": "ImageGlass_Kobe_$version_x86"
             }
         }
     }


### PR DESCRIPTION
replaced the wrong URLs SHA1s and regex strings with correct ones

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8611
<!-- or -->
Relates to #8611

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
