### PR TITLE
camstudio: Add version 2.7.4-r354

### DIFF
--- a/bucket/camstudio.json
+++ b/bucket/camstudio.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.7.4-r354",
+    "description": "Free desktop recorder and video streaming software",
+    "homepage": "https://camstudio.org/",
+    "license": "GPL-3.0-or-later",
+    "url": [
+        "https://eu2.contabostorage.com/a4054a9f5df24ecf87c4a33ac9b6477b:camstudio/CamStudioSetup.exe#/dl.exe",
+        "https://downloads.sourceforge.net/project/camstudio/legacy/CamStudioCodec_1.5_Setup.exe#/codec.7z_"
+    ],
+    "hash": [
+        "3fbe450e3267799f372a775e4c7e7c47c8bbffeebb0bd0c9690e63374eba8ba0",
+        "a589f791aea96adc4350b70ecde7572dadd7a80c1a054959874c3d6e01fa4b04"
+    ],
+    "pre_install": [
+        "Expand-InnoArchive \"$dir\\dl.exe\" \"$dir\" -Removal | Out-Null",
+        "Expand-7zipArchive \"$dir\\codec.7z_\" \"$dir\" -ExtractDir '$SYSDIR' -Overwrite All -Removal | Out-Null",
+        "Remove-Item \"$dir\\CamStudio.nsi\""
+    ],
+    "bin": "CamCommandLine.exe",
+    "shortcuts": [
+        [
+            "Recorder.exe",
+            "CamStudio"
+        ]
+    ],
+    "persist": [
+        "controller\\controller.ini",
+        "ffmpeg.log"
+    ]
+}


### PR DESCRIPTION
**[CamStudio](https://camstudio.org/)** is a free desktop recorder and video streaming software.

**NOTES**:
* Aside from `controller.ini`, most of the config is stored at registry: `HKCU:\SOFTWARE\CamStudioOpenSource for Nick`.
* *autoupdate* is not needed because last update was in 2015.