### PR TITLE
Bump klogg to 22.06.0.1289

### DIFF
--- a/bucket/klogg.json
+++ b/bucket/klogg.json
@@ -1,16 +1,16 @@
 {
-    "version": "22.06.0.1288",
+    "version": "22.06.0.1289",
     "description": "A faster, advanced log explorer",
     "homepage": "https://klogg.filimonov.dev",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/variar/klogg/releases/download/v22.06/klogg-22.06.0.1288-Win-x64-Qt6-portable.zip",
-            "hash": "014372ab1de02a0e63a73bad9d4974e3c1cdc772bcb07607a95b0de536e90563"
+            "url": "https://github.com/variar/klogg/releases/download/v22.06/klogg-22.06.0.1289-Win-x64-Qt6-portable.zip",
+            "hash": "b17fe823f03173f129ff8815c9b65e47a0fc7b571361743bb8cdd969eb3f0a55"
         },
         "32bit": {
-            "url": "https://github.com/variar/klogg/releases/download/v22.06/klogg-22.06.0.1288-Win-x86-Qt5-portable.zip",
-            "hash": "53d85948eb892e35e7dca7dc12199e1a877fbed9ff7ff034618f8e4609de4433"
+            "url": "https://github.com/variar/klogg/releases/download/v22.06/klogg-22.06.0.1289-Win-x86-Qt5-portable.zip",
+            "hash": "2a2b39d45affc1937c048475e480cd2fd7553d56b8ef11666063a5179cf4ce47"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninstal*\" -Recurse",


### PR DESCRIPTION
The binaries in the release have been updated to addres an issue with bug reporting link. This PR updates links and hashes in package.

Closes #8691

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
