### PR TITLE
tak@2.3.2: Update manifest, add autoupdate

### DIFF
--- a/bucket/tak.json
+++ b/bucket/tak.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.3.0",
+    "version": "2.3.2",
     "description": "Tom's lossless Audio Kompressor",
     "homepage": "https://wiki.hydrogenaud.io/index.php?title=TAK",
     "license": "Freeware",
-    "url": "http://thbeck.de/Download/TAK_2.3.0.zip",
-    "hash": "4bf6596a159aa28f6cb0d52a5c5c2229193ae00f2fd7fde0291f165568819e65",
+    "url": "http://thbeck.de/Download/TAK_2.3.2.zip",
+    "hash": "52913d01c5f0b4e1ef8e52b4854f1e987225966b15ccd014393c8cb4c28cea16",
     "extract_dir": "Applications",
     "bin": "Takc.exe",
     "shortcuts": [
@@ -12,5 +12,12 @@
             "Tak.exe",
             "Tak"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "http://thbeck.de/Tak/Tak.html",
+        "regex": "TAK_([\\d.]+) Final"
+    },
+    "autoupdate": {
+        "url": "http://thbeck.de/Download/TAK_$version.zip"
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The current manifest has a failing hash check because the developer's site seems to redirect links from old versions to the latest version. So this updates to the latest version available and adds autoupdate to handle that.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
