### PR TITLE
calibre-normal: Update to 6.0.0

### DIFF
--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -3,6 +3,7 @@
     "description": "Powerful and easy to use e-book manager",
     "homepage": "https://calibre-ebook.com",
     "license": "GPL-3.0-only",
+    "notes": "Calibre drops support for 32-bit CPUs after v6.0.0, if you are running a 32-bit system, please install calibre-normal5 from Versions bucket.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/kovidgoyal/calibre/releases/download/v6.0.0/calibre-64bit-6.0.0.msi",

--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/kovidgoyal/calibre/releases/download/v6.0.0/calibre-64bit-6.0.0.msi",
-            "hash": "8e5529d6d55a3e9ebac3d6ba588e4e2f8c88397ebefc841411a94d28d4b0192a",
+            "hash": "sha512:ac20d24a48ea8340aabd1381265a8d56c8bd745bfbbf2fe91a188841c7a170869f4cb240ee5e70a4eb8deca87f017e75277f9e59cdcd484cc091dbc0412d0ef7",
             "extract_dir": "PFiles\\Calibre2"
         }
     },
@@ -56,7 +56,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi"
+                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi",
+                "hash": {
+                    "url": "https://calibre-ebook.com/signatures/calibre-64bit-$version.msi.sha512"
+                }
             }
         }
     }

--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -1,25 +1,22 @@
 {
-    "version": "5.44.0",
+    "version": "6.0.0",
     "description": "Powerful and easy to use e-book manager",
     "homepage": "https://calibre-ebook.com",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.44.0/calibre-64bit-5.44.0.msi",
-            "hash": "708ba7db84ae9db684b643f81a4fb6b1c65f5e6dac0adc4721e6ed7d20677798",
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v6.0.0/calibre-64bit-6.0.0.msi",
+            "hash": "8e5529d6d55a3e9ebac3d6ba588e4e2f8c88397ebefc841411a94d28d4b0192a",
             "extract_dir": "PFiles\\Calibre2"
-        },
-        "32bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.44.0/calibre-5.44.0.msi",
-            "hash": "21903563b5bb5817ee33f3a3ea6b0f3b71c3eac1793069f89674d70a99f0f080",
-            "extract_dir": "PFiles\\Calibre"
         }
     },
     "bin": [
         "calibre.exe",
+        "calibre-complete.exe",
         "calibre-customize.exe",
         "calibredb.exe",
         "calibre-debug.exe",
+        "calibre-parallel.exe",
         "calibre-server.exe",
         "calibre-smtp.exe",
         "ebook-convert.exe",
@@ -60,9 +57,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi"
-            },
-            "32bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-$version.msi"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Calibre drops support for 32-bit CPUs after v6.0.0, if you are running a 32-bit system, please download `calibre-normal5` from Scoop Version bucket. 

> Source: https://calibre-ebook.com/new-in/fifteen

![image](https://user-images.githubusercontent.com/19755727/178400869-ce869b7d-2503-4914-a42f-59768f27090f.png)

Also, add two new bins, `calibre-parallel.exe` and `calibre-complete.exe`
![image](https://user-images.githubusercontent.com/19755727/178401047-e694af5a-08e8-4098-8f94-76c5263dd9a7.png)

