### PR TITLE
SpotX: Add version 1.2

### DIFF
--- a/bucket/spotx.json
+++ b/bucket/spotx.json
@@ -1,0 +1,12 @@
+{
+    "version": "1.2",
+    "description": "Blocks ads and updates for the desktop version of Spotify and more.",
+    "homepage": "https://github.com/amd64fox/SpotX/",
+    "license": "MIT License",    
+    "url": "https://github.com/amd64fox/SpotX/releases/download/1.2/Install.bat", 
+    "post_install": "Start-Process -FilePath $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\Install.bat",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"    
+    }  
+} 

--- a/bucket/spotx.json
+++ b/bucket/spotx.json
@@ -2,11 +2,11 @@
     "version": "1.2",
     "description": "Blocks ads and updates for the desktop version of Spotify and more.",
     "homepage": "https://github.com/amd64fox/SpotX/",
-    "license": "MIT License",    
-    "url": "https://github.com/amd64fox/SpotX/releases/download/1.2/Install.bat", 
-    "post_install": "Start-Process -FilePath $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\Install.bat",
+    "license": "MIT",
+    "url": "https://github.com/amd64fox/SpotX/releases/latest/download/Install.bat",
+    "post_install": "cd $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\; .\\Install.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"    
-    }  
-} 
+        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"
+    }
+}


### PR DESCRIPTION
SpotX blocks ads and updates for the desktop version of Spotify, disabling podcasts and more