### PR TITLE
handbrake: Update depends

### DIFF
--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -12,6 +12,7 @@
             "hash": "69e499d88df6f77a5ce663c8f5ae3ff2e6210a908152a7c437d10bca7294d0be"
         }
     },
+    "depends": "windowsdesktop-runtime",
     "extract_dir": "HandBrake",
     "installer": {
         "script": [

--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -3,9 +3,6 @@
     "description": "A tool for converting video from nearly any format to a selection of modern, widely supported codecs.",
     "homepage": "https://handbrake.fr",
     "license": "GPL-2.0-only",
-    "suggest": {
-        "windowsdesktop-runtime": "extras/windowsdesktop-runtime"
-    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/HandBrake/HandBrake/releases/download/1.5.1/HandBrake-1.5.1-x86_64-Win_GUI.zip",

--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -3,13 +3,13 @@
     "description": "A tool for converting video from nearly any format to a selection of modern, widely supported codecs.",
     "homepage": "https://handbrake.fr",
     "license": "GPL-2.0-only",
+    "depends": "extras/windowsdesktop-runtime",
     "architecture": {
         "64bit": {
             "url": "https://github.com/HandBrake/HandBrake/releases/download/1.5.1/HandBrake-1.5.1-x86_64-Win_GUI.zip",
             "hash": "69e499d88df6f77a5ce663c8f5ae3ff2e6210a908152a7c437d10bca7294d0be"
         }
     },
-    "depends": "extras/windowsdesktop-runtime",
     "extract_dir": "HandBrake",
     "installer": {
         "script": [

--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -12,7 +12,7 @@
             "hash": "69e499d88df6f77a5ce663c8f5ae3ff2e6210a908152a7c437d10bca7294d0be"
         }
     },
-    "depends": "windowsdesktop-runtime",
+    "depends": "extras/windowsdesktop-runtime",
     "extract_dir": "HandBrake",
     "installer": {
         "script": [


### PR DESCRIPTION
handbrake depends on .Net 5.0 which is [windowsdesktop-runtime](https://github.com/ScoopInstaller/Extras/blob/master/bucket/windowsdesktop-runtime.json) in scoop

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
