### PR TITLE
everything@1.4.1.1017: Add pre_uninstall script

### DIFF
--- a/bucket/everything.json
+++ b/bucket/everything.json
@@ -35,12 +35,15 @@
         "    $content | Set-Content -Path \"$dir\\$_\" -Encoding ascii",
         "}"
     ],
-    "uninstaller": {
-        "script": [
-            "Get-ChildItem \"$dir\\*\" -Include 'Everything.ini', 'Everything.db', 'Bookmarks.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
-            "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }"
-        ]
-    },
+    "pre_uninstall": [
+        "if (Get-Service 'Everything' -ErrorAction SilentlyContinue) {",
+        "    if (!(is_admin)) { error 'Admin rights are required to stop Everything service'; break }",
+        "    Stop-Service -Name 'Everything' -ErrorAction SilentlyContinue | Out-Null",
+        "    if ($cmd -eq 'uninstall') { sc.exe delete 'Everything' }",
+        "}",
+        "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
+        "Get-ChildItem \"$dir\\*\" -Include 'Everything.ini', 'Everything.db', 'Bookmarks.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
+    ],
     "bin": "Everything.exe",
     "shortcuts": [
         [

--- a/bucket/everything.json
+++ b/bucket/everything.json
@@ -36,6 +36,7 @@
         "}"
     ],
     "pre_uninstall": [
+        "Stop-Process -Name 'everything' -ErrorAction SilentlyContinue",
         "if (Get-Service 'Everything' -ErrorAction SilentlyContinue) {",
         "    if (!(is_admin)) { error 'Admin rights are required to stop Everything service'; break }",
         "    Stop-Service -Name 'Everything' -ErrorAction SilentlyContinue | Out-Null",


### PR DESCRIPTION
* This `pre_uninstall` script detects and stops **Everything service** before updating/uninstalling the app.

* Migrate existing actions from `uninstaller.scripts`.

* **Everything** requires admin rights to index NTFS volumes. This can either achieved by:
   (1) Always run *Everything* under admin
   (2) Install Everything service via Everything GUI, which is the more common way.

* However in the case of (2), users will have to either "stop everything service" or "terminate everything.exe" before updating the app via *Scoop*. Otherwise there will be a "file in use" error. This `pre_install` solves the problem.

* Using `Stop-Process` before stopping service because *Everything* **stays in tray** even after user closes the window. I think it is safe to kill the process because it does not break the app.

![everything](https://user-images.githubusercontent.com/27724471/173147389-7b0eab45-8093-4486-9629-9ae49a407ed8.jpg)


