### PR TITLE
SpotX: Add version 1.2

### DIFF
--- a/bucket/spotx.json
+++ b/bucket/spotx.json
@@ -1,0 +1,12 @@
+{
+    "version": "1.2",
+    "description": "Blocks ads and updates for the desktop version of Spotify and more.",
+    "homepage": "https://github.com/amd64fox/SpotX/",
+    "license": "MIT License",    
+    "url": "https://github.com/amd64fox/SpotX/releases/download/1.2/Install.bat", 
+    "post_install": "Start-Process -FilePath $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\Install.bat",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"    
+    }  
+} 

--- a/bucket/spotx.json
+++ b/bucket/spotx.json
@@ -2,11 +2,11 @@
     "version": "1.2",
     "description": "Blocks ads and updates for the desktop version of Spotify and more.",
     "homepage": "https://github.com/amd64fox/SpotX/",
-    "license": "MIT License",    
-    "url": "https://github.com/amd64fox/SpotX/releases/download/1.2/Install.bat", 
-    "post_install": "Start-Process -FilePath $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\Install.bat",
+    "license": "MIT",
+    "url": "https://github.com/amd64fox/SpotX/releases/latest/download/Install.bat",
+    "post_install": "cd $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\; .\\Install.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"    
-    }  
-} 
+        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"
+    }
+}

--- a/bucket/spotx.json
+++ b/bucket/spotx.json
@@ -8,6 +8,6 @@
     "post_install": "cd $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\; .\\Install.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/amd64fox/SpotX/releases/download/v$version/Install.bat"
+        "url": "https://github.com/amd64fox/SpotX/releases/download/$version/Install.bat"
     }
 }

--- a/bucket/spotx.json
+++ b/bucket/spotx.json
@@ -3,7 +3,8 @@
     "description": "Blocks ads and updates for the desktop version of Spotify and more.",
     "homepage": "https://github.com/amd64fox/SpotX/",
     "license": "MIT",
-    "url": "https://github.com/amd64fox/SpotX/releases/latest/download/Install.bat",
+    "url": "https://github.com/amd64fox/SpotX/releases/download/1.2/Install.bat",
+    "hash": "fa1c227614596f6eb930c08566a7d46af9b2590be78562cb2059bb6230cf7d4e",
     "post_install": "cd $env:USERPROFILE\\scoop\\apps\\spotx\\1.2\\; .\\Install.bat",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
SpotX blocks ads and updates for the desktop version of Spotify, disabling podcasts and more.