### PR TITLE
x64dbg: Persist symbols folder

### DIFF
--- a/bucket/x64dbg.json
+++ b/bucket/x64dbg.json
@@ -17,11 +17,13 @@
         "release\\x32\\garbage",
         "release\\x32\\db",
         "release\\x32\\plugins",
+        "release\\x32\\symbols",
         "release\\x64\\x64dbg.ini",
         "release\\x64\\memdumps",
         "release\\x64\\garbage",
         "release\\x64\\db",
-        "release\\x64\\plugins"
+        "release\\x64\\plugins",
+        "release\\x64\\symbols"
     ],
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

x64dbg can download debug symbols from Microsoft public symbol server. This PR add persist for downloaded symbols.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
