### PR TITLE
aimp: Fix checkver

### DIFF
--- a/bucket/aimp.json
+++ b/bucket/aimp.json
@@ -36,7 +36,7 @@
     ],
     "checkver": {
         "url": "http://aimp.su/update.php?id=1234&b=2169&p=aimp&lng=english&u=1",
-        "regex": "aimp_([\\d.]+)\\."
+        "regex": "aimp_([\\d.]+)"
     },
     "autoupdate": {
         "url": "http://www.aimp.ru/?do=download.file&id=8#/dl.zip"

--- a/bucket/aimp.json
+++ b/bucket/aimp.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.03",
+    "version": "5.03.2394",
     "description": "Audio player",
     "homepage": "http://www.aimp.ru",
     "license": {
@@ -7,7 +7,7 @@
         "url": "http://www.aimp.ru/files/windows/EULA_lang-en.txt"
     },
     "url": "http://www.aimp.ru/?do=download.file&id=8#/dl.zip",
-    "hash": "67e606ecf5aa4ba52f86e66b29e21ec7f5402c99fa017b1773405b1841f505f5",
+    "hash": "3b1c40272eeab0bc540eb06814e08f817b42284cd452d20015fba388698970f8",
     "extract_dir": "AIMP",
     "bin": [
         "AIMP.exe",


### PR DESCRIPTION
fix version checkver regex..

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

aimp have version format 5.03.xxxx. with current regex only returning 5.03. 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
