### PR TITLE
vnote@3.14.0: Use file url for special patch

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.14.0/vnote-win-x64_v3.14.0.zip",
+            "url": "https://github.com/vnotex/vnote/releases/download/v3.14.0/vnote-win-x64-qt5.15.2_v3.14.0.zip",
             "hash": "d92595bdd7490018edb61c369051480bea117aab53a23260bc868993c3cd0658"
         },
         "32bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Vnote upload a new release to fix some building problem, so change the download url for current version only.


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

