### PR TITLE
imhex@1.19.1: Fix autoupdate url

### DIFF
--- a/bucket/imhex.json
+++ b/bucket/imhex.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.18.2",
+    "version": "1.19.0",
     "description": "Hex editor",
     "homepage": "https://github.com/WerWolv/ImHex",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/WerWolv/ImHex/releases/download/v1.18.2/Windows.Portable.ZIP.zip",
-            "hash": "11bcfb34f636d3f9eaf342a36404a570b8f4d9e4f8f6cd6fc0db13f853207d33"
+            "url": "https://github.com/WerWolv/ImHex/releases/download/v1.19.0/ImHex-1.19.0-Windows-Portable.zip",
+            "hash": "79f728eadb7007c549c67672f22222a5305f4c20b2fe75057b1a79cd01759924"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\imgui.ini\")) { New-Item \"$dir\\imgui.ini\" | Out-Null }",
@@ -21,7 +21,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/WerWolv/ImHex/releases/download/v$version/Windows.Portable.ZIP.zip"
+                "url": "https://github.com/WerWolv/ImHex/releases/download/v$version/ImHex-$version-Windows-Portable.zip"
             }
         }
     }

--- a/bucket/imhex.json
+++ b/bucket/imhex.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.19.0",
+    "version": "1.19.1",
     "description": "Hex editor",
     "homepage": "https://github.com/WerWolv/ImHex",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/WerWolv/ImHex/releases/download/v1.19.0/ImHex-1.19.0-Windows-Portable.zip",
-            "hash": "79f728eadb7007c549c67672f22222a5305f4c20b2fe75057b1a79cd01759924"
+            "url": "https://github.com/WerWolv/ImHex/releases/download/v1.19.1/ImHex-1.19.1-Windows-Portable.zip",
+            "hash": "72ddfa47e8b194e23e008bcdb4a07149d0126410ec5c4275c1d17fed598f381a"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\imgui.ini\")) { New-Item \"$dir\\imgui.ini\" | Out-Null }",


### PR DESCRIPTION
fix autoupdate url and bump to 1.19.0

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
