### PR TITLE
viddy: Add version 0.3.4

### DIFF
--- a/bucket/viddy.json
+++ b/bucket/viddy.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.4/viddy_0.3.4_Windows_x86_64.tar.gz#/viddy.exe",
+            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.4/viddy_0.3.4_Windows_x86_64.tar.gz",
             "hash": "b7be4edf34ffb178121bf6fe4588b65c53feae8d2ba49f36f47271e6f5d3c287"
         },
         "32bit": {
-            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.4/viddy_0.3.4_Windows_i386.tar.gz#/viddy.exe",
+            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.4/viddy_0.3.4_Windows_i386.tar.gz",
             "hash": "51b18eef1c837b67d14c0de16e25516e986ded63a9952b68c13008bc8fd2f1bb"
         }
     },
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_x86_64.tar.gz#/viddy.exe"
+                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_x86_64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_i386.tar.gz#/viddy.exe"
+                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_i386.tar.gz"
             }
         },
         "hash": {

--- a/bucket/viddy.json
+++ b/bucket/viddy.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.3.4",
+    "description": "A modern watch command. Time machine and pager etc.",
+    "homepage": "https://github.com/sachaos/viddy",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.4/viddy_0.3.4_Windows_x86_64.tar.gz#/viddy.exe",
+            "hash": "b7be4edf34ffb178121bf6fe4588b65c53feae8d2ba49f36f47271e6f5d3c287"
+        },
+        "32bit": {
+            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.4/viddy_0.3.4_Windows_i386.tar.gz#/viddy.exe",
+            "hash": "51b18eef1c837b67d14c0de16e25516e986ded63a9952b68c13008bc8fd2f1bb"
+        }
+    },
+    "bin": "viddy.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_x86_64.tar.gz#/viddy.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_i386.tar.gz#/viddy.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Add a manifest for viddy - A modern watch command. Time machine and pager etc.
https://github.com/sachaos/viddy

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
