### PR TITLE
simple-assembly-explorer: Add version 1.14.4

### DIFF
--- a/bucket/simple-assembly-explorer.json
+++ b/bucket/simple-assembly-explorer.json
@@ -27,18 +27,5 @@
     "persist": [
         "user.config",
         "SimpleAssemblyExplorer.exe.Config"
-    ],
-    "checkver": {
-        "github": "https://github.com/wickyhu/simple-assembly-explorer/"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/wickyhu/simple-assembly-explorer/releases/download/v$version/SAE.v$version.x64.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/wickyhu/simple-assembly-explorer/releases/download/v$version/SAE.v$version.x86.7z"
-            }
-        }
-    }
+    ]
 }

--- a/bucket/simple-assembly-explorer.json
+++ b/bucket/simple-assembly-explorer.json
@@ -1,0 +1,44 @@
+{
+    "version": "1.14.4",
+    "description": "Open-source .NET assembly tool that can browse assembly classes, edit method instructions, and manipulate resources.",
+    "homepage": "https://code.google.com/archive/p/simple-assembly-exploror/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wickyhu/simple-assembly-explorer/releases/download/v1.14.4/SAE.v1.14.4.x64.7z",
+            "hash": "1ecf9b998b9698bd778a16ea6a7bfb9c3fdc5c6dbfd4d8551bd962fe4ab261e7"
+        },
+        "32bit": {
+            "url": "https://github.com/wickyhu/simple-assembly-explorer/releases/download/v1.14.4/SAE.v1.14.4.x86.7z",
+            "hash": "7664c9d6494ac900d6509ed72fa75dc636d5c6873ad5d0e063b4461caccff846"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\user.config\")) {",
+        "    Set-Content \"$dir\\user.config\" \"<SimpleAssemblyExplorer.Properties.Settings></SimpleAssemblyExplorer.Properties.Settings>`r`n\" -Encoding Ascii",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "SimpleAssemblyExplorer.exe",
+            "Simple Assembly Explorer"
+        ]
+    ],
+    "persist": [
+        "user.config",
+        "SimpleAssemblyExplorer.exe.Config"
+    ],
+    "checkver": {
+        "github": "https://github.com/wickyhu/simple-assembly-explorer/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wickyhu/simple-assembly-explorer/releases/download/v$version/SAE.v$version.x64.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/wickyhu/simple-assembly-explorer/releases/download/v$version/SAE.v$version.x86.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
**[Simple Assembly Explorer](https://code.google.com/archive/p/simple-assembly-exploror/)** is an open-source .NET assembly tool that can browse assembly classes, edit method instructions, and manipulate resources.

**NOTES**:
* **autoupdate** is not needed because last update was in 2015.
* The app requires .NET Framework 4.0, but I don't think we need to **suggest** it because Win10/11 already have .NET4.0 built-in.