### PR TITLE
keepass-plugin-keeagent@0.13.1: Fix download URL

### DIFF
--- a/bucket/keepass-plugin-keeagent.json
+++ b/bucket/keepass-plugin-keeagent.json
@@ -4,7 +4,7 @@
     "homepage": "https://lechnology.com/software/keeagent/",
     "license": "GPL-2.0-only",
     "depends": "extras/keepass",
-    "url": "https://github.com/dlech/KeeAgent/releases/download/v0.13.1/KeeAgent.plgx.zip",
+    "url": "https://github.com/dlech/KeeAgent/releases/download/v0.13.1/KeeAgent_v0.13.1.zip",
     "hash": "e5e48f503b9777265e37149fe1be72839389d29b5bdb94b7d192e1231ad0f263",
     "installer": {
         "script": "Copy-Item \"$dir\\KeeAgent.plgx\" \"$(appdir keepass $global)\\current\\Plugins\""
@@ -16,6 +16,6 @@
         "github": "https://github.com/dlech/KeeAgent"
     },
     "autoupdate": {
-        "url": "https://github.com/dlech/KeeAgent/releases/download/v$version/KeeAgent.plgx.zip"
+        "url": "https://github.com/dlech/KeeAgent/releases/download/v$version/KeeAgent_v$version.zip"
     }
 }


### PR DESCRIPTION
Updated URL and autoupdate URL to match current repository release URL structure.

Closes #8982

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
