### PR TITLE
komorebi: fix hash for v0.1.11

### DIFF
--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -14,7 +14,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/LGUG2Z/komorebi/releases/download/v0.1.11/komorebi-0.1.11-x86_64-pc-windows-msvc.zip",
-            "hash": "bfe7e333262f646df12713e1b3e20cd9e3848e7242e472cc4c471cba9a3e5f52"
+            "hash": "46a1d5d36ba0e99313be75788aed708e602304a2a1bc385624f3634f1068584f"
         }
     },
     "bin": [


### PR DESCRIPTION
Updates the hash of release `v0.1.11` of `komorebi`

https://github.com/LGUG2Z/komorebi/releases/tag/v0.1.11

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
