### PR TITLE
notepadplusplus: Correct license

### DIFF
--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -2,7 +2,7 @@
     "version": "8.4.2",
     "description": "A free source code editor and Notepad replacement that supports several languages.",
     "homepage": "https://notepad-plus-plus.org",
-    "license": "GPL-2.0-only",
+    "license": "GPL-3.0-or-later",
     "notes": "Add Notepad++ as a context menu option by running: reg import \"$dir\\install-context.reg\"",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Notepad++ uses GPL-3.0-or-later
https://raw.githubusercontent.com/notepad-plus-plus/notepad-plus-plus/master/LICENSE
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
