### PR TITLE
sunshine: Fix installation

### DIFF
--- a/bucket/sunshine.json
+++ b/bucket/sunshine.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/SunshineStream/Sunshine",
     "license": "GPL-3.0-only",
     "notes": [
-        "Run '$dir\\install-service.bat' to setup the service.",
+        "Run '$dir\\install-service.bat' and '$dir\\uninstall-service.bat' to install and uninstall the service correspondingly.",
         "Sunshine can be configured at https://localhost:47990/ by default."
     ],
     "architecture": {
@@ -13,23 +13,33 @@
             "hash": "bcc850e7b85c27f28f9765a12d9176daae8f1fb617363fa884002e54cd096e48"
         }
     },
+    "extract_dir": "Sunshine",
     "pre_install": [
         "Set-Content -Path \"$dir\\sunshine.bat\" -Value (@('@echo off', 'pushd %~dp0 && sunshine.exe %* && popd') -join \"`r`n\")",
         "# Create sunshine_state.json if it does not exist",
         "if (!(Test-Path \"$persist_dir\\sunshine_state.json\" -PathType Leaf)) {",
         "    Set-Content -Path \"$dir\\sunshine_state.json\" -Value \"{}\"",
-        "}"
+        "}",
+        "",
+        "# https://github.com/SunshineStream/Sunshine/issues/197",
+        "Copy-Item \"$bucketsdir\\extras\\scripts\\sunshine\\install-service.bat\" \"$dir\" | Out-Null",
+        "Copy-Item \"$bucketsdir\\extras\\scripts\\sunshine\\uninstall-service.bat\" \"$dir\" | Out-Null"
     ],
     "bin": [
         "sunshine.bat",
         "tools\\dxgi-info.exe",
         "tools\\audio-info.exe"
     ],
+    "shortcuts": [
+        [
+            "sunshine.exe",
+            "Sunshine"
+        ]
+    ],
     "persist": [
-        "sunshine_state.json",
+        "config",
         "credentials",
-        "assets\\sunshine.conf",
-        "assets\\apps_windows.json"
+        "sunshine_state.json"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/scripts/sunshine/install-service.bat
+++ b/scripts/sunshine/install-service.bat
@@ -1,0 +1,24 @@
+@echo off
+
+set SERVICE_NAME=sunshinesvc
+set SERVICE_BIN="%~dp0\tools\sunshinesvc.exe"
+set SERVICE_START_TYPE=auto
+
+rem Check if sunshinesvc already exists
+sc qc %SERVICE_NAME% > nul 2>&1
+if %ERRORLEVEL%==0 (
+    rem Stop the existing service if running
+    net stop %SERVICE_NAME%
+
+    rem Reconfigure the existing service
+    set SC_CMD=config
+) else (
+    rem Create a new service
+    set SC_CMD=create
+)
+
+rem Run the sc command to create/reconfigure the service
+sc %SC_CMD% %SERVICE_NAME% binPath= %SERVICE_BIN% start= %SERVICE_START_TYPE%
+
+rem Start the new service
+net start %SERVICE_NAME%

--- a/scripts/sunshine/uninstall-service.bat
+++ b/scripts/sunshine/uninstall-service.bat
@@ -1,0 +1,7 @@
+@echo off
+
+set SERVICE_NAME=sunshinesvc
+
+net stop %SERVICE_NAME%
+
+sc delete %SERVICE_NAME%


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Add `extract_dir`
- Copy `install-service.bat` and `uninstall-service.bat` to scripts for now because they were removed (https://github.com/SunshineStream/Sunshine/issues/197)
- Add a shortcut to match [installer](https://github.com/SunshineStream/Sunshine/releases/download/v0.14.0/sunshine-windows.exe) behavior.
- Fix `persist`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
