### PR TITLE
elasticsearch: Use `bin` path to avoid missing shims for older versions

### DIFF
--- a/bucket/elasticsearch.json
+++ b/bucket/elasticsearch.json
@@ -24,29 +24,7 @@
         "$cont = $cont -replace '#path.logs:.*$', \"path.logs: $persist_dir\\logs\"",
         "Set-Content \"$file\" ($cont -join \"`r`n\") -Encoding ASCII"
     ],
-    "bin": [
-        "bin\\elasticsearch-certgen.bat",
-        "bin\\elasticsearch-certutil.bat",
-        "bin\\elasticsearch-cli.bat",
-        "bin\\elasticsearch-create-enrollment-token.bat",
-        "bin\\elasticsearch-croneval.bat",
-        "bin\\elasticsearch-env.bat",
-        "bin\\elasticsearch-geoip.bat",
-        "bin\\elasticsearch-keystore.bat",
-        "bin\\elasticsearch-node.bat",
-        "bin\\elasticsearch-plugin.bat",
-        "bin\\elasticsearch-reconfigure-node.bat",
-        "bin\\elasticsearch-reset-password.bat",
-        "bin\\elasticsearch-saml-metadata.bat",
-        "bin\\elasticsearch-service-tokens.bat",
-        "bin\\elasticsearch-service.bat",
-        "bin\\elasticsearch-setup-passwords.bat",
-        "bin\\elasticsearch-shard.bat",
-        "bin\\elasticsearch-sql-cli.bat",
-        "bin\\elasticsearch-syskeygen.bat",
-        "bin\\elasticsearch-users.bat",
-        "bin\\elasticsearch.bat"
-    ],
+    "env_add_path": "bin",
     "persist": [
         "config",
         "plugins"


### PR DESCRIPTION
if you try to install a older version like '7.1.1' with scoop install <app>@<version> the shim fails to be created due to changes in the app structure,

actually the scoop installer itself should ignore missing shims in the cases were you are downgrading to a given version, I think that would be more appropriate.

in the meanwhile we can fix this by just putting the entire Elasticsearch 'bin' folder into PATH

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
