### PR TITLE
sysinternals: Use digital version number

### DIFF
--- a/bucket/sysinternals.json
+++ b/bucket/sysinternals.json
@@ -1,5 +1,5 @@
 {
-    "version": "2022.July.19",
+    "version": "2022.07.19",
     "description": "A set of utilities to manage, diagnose, troubleshoot, and monitor a Windows environment.",
     "homepage": "https://docs.microsoft.com/en-us/sysinternals/",
     "license": {
@@ -9,8 +9,8 @@
     "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip",
     "hash": "9f39ed4f94061e7b34d72bce326e8b951a3d4b80c244e046d8dd4cb18ef58501",
     "checkver": {
-        "url": "https://docs.microsoft.com/en-us/sysinternals/downloads/sysinternals-suite",
-        "regex": "\\bUpdated:\\s*(\\w+)\\s+(\\d+),\\s+(\\d+)\\b",
+        "url": "https://raw.githubusercontent.com/MicrosoftDocs/sysinternals/main/sysinternals/downloads/sysinternals-suite.md",
+        "regex": "ms\\.date: (\\d+)/(\\d+)/(\\d+)",
         "replace": "${3}.${1}.${2}"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Using version number from Sysinternals doc's source file (which is in GitHub).

- Closes #8962

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
