### PR TITLE
quarto@v1.1.189: Use new `quarto.exe` binary

### DIFF
--- a/bucket/quarto.json
+++ b/bucket/quarto.json
@@ -9,7 +9,7 @@
             "hash": "0d52ec84cad1d176bb18c2ed9639ea569fa999252a1c0cf0c07f2026993b87e6"
         }
     },
-    "bin": "bin\\quarto.cmd",
+    "bin": "bin\\quarto.exe",
     "checkver": {
         "github": "https://github.com/quarto-dev/quarto-cli"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This PR modies the `bin` property to use the new `quarto.exe` binary now included in the bundle. This new exe file solves some issues in some system and is the recommended way to call quarto now.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
