### PR TITLE
godot|-mono: Update checkver to rely on GitHub Releases

### DIFF
--- a/bucket/godot-mono.json
+++ b/bucket/godot-mono.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.4.4",
+    "version": "3.4.5",
     "description": "a feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/godotengine/godot/releases/download/3.4.4-stable/Godot_v3.4.4-stable_mono_win64.zip",
-            "hash": "d170f00b105114af2ddc464bbf74d535d9b8ef835964e7fad3602540eed2a9f7"
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.5-stable/Godot_v3.4.5-stable_mono_win64.zip",
+            "hash": "41458248f0f8bafb852b745ec2098e1e9553f91cf4a8a86e87e234230831ee14"
         },
         "32bit": {
-            "url": "https://github.com/godotengine/godot/releases/download/3.4.4-stable/Godot_v3.4.4-stable_mono_win32.zip",
-            "hash": "14f5d037ef1a03ee3d9d4455945fd7b99896873001bb66f22836c6e5acba91cb"
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.5-stable/Godot_v3.4.5-stable_mono_win32.zip",
+            "hash": "6dc00e0c41bb68191512de04e057ca9624e6446c99023ec33336417032193c48"
         }
     },
     "pre_install": [
@@ -26,8 +26,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/download",
-        "regex": "<h2>Godot <em>([\\d.]+)</em></h2>"
+        "url": "https://github.com/godotengine/godot/releases/latest",
+        "regex": "(?<version>[\\d\\w.]+)-stable"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.4.4",
+    "version": "3.4.5",
     "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/godotengine/godot/releases/download/3.4.4-stable/Godot_v3.4.4-stable_win64.exe.zip",
-            "hash": "7e7caba5fcc8a6ec205dc7879f62652362926d404f062bfd54b31ed3378ab5ff"
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.5-stable/Godot_v3.4.5-stable_win64.exe.zip",
+            "hash": "491d66e3a840ca0c8b2bd08191e41a1826715fbeec3a5bea46d01edea398ecb2"
         },
         "32bit": {
-            "url": "https://github.com/godotengine/godot/releases/download/3.4.4-stable/Godot_v3.4.4-stable_win32.exe.zip",
-            "hash": "bbf5b37fb7c2719e86d2c07d0fa80bd2b92250a9f9c5e7cf5b8f8aba38a8ff6e"
+            "url": "https://github.com/godotengine/godot/releases/download/3.4.5-stable/Godot_v3.4.5-stable_win32.exe.zip",
+            "hash": "f26e89181a1fc9f2485569d47b5c4a4a34994b48f30579d0c8122b0b20d87a41"
         }
     },
     "pre_install": "Get-ChildItem \"$dir\\Godot_*.exe\" | Rename-Item -NewName \"$dir\\godot.exe\"",
@@ -22,8 +22,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/download",
-        "regex": "<h2>Godot <em>([\\d.]+)</em></h2>"
+        "url": "https://github.com/godotengine/godot/releases/latest",
+        "regex": "(?<version>[\\d\\w.]+)-stable"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Download URLs are from GitHub Releases, so it makes more sense to use checkver from GitHub.

This also fixes checkver as it recently broke due to design changes on the Download page.

I ran checkver.ps1 locally to update the manifest and make sure it works as expected.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).