### PR TITLE
AppFlowy: Fix extract_dir

### DIFF
--- a/bucket/appflowy.json
+++ b/bucket/appflowy.json
@@ -9,9 +9,10 @@
             "hash": "6bb9d754154ce711b685d1ab634d425d51dde6252230afec326e4232e32b8755"
         }
     },
+    "extract_dir": "AppFlowy",
     "shortcuts": [
         [
-            "AppFlowy/app_flowy.exe",
+            "app_flowy.exe",
             "AppFlowy"
         ]
     ],

--- a/bucket/appflowy.json
+++ b/bucket/appflowy.json
@@ -11,7 +11,7 @@
     },
     "shortcuts": [
         [
-            "app_flowy.exe",
+            "AppFlowy/app_flowy.exe",
             "AppFlowy"
         ]
     ],


### PR DESCRIPTION
Fix `Creating shortcut for AppFlowy (app_flowy.exe) failed: Couldn't find D:\Scoop\apps\appflowy\current\app_flowy.exe`

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
