### PR TITLE
peid: Add version 0.95

### DIFF
--- a/bucket/peid.json
+++ b/bucket/peid.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.95",
+    "description": "Detects most common packers, cryptors and compilers for PE files. Supports more than 470 different signatures in PE files.",
+    "homepage": "https://web.archive.org/web/20110226030434/http://peid.info/",
+    "license": "Freeware",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/peid/PEiD-0.95.zip",
+    "hash": "67a0fe273a7273963fac97b808530b7a1d8088af350a06ed755d72c7eaab2de0",
+    "bin": "PEiD.exe",
+    "shortcuts": [
+        [
+            "PEiD.exe",
+            "PEiD"
+        ]
+    ]
+}


### PR DESCRIPTION
**PEiD** ([archived homepage](https://web.archive.org/web/20110226030434/http://peid.info/)) is a tool that detects most common packers, cryptors and compilers for PE files. It supports more than 470 different signatures in PE files.

**NOTES**:
* See [this page on Aldeid](https://www.aldeid.com/wiki/PEiD) for more info/usage.
* Using `ScoopInstaller/Binary` because the site http://peid.info is no longer valid.
* The app is built in **32-bit**.
* The app supports command-line args, for example:
> Information
PEiD detects most common packers, cryptors and compilers for PE files. It can currently detect more than 600 different signatures in PE files.
...
.4. Shell integration, Command line support, Always on top and Drag'n'Drop capabilities.

> PEiD News
...
New: Added a '-e' option to extract and save the binaries that it finds.

**SCREENSHOTS**:
![](https://www.aldeid.com/w/images/c/c6/Peid.png)
![](https://www.aldeid.com/w/images/7/7a/Peid-ep-section.png)