### PR TITLE
manifold|-viewer: quick-fix for extract_dir and checkver

### DIFF
--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -4,7 +4,7 @@
     "homepage": "https://manifold.net/",
     "license": "Freeware",
     "suggest": {
-        "Microsoft Visual C++ Redistributable 2017": "extras/vcredist2022"
+        "Microsoft Visual C++ Redistributable 2015-2022": "extras/vcredist2022"
     },
     "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-9.0.177-x64.zip",
     "hash": "6a861fffb2b6827d43f1d2b30d3c722eb09f28a999e37c14d70cc02b416704b8",
@@ -30,15 +30,11 @@
         }
     },
     "checkver": {
-        "url": "https://manifold.net/updates/download_viewer.shtml",
-        "regex": "https://manifoldgis.com/updates/working/manifold-viewer-([\\d.\\-r]+)-x64.zip"
+        "url": "https://georeference.org/forum/",
+        "regex": "(?sm)Manifold.*?([\\d.]+)</a>"
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-$version-x64.zip",
-        "extract_dir": "manifold-viewer-$version-x64",
-        "hash": {
-            "url": "https://manifold.net/updates/download_viewer.shtml",
-            "regex": "$basename.*?$sha256"
-        }
+        "extract_dir": "manifold-viewer-$version-x64"
     }
 }

--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -35,7 +35,7 @@
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-$version-x64.zip",
-        "extract_dir": "manifold-viewer-$matchHead.$buildVersion-x64",
+        "extract_dir": "manifold-viewer-$version-x64",
         "hash": {
             "url": "https://manifold.net/updates/download_viewer.shtml",
             "regex": "$basename.*?$sha256"

--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -30,8 +30,8 @@
         }
     },
     "checkver": {
-        "url": "https://georeference.org/forum/",
-        "regex": "(?sm)Manifold.*?([\\d.]+)</a>"
+        "url": "https://wingetgui.com/apps?id=ManifoldSoftware.Manifold.9",
+        "regex": "Release version: ([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-$version-x64.zip",

--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -8,7 +8,7 @@
     },
     "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-9.0.177-x64.zip",
     "hash": "6a861fffb2b6827d43f1d2b30d3c722eb09f28a999e37c14d70cc02b416704b8",
-    "extract_dir": "manifold-viewer-9.0.177.-x64",
+    "extract_dir": "manifold-viewer-9.0.177-x64",
     "architecture": {
         "64bit": {
             "bin": "bin64\\manifold.exe",

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -4,7 +4,7 @@
     "homepage": "https://manifold.net/",
     "license": "Proprietary",
     "suggest": {
-        "Microsoft Visual C++ Redistributable 2017": "extras/vcredist2022"
+        "Microsoft Visual C++ Redistributable 2015-2022": "extras/vcredist2022"
     },
     "url": "https://www.manifoldgis.com/updates/working/manifold-9.0.177-x64.zip",
     "hash": "3d074cbd63ee8189c8fde87d4a0807890ac80ab6441cae215a679208a6ec8b64",
@@ -30,15 +30,11 @@
         }
     },
     "checkver": {
-        "url": "https://manifold.net/updates/download_9.shtml",
-        "regex": "https://manifoldgis.com/updates/working/manifold-([\\d.\\-r]+)-x64.zip"
+        "url": "https://georeference.org/forum/",
+        "regex": "(?sm)Manifold.*?([\\d.]+)</a>"
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-$version-x64.zip",
-        "extract_dir": "manifold-$version-x64",
-        "hash": {
-            "url": "https://manifold.net/updates/download_9.shtml",
-            "regex": "$basename.*?$sha256"
-        }
+        "extract_dir": "manifold-$version-x64"
     }
 }

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -8,7 +8,7 @@
     },
     "url": "https://www.manifoldgis.com/updates/working/manifold-9.0.177-x64.zip",
     "hash": "3d074cbd63ee8189c8fde87d4a0807890ac80ab6441cae215a679208a6ec8b64",
-    "extract_dir": "manifold-9.0.177.-x64",
+    "extract_dir": "manifold-9.0.177-x64",
     "architecture": {
         "64bit": {
             "bin": "bin64\\manifold.exe",

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -30,8 +30,8 @@
         }
     },
     "checkver": {
-        "url": "https://georeference.org/forum/",
-        "regex": "(?sm)Manifold.*?([\\d.]+)</a>"
+        "url": "https://wingetgui.com/apps?id=ManifoldSoftware.Manifold.9",
+        "regex": "Release version: ([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-$version-x64.zip",

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -35,7 +35,7 @@
     },
     "autoupdate": {
         "url": "https://www.manifoldgis.com/updates/working/manifold-$version-x64.zip",
-        "extract_dir": "manifold-$matchHead.$buildVersion-x64",
+        "extract_dir": "manifold-$version-x64",
         "hash": {
             "url": "https://manifold.net/updates/download_9.shtml",
             "regex": "$basename.*?$sha256"


### PR DESCRIPTION
Version numbers of Manifold|-Viewer are:
9.0.xxx or 9.0.xxx.yy and occasionally 9.0.xxx.yy-rN 
Change in #8417 broke "extract_dir" autoupdate for  9.0.xxx

This is manual quick-fix while preparing permanent fix.

Relates to #8417 


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
