### PR TITLE
smplayer: Add version 22.2.0.0

### DIFF
--- a/bucket/smplayer.json
+++ b/bucket/smplayer.json
@@ -17,7 +17,7 @@
         "Rename-Item \"$dir\\SMPlayer.html\" 'dl.7z'",
         "Expand-7zipArchive \"$dir\\dl.7z\" \"$dir\" -ExtractDir 'smplayer-portable' -Removal | Out-Null",
         "'hdpi.ini', 'playlist.ini', 'favorites.m3u8', 'radio.m3u8', 'tv.m3u8' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" }",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
         "if (Test-Path \"$persist_dir\\smplayer.ini\") { Copy-Item \"$persist_dir\\smplayer.ini\" \"$dir\\smplayer.ini\" }"
     ],

--- a/bucket/smplayer.json
+++ b/bucket/smplayer.json
@@ -1,0 +1,52 @@
+{
+    "version": "22.2.0.0",
+    "description": "A video player forked from MPV. It can also play Youtube videos, search and download subtitles, and includes other features like a thumbnail generator and audio and video filters.",
+    "homepage": "https://www.smplayer.info/",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.fosshub.com/SMPlayer.html?dwl=smplayer-portable-22.2.0.0-x64.7z",
+            "hash": "c054f61eddc3ac97b0ce03c3001e6e080a9e6543de999a071df17e2a7fe3618d"
+        },
+        "32bit": {
+            "url": "https://www.fosshub.com/SMPlayer.html?dwl=smplayer-portable-22.2.0.0-win32-qt5.6.7z",
+            "hash": "be10cdc34a9b6282e1e91e9b789825a11939576750f1d5be839e2a4892532402"
+        }
+    },
+    "pre_install": [
+        "Rename-Item \"$dir\\SMPlayer.html\" 'dl.7z'",
+        "Expand-7zipArchive \"$dir\\dl.7z\" \"$dir\" -ExtractDir 'smplayer-portable' -Removal | Out-Null",
+        "'hdpi.ini', 'playlist.ini', 'favorites.m3u8', 'radio.m3u8', 'tv.m3u8' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "smplayer.exe",
+            "SMPlayer"
+        ]
+    ],
+    "persist": [
+        "screenshots",
+        "hdpi.ini",
+        "playlist.ini",
+        "smplayer.ini",
+        "favorites.m3u8",
+        "radio.m3u8",
+        "tv.m3u8"
+    ],
+    "checkver": {
+        "url": "https://www.fosshub.com/SMPlayer.html",
+        "regex": "smplayer-portable-([\\d.]+)-win32-qt(?<qtversion>[\\d.]+)\\.7z"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.fosshub.com/SMPlayer.html?dwl=smplayer-portable-$version-x64.7z"
+            },
+            "32bit": {
+                "url": "https://www.fosshub.com/SMPlayer.html?dwl=smplayer-portable-$version-win32-qt$matchQtversion.7z"
+            }
+        }
+    }
+}

--- a/bucket/smplayer.json
+++ b/bucket/smplayer.json
@@ -17,8 +17,13 @@
         "Rename-Item \"$dir\\SMPlayer.html\" 'dl.7z'",
         "Expand-7zipArchive \"$dir\\dl.7z\" \"$dir\" -ExtractDir 'smplayer-portable' -Removal | Out-Null",
         "'hdpi.ini', 'playlist.ini', 'favorites.m3u8', 'radio.m3u8', 'tv.m3u8' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
-        "}"
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" }",
+        "}",
+        "if (Test-Path \"$persist_dir\\smplayer.ini\") { Copy-Item \"$persist_dir\\smplayer.ini\" \"$dir\\smplayer.ini\" }"
+    ],
+    "pre_uninstall": [
+        "# The following must be done as SMPlayer deletes the original file which was linked to the persist folder when it saves settings, rather than editing the file.",
+        "Copy-Item \"$dir\\smplayer.ini\" \"$persist_dir\\smplayer.ini\""
     ],
     "shortcuts": [
         [
@@ -30,7 +35,6 @@
         "screenshots",
         "hdpi.ini",
         "playlist.ini",
-        "smplayer.ini",
         "favorites.m3u8",
         "radio.m3u8",
         "tv.m3u8"


### PR DESCRIPTION
* closes #8701

* **[SMPlayer](https://www.smplayer.info/)** is a video player forked from MPV. It can also play Youtube videos, search and download subtitles, and includes other features like a thumbnail generator and audio and video filters.

**NOTES**:
* not using `#/dl.7z` here because it will be treated as part of the input `www.fosshub.com/SMPlayer.html?dwl=...`, causing URL error.
* *persist*: **.m3u8** are playlists encoded in UTF-8. ([Wikipedia](https://en.wikipedia.org/wiki/M3U))