### PR TITLE
chromium@103.0.5060.134-r1002911: fix checkver and update

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,17 +1,17 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "103.0.5060.66-r1002911",
+    "version": "103.0.5060.134-r1002911",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v103.0.5060.66-r1002911/chrome.sync.7z",
-            "hash": "sha1:a133ccb2a19de065632ee575c5a88979a3ec92a8"
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v103.0.5060.134-r1002911/chrome.sync.7z",
+            "hash": "sha1:2b82f88c30809bb54310ea2c614d58723a01ef38"
         },
         "32bit": {
-            "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v103.0.5060.66-r1002911/chrome.sync.7z",
-            "hash": "sha1:41be8f368a2e7d125b970969d82cce9481b7942b"
+            "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v103.0.5060.134-r1002911/chrome.sync.7z",
+            "hash": "sha1:a6a9388f1bea8d8222460646f3b099e2921445ee"
         }
     },
     "extract_dir": "Chrome-bin",
@@ -37,8 +37,9 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-        "regex": ">v([\\d.\\-r]+)</h1>"
+        "url": "https://api.github.com/repos/Hibbiki/chromium-win64/tags",
+        "jsonpath": "$..name",
+        "regex": "v([\\d.\\-r]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
fixed the checkver by querying the github api for the lastest tag (as upstream sometimes only makes a tag and not a release while still uploading binaries)
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
