### PR TITLE
quarto: use zip bundle instead of msi file

### DIFF
--- a/bucket/quarto.json
+++ b/bucket/quarto.json
@@ -5,11 +5,10 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/quarto-dev/quarto-cli/releases/download/v1.0.35/quarto-1.0.35-win.msi",
-            "hash": "e5af67f70b669ca7b63da409556283f7f2ece4ffb447fa055a39017ad8c92034"
+            "url": "https://github.com/quarto-dev/quarto-cli/releases/download/v1.0.35/quarto-1.0.35-win.zip",
+            "hash": "b8a487e8f6002d5c798afda5dd85e7c3bf3b094545daf815e22e167913c07835"
         }
     },
-    "extract_dir": "Quarto",
     "bin": "bin\\quarto.cmd",
     "checkver": {
         "github": "https://github.com/quarto-dev/quarto-cli"
@@ -17,11 +16,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/quarto-dev/quarto-cli/releases/download/v$version/quarto-$version-win.msi"
+                "url": "https://github.com/quarto-dev/quarto-cli/releases/download/v$version/quarto-$version-win.zip"
             }
         },
         "hash": {
-            "url": "$baseurl/quarto-$version-checksums.txt"
+            "url": "$baseurl/quarto-$version-checksums.txt",
+            "find": "$sha256\\s+$basename"
         }
     }
 }


### PR DESCRIPTION
~This PR update Quarto to  last stable v1 version which is v1.0.35. ~ Update has been done in the meantime in the repo. 

It also change the bundle to use the zip file instead of the MSI file as the zip bundle provided by quarto team is the portable one. No need to download a msi file to unzip. 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
