### PR TITLE
sumatrapdf: Fix download urls

### DIFF
--- a/bucket/sumatrapdf.json
+++ b/bucket/sumatrapdf.json
@@ -5,11 +5,11 @@
     "license": "GPL-3.0-only,BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://www.sumatrapdfreader.org/dl/rel/3.4.6/SumatraPDF-3.4.6-64.zip",
+            "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/3.4.6/SumatraPDF-3.4.6-64.zip",
             "hash": "2bb05aa8b74bc748bc1f6a2b6f6ec4ba22bd5b1eaeec767d0a7f97cfd436d40d"
         },
         "32bit": {
-            "url": "https://www.sumatrapdfreader.org/dl/rel/3.4.6/SumatraPDF-3.4.6.zip",
+            "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/3.4.6/SumatraPDF-3.4.6.zip",
             "hash": "4eadd78dc8ae95a585474a9bff8fb25d84c239a9c7ca2bdc00a6a497283ef841"
         }
     },
@@ -39,10 +39,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.sumatrapdfreader.org/dl/rel/$version/SumatraPDF-$version-64.zip"
+                "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/$version/SumatraPDF-$version-64.zip"
             },
             "32bit": {
-                "url": "https://www.sumatrapdfreader.org/dl/rel/$version/SumatraPDF-$version.zip"
+                "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/$version/SumatraPDF-$version.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

It seems sumatrapdf's original download urls have some redirection error, so use target urls.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
