### PR TITLE
kubeconform: Add version 0.4.14

### DIFF
--- a/bucket/kubeconform.json
+++ b/bucket/kubeconform.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.4.14",
+    "description": "FAST Kubernetes manifests validator, with support for Custom Resources!",
+    "homepage": "https://github.com/yannh/kubeconform",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yannh/kubeconform/releases/download/v0.4.14/kubeconform-windows-amd64.zip",
+            "hash": "0ed2f7061b3719fb83cbd971b9b8e7d9a3feee6f7017677bd14e9248dc625b0f"
+        }
+    },
+    "bin": "kubeconform.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yannh/kubeconform/releases/download/v$version/kubeconform-windows-amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Just for confirmation:
```
C:\App\Scoop
❯❯ .\apps\scoop\current\bin\checkver.ps1 -App .\buckets\extras\bucket\kubeconform.json
kubeconform: 0.4.14
C:\App\Scoop took 1s282ms
❯❯ scoop install kubeconform
Installing 'kubeconform' (0.4.14) [64bit]
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 789c9d|OK  |   2.1MiB/s|C:/App/Scoop/cache/kubeconform#0.4.14#https_github.com_yannh_kubeconform_releases_download_v0.4.14_kubeconform-windows-amd64.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of kubeconform-windows-amd64.zip ... ok.
Extracting kubeconform-windows-amd64.zip ... done.
Linking C:\App\Scoop\apps\kubeconform\current => C:\App\Scoop\apps\kubeconform\0.4.14
Creating shim for 'kubeconform'.
'kubeconform' (0.4.14) was installed successfully!
C:\App\Scoop took 5s374ms
❯❯ kubeconform --help
Usage: C:\App\Scoop\apps\kubeconform\current\kubeconform.exe [OPTION]... [FILE OR FOLDER]...
  -cache string
        cache schemas downloaded via HTTP to this folder
  -cpu-prof string
        debug - log CPU profiling to file
  -exit-on-error
        immediately stop execution when the first error is encountered
  -h    show help information
  -ignore-filename-pattern value
        regular expression specifying paths to ignore (can be specified multiple times)
  -ignore-missing-schemas
        skip files with missing schemas instead of failing
  -insecure-skip-tls-verify
        disable verification of the server's SSL certificate. This will make your HTTPS connections insecure
  -kubernetes-version string
        version of Kubernetes to validate against, e.g.: 1.18.0 (default "master")
  -n int
        number of goroutines to run concurrently (default 4)
  -output string
        output format - json, junit, tap, text (default "text")
  -reject string
        comma-separated list of kinds to reject
  -schema-location value
        override schemas location search path (can be specified multiple times)
  -skip string
        comma-separated list of kinds to ignore
  -strict
        disallow additional properties not in schema or duplicated keys
  -summary
        print a summary at the end (ignored for junit output)
  -v    show version information
  -verbose
        print results for all resources (ignored for tap and junit output)
```