### PR TITLE
clash-mini: Add version 0.2.0

### DIFF
--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.1.8",
+    "version": "0.2.0",
     "description": "A simple GUI for Clash.",
     "homepage": "https://github.com/MetaCubeX/Clash.Mini",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.1.8/Clash.Mini_v0.1.8_x64.7z",
-            "hash": "6c5ea2e4c0f6f2219b0324d0406d8ad8b4466ae626e785cb26eb759f0255e6e6"
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.0/Clash.Mini_v0.2.0_x64.7z",
+            "hash": "c68e786355de0b09ffd0a3fc923a9b4de95655463011b31f8f96c0afa1729a73"
         },
         "32bit": {
-            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.1.8/Clash.Mini_v0.1.8_x86.7z",
-            "hash": "772d5c180d00823912b56f96b480cfcfba8647011e48e878cd08b274cb1c2c72"
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.0/Clash.Mini_v0.2.0_x86.7z",
+            "hash": "99fea7082914c2e73979e839615dc2da004d7fb4f9d48da6b622569b9a4b8a0f"
         }
     },
     "shortcuts": [

--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.0/Clash.Mini_v0.2.0_x64.7z",
-            "hash": "c68e786355de0b09ffd0a3fc923a9b4de95655463011b31f8f96c0afa1729a73"
+            "hash": "a5007c479c10be6929aa11fa6efb11c30bb990774babed9e374807320e339908"
         },
         "32bit": {
             "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.0/Clash.Mini_v0.2.0_x86.7z",
-            "hash": "99fea7082914c2e73979e839615dc2da004d7fb4f9d48da6b622569b9a4b8a0f"
+            "hash": "ad1f5e3c017497b964c943ac5ce0f74aa8ecfe6aa1d7507ca1ca924185a78bdc"
         }
     },
     "shortcuts": [
@@ -21,7 +21,8 @@
     ],
     "persist": [
         ".cm",
-        ".core"
+        ".core",
+        "log"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
[Clash.Mini](https://github.com/MetaCubeX/Clash.Mini) a simple GUI for [Clash](https://github.com/Dreamacro/clash).

Which first publish at #7921, and deprecated at [commit #054309](https://github.com/ScoopInstaller/Extras/commit/054309aea37ffaef4771f4c16d295bf43399abaf)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
