### PR TITLE
linphone@4.4.6: Fix hash

### DIFF
--- a/bucket/linphone.json
+++ b/bucket/linphone.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.linphone.org/releases/windows/app/Linphone-4.4.6-win64.exe#/dl.7z",
-            "hash": "cce3cd54aa15e78ae1419487ca2938c5c5002f8fda4712068fe4cdf504ffeea6"
+            "hash": "7a3e2ccefe26306479dce0426bbc6f9029dfa538a7737584ea2b05070f922b38"
         }
     },
     "bin": "bin\\linphone.exe",


### PR DESCRIPTION
Linphone seems to update their install file on the same version (as you can see in the issue history well). 
Closes #8710