### PR TITLE
manictime: Update to version 5.1.4.1

### DIFF
--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -1,13 +1,13 @@
 {
-    "version": "5.0.2.0",
+    "version": "5.1.4.1",
     "description": "A time tracking software",
     "homepage": "https://www.manictime.com",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.manictime.com/pricing"
     },
-    "url": "https://cdn.manictime.com/setup/v5_0_2_0/ManicTimeUsb.zip",
-    "hash": "dae68230aec2450719233c4a5a4bec6429a3d410d8104ab49facc693ae90e005",
+    "url": "https://cdn.manictime.com/setup/v5_1_4_1/manictime-portable-5.1.4.1-win-x64.zip",
+    "hash": "4b788872f1f0f62eb1f15c2093e1c0b77cd0a057f7a1314aa7e3938031bfaa03",
     "shortcuts": [
         [
             "ManicTimeClient.exe",
@@ -20,6 +20,6 @@
         "jsonpath": "$.version"
     },
     "autoupdate": {
-        "url": "https://cdn.manictime.com/setup/v$underscoreVersion/ManicTimeUsb.zip"
+        "url": "https://cdn.manictime.com/setup/v$underscoreVersion/manictime-portable-$version-win-x64.zip"
     }
 }

--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -6,8 +6,16 @@
         "identifier": "Proprietary",
         "url": "https://www.manictime.com/pricing"
     },
-    "url": "https://cdn.manictime.com/setup/v5_1_4_1/manictime-portable-5.1.4.1-win-x64.zip",
-    "hash": "4b788872f1f0f62eb1f15c2093e1c0b77cd0a057f7a1314aa7e3938031bfaa03",
+    "architecture": {
+        "32bit": {
+            "url": "https://cdn.manictime.com/setup/v5_1_4_1/manictime-portable-5.1.4.1-win-x86.zip",
+            "hash": "c165982777a8ad3572fbf48f06130c204d61483bd9625b98207c5a67e3ce0681"
+        },
+        "64bit": {
+            "url": "https://cdn.manictime.com/setup/v5_1_4_1/manictime-portable-5.1.4.1-win-x64.zip",
+            "hash": "4b788872f1f0f62eb1f15c2093e1c0b77cd0a057f7a1314aa7e3938031bfaa03"
+        }
+    },
     "shortcuts": [
         [
             "ManicTimeClient.exe",
@@ -20,6 +28,13 @@
         "jsonpath": "$.version"
     },
     "autoupdate": {
-        "url": "https://cdn.manictime.com/setup/v$underscoreVersion/manictime-portable-$version-win-x64.zip"
+        "architecture": {
+            "32bit": {
+                "url": "https://cdn.manictime.com/setup/v$underscoreVersion/manictime-portable-$version-win-x86.zip"
+            },
+            "64bit": {
+                "url": "https://cdn.manictime.com/setup/v$underscoreVersion/manictime-portable-$version-win-x64.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request will include the following updates:

- Support for new portable version release URL (so changed autoupdate url)
  - The file name has been changed from `ManicTimeUsb.zip` to `manictime-portable-$version-win-x64.zip` including the version name.
- Supports 64bit application added since ManicTime v5.1
  - See [ManicTime releases](https://www.manictime.com/Releases/)
- Update to version ManicTime v5.1.4.1 (Previously it was v5.0.2.0)

---

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).