### PR TITLE
paraview: Add version 5.10.1

### DIFF
--- a/bucket/paraview.json
+++ b/bucket/paraview.json
@@ -1,0 +1,28 @@
+{
+    "version": "5.10.1",
+    "description": "Open-source, multi-platform data analysis and visualization application.",
+    "homepage": "https://www.paraview.org/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.10&type=binary&os=Windows&downloadFile=ParaView-5.10.1-Windows-Python3.9-msvc2017-AMD64.zip#/dl.zip",
+            "hash": "md5:bae6ee1afb6441b3b684ad96ca9a431f",
+            "extract_dir": "ParaView-5.10.1-Windows-Python3.9-msvc2017-AMD64"
+        }
+    },
+    "bin": [
+        "bin\\paraview.exe",
+        "bin\\pvbatch.exe",
+        "bin\\pvdataserver.exe",
+        "bin\\pvpython.exe",
+        "bin\\pvrenderserver.exe",
+        "bin\\pvserver.exe",
+        "bin\\vrpn_server.exe"
+    ],
+    "shortcuts": [
+        [
+            "bin\\paraview.exe",
+            "ParaView"
+        ]
+    ]
+}

--- a/bucket/paraview.json
+++ b/bucket/paraview.json
@@ -25,4 +25,20 @@
             "ParaView"
         ]
     ]
+    "checkver": {
+        "url": "https://www.paraview.org/files/listing.txt",
+        "regex": "ParaView-([\\d.]+)-Windows-Python(?<pythonver>[\\d.]+)-msvc(?<msvcver>\\d+)-AMD64\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v$majorVersion.$minorVersion&type=binary&os=Windows&downloadFile=ParaView-$version-Windows-Python$matchPythonver-msvc$matchMsvcver-AMD64.zip#/dl.zip",
+                "extract_dir": "ParaView-$version-Windows-Python$matchPythonver-msvc$matchMsvcver-AMD64"
+            }
+        },
+        "hash": {
+            "url": "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v$majorVersion.$minorVersion&type=binary&os=Windows&downloadFile=md5sum.txt",
+            "regex": "$md5\\s+$basename"
+        }
+    }
 }

--- a/bucket/paraview.json
+++ b/bucket/paraview.json
@@ -24,7 +24,7 @@
             "bin\\paraview.exe",
             "ParaView"
         ]
-    ]
+    ],
     "checkver": {
         "url": "https://www.paraview.org/files/listing.txt",
         "regex": "ParaView-([\\d.]+)-Windows-Python(?<pythonver>[\\d.]+)-msvc(?<msvcver>\\d+)-AMD64\\.zip"


### PR DESCRIPTION
There once had been a bucket for Paraview, but it got removed: e6b9494eba9a88674569601fba3973557e0f5ecc. However, I cannot figure out the reason for this deletion.

This new PR installs correctly. But there are two caveats:

- How can we incorporate the [ParaView Settings Files](https://www.paraview.org/Wiki/ParaView_Settings_Files) into the `persist` directory? There seem to be two files under `%APPDATA%\ParaView`, namely `ParaView-UserSettings.json` and `ParaViewX.Y.ini`. In this filename, `X.Y` are kind of dynamically named. Maybe we could somehow use`$majorVersion.$minorVersion`?
- How can we add `checkver` and `autoupdate`? A machine-readable list of all versions can be found at https://www.paraview.org/files/listing.txt. But I cannot figure out how use this list in `checkver`.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
