### PR TITLE
SikuliX: Add version 2.0.5

### DIFF
--- a/bucket/sikulix.json
+++ b/bucket/sikulix.json
@@ -3,28 +3,18 @@
     "description": "Visual Automation and Testing",
     "homepage": "https://sikulix.github.io/",
     "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://launchpad.net/sikuli/sikulix/2.0.5/+download/sikulixide-2.0.5.jar",
-            "hash": "f4b0b50c8e413094e78cd1d8fed02ae65f62f8c53ed00da0562fdedf4acff729",
-            "bin": [
-                ["java.exe", "sikulix", "-jar $dir\\sikulixide-2.0.5.jar"]
-            ]
-        }
+    "suggest": {
+        "JDK17": "java/openjdk17",
+        "vcredist": "extras/vcredist2015"
     },
+    "url": "https://launchpad.net/sikuli/sikulix/2.0.5/+download/sikulixide-2.0.5.jar#/sikulix.jar",
+    "hash": "f4b0b50c8e413094e78cd1d8fed02ae65f62f8c53ed00da0562fdedf4acff729",
+    "bin": "sikulix.jar",
     "checkver": {
         "url": "https://raiman.github.io/SikuliX1/downloads.html",
         "regex": "Version ([\\d.]+) \\(latest stable version\\)"
     },
     "autoupdate": {
-        "url": "https://launchpad.net/sikuli/sikulix/$version/+download/sikulixide-$version.jar",
-        "bin": [
-            [
-                "java.exe",
-                "sikulix",
-                "-jar",
-                "\"$dir\\sikulixide-$version.jar\""
-            ]
-        ]
+        "url": "https://launchpad.net/sikuli/sikulix/$version/+download/sikulixide-$version.jar#/sikulix.jar"
     }
 }

--- a/bucket/sikulix.json
+++ b/bucket/sikulix.json
@@ -14,9 +14,17 @@
     },
     "checkver": {
         "url": "https://raiman.github.io/SikuliX1/downloads.html",
-        "regex": "Version \\d[.]\\d[.]\\d (latest stable version)"
+        "regex": "Version ([\\d.]+) \\(latest stable version\\)"
     },
     "autoupdate": {
-        "url": "https://launchpad.net/sikuli/sikulix/$version/+download/sikulixide-$version.jar"
+        "url": "https://launchpad.net/sikuli/sikulix/$version/+download/sikulixide-$version.jar",
+        "bin": [
+            [
+                "java.exe",
+                "sikulix",
+                "-jar",
+                "\"$dir\\sikulixide-$version.jar\""
+            ]
+        ]
     }
 }

--- a/bucket/x64dbg.json
+++ b/bucket/x64dbg.json
@@ -1,10 +1,10 @@
 {
-    "version": "2022-09-10_01-57",
+    "version": "2022-09-11_15-59",
     "description": "x64/x32 debugger",
     "homepage": "https://x64dbg.com/",
     "license": "GPL-3.0-only",
-    "url": "https://downloads.sourceforge.net/project/x64dbg/snapshots/snapshot_2022-09-10_01-57.zip",
-    "hash": "sha1:e6aa887c0cfe90bc9e62da8c20e46d6c8807cf1f",
+    "url": "https://downloads.sourceforge.net/project/x64dbg/snapshots/snapshot_2022-09-11_15-59.zip",
+    "hash": "sha1:1927f8f6c0d64f474a4c54123c39c6e0fe89c95c",
     "pre_install": [
         "'release\\x96dbg.ini', 'release\\x32\\x32dbg.ini', 'release\\x64\\x64dbg.ini' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item -ItemType File \"$dir\\$_\" | Out-Null }",


### PR DESCRIPTION
This PR adds support for installing [SikuliX](https://sikulix.github.io/), a really cool UI-based robotic process automation tool. SikuliX makes it really easy to automate just about anything on a computer. My thought is that it would get more usage if it was easier to install. As of today, all you need to do is download a JAR file and run it with Java, but who has time for that? I have wanted to do scoop install sikulix for years. Hopefully my dream will come true soon...

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
