### PR TITLE
pinta: Add version 2.0.2

### DIFF
--- a/bucket/pinta.json
+++ b/bucket/pinta.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.2",
+    "description": "Open source program for drawing and image editing.",
+    "homepage": "https://www.pinta-project.com/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PintaProject/Pinta/releases/download/2.0.2/Pinta.exe#/Pinta-dl.exe",
+            "hash": "66a58a19a0f254a24c90f662114d8b1380e5f8693dc4792f9e216ebe4d11608f"
+        }
+    },
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "Pinta.exe",
+            "Pinta"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/PintaProject/Pinta"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PintaProject/Pinta/releases/download/$version/Pinta.exe#/Pinta-dl.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to #8919
- Settings stored in `AppData\Roaming\Pinta`
- Downloaded file is renamed to `Pinta-dl.exe` so it doesn't conflict when the main program is unpacked as `Pinta.exe`
- 64-bit only, checked with `sigcheck`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
