### PR TITLE
lenovolegiontoolkit: Update to v2.0.0, fix autoupdate

### DIFF
--- a/bucket/lenovolegiontoolkit.json
+++ b/bucket/lenovolegiontoolkit.json
@@ -1,19 +1,20 @@
 {
-    "version": "1.7.2",
+    "version": "2.0.0",
     "description": "A lightweight alternative to the Lenovo Vantage Software created for Lenovo Legion laptops",
     "homepage": "https://github.com/BartoszCichecki/LenovoLegionToolkit",
     "license": "MIT",
     "depends": "versions/dotnet5-sdk",
-    "url": "https://github.com/BartoszCichecki/LenovoLegionToolkit/releases/download/1.7.2/Lenovo.Legion.Toolkit.exe",
-    "hash": "4d1b62a8af2c3f4c04f256d150330705f3ad271e890d8bb05b42d3231a449c9e",
+    "url": "https://github.com/BartoszCichecki/LenovoLegionToolkit/releases/download/2.0.0/LenovoLegionToolkitSetup.exe",
+    "hash": "9af4652fcbcab69f4bfe67a22b9faa158f214500c4ad888bf690809137206867",
+    "innosetup": true,
     "shortcuts": [
         [
-            "Lenovo.Legion.Toolkit.exe",
+            "Lenovo Legion Toolkit.exe",
             "Lenovo Legion Toolkit"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/BartoszCichecki/LenovoLegionToolkit/releases/download/$version/Lenovo.Legion.Toolkit.exe"
+        "url": "https://github.com/BartoszCichecki/LenovoLegionToolkit/releases/download/$version/LenovoLegionToolkitSetup.exe"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in download filename: https://github.com/ScoopInstaller/Extras/runs/6827520470?check_suite_focus=true#step:3:376

Added innosetup as it is no longer a standalone exe but an installer to be unpacked. Shortcut changed too.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
