### PR TITLE
Calibre: fix url

### DIFF
--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -57,7 +57,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi",
+                "url": "https://download.calibre-ebook.com/$version/calibre-64bit-$version.msi",
                 "hash": {
                     "url": "https://calibre-ebook.com/signatures/calibre-64bit-$version.msi.sha512"
                 }

--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -6,7 +6,7 @@
     "notes": "Calibre drops support for 32-bit CPUs after v6.0.0, if you are running a 32-bit system, please install calibre-normal5 from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v6.1.0/calibre-64bit-6.1.0.msi",
+            "url": "https://download.calibre-ebook.com/6.1.0/calibre-64bit-6.1.0.msi",
             "hash": "sha512:cadb1ae3b6cf9d5f62c9e9c82d85f333b23f74dae08c8a8d22836cbd2fff7c8597a401ed189579d6b655b4c022479a7a6b22430f163b214f0654d0279a79694d",
             "extract_dir": "PFiles\\Calibre2"
         }

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v6.1.0/calibre-portable-installer-6.1.0.exe",
+            "url": "https://download.calibre-ebook.com/6.1.0/calibre-portable-installer-6.1.0.exe",
             "hash": "sha512:b22f4f89a21ba752fb43846d7fdddec67e22a1190029b5b5b070b66cc4cc8cae8645a7f7026d1c4831ff0c096bef078ed8ab29715081b28b011f7d69bee026dc"
         }
     },

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -70,7 +70,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-portable-installer-$version.exe",
+                "url": "https://download.calibre-ebook.com/$version/calibre-portable-installer-$version.exe",
                 "hash": {
                     "url": "https://calibre-ebook.com/signatures/calibre-portable-installer-$version.exe.sha512"
                 }


### PR DESCRIPTION
calibre release assets is removed after a new version is relased. old version files are served at download.calibre-ebook.com