### PR TITLE
gtk-sharp: Add version 2.12.45

### DIFF
--- a/bucket/gtk-sharp.json
+++ b/bucket/gtk-sharp.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.12.45",
+    "description": "Runtime library for Gtk#-based applications on Microsoft .NET",
+    "homepage": "https://www.mono-project.com/docs/gui/gtksharp/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://xamarin.azureedge.net/GTKforWindows/Windows/gtk-sharp-2.12.45.msi#/setup.msi_",
+    "hash": "c944a52ca16d4c10f4619d4d7c9a46b358ffa798fa35641fc05030e59983e03d",
+    "pre_install": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "Start-Process msiexec -ArgumentList @('/i', \"`\"$dir\\setup.msi_`\"\", '/qn', '/norestart') -Wait -Verb RunAs"
+    ],
+    "pre_uninstall": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "Start-Process msiexec -ArgumentList @('/x', \"`\"$dir\\setup.msi_`\"\", '/qn', '/norestart') -Wait -Verb RunAs"
+    ],
+    "checkver": {
+        "url": "https://www.mono-project.com/download/stable/",
+        "regex": "gtk-sharp-([\\d.]+)\\.msi"
+    },
+    "autoupdate": {
+        "url": "https://xamarin.azureedge.net/GTKforWindows/Windows/gtk-sharp-$version.msi#/setup.msi_"
+    }
+}

--- a/bucket/gtk-sharp.json
+++ b/bucket/gtk-sharp.json
@@ -1,6 +1,6 @@
 {
     "version": "2.12.45",
-    "description": "Runtime library for Gtk#-based applications on Microsoft .NET",
+    "description": "Runtime library for Gtk-based applications on Microsoft .NET",
     "homepage": "https://www.mono-project.com/docs/gui/gtksharp/",
     "license": "GPL-2.0-or-later",
     "url": "https://xamarin.azureedge.net/GTKforWindows/Windows/gtk-sharp-2.12.45.msi#/setup.msi_",


### PR DESCRIPTION
* closes #8972

**[GTK#](https://www.mono-project.com/docs/gui/gtksharp/)** is a runtime library for Gtk-based applications on Microsoft .NET.

**NOTES**:
* The app is built in 32-bit.
* Using `Start-Process` (instead of `Invoke-ExternalCommand`) as a workaround to avoid error when `$dir` **contains spaces**.