### PR TITLE
WSL-distrod: Add version 0.1.7

### DIFF
--- a/bucket/wsl-distrod.json
+++ b/bucket/wsl-distrod.json
@@ -10,6 +10,7 @@
             "extract_dir": "distrod_wsl_launcher-x86_64"
         }
     },
+    "bin": "distrod_wsl_launcher.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/wsl-distrod.json
+++ b/bucket/wsl-distrod.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.1.7",
+    "description": "Distrod is a meta-distro for WSL 2 which installs Ubuntu, Arch, Debian, Gentoo, etc. with systemd in a minute for you. Distrod also has built-in auto-start feature on Windows startup and port forwarding ability.",
+    "homepage": "https://github.com/nullpo-head/wsl-distrod",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/nullpo-head/wsl-distrod/releases/download/v0.1.7/distrod_wsl_launcher-x86_64.zip",
+            "hash": "168ed22170e2c38914e11fb4d6e18822dbb2c85730f86e166eb99f2927634fd2",
+            "bin": "distrod_wsl_launcher-x86_64\\distrod_wsl_launcher.exe"
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/nullpo-head/wsl-distrod/releases/download/v$version/distrod_wsl_launcher-x86_64.zip"
+            }
+        }
+    }
+}

--- a/bucket/wsl-distrod.json
+++ b/bucket/wsl-distrod.json
@@ -1,6 +1,6 @@
 {
     "version": "0.1.7",
-    "description": "Distrod is a meta-distro for WSL 2 which installs Ubuntu, Arch, Debian, Gentoo, etc. with systemd in a minute for you. Distrod also has built-in auto-start feature on Windows startup and port forwarding ability.",
+    "description": "A meta-distro for WSL 2 which installs Ubuntu, Arch, Debian, Gentoo, etc. with systemd in a minute for you",
     "homepage": "https://github.com/nullpo-head/wsl-distrod",
     "license": "MIT",
     "architecture": {

--- a/bucket/wsl-distrod.json
+++ b/bucket/wsl-distrod.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/nullpo-head/wsl-distrod/releases/download/v0.1.7/distrod_wsl_launcher-x86_64.zip",
             "hash": "168ed22170e2c38914e11fb4d6e18822dbb2c85730f86e166eb99f2927634fd2",
-            "bin": "distrod_wsl_launcher-x86_64\\distrod_wsl_launcher.exe"
+            "extract_dir": "distrod_wsl_launcher-x86_64"
         }
     },
     "checkver": "github",


### PR DESCRIPTION
## WSL-distrod

Distrod is a meta-distro for WSL 2 which installs Ubuntu, Arch, Debian, Gentoo, etc. with systemd in a minute for you. Distrod also has built-in auto-start feature on Windows startup and port forwarding ability.