### PR TITLE
Fix: vcredist-aio getting stuck during install

### DIFF
--- a/bucket/vcredist-aio.json
+++ b/bucket/vcredist-aio.json
@@ -9,8 +9,7 @@
     "installer": {
         "file": "VisualCppRedist_AIO_x86_x64.exe",
         "args": [
-            "/ai",
-            "/gm2"
+            "/ai"
         ],
         "keep": true
     },


### PR DESCRIPTION
Fix hanging installation by removing option in manifest: "/gm2"

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
