### PR TITLE
imo-messenger: Add version 1.4.1.6

### DIFF
--- a/bucket/imo-messenger.json
+++ b/bucket/imo-messenger.json
@@ -20,7 +20,7 @@
     "shortcuts": [
         [
             "ImoDesktopApp.exe",
-            "Imo Messenger"
+            "imo Messenger"
         ]
     ],
     "persist": [

--- a/bucket/imo-messenger.json
+++ b/bucket/imo-messenger.json
@@ -1,0 +1,37 @@
+{
+    "##": "The homepage requires JS to load (not suitable for checkver)",
+    "version": "1.4.1.6",
+    "description": "Video calls and chat software",
+    "homepage": "https://imo.im/",
+    "depends": "extras/uniextract2",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://imo.im/policies/terms_of_service.html"
+    },
+    "url": "https://static-web.imoim.net/as/indigo-static/imo-app/imo-Windows/ImoSetup_1.4.1.6_Release.exe#/dl.exe",
+    "hash": "a752c5d464597d99cfadab2009353d3420a761738d8ab301692584159a54c4a7",
+    "pre_install": [
+        "New-Item \"$dir\\extract\" -ItemType Directory | Out-Null",
+        "Invoke-ExternalCommand uniextract -ArgumentList @(\"`\"$dir\\dl.exe`\"\", \"`\"$dir\\extract`\"\", '/silent') | Out-Null",
+        "Expand-MsiArchive \"$dir\\extract\\AttachedContainer\\ImoInstaller.msi\" \"$dir\" -ExtractDir \"imo\\$version\" | Out-Null",
+        "Remove-Item \"$dir\\dl.exe\", \"$dir\\extract\" -Force -Recurse"
+    ],
+    "pre_uninstall": "Stop-Process -Name 'ImoDesktopApp' -ErrorAction SilentlyContinue | Out-Null",
+    "shortcuts": [
+        [
+            "ImoDesktopApp.exe",
+            "Imo Messenger"
+        ]
+    ],
+    "persist": [
+        "data",
+        "Logs"
+    ],
+    "checkver": {
+        "url": "https://downloads.digitaltrends.com/imo/windows",
+        "regex": "\"Imo ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://static-web.imoim.net/as/indigo-static/imo-app/imo-Windows/ImoSetup_$version_Release.exe#/dl.exe"
+    }
+}


### PR DESCRIPTION
* Closes #8677

* **[IMO Messenger](https://imo.im/)** is a free video calls and chat software.

**NOTES**:
* **package naming**: I named the package `imo-meessenger` (instead of `imo`) because both the shortcut *(created by the installer)* and window title says `imo Messenger`.

* The app is built in **32-bit**.

* `pre_uninstall` is used here because imo Messenger **stays in tray** after closing the window.

* **checkver**: using **third-party site** for *checkver* because imo's homepage **requires JS to load**.
  I think it won't hurt because *imo* keeps their old releases on thier site. (which means it will not cause the installation failures even if the third-party site need a bit of time to catch up with the update). If there is a better source for *checkver*, please tell me. Thanks!