### PR TITLE
qbittorrent-enhanced: Update to version 4.4.3.12

### DIFF
--- a/bucket/qbittorrent-enhanced.json
+++ b/bucket/qbittorrent-enhanced.json
@@ -3,8 +3,12 @@
     "description": "qBittorrent BitTorrent client with anti-leech enhancements",
     "homepage": "https://github.com/c0re100/qBittorrent-Enhanced-Edition",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.3.12/qbittorrent_enhanced_4.4.3.12_Qt6_setup.exe#/dl.7z",
-    "hash": "f50cffc29e4354681e08b6a14aeb29f1713583b3affea99be9c174e395402b1c",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.3.12/qbittorrent_enhanced_4.4.3.12_Qt6_setup.exe#/dl.7z",
+            "hash": "f50cffc29e4354681e08b6a14aeb29f1713583b3affea99be9c174e395402b1c"
+        }
+    },
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
     "bin": "qbittorrent.exe",
     "shortcuts": [
@@ -19,6 +23,10 @@
         "regex": "releases/tag/release-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_Qt6_setup.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_Qt6_setup.exe#/dl.7z"
+            }
+        }
     }
 }

--- a/bucket/qbittorrent-enhanced.json
+++ b/bucket/qbittorrent-enhanced.json
@@ -1,18 +1,10 @@
 {
-    "version": "4.4.2.10",
+    "version": "4.4.3.12",
     "description": "qBittorrent BitTorrent client with anti-leech enhancements",
     "homepage": "https://github.com/c0re100/qBittorrent-Enhanced-Edition",
     "license": "GPL-2.0-or-later",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.2.10/qbittorrent_enhanced_4.4.2.10_Qt6_x64_setup.exe#/dl.7z",
-            "hash": "e8cddb2a2847bdedc0d3e07acb688747f9da734a5064a047ea379ddcad4ae2da"
-        },
-        "32bit": {
-            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.2.10/qbittorrent_enhanced_4.4.2.10_setup.exe#/dl.7z",
-            "hash": "5464423268ffeded3f1ef3346f8bf3960db7ab4b141d5eb01e60faf38db4be9e"
-        }
-    },
+    "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.3.12/qbittorrent_enhanced_4.4.3.12_Qt6_setup.exe#/dl.7z",
+    "hash": "f50cffc29e4354681e08b6a14aeb29f1713583b3affea99be9c174e395402b1c",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
     "bin": "qbittorrent.exe",
     "shortcuts": [
@@ -27,13 +19,6 @@
         "regex": "releases/tag/release-([\\d.]+)"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_Qt6_x64_setup.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_setup.exe#/dl.7z"
-            }
-        }
+        "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_Qt6_setup.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Since v4.4.3.12, the released file of qbittorrent-enhanced had changed its name from `qbittorrent_enhanced_4.4.2.10_Qt6_x64_setup.exe` to `qbittorrent_enhanced_4.4.3.12_Qt6_setup.exe`

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
