### PR TITLE
folder-marker: Add version 4.6

### DIFF
--- a/bucket/folder-marker.json
+++ b/bucket/folder-marker.json
@@ -27,7 +27,7 @@
         "}",
         "# Restart explorer so that ShellExt(-64).dll can be removed",
         "Stop-Process -Name 'explorer'; Start-Sleep -Seconds 2",
-        "if (!(Get-Process 'explorer' -ErrorAction SilentlyContinue)) { Start-Process explorer }"
+        "if (!(Get-Process -Name 'explorer' -ErrorAction SilentlyContinue)) { Start-Process 'explorer' }"
     ],
     "env_set": {
         "FOLDER_MARKER_DIR": "$dir"

--- a/bucket/folder-marker.json
+++ b/bucket/folder-marker.json
@@ -1,6 +1,6 @@
 {
     "version": "4.6",
-    "description": "Label folders with color-coded / image-coded icon",
+    "description": "A tool to label folders with color-coded / image-coded icon",
     "homepage": "https://foldermarker.com/en/",
     "license": "Freeware",
     "url": "https://foldermarker.com/FolderMarker_Free.exe",

--- a/bucket/folder-marker.json
+++ b/bucket/folder-marker.json
@@ -1,0 +1,48 @@
+{
+    "version": "4.6",
+    "description": "Label folders with color-coded / image-coded icon",
+    "homepage": "https://foldermarker.com/en/",
+    "license": "Freeware",
+    "url": "https://foldermarker.com/FolderMarker_Free.exe",
+    "hash": "f86645659df6703f90d617c36f0db214a68ce0a240c97a8e4f23219ba4891404",
+    "innosetup": true,
+    "pre_install": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\" }",
+        "",
+        "Rename-Item \"$dir\\icl\\fColors,3.icl\" 'fColors.icl'; Remove-Item \"$dir\\icl\\fColors,*.icl\"",
+        "Rename-Item \"$dir\\icl\\fMain,3.icl\" 'fMain.icl'; Remove-Item \"$dir\\icl\\fMain,*.icl\"",
+        "",
+        "Invoke-ExternalCommand regsvr32 -ArgumentList @(\"`\"$dir\\FMADM.dll`\"\", '/s') -RunAs | Out-Null",
+        "Invoke-ExternalCommand regsvr32 -ArgumentList @(\"`\"$dir\\ShellExt.dll`\"\", '/s') -RunAs | Out-Null",
+        "if ($architecture -eq '64bit') {",
+        "    Invoke-ExternalCommand regsvr32 -ArgumentList @(\"`\"$dir\\ShellExt64.dll`\"\", '/s') -RunAs | Out-Null",
+        "}"
+    ],
+    "pre_uninstall": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\" }",
+        "Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"`\"$dir\\FMADM.dll`\"\", '/s') -RunAs | Out-Null",
+        "Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"`\"$dir\\ShellExt.dll`\"\", '/s') -RunAs | Out-Null",
+        "if ($architecture -eq '64bit') {",
+        "    Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"`\"$dir\\ShellExt64.dll`\"\", '/s') -RunAs | Out-Null",
+        "}",
+        "# Restart explorer so that ShellExt(-64).dll can be removed",
+        "Stop-Process -Name 'explorer'; Start-Sleep -Seconds 2",
+        "if (!(Get-Process 'explorer' -ErrorAction SilentlyContinue)) { Start-Process explorer }"
+    ],
+    "env_set": {
+        "FOLDER_MARKER_DIR": "$dir"
+    },
+    "shortcuts": [
+        [
+            "FolderMarker.exe",
+            "Folder Marker"
+        ]
+    ],
+    "checkver": {
+        "url": "https://foldermarker.com/en/download/",
+        "regex": "Version\\: ([\\d.]+)</p>"
+    },
+    "autoupdate": {
+        "url": "https://foldermarker.com/FolderMarker_Free.exe"
+    }
+}


### PR DESCRIPTION
* closes https://github.com/ScoopInstaller/Nonportable/issues/3
* **[Folder Marker](https://foldermarker.com/en/)** is a tool to label folders with color-coded / image-coded icon.

**NOTES**:
* This app requires **admin rights** to install because it requires registering DLLs. See [extracted InnoSetup script](https://github.com/ScoopInstaller/Extras/files/8930918/install_script.iss.txt) for more details.

* However, I think it is **accpetable** for `Extras` because we are simply extracting files and set up envs for it to work. (rather than running the installer).

* The app is built in **32-bit**.

* *license* info can be found in `License.rtf` under installation directory.

* config location: `HCKU:\Software\ArcticLine\FolderMarker`.