### PR TITLE
jpass: Add version 0.1.28

### DIFF
--- a/bucket/jpass.json
+++ b/bucket/jpass.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.1.28",
+    "description": "Password manager application with strong encryption (AES-256)",
+    "homepage": "https://github.com/gaborbata/jpass",
+    "license": {
+        "identifier": "MIT|GPL-3.0|LGPL-3.0|Apache-2.0|BSD-3-Clause|CC-BY-4.0",
+        "url": "https://github.com/gaborbata/jpass/blob/master/LICENSE"
+    },
+    "notes": [
+        "Install Java (JDK or JRE) if you do not already have. JPass will not work without it.",
+        "Please make sure PATH, or JAVA_HOME environment variables point to a valid Java installation."
+    ],
+    "suggest": {
+        "java": [
+            "java/openjdk",
+            "java/openjdk17",
+            "java/openjdk11"
+        ]
+    },
+    "url": "https://github.com/gaborbata/jpass/releases/download/v0.1.28/jpass-0.1.28-RELEASE.zip",
+    "hash": "6a2a4d283f7876653dd7749b74cb9504079d85f7c2b157dffaa02aa672bbb320",
+    "bin": "jpass.bat",
+    "shortcuts": [
+        [
+            "jpass.bat",
+            "JPass",
+            "",
+            "jpass.ico"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/gaborbata/jpass"
+    },
+    "autoupdate": {
+        "url": "https://github.com/gaborbata/jpass/releases/download/v$version/jpass-$version-RELEASE.zip",
+        "hash": "$url.sha256"
+    }
+}


### PR DESCRIPTION
Add JPass version 0.1.28 - Password manager application with strong encryption (AES-256)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
