### PR TITLE
draw.io: Update to version 19.0.3, fix autoupdate

### DIFF
--- a/bucket/draw.io.json
+++ b/bucket/draw.io.json
@@ -1,20 +1,20 @@
 {
-    "version": "19.0.0",
+    "version": "19.0.3",
     "description": "Professional diagramming",
     "homepage": "https://www.diagrams.net",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jgraph/drawio-desktop/releases/download/v19.0.0/draw.io-x64-19.0.0.exe#/dl.7z",
-            "hash": "78aab754c62766f93f860daf039ab02647c1e4218bc8ed216b81e1e7b47ff47d",
+            "url": "https://github.com/jgraph/drawio-desktop/releases/download/v19.0.3/draw.io-19.0.3-windows-installer.exe#/dl.7z",
+            "hash": "c8cac72683f77a518607559d58a802aacae41e6801f9d8946a758213addf3e45",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
             ]
         },
         "32bit": {
-            "url": "https://github.com/jgraph/drawio-desktop/releases/download/v19.0.0/draw.io-ia32-19.0.0.exe#/dl.7z",
-            "hash": "f9ad7678cb4b4ba264f9ad30c37a9c1ceddbdba0f4e227cd40c561a58b0078c3",
+            "url": "https://github.com/jgraph/drawio-desktop/releases/download/v19.0.3/draw.io-ia32-19.0.3-windows-32bit-installer.exe#/dl.7z",
+            "hash": "f212a0203d0fa294ed23030db7fdae1ab2a08143f50f5314b647ec6dcea822e0",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
@@ -34,10 +34,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jgraph/drawio-desktop/releases/download/v$version/draw.io-x64-$version.exe#/dl.7z"
+                "url": "https://github.com/jgraph/drawio-desktop/releases/download/v$version/draw.io-$version-windows-installer.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/jgraph/drawio-desktop/releases/download/v$version/draw.io-ia32-$version.exe#/dl.7z"
+                "url": "https://github.com/jgraph/drawio-desktop/releases/download/v$version/draw.io-ia32-$version-windows-32bit-installer.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in download filenames: https://github.com/ScoopInstaller/Extras/runs/6827520470?check_suite_focus=true#step:3:229

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
