### PR TITLE
filelight: fix version to 22.08.0

### DIFF
--- a/bucket/filelight.json
+++ b/bucket/filelight.json
@@ -1,12 +1,13 @@
 {
-    "version": "22.08.1-1114",
+    "version": "22.08.0",
     "description": "Disk usage visualizer",
     "homepage": "https://apps.kde.org/filelight",
     "license": "GPL-2.0-or-later",
+    "notes": "If you want to get the latest development branch-based installer, please install `filelight-nightly` from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Filelight_Release_win64/lastSuccessfulBuild/artifact/filelight-22.08.1-1114-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "6809d4db1cef928e07f042f8988256bf6f18ecb456ceae35081a87737fe29713"
+            "url": "https://download.kde.org/stable/release-service/22.08.0/windows/filelight-22.08.0-windows-msvc2019_64-cl.exe#/dl.7z",
+            "hash": "89768ae0e33dee2470d63388cad025c5f42c5a86f17e31fd6009d77f37cd7c0a"
         }
     },
     "pre_install": [
@@ -22,15 +23,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Filelight_Release_win64/lastSuccessfulBuild/artifact/",
-        "regex": "filelight-([\\d.-]+)-windows-msvc(?<msvcver>\\d+)_64-cl\\.7z"
+        "url": "https://apps.kde.org/filelight",
+        "regex": "filelight-([\\d.-]+)-windows-(?<lib>\\w+)-cl\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Filelight_Release_win64/lastSuccessfulBuild/artifact/filelight-$version-windows-msvc$matchMsvcver_64-cl.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$version/windows/filelight-$version-windows-$matchLib-cl.exe#/dl.7z",
                 "hash": {
-                    "url": "$url.sha256"
+                    "url": "https://apps.kde.org/filelight",
+                    "regex": "sha256:</strong> $sha256</div>"
                 }
             }
         }


### PR DESCRIPTION
Relates to [#9298](https://github.com/ScoopInstaller/Extras/pull/9298#issuecomment-1256052250)

And also add filelight-nightly version manifest to Version bucket.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).