### PR TITLE
raindrop.io: Add version 5.5.5

### DIFF
--- a/bucket/raindrop.io.json
+++ b/bucket/raindrop.io.json
@@ -1,0 +1,32 @@
+{
+    "version": "5.5.5",
+    "description": "A all-in-one bookmark manager", 
+    "homepage": "https://raindrop.io/",
+    "license": "Unknown",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/raindropio/desktop/releases/download/v5.5.5/Raindrop.io-5.5.5-full.nupkg",
+            "hash": "sha1:405d100e030f8025cc59745fdd4164f8951fe978"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "shortcuts": [
+        [
+            "Raindrop.io.exe",
+            "Raindrop.io"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/raindropio/desktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/raindropio/desktop/releases/download/v$version/Raindrop.io-$version-full.nupkg",
+                "hash": {
+                    "url": "$baseurl/RELEASES"
+                }
+            }
+        }
+    }
+}

--- a/bucket/raindrop.io.json
+++ b/bucket/raindrop.io.json
@@ -1,6 +1,6 @@
 {
     "version": "5.5.5",
-    "description": "A all-in-one bookmark manager", 
+    "description": "A all-in-one bookmark manager",
     "homepage": "https://raindrop.io/",
     "license": "Unknown",
     "architecture": {


### PR DESCRIPTION
Relates to #8849

The issue mentions that the license is MIT, but I can't find the source information, so I'm using Unknown for now.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

