### PR TITLE
vnote: Update to version 3.15.0

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/vnotex/vnote/releases/download/v3.14.0/vnote-win-x64-qt5.15.2_v3.14.0.zip",
-            "hash": "d92595bdd7490018edb61c369051480bea117aab53a23260bc868993c3cd0658"
+            "hash": "8e680efc84c22b0ad5b908bb4c3e77cfea7103d09ee408256e5b697f66992b5c"
         },
         "32bit": {
             "url": "https://github.com/vnotex/vnote/releases/download/v3.14.0/vnote-win-x86_v3.14.0.zip",

--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.14.0",
+    "version": "3.15.0",
     "description": "A Vim-inspired note-taking platform",
     "homepage": "https://vnotex.github.io/vnote/en_us/",
     "license": "LGPL-3.0-only",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.14.0/vnote-win-x64-qt5.15.2_v3.14.0.zip",
-            "hash": "8e680efc84c22b0ad5b908bb4c3e77cfea7103d09ee408256e5b697f66992b5c"
+            "url": "https://github.com/vnotex/vnote/releases/download/v3.15.0/vnote-win-x64-qt5.15.x_v3.15.0.zip",
+            "hash": "051f58c3db002e142e202634e2f9d2626ba153ceb28a9e35b391ad4a28e2f052"
         },
         "32bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.14.0/vnote-win-x86_v3.14.0.zip",
-            "hash": "7d3feac14e4fc5a36d82610d35458a89ca420017a042c2cf3027cb8b86d1ffb3"
+            "url": "https://github.com/vnotex/vnote/releases/download/v3.15.0/vnote-win-x86-qt5.15.2_v3.15.0.zip",
+            "hash": "967f5aadf7851652851a0ff45059affa7d916fc14fb25b669c47d6a03726db1b"
         }
     },
     "pre_install": "Remove-Item \"$dir\\vcredist_*exe\"",
@@ -25,15 +25,34 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/vnotex/vnote"
+        "script": [
+            "# Using checkver script because 64-bit and 32-bit can use different version of Qt",
+            "# , and the 32-bit file can be above or below the 64-bit one",
+            "$url = 'https://github.com/vnotex/vnote/releases/latest'",
+            "",
+            "$cont = (Invoke-WebRequest $url).Content",
+            "$r = 'tag/v([\\d.]+)'",
+            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; break }",
+            "$ver = $matches[1]",
+            "",
+            "$r = \"vnote-win-x64-qt([\\w.]+)_v$ver.zip\"",
+            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; break }",
+            "$qt64bit = $matches[1]",
+            "$r = \"vnote-win-x86-qt([\\w.]+)_v$ver.zip\"",
+            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; break }",
+            "$qt32bit = $matches[1]",
+            "Write-Host $ver $qt64bit $qt32bit",
+            "Write-Output $ver $qt64bit $qt32bit"
+        ],
+        "regex": "([\\d.]+) (?<qt64bit>[\\w.]+) (?<qt32bit>[\\w.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vnotex/vnote/releases/download/v$version/vnote-win-x64_v$version.zip"
+                "url": "https://github.com/vnotex/vnote/releases/download/v$version/vnote-win-x64-qt$matchQt64bit_v$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/vnotex/vnote/releases/download/v$version/vnote-win-x86_v$version.zip"
+                "url": "https://github.com/vnotex/vnote/releases/download/v$version/vnote-win-x86-qt$matchQt32bit_v$version.zip"
             }
         }
     }


### PR DESCRIPTION
in previous PR https://github.com/ScoopInstaller/Extras/pull/9080 I update the file url for 3.14.0 only, but didn't find that the file hash also changed.


🤔 if i recall correctly there is a CI to check file hash?


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
