### PR TITLE
pet: Add version 0.4.0

### DIFF
--- a/bucket/pet.json
+++ b/bucket/pet.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.4.0",
+    "description": "Simple command-line snippet manager, written in Go.",
+    "homepage": "https://github.com/knqyf263/pet",
+    "license": "MIT",
+    "suggest": {
+        "fzf": "fzf"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/knqyf263/pet/releases/download/v0.4.0/pet_0.4.0_windows_amd64.tar.gz",
+            "hash": "0f25fb09ae0014137ed9ca8cbbacacf45cf36b447c4a06301cbf80d9607742f0"
+        },
+        "32bit": {
+            "url": "https://github.com/knqyf263/pet/releases/download/v0.4.0/pet_0.4.0_windows_386.tar.gz",
+            "hash": "a6b1e4de07688c9d83a4099940196e523b12d2fbe53dbb9f519ab79fbee17404"
+        }
+    },
+    "bin": "pet.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/knqyf263/pet/releases/download/v$version/pet_$version_windows_amd64.tar.gz",
+                "extract_dir": "pet_$version_windows_amd64"
+            },
+            "32bit": {
+                "url": "https://github.com/knqyf263/pet/releases/download/v$version/pet_$version_windows_386.tar.gz",
+                "extract_dir": "pet_$version_windows_386"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Name: Pet
- Description: Simple command-line snippet manager, written in Go.
- Homepage: https://github.com/knqyf263/pet
- Download link(s): https://github.com/knqyf263/pet/releases
- Popularity: Star 3.5k, Fork 176
- Config and snippets are stored in `AppData\Roaming\pet`

---

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
