### PR TITLE
pixitracker(-1bit): Add version 1.6.5

### DIFF
--- a/bucket/pixitracker-1bit.json
+++ b/bucket/pixitracker-1bit.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.6.5",
+    "description": "A simple tool to quickly create musical sketches, chiptunes and sound experiments, without requiring a lot of musical knowledge. (retro-style 1bit version)",
+    "homepage": "https://warmplace.ru/soft/pixitracker/",
+    "license": "Freeware",
+    "url": "https://warmplace.ru/soft/pixitracker/pixitracker_1bit-1.6.5.zip",
+    "hash": "d29d0cca59d176d4d2dd065b23ee3f5da9fbe5a08eadbaf15c70a618858d8baf",
+    "extract_dir": "pixitracker_1bit",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\pixilang_log.txt\")) { New-Item \"$dir\\pixilang_log.txt\" | Out-Null }",
+        "if (Test-Path \"$persist_dir\\.pxtracker1bit_backup.piximod\") { Copy-Item \"$persist_dir\\.pxtracker1bit_backup.piximod\" \"$dir\\\" }"
+    ],
+    "pre_uninstall": "if (Test-Path \"$dir\\.pxtracker1bit_backup.piximod\") { Copy-Item \"$dir\\.pxtracker1bit_backup.piximod\" \"$persist_dir\\\" }",
+    "shortcuts": [
+        [
+            "START_WINDOWS.exe",
+            "PixiTracker (1 Bit)"
+        ],
+        [
+            "START_WINDOWS_NO_OPENGL.exe",
+            "PixiTracker (1 Bit) (No OpenGL)"
+        ]
+    ],
+    "persist": "pixilang_config.ini",
+    "checkver": "pixitracker_1bit-([\\d.]+)\\.zip",
+    "autoupdate": {
+        "url": "https://warmplace.ru/soft/pixitracker/pixitracker_1bit-$version.zip"
+    }
+}

--- a/bucket/pixitracker.json
+++ b/bucket/pixitracker.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.6.5",
+    "description": "A simple tool to quickly create musical sketches, chiptunes and sound experiments, without requiring a lot of musical knowledge.",
+    "homepage": "https://warmplace.ru/soft/pixitracker/",
+    "license": "Freeware",
+    "url": "https://warmplace.ru/soft/pixitracker/pixitracker-1.6.5.zip",
+    "hash": "638c5a7ee9e3c67433d3617805ed73ef011c97a13def40dca3a18b7a3460466b",
+    "extract_dir": "pixitracker",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\pixilang_log.txt\")) { New-Item \"$dir\\pixilang_log.txt\" | Out-Null }",
+        "if (Test-Path \"$persist_dir\\.pxtracker_backup.piximod\") { Copy-Item \"$persist_dir\\.pxtracker_backup.piximod\" \"$dir\\\" }"
+    ],
+    "pre_uninstall": "if (Test-Path \"$dir\\.pxtracker_backup.piximod\") { Copy-Item \"$dir\\.pxtracker_backup.piximod\" \"$persist_dir\\\" }",
+    "shortcuts": [
+        [
+            "START_WINDOWS.exe",
+            "PixiTracker"
+        ],
+        [
+            "START_WINDOWS_NO_OPENGL.exe",
+            "PixiTracker (No OpenGL)"
+        ]
+    ],
+    "persist": "pixilang_config.ini",
+    "checkver": "pixitracker-([\\d.]+)\\.zip",
+    "autoupdate": {
+        "url": "https://warmplace.ru/soft/pixitracker/pixitracker-$version.zip"
+    }
+}


### PR DESCRIPTION
**[PixiTracker](https://warmplace.ru/soft/pixitracker/)** is a simple tool to quickly create **musical sketches**, chiptunes and sound experiments, without requiring a lot of musical knowledge.

The app comes with 2 variants: regular **16Bit** (high quality) and retro-style **1Bit**.

**NOTES**:
* The app is built in 32-bit.
* license info is written in `$dir\docs\license`.

**SCREENSHOTS**:

![](https://warmplace.ru/soft/pixitracker/screen01.png)
![](https://warmplace.ru/soft/pixitracker/screen02.png)
![](https://warmplace.ru/soft/pixitracker/screen04.png)