### PR TITLE
protonmail-bridge: Add version 2.1.3

### DIFF
--- a/bucket/protonmail-bridge.json
+++ b/bucket/protonmail-bridge.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.1.3",
+    "description": "Bridge that allows to keep using a desktop client while benefiting from Proton Mail’s end-to-end encryption.",
+    "homepage": "https://proton.me/mail/bridge",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v2.1.3/Bridge-Installer.exe#/dl.exe",
+    "hash": "ddfaa8f2cbf81d8d6d4bacee53eb042eb8e068b878973d1b1b96a01022608e28",
+    "pre_install": [
+        "New-Item \"$dir\\extract\" -ItemType Directory | Out-Null",
+        "Invoke-ExternalCommand \"$dir\\dl.exe\" -ArgumentList (\"/extract:`\"$dir\\extract`\"\") | Out-Null",
+        "Expand-MsiArchive \"$dir\\extract\\Bridge-Installer.msi\" \"$dir\" | Out-Null",
+        "Remove-Item \"$dir\\dl.exe\", \"$dir\\extract\" -Force -Recurse"
+    ],
+    "pre_uninstall": "Stop-Process -Name 'proton-bridge' -ErrorAction SilentlyContinue",
+    "shortcuts": [
+        [
+            "Desktop-Bridge.exe",
+            "ProtonMail Bridge"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ProtonMail/proton-bridge"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v$version/Bridge-Installer.exe#/dl.exe"
+    }
+}

--- a/bucket/protonmail-bridge.json
+++ b/bucket/protonmail-bridge.json
@@ -3,7 +3,7 @@
     "description": "Bridge app that allows to keep using a desktop client while benefiting from Proton Mail’s end-to-end encryption.",
     "homepage": "https://proton.me/mail/bridge",
     "license": "GPL-3.0-only",
-    "architecure": {
+    "architecture": {
         "64bit": {
             "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v2.1.3/Bridge-Installer.exe#/dl.exe",
             "hash": "ddfaa8f2cbf81d8d6d4bacee53eb042eb8e068b878973d1b1b96a01022608e28"
@@ -26,7 +26,7 @@
         "github": "https://github.com/ProtonMail/proton-bridge"
     },
     "autoupdate": {
-        "architecure": {
+        "architecture": {
             "64bit": {
                 "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v$version/Bridge-Installer.exe#/dl.exe"
             }

--- a/bucket/protonmail-bridge.json
+++ b/bucket/protonmail-bridge.json
@@ -1,10 +1,14 @@
 {
     "version": "2.1.3",
-    "description": "Bridge that allows to keep using a desktop client while benefiting from Proton Mail’s end-to-end encryption.",
+    "description": "Bridge app that allows to keep using a desktop client while benefiting from Proton Mail’s end-to-end encryption.",
     "homepage": "https://proton.me/mail/bridge",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v2.1.3/Bridge-Installer.exe#/dl.exe",
-    "hash": "ddfaa8f2cbf81d8d6d4bacee53eb042eb8e068b878973d1b1b96a01022608e28",
+    "architecure": {
+        "64bit": {
+            "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v2.1.3/Bridge-Installer.exe#/dl.exe",
+            "hash": "ddfaa8f2cbf81d8d6d4bacee53eb042eb8e068b878973d1b1b96a01022608e28"
+        }
+    },
     "pre_install": [
         "New-Item \"$dir\\extract\" -ItemType Directory | Out-Null",
         "Invoke-ExternalCommand \"$dir\\dl.exe\" -ArgumentList (\"/extract:`\"$dir\\extract`\"\") | Out-Null",
@@ -22,6 +26,10 @@
         "github": "https://github.com/ProtonMail/proton-bridge"
     },
     "autoupdate": {
-        "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v$version/Bridge-Installer.exe#/dl.exe"
+        "architecure": {
+            "64bit": {
+                "url": "https://github.com/ProtonMail/proton-bridge/releases/download/v$version/Bridge-Installer.exe#/dl.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
* Closes #7139
* **[ProtonMail Bridge](https://proton.me/mail/bridge)** is a bridge app that allows to keep using a desktop client while benefiting from Proton Mail’s end-to-end encryption.

**NOTES**:
* config location: `$Env:AppData\protonmail`.
* Using `pre_uninstall` because the app stays in tray after closing the window.