### PR TITLE
sidebar-diagnostics: Add version 3.6.2

### DIFF
--- a/bucket/sidebar-diagnostics.json
+++ b/bucket/sidebar-diagnostics.json
@@ -1,0 +1,26 @@
+{
+    "version": "3.6.2",
+    "description": "A simple sidebar that displays hardware diagnostic information.",
+    "homepage": "https://github.com/ArcadeRenegade/SidebarDiagnostics",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ArcadeRenegade/SidebarDiagnostics/releases/download/v3.6.2/Standalone.zip",
+            "hash": "773B6B1AADF524C4A33501BD628FA82CA874095B06463B9148EB28D697A4292D"
+        }
+    },
+    "shortcuts": [
+        [
+            "SidebarDiagnostics.exe",
+            "Sidebar Diagnostics"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ArcadeRenegade/SidebarDiagnostics/releases/download/v$version/Standalone.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Added Sidebar Diagnostics. A simple sidebar that displays hardware diagnostic information.
64bit
Stores settings at `%localappdata%\SidebarDiagnostics`
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/ScoopInstaller/Extras/issues/8641
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
