### PR TITLE
sleek: Add version 1.2.1

### DIFF
--- a/bucket/sleek.json
+++ b/bucket/sleek.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.2.1",
+    "description": "Open-source todo.txt manager",
+    "homepage": "https://github.com/ransome1/sleek",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ransome1/sleek/releases/download/v1.2.1/sleek-1.2.1-win.zip",
+            "hash": "acdb52473dfe02fb234ef78f9173784d2668c5d368fe25f02dc6ecd5d2f137f0"
+        }
+    },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\user-preferences.json\")) { New-Item \"$dir\\user-preferences.json\" | Out-Null }",
+    "bin": "sleek.exe",
+    "shortcuts": [
+        [
+            "sleek.exe",
+            "Sleek"
+        ]
+    ],
+    "persist": "user-preferences.json",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ransome1/sleek/releases/download/v$version/sleek-$version-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* closes #8766
* **[Sleek](https://github.com/ransome1/sleek)** is an open-source todo.txt manager.

**NOTES**:
* The app supports **command-line args**. See [wiki/Hidden preferences, custom variables and command line parameters](https://github.com/ransome1/sleek/wiki/Hidden-preferences,-custom-variables-and-command-line-parameters) for examples.
* [$baseurl/latest.yml](https://github.com/ransome1/sleek/releases/download/v1.2.1/latest.yml) only contains SHA-512 hash for installers, but not for portable ZIPs.
* Aside from `user-preferences.json`, some of the config is stored at `$Env:AppData\sleek`.