### PR TITLE
chromium: Fix autoupdate.hash for old versions

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -11,7 +11,7 @@
         },
         "32bit": {
             "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v103.0.5060.66-r1002911/chrome.sync.7z",
-            "hash": "sha1:f388306b3b0ed7cc709f48c270ca58ff64fb53c8"
+            "hash": "sha1:41be8f368a2e7d125b970969d82cce9481b7942b"
         }
     },
     "extract_dir": "Chrome-bin",

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -37,7 +37,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://github.com/Hibbiki/chromium-win64/releases/tag/v$version",
+        "url": "https://github.com/Hibbiki/chromium-win32/releases/latest",
         "regex": ">v([\\d.\\-r]+)</h1>"
     },
     "autoupdate": {
@@ -45,14 +45,14 @@
             "64bit": {
                 "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version/chrome.sync.7z",
                 "hash": {
-                    "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
+                    "url": "https://github.com/Hibbiki/chromium-win64/releases/tag/v$version",
                     "regex": "$sha1 \\.\\./out/x64/chrome.sync.7z"
                 }
             },
             "32bit": {
                 "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v$version/chrome.sync.7z",
                 "hash": {
-                    "url": "https://github.com/Hibbiki/chromium-win32/releases/latest",
+                    "url": "https://github.com/Hibbiki/chromium-win32/releases/tag/v$version",
                     "regex": "$sha1 \\.\\./out/x86/chrome.sync.7z"
                 }
             }

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -37,7 +37,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://github.com/Hibbiki/chromium-win32/releases/latest",
+        "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
         "regex": ">v([\\d.\\-r]+)</h1>"
     },
     "autoupdate": {

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -37,7 +37,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
+        "url": "https://github.com/Hibbiki/chromium-win64/releases/tag/v$version",
         "regex": ">v([\\d.\\-r]+)</h1>"
     },
     "autoupdate": {


### PR DESCRIPTION
Chromium can't be updated to a previous version because the hash check fails. The hash check fails because it's always comparing against the `latest` version instead of the version being installed.

```
$ scoop install chromium@102.0.5005.115-r1142
WARN  Given version (102.0.5005.115-r1142) does not match manifest (103.0.5060.66-r1002911)
WARN  Attempting to generate manifest for 'chromium' (102.0.5005.115-r1142)
Autoupdating chromium
Searching hash for chrome.sync.7z in https://github.com/Hibbiki/chromium-win32/releases/latest
Found: sha1:41be8f368a2e7d125b970969d82cce9481b7942b using Extract Mode
Searching hash for chrome.sync.7z in https://github.com/Hibbiki/chromium-win64/releases/latest
Found: sha1:a133ccb2a19de065632ee575c5a88979a3ec92a8 using Extract Mode
Writing updated chromium manifest
Installing 'chromium' (102.0.5005.115-r1142) [64bit]
chrome.sync.7z (255.1 MB) [===================================================================================] 100%
Checking hash of chrome.sync.7z ... ERROR Hash check failed!
App:         chromium
URL:         https://github.com/Hibbiki/chromium-win64/releases/download/v102.0.5005.115-r1142/chrome.sync.7z
First bytes: 37 7A BC AF 27 1C 00 04
Expected:    a133ccb2a19de065632ee575c5a88979a3ec92a8
Actual:      9ae04895ab4383c860fd0b15a8038e7618daaabb
```

In this case, `a133ccb2a19de065632ee575c5a88979a3ec92a8` is the correct hash for `latest` (v103.0.5060.66-r1002911 at the moment), but `9ae04895ab4383c860fd0b15a8038e7618daaabb` is the correct hash for `https://github.com/Hibbiki/chromium-win64/releases/download/v102.0.5005.115-r1142/chrome.sync.7z`.