### PR TITLE
zlib: Add version 1.2.12

### DIFF
--- a/bucket/zlib.json
+++ b/bucket/zlib.json
@@ -12,8 +12,8 @@
     "post_install": [
         "$dirpath = \"$dir\".Replace('\\', '\\\\')",
         "'register', 'unregister' | ForEach-Object {",
-        "  if (Test-Path \"$bucketsdir\\local\\scripts\\zlib\\$_.reg\") {",
-        "    $content = Get-Content \"$bucketsdir\\local\\scripts\\zlib\\$_.reg\"",
+        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\zlib\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\zlib\\$_.reg\"",
         "    $content = $content.Replace('$dir', $dirpath)",
         "    $content | Set-Content -Path \"$dir\\$_.reg\"",
         "  }",

--- a/bucket/zlib.json
+++ b/bucket/zlib.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.2.12",
+    "description": "Massively spiffy yet delicately unobtrusive compression library. Unencumbered by patents.",
+    "homepage": "http://www.zlib.net/",
+    "license": "Zlib",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/zlib/zlib-1.2.12-windows-32bit-vc14.2.7z",
+    "hash": "0d7245a2e499320cb4803b3889df8a9051d2dfc0c53d2908a3d99b687943c68b",
+    "notes": [
+        "For CMake (and other build tools) to find this installation of zlib, run:",
+        "\"$dir\\register.reg\""
+    ],
+    "post_install": [
+        "$dirpath = \"$dir\".Replace('\\', '\\\\')",
+        "'register', 'unregister' | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\local\\scripts\\zlib\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\local\\scripts\\zlib\\$_.reg\"",
+        "    $content = $content.Replace('$dir', $dirpath)",
+        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
+        "  }",
+        "}"
+    ],
+    "pre_uninstall": [
+        "if ($cmd -eq 'uninstall') {",
+        "    $key = Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\GnuWin32\\Zlib' -Name 'InstallPath' -ErrorAction SilentlyContinue",
+        "    if ($key.InstallPath.Contains('apps\\zlib\\current')) {",
+        "        if (!(is_admin)) { error \"$app requies admin rights to unregister the installation path\"; break }",
+        "        Invoke-ExternalCommand reg -ArgumentList @('import', \"$dir\\unregister.reg\") -RunAs | Out-Null",
+        "    }",
+        "}"
+    ],
+    "checkver": "zlib ([\\d.]+)</B>"
+}

--- a/bucket/zlib.json
+++ b/bucket/zlib.json
@@ -22,7 +22,7 @@
     "pre_uninstall": [
         "if ($cmd -eq 'uninstall') {",
         "    $key = Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\GnuWin32\\Zlib' -Name 'InstallPath' -ErrorAction SilentlyContinue",
-        "    if ($key.InstallPath.Contains('apps\\zlib\\current')) {",
+        "    if ($key -and $key.InstallPath.Contains('apps\\zlib\\current')) {",
         "        if (!(is_admin)) { error \"$app requies admin rights to unregister the installation path\"; break }",
         "        Invoke-ExternalCommand reg -ArgumentList @('import', \"$dir\\unregister.reg\") -RunAs | Out-Null",
         "    }",

--- a/bucket/zlib.json
+++ b/bucket/zlib.json
@@ -27,6 +27,5 @@
         "        Invoke-ExternalCommand reg -ArgumentList @('import', \"$dir\\unregister.reg\") -RunAs | Out-Null",
         "    }",
         "}"
-    ],
-    "checkver": "zlib ([\\d.]+)</B>"
+    ]
 }

--- a/scripts/zlib/register.reg
+++ b/scripts/zlib/register.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\GnuWin32\Zlib]
+"InstallPath"="$dir"

--- a/scripts/zlib/unregister.reg
+++ b/scripts/zlib/unregister.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_LOCAL_MACHINE\SOFTWARE\GnuWin32\Zlib]


### PR DESCRIPTION
**[zlib](http://www.zlib.net/)** is a massively spiffy yet delicately unobtrusive compression library. Unencumbered by patents. It is being used in many well-known apps including *FFMpeg*, *MiKTex*, *caffe*, *PyTorch*, etc.

* This package is mainly for users who are building **projects that depends on zlib**.

* The app is built in **32-bit**.

* [The zlib license](https://spdx.org/licenses/Zlib.html) is an SPDX license.

* I did not add `$dir\bin` (which contains `zlib.dll`) to PATH because the file should be **bundled** with the app that is using it. Having `zlib.dll` in PATH may lead to some confusing situations.

* This package has to be **manually updated**, but I think it's fine because *zlib* does not receive updates very often. They have a recent bug fix in **2022.3**. The update before that one was in **2017**.


* `register.reg` is for **CMake** and other build tools to find *zlib*. The key needs to be in `HKLM`. See [CMake's FindZLIB](https://cmake.org/cmake/help/latest/module/FindZLIB.html) for details.

* I built the binaries with the following steps:
(1) Download zlib source code (http://www.zlib.net/zlib1212.zip) and extract it.
(2) Open the folder `zlib-1.2.12` with *cmake-gui*. Select VS2022 as the compiler.
(3) Set build location to `zlib-1.2.12/win32`, and set both `AMD64` and `ASM686` switches **off**.
(4) Press 'Configure' and 'Generate'
(5) Open VS2022 dev command prompt, and run `msbuild zlib-1.2.12\win32\zlib.sln /property:Configuration=Release`
(6) Orginize the product:
Put `zlib.dll` under `bin` folder.
Put `.lib` and `.exp` files under `lib` folder.
Copy `.h` files from source code, and put them under `include` folder.