### PR TITLE
okular: Update to 22.08.0

### DIFF
--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -1,12 +1,13 @@
 {
-    "version": "22.04.1",
+    "version": "22.08.0",
     "description": "Universal document viewer",
     "homepage": "https://okular.kde.org",
     "license": "LGPL-2.0-only",
+    "notes": "If you want to get the latest development branch-based installer, please install `okular-nightly` from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/release-service/21.12.3/windows/okular-21.12.3-946-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "60858ce3823f1e04ce9fa2c0d8dfec2d4649c77167d21770e83d1c87203a71a7"
+            "url": "https://download.kde.org/stable/release-service/22.08.0/windows/okular-22.08.0-windows-msvc2019_64-cl.exe#/dl.7z",
+            "hash": "312c9951712257599420bc77c97c8e7bb719e732ac506f5f926d7be9c6f591c3"
         }
     },
     "pre_install": [
@@ -23,12 +24,12 @@
     ],
     "checkver": {
         "url": "https://apps.kde.org/okular",
-        "regex": "okular-([\\d.]+)-(?<build>[\\d]+)-windows-(?<lib>\\w+)-cl\\.exe"
+        "regex": "okular-([\\d.]+)-windows-(?<lib>\\w+)-cl\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/release-service/21.12.3/windows/okular-21.12.3-946-windows-msvc2019_64-cl.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$version/windows/okular-$version-windows-$matchLib-cl.exe#/dl.7z",
                 "hash": {
                     "url": "https://apps.kde.org/okular",
                     "regex": "sha256:</strong> $sha256</div>"


### PR DESCRIPTION
Relates to [#9298](https://github.com/ScoopInstaller/Extras/pull/9298#issuecomment-1256052250)

`okular-nightly` already exists.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).