### PR TITLE
pia-desktop: Add version 3.3-06906

### DIFF
--- a/bucket/pia-desktop.json
+++ b/bucket/pia-desktop.json
@@ -1,0 +1,47 @@
+{
+    "version": "3.3-06906",
+    "description": "Private Internet Access - Desktop VPN Client for Windows/macOS/Linux",
+    "homepage": "https://github.com/pia-foss/desktop",
+    "license": "Freeware",
+    "architecture": {
+        "32bit": {
+            "url": "https://privateinternetaccess-storage.s3.amazonaws.com/pub/pia_desktop/builds/pia-windows-x86-3.3-06906.exe#/dl.7z",
+            "hash": "774049b786ae4cab7a56d304e65f2e6e17e4aad12200f1a631a11c3f3b65637b"
+        },
+        "64bit": {
+            "url": "https://privateinternetaccess-storage.s3.amazonaws.com/pub/pia_desktop/builds/pia-windows-x64-3.3-06906.exe#/dl.7z",
+            "hash": "1fdc61f2283d117bc707b55ce3cca172826e7e924020f85b6ffc512d3d525872"
+        }
+    },
+    "bin": [
+        "openvpn_updown.bat",
+        "pia-hnsd.exe",
+        "pia-openvpn.exe",
+        "pia-service.exe",
+        "pia-ss-local.exe",
+        "pia-unbound.exe",
+        "pia-wgservice.exe",
+        "pia-winsvcstub.exe",
+        "piactl.exe"
+    ],
+    "shortcuts": [
+        [
+            "pia-client.exe",
+            "Pia-client"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/pia-foss/desktop/releases",
+        "regex": "/pia_desktop/builds/pia-windows-x64-([\\d.-]+).exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://privateinternetaccess-storage.s3.amazonaws.com/pub/pia_desktop/builds/pia-windows-x86-$version.exe#/dl.7z"
+            },
+            "64bit": {
+                "url": "https://privateinternetaccess-storage.s3.amazonaws.com/pub/pia_desktop/builds/pia-windows-x64-$version.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/pia-desktop.json
+++ b/bucket/pia-desktop.json
@@ -32,7 +32,7 @@
     ],
     "checkver": {
         "url": "https://github.com/pia-foss/desktop/releases",
-        "regex": "/pia_desktop/builds/pia-windows-x64-([\\d.-]+).exe"
+        "regex": "/pia_desktop/builds/pia-windows-x64-([\\d.-]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION

Closes #9112
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

config location: $env:LocalAppData/Private Internet Access