### PR TITLE
vscode, vscodium: fix reg import cmds in notes

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -7,8 +7,8 @@
         "url": "https://code.visualstudio.com/License/"
     },
     "notes": [
-        "Add Visual Studio Code as a context menu option by running: '$dir\\install-context.reg'",
-        "For file associations, run '$dir\\install-associations.reg'"
+        "Add Visual Studio Code as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
+        "For file associations, run 'reg import \"$dir\\install-associations.reg\"'"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -4,8 +4,8 @@
     "homepage": "https://github.com/VSCodium/vscodium",
     "license": "MIT",
     "notes": [
-        "Add VSCodium as a context menu option by running: '$dir\\install-context.reg'",
-        "For file associations, run '$dir\\install-associations.reg'"
+        "Add VSCodium as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
+        "For file associations, run 'reg import \"$dir\\install-associations.reg\"'"
     ],
     "architecture": {
         "64bit": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Users cannot import reg using previous commands in `"notes"`