### PR TITLE
Generate PowerShell profile modifier without templete files

### DIFF
--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "notes": [
         "Run following command to import scoop-completion automatically in Powershell:",
-        "$dir\\append-to-profile.ps1"
+        "$dir\\add-profile-content.ps1"
     ],
     "url": "https://github.com/Moeologist/scoop-completion/archive/v0.2.3.zip",
     "hash": "59fcda6e723b2c0bf7430668ccfb57086d82e9472733a01f9f7f9315768b5e5f",
@@ -16,21 +16,21 @@
     "post_install": [
         "Get-ChildItem -Path \"$dir\" -Filter \"scoop-completion-$version\" -Directory | Remove-Item -Force -Recurse",
         "Import-Module scoop-completion",
-        "$ScriptsDir = $(Join-Path $(Find-BucketDirectory -Root -Name extras) scripts/scoop-completion)",
-        "$ModifierPath = $(Join-Path $(Find-BucketDirectory -Root -Name extras) scripts/ModifyPSProfile.psm1)",
-        "'append-to-profile.ps1', 'remove-from-profile.ps1' | ForEach-Object {",
-        "    if ((Test-Path \"$ScriptsDir\\$_\") -and (Test-Path \"$ModifierPath\")) {",
-        "        Copy-Item \"$ScriptsDir\\$_\" \"$dir\\\"",
-        "        $Content = (Get-Content \"$dir\\$_\").Replace('$ModifyPSProfile', \"$ModifierPath\")",
-        "        $content | Set-Content -Path \"$dir\\$_\"",
-        "    } else {",
-        "        Write-Host 'Missing files, please update scoop buckets and reinstall this module again' -ForegroundColor Red",
-        "    }",
+        "$BucketDir = Find-BucketDirectory -Root -Name extras",
+        "$UtilsPath = $BucketDir | Join-Path -ChildPath \"scripts\\ModifyPSProfile.psm1\"",
+        "if (Test-Path $UtilsPath) {",
+        "    Import-Module $UtilsPath",
+        "    New-ProfileModifier -Type ImportModule -Name scoop-completion -BucketDir $BucketDir",
+        "    New-ProfileModifier -Type RemoveModule -Name scoop-completion -BucketDir $BucketDir",
+        "    Remove-Module ModifyPSProfile",
+        "} else {",
+        "    Write-Host 'Missing files, please update scoop buckets and reinstall this app.' -ForegroundColor Red",
         "}"
     ],
     "pre_uninstall": [
-        "if (($cmd -eq 'uninstall') -and (Test-Path \"$dir\\remove-from-profile.ps1\")) {",
-        "    & \"$dir\\remove-from-profile.ps1\"",
+        "$UtilsPath = Find-BucketDirectory -Root -Name extras | Join-Path -ChildPath \"scripts\\ModifyPSProfile.psm1\"",
+        "if (($cmd -eq 'uninstall') -and (Test-Path \"$dir\\remove-profile-content.ps1\") -and (Test-Path $UtilsPath)) {",
+        "    & \"$dir\\remove-profile-content.ps1\"",
         "}"
     ],
     "checkver": {

--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -18,6 +18,7 @@
         "Import-Module scoop-completion",
         "$BucketDir = Find-BucketDirectory -Root -Name extras",
         "$UtilsPath = $BucketDir | Join-Path -ChildPath \"scripts\\ModifyPSProfile.psm1\"",
+        "Unblock-File $UtilsPath",
         "if (Test-Path $UtilsPath) {",
         "    Import-Module $UtilsPath",
         "    New-ProfileModifier -Type ImportModule -Name scoop-completion -BucketDir $BucketDir",

--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -18,8 +18,8 @@
         "Import-Module scoop-completion",
         "$BucketDir = Find-BucketDirectory -Root -Name extras",
         "$UtilsPath = $BucketDir | Join-Path -ChildPath \"scripts\\ModifyPSProfile.psm1\"",
-        "Unblock-File $UtilsPath",
         "if (Test-Path $UtilsPath) {",
+        "    Unblock-File $UtilsPath",
         "    Import-Module $UtilsPath",
         "    New-ProfileModifier -Type ImportModule -Name scoop-completion -BucketDir $BucketDir",
         "    New-ProfileModifier -Type RemoveModule -Name scoop-completion -BucketDir $BucketDir",
@@ -31,6 +31,7 @@
     "pre_uninstall": [
         "$UtilsPath = Find-BucketDirectory -Root -Name extras | Join-Path -ChildPath \"scripts\\ModifyPSProfile.psm1\"",
         "if (($cmd -eq 'uninstall') -and (Test-Path \"$dir\\remove-profile-content.ps1\") -and (Test-Path $UtilsPath)) {",
+        "    Unblock-File $UtilsPath",
         "    & \"$dir\\remove-profile-content.ps1\"",
         "}"
     ],

--- a/scripts/ModifyPSProfile.psm1
+++ b/scripts/ModifyPSProfile.psm1
@@ -76,7 +76,7 @@ function Add-ProfileContent {
         [string] $Content
     )
 
-    if (-not(test-path $PROFILE)) {
+    if (-not(Test-Path $PROFILE)) {
         New-Item -Path $PROFILE -Value "$Content" -ItemType File -Force | Out-Null
     }
     else {
@@ -98,7 +98,7 @@ function Remove-ProfileContent {
         [string] $Content
     )
 
-    if (-not(test-path $PROFILE)) {
+    if (-not(Test-Path $PROFILE)) {
         Return
     }
 

--- a/scripts/ModifyPSProfile.psm1
+++ b/scripts/ModifyPSProfile.psm1
@@ -1,6 +1,59 @@
-#Requires -Version 5.1
+#Requires -Version 5.0
 
-function AppendtoProfile {
+function New-ProfileModifier {
+    <#
+    .SYNOPSIS
+        Generate scripts from template.
+
+    .PARAMETER Type
+        Type of scripts to generate.
+
+    .PARAMETER Name
+        Name of manifest.
+
+    .PARAMETER BucketDir
+        Path of bucket root directory.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $Type,
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $Name,
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $BucketDir
+    )
+
+    $SupportedType = @("ImportModule", "RemoveModule")
+
+    if ($SupportedType -notcontains $Type) {
+        Write-Host "Error: Unsupported type." -ForegroundColor Red
+        Return
+    }
+
+    $UtilsPath = $BucketDir | Join-Path -ChildPath "\scripts\ModifyPSProfile.psm1"
+    $ScoopDir = Split-Path $BucketDir | Split-Path
+    $AppDir = $ScoopDir | Join-Path -ChildPath "\apps\$Name\current\"
+
+    $ImportUtilsCommand = ("Import-Module ", $UtilsPath) -Join("")
+    $RemoveUtilsCommand = "Remove-Module -Name ModifyPSProfile"
+
+    $ImportModuleCommand = ("Add-ProfileContent 'Import-Module ", $Name, "'") -Join("")
+    $RemoveModuleCommand = ("Remove-ProfileContent 'Import-Module ", $Name, "'") -Join("")
+
+    switch ($Type) {
+        {$_ -eq "ImportModule"} {
+            $GenerateContent = ($ImportUtilsCommand, $RemoveModuleCommand, $ImportModuleCommand, $RemoveUtilsCommand) -Join("`r`n")
+            $GenerateContent | Set-Content -Path "$AppDir\add-profile-content.ps1"
+        }
+        {$_ -eq "RemoveModule"} {
+            $GenerateContent = ($ImportUtilsCommand, $RemoveModuleCommand, $RemoveUtilsCommand) -Join("`r`n")
+            $GenerateContent | Set-Content -Path "$AppDir\remove-profile-content.ps1"
+        }
+    }
+}
+
+function Add-ProfileContent {
     <#
     .SYNOPSIS
         Add certain content to PSProfile.
@@ -14,14 +67,15 @@ function AppendtoProfile {
         [string] $Content
     )
 
-    if (!(test-path $profile)) {
-        New-Item -Path $profile -Value "$content" -ItemType File -Force | Out-Null
-    } else {
-        Add-Content -Path $profile -Value "`n$content" -NoNewLine
+    if (!(test-path $PROFILE)) {
+        New-Item -Path $PROFILE -Value "$Content" -ItemType File -Force | Out-Null
+    }
+    else {
+        Add-Content -Path $PROFILE -Value "`r`n$Content" -NoNewLine
     }
 }
 
-function RemovefromProfile {
+function Remove-ProfileContent {
     <#
     .SYNOPSIS
         Remove certain content from PSProfile.
@@ -35,9 +89,15 @@ function RemovefromProfile {
         [string] $Content
     )
 
-    ((Get-Content -Path $profile -raw) -replace "[\r\n]*$content",'').trim() | Set-Content $profile -NoNewLine
+    ((Get-Content -Path $PROFILE -raw) -replace "[\r\n]*$Content",'').trim() | Set-Content $PROFILE -NoNewLine
 }
+
+Set-Alias AppendtoProfile Add-ProfileContent
+Set-Alias RemovefromProfile Remove-ProfileContent
+Export-ModuleMember -Alias *
 
 Export-ModuleMember `
     -Function `
-        AppendtoProfile, RemovefromProfile
+        New-ProfileModifier, `
+        Add-ProfileContent, `
+        Remove-ProfileContent

--- a/scripts/ModifyPSProfile.psm1
+++ b/scripts/ModifyPSProfile.psm1
@@ -98,7 +98,13 @@ function Remove-ProfileContent {
         [string] $Content
     )
 
-    ((Get-Content -Path $PROFILE -raw) -replace "[\r\n]*$Content",'').trim() | Set-Content $PROFILE -NoNewLine
+    $RawProfile = Get-Content -Path $PROFILE -raw
+
+    if ($null -eq $RawProfile) {
+        Return
+    }
+
+    ($RawProfile -replace "[\r\n]*$Content",'').trim() | Set-Content $PROFILE -NoNewLine
 }
 
 Set-Alias AppendtoProfile Add-ProfileContent

--- a/scripts/ModifyPSProfile.psm1
+++ b/scripts/ModifyPSProfile.psm1
@@ -76,7 +76,7 @@ function Add-ProfileContent {
         [string] $Content
     )
 
-    if (!(test-path $PROFILE)) {
+    if (-not(test-path $PROFILE)) {
         New-Item -Path $PROFILE -Value "$Content" -ItemType File -Force | Out-Null
     }
     else {
@@ -97,6 +97,10 @@ function Remove-ProfileContent {
         [Parameter(Mandatory = $true, Position = 0)]
         [string] $Content
     )
+
+    if (-not(test-path $PROFILE)) {
+        Return
+    }
 
     $RawProfile = Get-Content -Path $PROFILE -raw
 

--- a/scripts/ModifyPSProfile.psm1
+++ b/scripts/ModifyPSProfile.psm1
@@ -13,15 +13,20 @@ function New-ProfileModifier {
 
     .PARAMETER BucketDir
         Path of bucket root directory.
+
+    .PARAMETER ModuleName
+        Use this parameter if module name differs from app name.
     #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0)]
         [string] $Type,
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory = $true, Position = 1)]
         [string] $Name,
-        [Parameter(Mandatory = $true, Position = 0)]
-        [string] $BucketDir
+        [Parameter(Mandatory = $true, Position = 2)]
+        [string] $BucketDir,
+        [Parameter(Mandatory = $false, Position = 3)]
+        [string] $ModuleName
     )
 
     $SupportedType = @("ImportModule", "RemoveModule")
@@ -31,6 +36,10 @@ function New-ProfileModifier {
         Return
     }
 
+    if (-not($ModuleName)) {
+        $ModuleName = $Name
+    }
+
     $UtilsPath = $BucketDir | Join-Path -ChildPath "\scripts\ModifyPSProfile.psm1"
     $ScoopDir = Split-Path $BucketDir | Split-Path
     $AppDir = $ScoopDir | Join-Path -ChildPath "\apps\$Name\current\"
@@ -38,8 +47,8 @@ function New-ProfileModifier {
     $ImportUtilsCommand = ("Import-Module ", $UtilsPath) -Join("")
     $RemoveUtilsCommand = "Remove-Module -Name ModifyPSProfile"
 
-    $ImportModuleCommand = ("Add-ProfileContent 'Import-Module ", $Name, "'") -Join("")
-    $RemoveModuleCommand = ("Remove-ProfileContent 'Import-Module ", $Name, "'") -Join("")
+    $ImportModuleCommand = ("Add-ProfileContent 'Import-Module ", $ModuleName, "'") -Join("")
+    $RemoveModuleCommand = ("Remove-ProfileContent 'Import-Module ", $ModuleName, "'") -Join("")
 
     switch ($Type) {
         {$_ -eq "ImportModule"} {

--- a/scripts/scoop-completion/append-to-profile.ps1
+++ b/scripts/scoop-completion/append-to-profile.ps1
@@ -1,4 +1,0 @@
-Import-Module $ModifyPSProfile
-RemovefromProfile 'Import-Module scoop-completion'
-AppendtoProfile 'Import-Module scoop-completion'
-Remove-Module -Name ModifyPSProfile

--- a/scripts/scoop-completion/remove-from-profile.ps1
+++ b/scripts/scoop-completion/remove-from-profile.ps1
@@ -1,3 +1,0 @@
-Import-Module $ModifyPSProfile
-RemovefromProfile 'Import-Module scoop-completion'
-Remove-Module -Name ModifyPSProfile


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR is related to #8948 , which added a PowerShell module. 
The module is aimed to provide a tool for each psmodule-like app to edit PowerShell profile, but all of them needs templet files created in advance, so I added a function to generate files without template.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
