### PR TITLE
asar7z: Add version 1.3

### DIFF
--- a/bucket/asar7z.json
+++ b/bucket/asar7z.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.3",
+    "description": "7-Zip plugin that allows 7-zip to open, modify, or create Electron .asar archives.",
+    "homepage": "https://www.tc4shell.com/en/7zip/asar/",
+    "license": "Freeware",
+    "url": "https://www.tc4shell.com/binary/Asar.zip",
+    "hash": "cbcffdcfffe49adcbf851e02ad59acfe392f74a1b2d4db86035f00b94881567b",
+    "pre_install": [
+        "$7z_folder = Split-Path (scoop which 7z)",
+        "if (!(Test-Path $7z_folder)) { error 'Could not find 7z.exe in PATH. Abort installation.'; break }",
+        "if ($architecture -eq '64bit') { Copy-Item \"$dir\\Asar.64.dll\" \"$7z_folder\\Formats\\\" -Force }",
+        "elseif ($architecture -eq '32bit') { Copy-Item \"$dir\\Asar.32.dll\" \"$7z_folder\\Formats\\\" -Force }"
+    ],
+    "pre_uninstall": [
+        "$7z_folder = Split-Path (scoop which 7z)",
+        "if (!(Test-Path $7z_folder)) { warn 'Could not find 7z.exe in PATH.' }",
+        "if ($architecture -eq '64bit') { Remove-Item \"$7z_folder\\Formats\\Asar.64.dll\" }",
+        "elseif ($architecture -eq '32bit') { Remove-Item \"$7z_folder\\Formats\\Asar.32.dll\" }"
+    ],
+    "checkver": "Plugin version: ([\\d.]+)",
+    "autoupdate": {
+        "url": "https://www.tc4shell.com/binary/Asar.zip"
+    }
+}


### PR DESCRIPTION
* closes #3797
* relates to https://github.com/ScoopInstaller/Main/issues/849


**[Asar7z](https://www.tc4shell.com/en/7zip/asar/)** is a 7-zip plugin that allows 7-zip to open, modify, or create **Electron .asar archives**.

**NOTES:**
* Using **path checks** for 7z (instead of `"depends": "7zip"`) so that the package is compatible with **other variants of 7-zip**, such as `versions/7zip-zstd`.

* I tested the plugin with this file: [betterdiscord.asar](https://github.com/BetterDiscord/BetterDiscord/releases/download/v1.6.2/betterdiscord.asar)

* Last update of the plugin was on `09 Jul 2022`.