### PR TITLE
propertree: add persist and shortcut

### DIFF
--- a/bucket/propertree.json
+++ b/bucket/propertree.json
@@ -8,6 +8,16 @@
     "hash": "c15aa8bc2192304d2cfd006d6324ccb1615605b3259d73d3ab73b6d04f19a195",
     "extract_dir": "ProperTree-de5bab39010b47828f140df4ce335baca33bbd8c",
     "bin": "ProperTree.bat",
+    "shortcuts": [
+        [
+            "ProperTree.bat",
+            "ProperTree"
+        ]
+    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\Scripts\\settings.json\")) { Set-Content \"$dir\\Scripts\\settings.json\" '{}' -Encoding Ascii }",
+    "persist": [
+        "Scripts\\settings.json"
+    ],
     "checkver": {
         "url": "https://github.com/corpnewt/ProperTree/commits/master.atom",
         "regex": "(?s)>(\\d+)-(\\d+)-(\\d+)T.*?/(?<sha>[0-9a-f]{40})",


### PR DESCRIPTION


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


propertree has a GUI so it need shortcut