### PR TITLE
exeinfo-pe: Add version 0.0.6.9

### DIFF
--- a/bucket/exeinfo-pe.json
+++ b/bucket/exeinfo-pe.json
@@ -1,0 +1,32 @@
+{
+    "##": "The homepage requires JS to load (not suitable for checkver)",
+    "version": "0.0.6.9",
+    "description": "EXE analyzer inspired by PEiD. Designed to detect exe signatures, compressor format and dump internal information.",
+    "homepage": "http://exeinfo.booomhost.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://exeinfo.booomhost.com/"
+    },
+    "url": "https://raw.githubusercontent.com/ExeinfoASL/ASL/master/exeinfope.zip",
+    "hash": "8935616b2f9a344f076b82ba8f3051b4d9bf42b199e2219f568ee373d6b9ab5a",
+    "extract_dir": "ExeinfoPe",
+    "bin": "exeinfope.exe",
+    "shortcuts": [
+        [
+            "exeinfope.exe",
+            "Exeinfo PE"
+        ]
+    ],
+    "persist": [
+        "plugins",
+        "exeinfopeRUN.cfg",
+        "userdb.txt"
+    ],
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/ExeinfoASL/ASL/master/README.md",
+        "regex": "Version\\s+\\: ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/ExeinfoASL/ASL/master/exeinfope.zip"
+    }
+}

--- a/bucket/peid.json
+++ b/bucket/peid.json
@@ -3,6 +3,10 @@
     "description": "Detects most common packers, cryptors and compilers for PE files. Supports more than 470 different signatures in PE files.",
     "homepage": "https://web.archive.org/web/20110226030434/http://peid.info/",
     "license": "Freeware",
+    "notes": [
+        "PEiD is not being maintained anymore. We recommend using Exeinfo PE for latest features/fixes",
+        "To install it, run: scoop install exeinfo-pe"
+    ],
     "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/peid/PEiD-0.95.zip",
     "hash": "67a0fe273a7273963fac97b808530b7a1d8088af350a06ed755d72c7eaab2de0",
     "bin": "PEiD.exe",


### PR DESCRIPTION
**[ExeInfo PE](http://exeinfo.booomhost.com/?i=1)** is an EXE analyzer inspired by **PEiD** (#8639). It is designed to detect exe signatures, compressor format and dump internal information.

**NOTES**:
* The app is built in **32-bit**.
* `exeinfope.exe` supports command-line args. 
   For example, you can open an exe/dll by running `exeinfo (file path)`.
* Add **notes** to `extras/peid` that refers to this app.

**SCREENSHOTS**:
![](https://www.thewindowsclub.com/wp-content/uploads/2019/10/Exeinfo-PE.png)