### PR TITLE
svn2gitnet: Add Version 1.0.0

### DIFF
--- a/bucket/svn2gitnet.json
+++ b/bucket/svn2gitnet.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.0.0",
+    "description": "A cross-platform svn to git migrator.",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mazong1123/svn2gitnet/releases/download/1.0.0/svn2gitnet-win-x64.zip",
+            "hash": "914135E874B30D3ECF1AF8DFD9EE12DCD1ACAA4129FFCEC84C8161982D3B9984"
+        },
+        "32bit": {
+            "url": "https://github.com/mazong1123/svn2gitnet/releases/download/1.0.0/svn2gitnet-win-x86.zip",
+            "hash": "CF235FF263C871902F98B1F9097B8F8DB5512A7E746892370D3B073523D7153E"
+        }
+    },
+    "homepage": "https://github.com/mazong1123/svn2gitnet",
+    "bin":  "svn2gitnet.exe",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mazong1123/svn2gitnet/releases/download/$version/svn2gitnet-win-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/mazong1123/svn2gitnet/releases/download/$version/svn2gitnet-win-x86.zip"
+            }
+        }
+    }
+}

--- a/bucket/svn2gitnet.json
+++ b/bucket/svn2gitnet.json
@@ -1,6 +1,7 @@
 {
     "version": "1.0.0",
     "description": "A cross-platform svn to git migrator.",
+    "homepage": "https://github.com/mazong1123/svn2gitnet",
     "license": "MIT",
     "architecture": {
         "64bit": {
@@ -12,7 +13,6 @@
             "hash": "CF235FF263C871902F98B1F9097B8F8DB5512A7E746892370D3B073523D7153E"
         }
     },
-    "homepage": "https://github.com/mazong1123/svn2gitnet",
     "bin":  "svn2gitnet.exe",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Adds Version 1.0.0 of svn2gitnet - A cross-platform svn to git migrator. The original svn2git (ruby gem) has several problems on windows. This re-implementation is a reliable way to run snv to git migrations on Windows systems.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
