### PR TITLE
divoom-cli, divoom-gateway: Add version 0.1.25

### DIFF
--- a/bucket/divoom-cli.json
+++ b/bucket/divoom-cli.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.1.25",
+  "description": "Command line tool built on top of divoom APIs for controlling divoom devices, like pixoo.",
+  "homepage": "https://github.com/r12f/divoom",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/r12f/divoom/releases/download/0.1.25/divoom-cli.0.1.25.windows.x64.zip",
+      "hash": "5c9098aed7e8e70ba116c9c6083294baa7c7521f1b8f8f3a41e8a9c87673691b"
+    },
+    "32bit": {
+      "url": "https://github.com/r12f/divoom/releases/download/0.1.25/divoom-cli.0.1.25.windows.x86.zip",
+      "hash": "75044e4e9bd86e45248661a2bf9cac932d297abef296a17fe7ae0bef868e7815"
+    }
+  },
+  "bin": "divoom-cli.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/r12f/divoom/releases/download/$version/divoom-cli.$version.windows.x64.zip"
+      },
+      "32bit": {
+        "url": "https://github.com/r12f/divoom/releases/download/$version/divoom-cli.$version.windows.x86.zip"
+      }
+    }
+  }
+}
+

--- a/bucket/divoom-gateway.json
+++ b/bucket/divoom-gateway.json
@@ -13,7 +13,7 @@
       "hash": "a67c5e34ffcaaa6e52fa8e9883bf55bafea5fd6795b810ca14b5cb3e8ebf2957"
     }
   },
-  "bin": "divoom-cli.exe",
+  "bin": "divoom-gateway.exe",
   "checkver": "github",
   "autoupdate": {
     "architecture": {

--- a/bucket/divoom-gateway.json
+++ b/bucket/divoom-gateway.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.1.25",
+  "description": "A REST API gateway with swagger UI provided that wraps divoom HTTP APIs for controlling divoom devices, like pixoo.",
+  "homepage": "https://github.com/r12f/divoom",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/r12f/divoom/releases/download/0.1.25/divoom-gateway.0.1.25.windows.x64.zip",
+      "hash": "02bca681a22b5faf5b74b61243f3e7eef6a1723aed5d9a57725a7d07723ec479"
+    },
+    "32bit": {
+      "url": "https://github.com/r12f/divoom/releases/download/0.1.25/divoom-gateway.0.1.25.windows.x86.zip",
+      "hash": "a67c5e34ffcaaa6e52fa8e9883bf55bafea5fd6795b810ca14b5cb3e8ebf2957"
+    }
+  },
+  "bin": "divoom-cli.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/r12f/divoom/releases/download/$version/divoom-gateway.$version.windows.x64.zip"
+      },
+      "32bit": {
+        "url": "https://github.com/r12f/divoom/releases/download/$version/divoom-gateway.$version.windows.x86.zip"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
2 command line tools for controlling the [divoom device](https://www.divoom.com/products/pixoo-64).

Repo and more README could be found here: https://github.com/r12f/divoom.
- divoom-cli: https://github.com/r12f/divoom/tree/main/divoom_cli
- divoom-gateway: https://github.com/r12f/divoom/tree/main/divoom_gateway

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
