### PR TITLE
AltSnap: Add bin

### DIFF
--- a/bucket/altsnap.json
+++ b/bucket/altsnap.json
@@ -19,6 +19,7 @@
             "AltSnap"
         ]
     ],
+    "bin": "AltSnap.exe",
     "persist": "AltSnap.ini",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
AltSnap is receiving a feature where it can be invoked from a shell to perform actions with args, so it only makes sense to add a bin shim.
https://github.com/RamonUnch/AltSnap/issues/285

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
