### PR TITLE
soundswitch: Add version 6.2.4

### DIFF
--- a/bucket/soundswitch.json
+++ b/bucket/soundswitch.json
@@ -1,0 +1,21 @@
+{
+    "version": "6.2.4",
+    "description": "Switch your default playback devices and/or recording devices using simple hotkeys",
+    "homepage": "https://soundswitch.aaflalo.me/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/Belphemur/SoundSwitch/releases/download/v6.2.4/SoundSwitch_v6.2.4.0_Release_Installer.exe",
+    "hash": "0a893b2a0e52c4bea48c4624580d9abc3814d6ce51f20ddd602af2d5a223acc8",
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "SoundSwitch.exe",
+            "SoundSwitch"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Belphemur/SoundSwitch"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Belphemur/SoundSwitch/releases/download/v$version/SoundSwitch_v$version.0_Release_Installer.exe"
+    }
+}


### PR DESCRIPTION
[SoundSwitch](https://soundswitch.aaflalo.me/): Switch your default playback devices and/or recording devices using simple hotkeys

- No persist needed:

  ![](https://user-images.githubusercontent.com/32133670/173813798-6fb150fb-9c3c-414e-8e3e-2c151ca6ca10.png)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
