### PR TITLE
handbrake: update depends

### DIFF
--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -3,7 +3,7 @@
     "description": "A tool for converting video from nearly any format to a selection of modern, widely supported codecs.",
     "homepage": "https://handbrake.fr",
     "license": "GPL-2.0-only",
-    "depends": "extras/windowsdesktop-runtime",
+    "depends": "extras/windowsdesktop-runtime-lts",
     "architecture": {
         "64bit": {
             "url": "https://github.com/HandBrake/HandBrake/releases/download/1.5.1/HandBrake-1.5.1-x86_64-Win_GUI.zip",


### PR DESCRIPTION
See https://forum.handbrake.fr/viewtopic.php?t=42066 and https://github.com/HandBrake/HandBrake/issues/4312
"HandBrake 1.5.1 ONLY requires .NET 6 Desktop Runtime."
dotnet 6.0 Desktop Runtime which is "extras/windowsdesktop-runtime-lts" in Scoop

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
