### PR TITLE
fvm: Add version 2.4.1

### DIFF
--- a/bucket/fvm.json
+++ b/bucket/fvm.json
@@ -1,0 +1,44 @@
+{
+    "version": "2.4.1",
+    "description": "Flutter Version Management: A simple CLI to manage Flutter SDK versions.",
+    "homepage": "https://fvm.app/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fluttertools/fvm/releases/download/2.4.1/fvm-2.4.1-windows-x64.zip",
+            "hash": "eb57c714add36e010113fafbcaf64c86b3e64d7dd239755666d143d2d5479cf2"
+        },
+        "32bit": {
+            "url": "https://github.com/fluttertools/fvm/releases/download/2.4.1/fvm-2.4.1-windows-ia32.zip",
+            "hash": "bb323f2e4618450dc4e1fa47b4b9a262a523b5cd9b24352d26e22dade234aefe"
+        }
+    },
+    "extract_dir": "fvm",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\versions\")) {",
+        "   New-Item \"$dir\\versions\" -ItemType Directory | Out-Null",
+        "   New-Item \"$dir\\.settings\" -ItemType File | Out-Null",
+        "}"
+    ],
+    "bin": "fvm.bat",
+    "env_set": {
+        "FVM_HOME": "$dir"
+    },
+    "persist": [
+        "versions",
+        ".settings"
+    ],
+    "checkver": {
+        "github": "https://github.com/fluttertools/fvm"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fluttertools/fvm/releases/download/$version/fvm-$version-windows-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/fluttertools/fvm/releases/download/$version/fvm-$version-windows-ia32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #8819
- Settings stored in `$dir\.settings` and is persisted
- Installed versions of Flutter go in `$dir\versions` and are persisted
- Environment variaable `FVM_HOME` set so that it can find the installed versions

Tested with 32bit and 64bit. Tested by running `fvm install stable` and then `fvm spawn stable --version` which outputs:
```
Spawning version "stable"...
Flutter 3.0.4 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 85684f9300 (8 days ago) • 2022-06-30 13:22:47 -0700
Engine • revision 6ba2af10bb
Tools • Dart 2.17.5 • DevTools 2.12.2
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
