### PR TITLE
runcat: Update to version 2.0, Fix autoupdate

### DIFF
--- a/bucket/runcat.json
+++ b/bucket/runcat.json
@@ -3,7 +3,7 @@
     "description": "A cute running cat animation on your windows taskbar (based on CPU load)",
     "homepage": "https://github.com/Kyome22/RunCat_for_windows",
     "license": "Apache-2.0",
-    "depends": "extras/windowsdesktop-runtime",
+    "depends": "extras/windowsdesktop-runtime-lts",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Kyome22/RunCat_for_windows/releases/download/2.0/RunCat-x64.zip",

--- a/bucket/runcat.json
+++ b/bucket/runcat.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.11",
+    "version": "2.0",
     "description": "A cute running cat animation on your windows taskbar (based on CPU load)",
     "homepage": "https://github.com/Kyome22/RunCat_for_windows",
     "license": "Apache-2.0",
     "depends": "extras/windowsdesktop-runtime",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Kyome22/RunCat_for_windows/releases/download/1.11/RunCat_x64.zip",
-            "hash": "1beb624aa4a270a0b604e342c8332c46a86fee856e2ddf2f0124dbf46e792cb3"
+            "url": "https://github.com/Kyome22/RunCat_for_windows/releases/download/2.0/RunCat-x64.zip",
+            "hash": "eac57dff96005068b5a150b261812ce8a8942d934ef2bd1022fecd8481cf7fb5"
         }
     },
     "shortcuts": [
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Kyome22/RunCat_for_windows/releases/download/$version/RunCat_x64.zip"
+                "url": "https://github.com/Kyome22/RunCat_for_windows/releases/download/$version/RunCat-x64.zip"
             }
         }
     }


### PR DESCRIPTION
I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).