### PR TITLE
multibootusb: Add version 9.2.0

### DIFF
--- a/bucket/multibootusb.json
+++ b/bucket/multibootusb.json
@@ -1,7 +1,7 @@
 {
     "version": "9.2.0",
     "description": "Create multiboot live Linux on a USB disk.",
-    "homepage": "http://multibootusb.org/",
+    "homepage": "https://github.com/mbusb/multibootusb",
     "license": "GPL-2.0-or-later",
     "url": "https://github.com/mbusb/multibootusb/releases/download/v9.2.0/multibootusb-9.2.0-setup.exe#/dl.7z",
     "hash": "0e9108b4f95562727d0e557e86e7b8f4b83cf942303bd67c2350d8820289fe17",
@@ -16,9 +16,7 @@
         ]
     ],
     "persist": "multibootusb.log",
-    "checkver": {
-        "github": "https://github.com/mbusb/multibootusb"
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/mbusb/multibootusb/releases/download/v$version/multibootusb-$version-setup.exe#/dl.7z"
     }

--- a/bucket/multibootusb.json
+++ b/bucket/multibootusb.json
@@ -1,0 +1,25 @@
+{
+    "version": "9.2.0",
+    "description": "Create multiboot live Linux on a USB disk.",
+    "homepage": "http://multibootusb.org/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/mbusb/multibootusb/releases/download/v9.2.0/multibootusb-9.2.0-setup.exe#/dl.7z",
+    "hash": "0e9108b4f95562727d0e557e86e7b8f4b83cf942303bd67c2350d8820289fe17",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\multibootusb.log\")) { New-Item \"$dir\\multibootusb.log\" | Out-Null }",
+        "Remove-Item  \"$dir\\uninst.exe\""
+    ],
+    "shortcuts": [
+        [
+            "multibootusb.exe",
+            "MultiBootUSB"
+        ]
+    ],
+    "persist": "multibootusb.log",
+    "checkver": {
+        "github": "https://github.com/mbusb/multibootusb"
+    },
+    "autoupdate": {
+        "url": "https://github.com/mbusb/multibootusb/releases/download/v$version/multibootusb-$version-setup.exe#/dl.7z"
+    }
+}

--- a/bucket/multibootusb.json
+++ b/bucket/multibootusb.json
@@ -15,9 +15,5 @@
             "MultiBootUSB"
         ]
     ],
-    "persist": "multibootusb.log",
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/mbusb/multibootusb/releases/download/v$version/multibootusb-$version-setup.exe#/dl.7z"
-    }
+    "persist": "multibootusb.log"
 }


### PR DESCRIPTION
* closes #7143

* [MultiBootUSB](https://github.com/mbusb/multibootusb) is a tool that creates multiboot live Linux on a USB disk.

**NOTES**:
* The app is built in **32-bit**.
* Aside from the log, other config data is stored at `$Env:LocalAppData\Temp\multibootusb`.