### PR TITLE
appflowy: Add Version 0.0.4

### DIFF
--- a/bucket/appflowy.json
+++ b/bucket/appflowy.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.0.4",
+    "description": "An open-source alternative to Notion. You are in charge of your data and customizations.",
+    "homepage": "https://www.appflowy.io/",
+    "license": "AGPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.0.4/AppFlowy-Windows-x86_64.zip",
+            "hash": "6bb9d754154ce711b685d1ab634d425d51dde6252230afec326e4232e32b8755"
+        }
+    },
+    "shortcuts": [
+        [
+            "app_flowy.exe",
+            "AppFlowy"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/AppFlowy-IO/AppFlowy"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/$version/AppFlowy-Windows-x86_64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
appflowy tops 1st in [GitHub Trending](https://github.com/trending) today

AppFlowy is an open-source alternative to Notion. You are in charge of your data and customizations. Built with Flutter and Rust.

24k stars

https://github.com/ScoopInstaller/Main/pull/3770

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).