### PR TITLE
litebrowser: Add version 7ee5c11

### DIFF
--- a/bucket/litebrowser.json
+++ b/bucket/litebrowser.json
@@ -1,6 +1,6 @@
 {
     "version": "7ee5c11",
-    "description": "A simple web-browser designed to test the litehtml HTML rendering engine.",
+    "description": "A simple web browser designed to test the litehtml HTML rendering engine.",
     "homepage": "https://github.com/litehtml/litebrowser",
     "license": "BSD-3-Clause",
     "url": "http://www.litehtml.com/download/litehtml/litebrowser.zip",

--- a/bucket/litebrowser.json
+++ b/bucket/litebrowser.json
@@ -1,0 +1,15 @@
+{
+    "version": "7ee5c11",
+    "description": "A simple web-browser designed to test the litehtml HTML rendering engine.",
+    "homepage": "https://github.com/litehtml/litebrowser",
+    "license": "BSD-3-Clause",
+    "url": "http://www.litehtml.com/download/litehtml/litebrowser.zip",
+    "hash": "7dac1873063a96b72e1d4b879e318d489e046eeba7e8a2d2c6f67667b44999c9",
+    "bin": "litebrowser.exe",
+    "shortcuts": [
+        [
+            "litebrowser.exe",
+            "LiteBrowser"
+        ]
+    ]
+}


### PR DESCRIPTION
**[LiteBrowser](https://github.com/litehtml/litebrowser)** is a simple web browser designed to test the [litehtml HTML rendering engine](https://github.com/litehtml/litehtml).

**NOTES**:
* The version number `7ee5c11` comes from [the download page](http://www.litehtml.com/download.html).
> Download litebrowser
Built from 7ee5c11 commit (October 23 2015)

* The app is built in **32-bit**.

* **Command-line** usage can be found in [ReadMe](https://github.com/litehtml/litebrowser#readme).
> Run litebrowser with command line parameter:
litebrowser.exe http://www.litehtml.com
If you run litebrowser without parameter, the dmoz.org will be opened.

* Not suggesting `litehtml` here because (1) There is no `litehtml` in Scoop's official buckets. (2) I couldn't find a reliable distribution of pre-built *litehtml* binaries.

* I couldn't find any config files being stored after running *LiteBrowser* in sandbox.
