### PR TITLE
strawberry: Update to version 1.0.5, remove 32bit

### DIFF
--- a/bucket/strawberry.json
+++ b/bucket/strawberry.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "A music player and music collection organizer",
     "homepage": "https://www.strawbs.org/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://files.jkvinge.net/packages/strawberry/StrawberrySetup-1.0.4-mingw-x64.exe#/dl.7z",
-            "hash": "04912387a5e4a61c3bcd81b840f29a6de52138f23ab837dd6cfa9c9004476fb6"
-        },
-        "32bit": {
-            "url": "https://files.jkvinge.net/packages/strawberry/StrawberrySetup-1.0.4-mingw-x86.exe#/dl.7z",
-            "hash": "2e25a5f88f8a13dfff973132bd155d01c94e2f0d853dcedf5c21af32cf824de8"
+            "url": "https://files.jkvinge.net/packages/strawberry/StrawberrySetup-1.0.5-mingw-x64.exe#/dl.7z",
+            "hash": "863da3de44e3019adf9c18a905049149a233e2b3468051294367ac7c07d59133"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
@@ -28,9 +24,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://files.jkvinge.net/packages/strawberry/StrawberrySetup-$version-mingw-x64.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://files.jkvinge.net/packages/strawberry/StrawberrySetup-$version-mingw-x86.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to find 32bit version in autoupdate: https://github.com/ScoopInstaller/Extras/runs/6842092174?check_suite_focus=true#step:3:428

32bit version is no longer in the file list and is no longer mentioned on the homepage: https://www.strawberrymusicplayer.org/

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
