### PR TITLE
ilmerge: Add version 3.0.41

### DIFF
--- a/bucket/ilmerge.json
+++ b/bucket/ilmerge.json
@@ -1,0 +1,10 @@
+{
+    "version": "3.0.41",
+    "description": "A static linker for .NET Assemblies developed by Microsoft .NET team.",
+    "homepage": "https://github.com/dotnet/ILMerge",
+    "license": "MIT",
+    "url": "https://globalcdn.nuget.org/packages/ilmerge.3.0.41.nupkg",
+    "hash": "9121fe69cbde20180aff5f7ff0ca18c857c6b6de375ae3fbe48ff189b51f1637",
+    "extract_dir": "tools\\net452",
+    "bin": "ILMerge.exe"
+}

--- a/bucket/ilmerge.json
+++ b/bucket/ilmerge.json
@@ -1,6 +1,6 @@
 {
     "version": "3.0.41",
-    "description": "A static linker for .NET Assemblies developed by Microsoft .NET team.",
+    "description": "A static linker for .NET assemblies developed by Microsoft .NET team.",
     "homepage": "https://github.com/dotnet/ILMerge",
     "license": "MIT",
     "url": "https://globalcdn.nuget.org/packages/ilmerge.3.0.41.nupkg",


### PR DESCRIPTION
**[ILMerge](https://github.com/dotnet/ILMerge)** is a static linker for .NET Assemblies developed by Microsoft .NET team.

**NOTES**:
* This is a command-line tool. I put this in `Extras` due to **popularity issues**. *ILMerge* is developed by Microsoft and has 1K starts, but this project has been **archived** and somewhat outdated. Some projects are still using it though.
* The app is built in **32-bit**.