### PR TITLE
uniextract2: Prevent setup window from showing up upon first run

### DIFF
--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -10,7 +10,7 @@
         "$cont = Get-Content \"$dir\\UniExtract.ini\"",
         "# Set 'ID' as a random 25-digit hex if 'ID' is empty",
         "# This will prevent setup window from popping up upon first run. Useful when we are using UniExtract to extract files for other packages.",
-        "if (!($cont -match 'ID=\\d+')) {",
+        "if (!($cont -match 'ID=[0-9A-F]+')) {",
         "    $new_id = ''",
         "    1..25 | ForEach-Object { $new_id += '{0:X}' -f (Get-Random -Max 15) }",
         "    $cont = $cont.Replace('ID=', \"ID=$new_id\")",

--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -6,6 +6,17 @@
     "url": "https://github.com/Bioruebe/UniExtract2/releases/download/v2.0.0-rc.3/UniExtractRC3.zip",
     "hash": "03170680b80f2afdf824f4d700c11b8e2dac805a4d9bd3d24f53e43bd7131c3a",
     "extract_dir": "UniExtract",
+    "post_install": [
+        "$cont = Get-Content \"$dir\\UniExtract.ini\"",
+        "# Set 'ID' as a random 25-digit hex if 'ID' is empty",
+        "# This will prevent setup window from popping up upon first run. Useful when we are using UniExtract to extract files for other packages.",
+        "if (!($cont -match 'ID=\\d+')) {",
+        "    $new_id = ''",
+        "    1..25 | ForEach-Object { $new_id += '{0:X}' -f (Get-Random -Max 15) }",
+        "    $cont = $cont.Replace('ID=', \"ID=$new_id\")",
+        "    $cont | Set-Content \"$dir\\UniExtract.ini\" -Encoding Ascii",
+        "}"
+    ],
     "bin": "UniExtract.exe",
     "persist": [
         "log",


### PR DESCRIPTION
This solves the issue mentioned in https://github.com/ScoopInstaller/Extras/pull/8681#pullrequestreview-1005860044.