### PR TITLE
rustdesk: Change license to AGPL-3.0-only, Remove `bin`

### DIFF
--- a/bucket/rustdesk.json
+++ b/bucket/rustdesk.json
@@ -15,11 +15,11 @@
     },
     "shortcuts": [
         [
-            "rustdesk.exe",
+            "RustDesk.exe",
             "RustDesk"
         ]
     ],
-    "pre_install": "Get-ChildItem \"$dir\" 'rustdesk-*.exe' | Select-Object -First 1 | Rename-Item -NewName 'rustdesk.exe'",
+    "pre_install": "Get-ChildItem \"$dir\" 'rustdesk-*.exe' | Select-Object -First 1 | Rename-Item -NewName 'RustDesk.exe'",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/rustdesk.json
+++ b/bucket/rustdesk.json
@@ -19,7 +19,6 @@
             "RustDesk"
         ]
     ],
-    "bin": "rustdesk.exe",
     "pre_install": "Get-ChildItem \"$dir\" 'rustdesk-*.exe' | Select-Object -First 1 | Rename-Item -NewName 'rustdesk.exe'",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/rustdesk.json
+++ b/bucket/rustdesk.json
@@ -2,7 +2,7 @@
     "version": "1.1.9",
     "description": "An open-source remote desktop software, written in Rust.",
     "homepage": "https://github.com/rustdesk/rustdesk",
-    "license": "GPL-3.0-only",
+    "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/rustdesk/rustdesk/releases/download/1.1.9/rustdesk-1.1.9-windows_x64.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Looks like they silently changed their license in (https://github.com/rustdesk/rustdesk/commit/bf736c80e99d411b58eff8f206e871e445854ce9, https://github.com/rustdesk/rustdesk/commit/66070320b5c88836a6fa80f5c916276f583aed27)
- Remove `bin` as it has no CLI
- Capitalize `RustDesk.exe`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
