### PR TITLE
nilesoft-shell: Add version 1.6

### DIFF
--- a/bucket/nilesoft-shell.json
+++ b/bucket/nilesoft-shell.json
@@ -1,0 +1,51 @@
+{
+    "version": "1.6",
+    "description": "A context menu extender that lets you handpick the items to integrate into Windows File Explorer context menu",
+    "homepage": "https://nilesoft.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://nilesoft.org/download/shell.zip",
+            "hash": "2abc4df3e2a8a488a5426e5ba307b61063e2bde9966007cec35fa336b77929f2"
+        },
+        "32bit": {
+            "url": "https://nilesoft.org/download/shell-32.zip",
+            "hash": "b11077a3da74bf8eafcb15dacf854a3d5c75bc9c1d4a2f43018124d6405a28f9"
+        }
+    },
+    "pre_install": "if(!(Test-Path \"$persist_dir\\shell.log\")) { New-Item \"$dir\\shell.log\" | Out-Null }",
+    "uninstaller": {
+        "script": [
+            "if ($cmd -eq 'uninstall') {",
+            "    $regkey = Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\background\\shellex\\ContextMenuHandlers\\nilesoft.shell' -ErrorAction SilentlyContinue",
+            "    if ($regkey) {",
+            "        if (!(is_admin)) { error 'Admin rights is required to unregister nilesoft shell'; break }",
+            "        Invoke-ExternalCommand \"$dir\\shell.exe\" -ArgumentList @('-unregister', '-restart', '-silent') -RunAs | Out-Null",
+            "        if (Get-Process -Name 'shell' -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 2 }",
+            "    }",
+            "}"
+        ]
+    },
+    "bin": "shell.exe",
+    "shortcuts": [
+        [
+            "shell.exe",
+            "Nilesoft Shell"
+        ]
+    ],
+    "persist": "shell.log",
+    "checkver": {
+        "url": "https://nilesoft.org/download",
+        "regex": "Shell version ([\\d.]+)</h5>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://nilesoft.org/download/shell.zip"
+            },
+            "32bit": {
+                "url": "https://nilesoft.org/download/shell-32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* closes #8630

**[NileSoft Shell](https://nilesoft.org/)** is a context menu extender that lets you handpick the items to integrate into Windows File Explorer context menu.

**NOTES**:
* `shell.exe` supports command-line args. See https://nilesoft.org/docs/installation for examples.
> shell -[options]
Options
-register (-r)	Registering.
-unregister (-u)	Unregistering.
-init (-i)	Initialize image cache.
-restart (-re)	Restart Windows Explorer.
-silent (-s)	Prevents displaying messages.
-?	Display this help message.
* *persist* is only required for `shell.log` because settings (user-defined context menu in this case) is stored in **registry**.