### PR TITLE
kdeconnect: Update to 22.08.0

### DIFF
--- a/bucket/kdeconnect.json
+++ b/bucket/kdeconnect.json
@@ -1,12 +1,13 @@
 {
-    "version": "22.04.1",
+    "version": "22.08.0",
     "description": "Communications and data transfer between devices over local networks",
     "homepage": "https://kdeconnect.kde.org/",
     "license": "GPL-3.0-or-later",
+    "notes": "If you want to get the latest development branch-based installer, please install `kdeconnect-nightly` from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/release-service/22.04.1/windows/kdeconnect-kde-22.04.1-986-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "37f5315ed8724a2edb37ca5f1ba1ec3ffa0a8a609d9474b3015e58dfed15152b"
+            "url": "https://download.kde.org/stable/release-service/22.08.0/windows/kdeconnect-kde-22.08.0-windows-msvc2019_64-cl.exe#/dl.7z",
+            "hash": "4f918ba88f947b81bbed7bc66d9d18a71eeafd4956667a4cf0769c5745f50c2c"
         }
     },
     "pre_install": [
@@ -23,12 +24,12 @@
     ],
     "checkver": {
         "url": "https://apps.kde.org/kdeconnect",
-        "regex": "kdeconnect-kde-([\\d.]+)-(?<build>[\\d]+)-windows-(?<lib>\\w+)-cl\\.exe"
+        "regex": "kdeconnect-kde-([\\d.]+)-windows-(?<lib>\\w+)-cl\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/release-service/$version/windows/kdeconnect-kde-$version-$matchBuild-windows-$matchLib-cl.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$version/windows/kdeconnect-kde-$version-windows-$matchLib-cl.exe#/dl.7z",
                 "hash": {
                     "url": "https://apps.kde.org/kdeconnect",
                     "regex": "sha256:</strong> $sha256</div>"


### PR DESCRIPTION
Relates to [#9298](https://github.com/ScoopInstaller/Extras/pull/9298#issuecomment-1256052250)

And also add kdeconnect-nightly version manifest to Version bucket.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).