### PR TITLE
mpress: Add version 2.19

### DIFF
--- a/bucket/mpress.json
+++ b/bucket/mpress.json
@@ -1,0 +1,9 @@
+{
+    "version": "2.19",
+    "description": "High-performance executable packer for PE32+ and .NET",
+    "homepage": "https://www.matcode.com/mpress.htm",
+    "license": "BSD-3-Clause",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/mpress/mpress-2.19.zip",
+    "hash": "19ffee93706dff67f83d9ef48c0c794dea761d4459b11c37f9bc65b04af736c5",
+    "bin": "mpress.exe"
+}


### PR DESCRIPTION
**[MPress](https://www.matcode.com/mpress.htm)** is a high-performance executable packer for PE32+ and .NET.

**NOTES**:
* This is a command-line app. I add this package to `Extras` due to popularity issues.
* The app is built in **32-bit**.
* Using `ScoopInstaller/Binary` because the download link was removed from their website (not sure why though). The file is retrieved from snapshots on `archive.org`.