### PR TITLE
caesium-image-compressor: fix auto update for extract_dir

### DIFF
--- a/bucket/caesium-image-compressor.json
+++ b/bucket/caesium-image-compressor.json
@@ -6,8 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Lymphatus/caesium-image-compressor/releases/download/v2.2.0/caesium-image-compressor-2.2.0-win.zip",
-            "hash": "e2a972e545f542101021a425b9010a0fa918194f03e43bdfb4c3701635c9799e",
-            "extract_dir": "caesium-image-compressor-2.1.0-win"
+            "hash": "2cd4f21e696aacf6278b072079b155666877e08788b29b952ca509caf88f4841",
+            "extract_dir": "caesium-image-compressor-2.2.0-win"
         }
     },
     "shortcuts": [
@@ -22,7 +22,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Lymphatus/caesium-image-compressor/releases/download/v$version/caesium-image-compressor-$version-win.zip"
+                "url": "https://github.com/Lymphatus/caesium-image-compressor/releases/download/v$version/caesium-image-compressor-$version-win.zip",
+                "extract_dir": "caesium-image-compressor-$version-win"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
