### PR TITLE
cfssl: Update to version 1.6.2, add autoupdate

### DIFF
--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -1,29 +1,29 @@
 {
-    "version": "1.6.1",
+    "version": "1.6.2",
     "description": "Command line tool and an HTTP API server for signing, verifying, and bundling TLS certificates.",
     "homepage": "https://cfssl.org",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssl_1.6.1_windows_amd64.exe#/cfssl.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssl-bundle_1.6.1_windows_amd64.exe#/cfssl-bundle.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssl-certinfo_1.6.1_windows_amd64.exe#/cfssl-certinfo.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssl-newkey_1.6.1_windows_amd64.exe#/cfssl-newkey.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssl-scan_1.6.1_windows_amd64.exe#/cfssl-scan.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssljson_1.6.1_windows_amd64.exe#/cfssljson.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/mkbundle_1.6.1_windows_amd64.exe#/mkbundle.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.6.1/multirootca_1.6.1_windows_amd64.exe#/multirootca.exe"
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl_1.6.2_windows_amd64.exe#/cfssl.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-bundle_1.6.2_windows_amd64.exe#/cfssl-bundle.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-certinfo_1.6.2_windows_amd64.exe#/cfssl-certinfo.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-newkey_1.6.2_windows_amd64.exe#/cfssl-newkey.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-scan_1.6.2_windows_amd64.exe#/cfssl-scan.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssljson_1.6.2_windows_amd64.exe#/cfssljson.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/mkbundle_1.6.2_windows_amd64.exe#/mkbundle.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.6.2/multirootca_1.6.2_windows_amd64.exe#/multirootca.exe"
             ],
             "hash": [
-                "3bcbacdf2fb0988bc0364cdecb16fbb059236daaea996d47be73967cfdd2132e",
-                "e646c6108b23e0e15c2430ca441601ab986c18d81d74428a82bf3eeeba4ebedf",
-                "04292efc272f481a666009c04ed1a75fcdf604e332e9d22768efc6efa6ef4a76",
-                "6ba8f472dc9f2ca1d9e688e12e309ce930862688c43266e7df2c4d4538c79211",
-                "988cd75ff265dca4b41ecc160ab033eca9bc7547e8b0eca5811e7886958a249c",
-                "bcfde30434969c8d1252e350d8387e465936895a5a1d61b986d46a8782aae28c",
-                "a8a9e9bc22fb34b5b8116d69ee59bbd2d0f9f35f23718b6b5af20f46d2a7dd77",
-                "31085378f95a242891be56c4dbd847b9eb543d4ee3feb6f762d8d2b4af65dc3f"
+                "4a7ab4adf1cb8755dde9f1730400e6fe282bdd5d6a4e9501ca1b7108543e853d",
+                "d02afbed39f2133812b263e00623fe8f5faa40a2b58c74cb9c7794fa0be89249",
+                "ce34a69a3222d98b7b76810ea569b25ef73a181669633670443e11a4770ba33f",
+                "122d542088dba92c388af737aa86d393911acf6f2d78e3f47614bd580f4c7a89",
+                "89dcbe956b2a188282b0595158af5f6c0633eb3ab1d4fc8b731e35305316c016",
+                "902cb7036079cfacc5a3710fd2500f453d177cfe6c2cb8f03ae0014c063c2e56",
+                "c86b4008ac889369ebd3de011a6cc3738e075b6a35d166372383675f006e1a56",
+                "19a7c3143bda7f60d95af37a1b951961e205d67f1c66cbb5b1b1bbf567592621"
             ]
         }
     },
@@ -39,5 +39,24 @@
     ],
     "checkver": {
         "github": "https://github.com/cloudflare/cfssl"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl_$version_windows_amd64.exe#/cfssl.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl-bundle_$version_windows_amd64.exe#/cfssl-bundle.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl-certinfo_$version_windows_amd64.exe#/cfssl-certinfo.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl-newkey_$version_windows_amd64.exe#/cfssl-newkey.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl-scan_$version_windows_amd64.exe#/cfssl-scan.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssljson_$version_windows_amd64.exe#/cfssljson.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/mkbundle_$version_windows_amd64.exe#/mkbundle.exe",
+                    "https://github.com/cloudflare/cfssl/releases/download/v$version/multirootca_$version_windows_amd64.exe#/multirootca.exe"
+                ],
+                "hash": {
+                    "url": "$baseurl/cfssl_$version_checksums.txt"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
<!-- or -->
Relates to Excavator found update but no autoupdate in manifest: https://github.com/ScoopInstaller/Extras/runs/8109300378?check_suite_focus=true#step:3:214

 `cfssl: 1.6.2 (scoop version is 1.6.1)`

Opening a PR because I wasn't sure if autoupdate was omitted for a specific reason, seems to work okay for me. I suspect maybe autoupdate hash extraction didn't work before for one checksum and multiple files?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
