### PR TITLE
Siyuan-Note@2.0.17: license & homepage changed

### DIFF
--- a/bucket/siyuan-note.json
+++ b/bucket/siyuan-note.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.17",
     "description": "SiYuan is a Markdown Block-Reference and Bidirectional-Link note-taking application",
-    "homepage": "https://github.com/siyuan-note/siyuan/",
+    "homepage": "https://b3log.org/siyuan",
     "license": {
         "identifier": "AGPL-3.0-only",
         "url": "https://github.com/siyuan-note/siyuan/blob/master/LICENSE"

--- a/bucket/siyuan-note.json
+++ b/bucket/siyuan-note.json
@@ -1,10 +1,10 @@
 {
     "version": "2.0.17",
     "description": "SiYuan is a Markdown Block-Reference and Bidirectional-Link note-taking application",
-    "homepage": "https://b3log.org/siyuan",
+    "homepage": "https://github.com/siyuan-note/siyuan/",
     "license": {
-        "identifier": "Proprietary",
-        "url": "https://b3log.org/siyuan/eula.html"
+        "identifier": "AGPL-3.0-only",
+        "url": "https://github.com/siyuan-note/siyuan/blob/master/LICENSE"
     },
     "architecture": {
         "64bit": {

--- a/bucket/siyuan-note.json
+++ b/bucket/siyuan-note.json
@@ -2,9 +2,7 @@
     "version": "2.0.17",
     "description": "SiYuan is a Markdown Block-Reference and Bidirectional-Link note-taking application",
     "homepage": "https://b3log.org/siyuan",
-    "license": {
-        "identifier": "AGPL-3.0-only",
-    },
+    "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/siyuan-note/siyuan/releases/download/v2.0.17/siyuan-2.0.17-win.exe#/dl.7z",

--- a/bucket/siyuan-note.json
+++ b/bucket/siyuan-note.json
@@ -4,7 +4,6 @@
     "homepage": "https://b3log.org/siyuan",
     "license": {
         "identifier": "AGPL-3.0-only",
-        "url": "https://github.com/siyuan-note/siyuan/blob/master/LICENSE"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Siyuan-Note opened its source code with AGPL since v2.0.14.

https://github.com/siyuan-note/siyuan/blob/master/LICENSE

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
