### PR TITLE
dnspyex: Remove pre_install

### DIFF
--- a/bucket/dnspyex.json
+++ b/bucket/dnspyex.json
@@ -5,19 +5,14 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v6.2.0/dnSpy-net-win64.zip#/dl.zip_",
+            "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v6.2.0/dnSpy-net-win64.zip",
             "hash": "e2d794d4ba7d792966a0e0c70878963d3070ba4fca557bfc93cb784cb31f8d1a"
         },
         "32bit": {
-            "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v6.2.0/dnSpy-net-win32.zip#/dl.zip_",
+            "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v6.2.0/dnSpy-net-win32.zip",
             "hash": "460901e4f07f4c0bf0ddcd82535ea21e4fad6e368b445bb5687f8b43123b29b0"
         }
     },
-    "pre_install": [
-        "Expand-7zipArchive \"$dir\\dl.zip_\" \"$dir\" -Removal | Out-Null",
-        "$archive = Get-ChildItem \"$dir\\*.zip\" | Select -First 1 -ExpandProperty FullName",
-        "Expand-7zipArchive \"$archive\" \"$dir\" -Removal | Out-Null"
-    ],
     "bin": "dnSpy.Console.exe",
     "shortcuts": [
         [
@@ -29,10 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win64.zip#/dl.zip_"
+                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win64.zip"
             },
             "32bit": {
-                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win32.zip#/dl.zip_"
+                "url": "https://github.com/dnSpyEx/dnSpy/releases/download/v$version/dnSpy-net-win32.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

As of https://github.com/dnSpyEx/dnSpy/releases/tag/v6.2.0, dnSpyEx is no longer double zipped.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
