### PR TITLE
foobar2000: Persist components dir

### DIFF
--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -41,7 +41,10 @@
             "Foobar2000"
         ]
     ],
-    "persist": "profile",
+    "persist": [
+        "profile",
+        "components"
+    ],
     "checkver": {
         "url": "https://www.foobar2000.org/download",
         "regex": "foobar2000_v([\\d.]+)\\."


### PR DESCRIPTION
This persists the components dir which will allow the user to install desired components and keep them between versions.



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
