### PR TITLE
kate: Update to 22.08.0

### DIFF
--- a/bucket/kate.json
+++ b/bucket/kate.json
@@ -1,12 +1,12 @@
 {
-    "version": "22.04.1",
+    "version": "22.08.0",
     "description": "Multi-document editor",
     "homepage": "https://kate-editor.org",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/release-service/22.04.1/windows/kate-22.04.1-1674-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "e56eabece1b022d7a31dabb245a06a474176a988c7ce505741401cd6e6c87853"
+            "url": "https://download.kde.org/stable/release-service/22.08.0/windows/kate-22.08.0-windows-msvc2019_64-cl.exe#/dl.7z",
+            "hash": "3048b229e89f65dbfba63d64c5eae32c01f3ebfdeb98bd3cbd0339c70af3462d"
         }
     },
     "pre_install": [
@@ -23,12 +23,12 @@
     ],
     "checkver": {
         "url": "https://apps.kde.org/kate",
-        "regex": "kate-([\\d.]+)-(?<build>[\\d]+)-windows-(?<lib>\\w+)-cl\\.exe"
+        "regex": "kate-([\\d.]+)-windows-(?<lib>\\w+)-cl\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/release-service/$version/windows/kate-$version-$matchBuild-windows-$matchLib-cl.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$version/windows/kate-$version-windows-$matchLib-cl.exe#/dl.7z",
                 "hash": {
                     "url": "https://apps.kde.org/kate",
                     "regex": "sha256:</strong> $sha256</div>"


### PR DESCRIPTION
Closes #9289

Although the official website indicates that version 22.08.1 is available, the corresponding installer with language and translation is not yet available. Therefore, only the update to version 22.08.0 is available for now.

![image](https://user-images.githubusercontent.com/19755727/191888000-6f6a0d76-8e40-417e-9930-cf9ba00e01fc.png)

Since checkver and autoupdate have been fixed, if the 22.08.1 installer is released on the official website, it should be updated properly.

btw, the installation package without translations for the new version is available at https://binary-factory.kde.org/job/Kate_Release_win64/. Personally, I think it is better to use the installation package released on the official website rather than the one in https://binary-factory.kde.org/job/Kate_Release_win64/



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
