### PR TITLE
autoruns: Add version 14.09

### DIFF
--- a/bucket/autoruns.json
+++ b/bucket/autoruns.json
@@ -1,0 +1,9 @@
+{
+    "version": "14.09",
+    "description": "This utility, which has the most comprehensive knowledge of auto-starting locations of any startup monitor, shows you what programs are configured to run during system bootup or login, and when you start various built-in Windows applications like Internet Explorer, Explorer and media players. These programs and drivers include ones in your startup folder, Run, RunOnce, and other Registry keys. Autoruns reports Explorer shell extensions, toolbars, browser helper objects, Winlogon notifications, auto-start services, and much more. Autoruns goes way beyond other autostart utilities.",
+    "homepage": "https://sysinternals.com",
+    "license": "Proprietary",
+    "url": "https://live.sysinternals.com/autoruns.exe",
+    "hash": "64d490783abd017ac36a017b9cb7dcfc2fcee85f7ae8ee203a0c898da6d37533",
+    "bin": "autoruns.exe"
+}

--- a/bucket/autoruns.json
+++ b/bucket/autoruns.json
@@ -2,6 +2,10 @@
     "version": "14.09",
     "description": "This utility, which has the most comprehensive knowledge of auto-starting locations of any startup monitor, shows you what programs are configured to run during system bootup or login, and when you start various built-in Windows applications like Internet Explorer, Explorer and media players. These programs and drivers include ones in your startup folder, Run, RunOnce, and other Registry keys. Autoruns reports Explorer shell extensions, toolbars, browser helper objects, Winlogon notifications, auto-start services, and much more. Autoruns goes way beyond other autostart utilities.",
     "homepage": "https://sysinternals.com",
+    "checkver": {
+        "url": "https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns",
+        "regex": "Autoruns for Windows v([\\d.]+)"
+    },
     "license": "Proprietary",
     "url": "https://live.sysinternals.com/autoruns.exe",
     "hash": "64d490783abd017ac36a017b9cb7dcfc2fcee85f7ae8ee203a0c898da6d37533",


### PR DESCRIPTION
Added a manifest for an utility from windows: "This utility, which has the most comprehensive knowledge of auto-starting locations of any startup monitor, shows you what programs are configured to run during system bootup or login, and when you start various built-in Windows applications like Internet Explorer, Explorer and media players. These programs and drivers include ones in your startup folder, Run, RunOnce, and other Registry keys. Autoruns reports Explorer shell extensions, toolbars, browser helper objects, Winlogon notifications, auto-start services, and much more. Autoruns goes way beyond other autostart utilities."

https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
