### PR TITLE
pterm: Add version 0.77

### DIFF
--- a/bucket/pterm.json
+++ b/bucket/pterm.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.77",
+    "description": "a PuTTY-like wrapper program for Windows command prompts (or anything else running in a Windows console) that is not included in putty all-in-one archive/installer",
+    "homepage": "https://www.chiark.greenend.org.uk/~sgtatham/putty/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://the.earth.li/~sgtatham/putty/latest/w64/pterm.exe",
+            "hash": "sha512:10908538ccf762bf412ecf6ba8d8409ae723aead6f4911f9643c6f9b27bd19c6c85f287aa3fbb6cfe5ee9d20754a0a05781d6185eb09b487da09a3308e055eb5"
+        },
+        "32bit": {
+            "url": "https://the.earth.li/~sgtatham/putty/latest/w32/pterm.exe",
+            "hash": "sha512:4f7ed297dca1cb86da989671f3a3522dc8afa916845d6aea93641fdf1a677c2e0f0b4a5509fdf30ab290372cfaba413f5481107b0e715139129732eca5e4ad8b"
+        }
+    },
+    "bin": "pterm.exe",
+    "shortcuts": [
+    	[
+            "pterm.exe",
+            "Pterm (PuTTY Windows Command Prompt Wrapper)"
+        ]
+    ],
+    "checkver": "The latest version is ([\\d.]+)\\.",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://the.earth.li/~sgtatham/putty/latest/w64/pterm.exe",
+                "hash": {
+                    "url": "https://the.earth.li/~sgtatham/putty/latest/sha512sums",
+                    "regex": "$sha512\\s+w64/pterm.exe"
+                }
+            },
+            "32bit": {
+                "url": "https://the.earth.li/~sgtatham/putty/latest/w32/pterm.exe",
+                "hash": {
+                    "url": "https://the.earth.li/~sgtatham/putty/latest/sha512sums",
+                    "regex": "$sha512\\s+w32/pterm.exe"
+                }
+            }
+        }
+    }
+}

--- a/bucket/pterm.json
+++ b/bucket/pterm.json
@@ -15,7 +15,7 @@
     },
     "bin": "pterm.exe",
     "shortcuts": [
-    	[
+        [
             "pterm.exe",
             "Pterm (PuTTY Windows Command Prompt Wrapper)"
         ]

--- a/bucket/pterm.json
+++ b/bucket/pterm.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://the.earth.li/~sgtatham/putty/latest/w64/pterm.exe",
+            "url": "https://the.earth.li/~sgtatham/putty/0.77/w64/pterm.exe",
             "hash": "sha512:10908538ccf762bf412ecf6ba8d8409ae723aead6f4911f9643c6f9b27bd19c6c85f287aa3fbb6cfe5ee9d20754a0a05781d6185eb09b487da09a3308e055eb5"
         },
         "32bit": {
-            "url": "https://the.earth.li/~sgtatham/putty/latest/w32/pterm.exe",
+            "url": "https://the.earth.li/~sgtatham/putty/0.77/w32/pterm.exe",
             "hash": "sha512:4f7ed297dca1cb86da989671f3a3522dc8afa916845d6aea93641fdf1a677c2e0f0b4a5509fdf30ab290372cfaba413f5481107b0e715139129732eca5e4ad8b"
         }
     },
@@ -24,16 +24,16 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://the.earth.li/~sgtatham/putty/latest/w64/pterm.exe",
+                "url": "https://the.earth.li/~sgtatham/putty/$version/w64/pterm.exe",
                 "hash": {
-                    "url": "https://the.earth.li/~sgtatham/putty/latest/sha512sums",
+                    "url": "https://the.earth.li/~sgtatham/putty/$version/sha512sums",
                     "regex": "$sha512\\s+w64/pterm.exe"
                 }
             },
             "32bit": {
-                "url": "https://the.earth.li/~sgtatham/putty/latest/w32/pterm.exe",
+                "url": "https://the.earth.li/~sgtatham/putty/$version/w32/pterm.exe",
                 "hash": {
-                    "url": "https://the.earth.li/~sgtatham/putty/latest/sha512sums",
+                    "url": "https://the.earth.li/~sgtatham/putty/$version/sha512sums",
                     "regex": "$sha512\\s+w32/pterm.exe"
                 }
             }


### PR DESCRIPTION
PuTTY 0.77 added the pterm application which is a wrapper around the Windows Command Prompt or other Windows Console applications. It is not included in the main PuTTY installation package.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8628 
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
