### PR TITLE
vnote 3.15.0: fix 64bit url and hash

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.15.0/vnote-win-x64-qt5.15.x_v3.15.0.zip",
-            "hash": "051f58c3db002e142e202634e2f9d2626ba153ceb28a9e35b391ad4a28e2f052"
+            "url": "https://github.com/vnotex/vnote/releases/download/v3.15.0/vnote-win-x64-qt5.15.2_v3.15.0.zip",
+            "hash": "93319acb6ae367c0dbf1b6e5f17585b2dd875dda9e8dc9dd0498173ca3515a31"
         },
         "32bit": {
             "url": "https://github.com/vnotex/vnote/releases/download/v3.15.0/vnote-win-x86-qt5.15.2_v3.15.0.zip",


### PR DESCRIPTION
... Why they change release url again?