### PR TITLE
dotnet-generic-unpacker: Add version 1.0.0.1

### DIFF
--- a/bucket/dotnet-generic-unpacker.json
+++ b/bucket/dotnet-generic-unpacker.json
@@ -1,9 +1,9 @@
 {
-    "##": "Only 32-bit version of .NET Generic Unpacker can dump 32-bit executables. (The same rule applies to 64-bit version)",
     "version": "1.0.0.1",
     "description": "A program to dump .NET packed applications",
     "homepage": "https://ntcore.com/?page_id=353",
     "license": "Freeware",
+    "notes": "Only 32-bit version of .NET Generic Unpacker can dump 32-bit executables. (The same rule applies to 64-bit version)",
     "architecture": {
         "64bit": {
             "url": [

--- a/bucket/dotnet-generic-unpacker.json
+++ b/bucket/dotnet-generic-unpacker.json
@@ -1,0 +1,44 @@
+{
+    "##": "Only 32-bit version of .NET Generic Unpacker can dump 32-bit executables. (The same rule applies to 64-bit version)",
+    "version": "1.0.0.1",
+    "description": "A program to dump .NET packed applications",
+    "homepage": "https://ntcore.com/?page_id=353",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://ntcore.com/files/NETUnpack.zip",
+                "https://ntcore.com/files/NETUnpack_x64.zip#/64bit.zip_"
+            ],
+            "hash": [
+                "e46bd2ecdd1cc72c011406fa07d239f1ad8d8cd5e6c5e9945d186078c3e24278",
+                "af7f2ca052855d6c1613eb6901897ab9c1ffa4eda17b115e71651fbdcec13852"
+            ],
+            "pre_install": [
+                "Rename-Item \"$dir\\NETUnpack.exe\" 'NETUnpack_32bit.exe'",
+                "Expand-7zipArchive \"$dir\\64bit.zip_\" \"$dir\" -Removal | Out-Null",
+                "Rename-Item \"$dir\\NETUnpack.exe\" 'NETUnpack_64bit.exe'"
+            ],
+            "shortcuts": [
+                [
+                    "NETUnpack_32bit.exe",
+                    ".NET Generic Unpacker (32-bit)"
+                ],
+                [
+                    "NETUnpack_64bit.exe",
+                    ".NET Generic Unpacker (64-bit)"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://ntcore.com/files/NETUnpack.zip",
+            "hash": "e46bd2ecdd1cc72c011406fa07d239f1ad8d8cd5e6c5e9945d186078c3e24278",
+            "shortcuts": [
+                [
+                    "NETUnpack.exe",
+                    ".NET Generic Unpacker (32-bit)"
+                ]
+            ]
+        }
+    }
+}


### PR DESCRIPTION
**[.NET Generic Unpacker](https://ntcore.com/?page_id=353)** is a program to dump .NET packed applications.

**NOTES**:
* Only **32-bit version** of .NET Generic Unpacker can dump **32-bit executables**. The same rule applies to 64-bit version.
> Download the x64 version of the .NET Generic Unpacker only if the process is not an x86 process. In all other cases download the x86 version.
* *autoupdate* is not needed because last update was in 2008.