### PR TITLE
Update fluent search version to 0.9.90.0

### DIFF
--- a/bucket/fluent-search.json
+++ b/bucket/fluent-search.json
@@ -21,7 +21,7 @@
         "Blast\\Settings"
     ],
     "checkver": {
-        "url": "https://fluentsearch.net/categories/release",
+        "url": "https://fluentsearch.net/blog",
         "regex": "Fluent Search version ([\\d.]+)</a>"
     },
     "autoupdate": {

--- a/bucket/fluent-search.json
+++ b/bucket/fluent-search.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.66.0",
+    "version": "0.9.90.0",
     "description": "Search tool for running apps, browser tabs, in-app content, files and more.",
     "homepage": "https://fluentsearch.net/",
     "license": "Freeware",


### PR DESCRIPTION
According to [Fluent Search blog post](https://fluentsearch.net/posts/fluent-search-version-09900), by the time PR #8362 created it is version 0.9.90.0.

Relates to #8362 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
