### PR TITLE
android-messages: Update to 5.3.4

### DIFF
--- a/bucket/android-messages.json
+++ b/bucket/android-messages.json
@@ -33,6 +33,10 @@
         "regex": "/tree/v([\\w.-]+)\""
     },
     "autoupdate": {
-        "url": "https://github.com/OrangeDrangon/android-messages-desktop/releases/download/v$version/Android-Messages-v$version-win-x64.portable.exe#/dl.7z"
+        "url": "https://github.com/OrangeDrangon/android-messages-desktop/releases/download/v$version/Android-Messages-v$version-win-x64.portable.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "regex": "sha512:\\s+$base64"
+        }
     }
 }

--- a/bucket/android-messages.json
+++ b/bucket/android-messages.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.1.0",
+    "version": "5.3.4",
     "description": "Cross-platform Desktop App for android messages.",
-    "homepage": "https://github.com/chrisknepper/android-messages-desktop/",
+    "homepage": "https://github.com/OrangeDrangon/android-messages-desktop",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/chrisknepper/android-messages-desktop/releases/download/v1.0.1/android-messages-desktop-setup-1.0.1.exe#/dl.7z",
-            "hash": "sha512:57d879f793bd19bf0a2f9a9b1f1848b247b242fa4094c41ef97d1c311cb4d1d407f3d34e6e1b4c23cc74864170992a9c5c7e52d703f9197019eecff8e25c3d26",
+            "url": "https://github.com/OrangeDrangon/android-messages-desktop/releases/download/v5.3.4/Android-Messages-v5.3.4-win-x64.portable.exe#/dl.7z",
+            "hash": "135cc1df811416b7ede253b31905828399b870baf7a794445e75beb164650eb4",
             "extract_dir": "$PLUGINSDIR"
         }
     },
@@ -16,19 +16,23 @@
             "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal"
         ]
     },
-    "bin": "Android Messages.exe",
+    "bin": [
+        [
+            "Android Messages.exe",
+            "AndroidMessages"
+        ]
+    ],
     "shortcuts": [
         [
             "Android Messages.exe",
             "Android Messages"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/OrangeDrangon/android-messages-desktop/releases",
+        "regex": "/tree/v([\\w.-]+)\""
+    },
     "autoupdate": {
-        "url": "https://github.com/chrisknepper/android-messages-desktop/releases/download/v1.0.1/android-messages-desktop-setup-1.0.1.exe#/dl.7z",
-        "hash": {
-            "url": "$baseurl/latest.yml",
-            "regex": "sha512:\\s+$base64"
-        }
+        "url": "https://github.com/OrangeDrangon/android-messages-desktop/releases/download/v$version/Android-Messages-v$version-win-x64.portable.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
and switch to maintained fork. 

The current version 3.0.1 points to 1.0.1.

Source: https://github.com/rasa/scoops/blob/master/bucket/android-messages.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
