### PR TITLE
keepass-plugin-keeagent@0.13.1: Fix autoupdate and update

### DIFF
--- a/bucket/keepass-plugin-keeagent.json
+++ b/bucket/keepass-plugin-keeagent.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.12.1",
+    "version": "0.13.1",
     "description": "Plugin for KeePass 2.x that allows SSH keys stored in a KeePass database to be used for SSH authentication by other programs.",
     "homepage": "https://lechnology.com/software/keeagent/",
     "license": "GPL-2.0-only",
     "depends": "extras/keepass",
-    "url": "https://github.com/dlech/KeeAgent/releases/download/v0.12.1/KeeAgent_v0.12.1.zip",
-    "hash": "5d22fa0991386211d832cb9ea13bf916a4f173213d16a58f912cdf69d9cf7787",
+    "url": "https://github.com/dlech/KeeAgent/releases/download/v0.13.1/KeeAgent.plgx.zip",
+    "hash": "e5e48f503b9777265e37149fe1be72839389d29b5bdb94b7d192e1231ad0f263",
     "installer": {
         "script": "Copy-Item \"$dir\\KeeAgent.plgx\" \"$(appdir keepass $global)\\current\\Plugins\""
     },
@@ -16,6 +16,6 @@
         "github": "https://github.com/dlech/KeeAgent"
     },
     "autoupdate": {
-        "url": "https://github.com/dlech/KeeAgent/releases/download/v$version/KeeAgent_v$version.zip"
+        "url": "https://github.com/dlech/KeeAgent/releases/download/v$version/KeeAgent.plgx.zip"
     }
 }


### PR DESCRIPTION
Fix the autoupdate url and update version to 0.13.1.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
