### PR TITLE
nvidia-profile-inspector-foulplay: Add version 2.4.6.2

### DIFF
--- a/bucket/nvidia-profile-inspector-foulplay.json
+++ b/bucket/nvidia-profile-inspector-foulplay.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.4.6.2",
+    "description": "This is FoulPlay's fork of the NVIDIA Profile Inspector. The tool is used to modify game profiles inside the internal driver database of the NVIDIA driver. All game profiles are provided by the NVIDIA driver, but you can add your own profiles for games missing in the driver database. You also have access to hidden and undocumented settings, which are not provided by the driver's control panel.",
+    "homepage": "https://github.com/FoulPlay/nvidiaProfileInspector",
+    "license": "MIT",
+    "url": "https://github.com/FoulPlay/nvidiaProfileInspector/releases/download/2.4.6.2/nvidiaProfileInspector.zip",
+    "hash": "8f55a9df47ccf65641b462c1f0c0d928ae418b989dc12017e79369bfb1d67e9e",
+    "bin": "nvidiaProfileInspector.exe",
+    "shortcuts": [
+        [
+            "nvidiaProfileInspector.exe",
+            "NVIDIA Profile Inspector"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/FoulPlay/nvidiaProfileInspector/releases/download/$version/nvidiaProfileInspector.zip"
+    }
+}


### PR DESCRIPTION
This is FoulPlay's fork of the NVIDIA Profile Inspector. The original project by [Orbmu2k](https://github.com/Orbmu2k) has been inactive for a very long time (the latest stable version used in the original manifest is from Jan 13, 2020).

FoulPlay's fork is what's mentioned on the [PCGamingWiki](https://www.pcgamingwiki.com/wiki/Nvidia_Profile_Inspector).

The tool is used to modify game profiles inside the internal driver database of the NVIDIA driver. All game profiles are provided by the NVIDIA driver, but you can add your own profiles for games missing in the driver database. You also have access to hidden and undocumented settings, which are not provided by the driver's control panel.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
