### PR TITLE
liquidsoap: Update to version 2.0.5, fix autoupdate

### DIFF
--- a/bucket/liquidsoap.json
+++ b/bucket/liquidsoap.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Icecast-compatible streamer for streaming audio and video",
     "homepage": "https://www.liquidsoap.info",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/savonet/liquidsoap/releases/download/v2.0.4/liquidsoap-v2.0.4-win64.zip",
-            "hash": "3d62b8419f501efe1230639aaf0a4b2835bbe8c2ff0a807440bf98b04eb0a9b0",
-            "extract_dir": "liquidsoap-v2.0.4-win64"
+            "url": "https://github.com/savonet/liquidsoap/releases/download/v2.0.5/liquidsoap-v2.0.5-2.0.5-win64.zip",
+            "hash": "fc24b0f1e3696366ca28b75cb752685cea62895f23961c9faaab13d82807f40a",
+            "extract_dir": "liquidsoap-v2.0.5-2.0.5-win64"
         }
     },
     "bin": "liquidsoap.exe",
@@ -17,8 +17,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/savonet/liquidsoap/releases/download/v$version/liquidsoap-v$version-win64.zip",
-                "extract_dir": "liquidsoap-v$version-win64"
+                "url": "https://github.com/savonet/liquidsoap/releases/download/v$version/liquidsoap-v$version-$version-win64.zip",
+                "extract_dir": "liquidsoap-v$version-$version-win64"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in file name: https://github.com/ScoopInstaller/Extras/runs/6722644998?check_suite_focus=true#step:3:263

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
