### PR TITLE
vscodium: fix autoupdate for 32bit

### DIFF
--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.70.0",
+    "version": "1.70.1",
     "description": "Binary releases of VS Code without MS branding/telemetry/licensing.",
     "homepage": "https://github.com/VSCodium/vscodium",
     "license": "MIT",
@@ -9,12 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.70.0/VSCodium-win32-x64-1.70.0.zip",
-            "hash": "e8ac397bbe42e06c6c69a2913006cf3ac3f52159581e639d23bc4d07ac7d813d"
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.70.1/VSCodium-win32-x64-1.70.1.zip",
+            "hash": "0a3085d26c5fb76d74fe616eec877e2362e1592b43ee40358479780e64ed1249"
         },
         "32bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.70.0/VSCodium-win32-ia32-1.70.0.zip",
-            "hash": "4072cece6ae697045ad8a5b131f8647b3d7f3f8629014d7ca6b3f2b75943e611"
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.70.1/VSCodium-win32-ia32-1.70.1.zip",
+            "hash": "e18ec423d3891ad3fca4a611b289b96a8064aa0f4064191cd4c1b75c7194b38c"
         }
     },
     "env_add_path": "bin",

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -56,7 +56,7 @@
                 "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-x64-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/VSCodium/vscodium/releases/download/1.70.0/VSCodium-win32-ia32-$version.zip"
+                "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-ia32-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
version was written as static.
when auto updating this causes 404 errors.

Relates to #9014
This PR added 32bit version but failed to get upstream version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
