### PR TITLE
stretchly: Update to version 1.11.0, Remove 32bit

### DIFF
--- a/bucket/stretchly.json
+++ b/bucket/stretchly.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.10.0",
+    "version": "1.11.0",
     "description": "Break time reminder",
     "homepage": "https://hovancik.net/stretchly/",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hovancik/stretchly/releases/download/v1.10.0/stretchly-1.10.0-win.7z",
-            "hash": "540b0e995fdc851331653996b78829e255c5fe90e12b3aff81c5d77ad755cad7"
-        },
-        "32bit": {
-            "url": "https://github.com/hovancik/stretchly/releases/download/v1.10.0/stretchly-1.10.0-ia32-win.7z",
-            "hash": "bfd5a5da7e146c6c4c8a448b92530d504a44c492991ca0312cfb4ecbdd40fd1b"
+            "url": "https://github.com/hovancik/stretchly/releases/download/v1.11.0/stretchly-1.11.0-win.7z",
+            "hash": "2545fce30813cdc05b170d50cc2a259abcb98d02b54870cb3a10acf6a2d85597"
         }
     },
     "bin": "stretchly.exe",
@@ -27,9 +23,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/hovancik/stretchly/releases/download/v$version/stretchly-$version-win.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/hovancik/stretchly/releases/download/v$version/stretchly-$version-ia32-win.7z"
             }
         }
     }


### PR DESCRIPTION
https://github.com/hovancik/stretchly/releases/tag/v1.11.0

> ## Changed
>
> - no Linux 32 builds, as Electron does not support them anymore

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
