### PR TITLE
sophiapp: Remove SophiApp.exe.config from persist section

### DIFF
--- a/bucket/sophiapp.json
+++ b/bucket/sophiapp.json
@@ -13,7 +13,6 @@
         ]
     ],
     "persist": [
-        "SophiApp.exe.config",
         "Logs"
     ],
     "checkver": "github",


### PR DESCRIPTION
### This was done to prevent SophiApp.exe.config.original from being created when the app is updated.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
