### PR TITLE
vcredist*: Fixed ArgumentList in post_install scripts.

### DIFF
--- a/bucket/vcredist2008.json
+++ b/bucket/vcredist2008.json
@@ -21,7 +21,7 @@
         "    1638 = 'This product is already installed';",
         "    3010 = 'A restart is required to complete the installation';",
         "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x64.exe\" -ArgumentList '/fo /qn /norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x86.exe\" -ArgumentList '/fo /qn /norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x64.exe\" -ArgumentList '/fo', '/qn', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x86.exe\" -ArgumentList '/fo', '/qn', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
     ]
 }

--- a/bucket/vcredist2012.json
+++ b/bucket/vcredist2012.json
@@ -21,7 +21,7 @@
         "    1638 = 'This product is already installed';",
         "    3010 = 'A restart is required to complete the installation';",
         "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x64.exe\" -ArgumentList \"/fo /quiet /norestart\" -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x86.exe\" -ArgumentList \"/fo /quiet /norestart\" -ContinueExitCodes $ec -RunAs | Out-Null"
+        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
     ]
 }

--- a/bucket/vcredist2013.json
+++ b/bucket/vcredist2013.json
@@ -21,7 +21,7 @@
         "    1638 = 'This product is already installed';",
         "    3010 = 'A restart is required to complete the installation';",
         "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x64.exe\" -ArgumentList '/fo /quiet /norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x86.exe\" -ArgumentList '/fo /quiet /norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+        "Invoke-ExternalCommand -FilePath \"$dir\\vcredist_x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
     ]
 }

--- a/bucket/vcredist2015.json
+++ b/bucket/vcredist2015.json
@@ -21,7 +21,7 @@
         "    1638 = 'This product is already installed';",
         "    3010 = 'A restart is required to complete the installation';",
         "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo /quiet /norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo /quiet /norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
     ]
 }

--- a/bucket/vcredist2017.json
+++ b/bucket/vcredist2017.json
@@ -21,7 +21,7 @@
         "    1638 = 'This product is already installed';",
         "    3010 = 'A restart is required to complete the installation';",
         "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo /quiet /norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo /quiet /norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
     ]
 }


### PR DESCRIPTION
Hi guys, this is my first MR in this repo, please advice me on anything I am doing wrong.
I had the issue today, that the ArgumentList that was passed to the vcredist2013 package was ignored (/quiet),
so scoop was always opening the prompt to accept the license informations to install.

That halts my automation script and I realized this behaviour is not expected, it's a small bug in the post_install script.
So.. there is the fix!