### PR TITLE
discord-rpc-extension: Add version 0.1.2

### DIFF
--- a/bucket/discord-rpc-extension.json
+++ b/bucket/discord-rpc-extension.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.1.2",
+    "description": "Server for the Discord RPC Extension",
+    "homepage": "https://github.com/lolamtisch/Discord-RPC-Extension",
+    "license": "GPL-3.0-only",
+    "notes": "Run \"$dir\\startup_windows.bat\" to enable or disable the server on startup.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lolamtisch/Discord-RPC-Extension/releases/download/0.1.2/windows_64bit.zip",
+            "hash": "3d414d846547e2f1d225191a6f5acff1a1f3c68ea63887997b063082a6bf37fe"
+        },
+        "32bit": {
+            "url": "https://github.com/lolamtisch/Discord-RPC-Extension/releases/download/0.1.2/windows_32bit.zip",
+            "hash": "a9b478d6706802c29abc92f3eb171e08683f498da7f38aed436af298543c35e6"
+        }
+    },
+    "shortcuts": [
+        [
+            "server_win.exe",
+            "Discord RPC Extension Server"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lolamtisch/Discord-RPC-Extension/releases/download/$version/windows_64bit.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/lolamtisch/Discord-RPC-Extension/releases/download/$version/windows_32bit.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Server for the [Discord RPC Extension](https://github.com/lolamtisch/Discord-RPC-Extension), which is used by [PreWrap](https://github.com/lolamtisch/PreWrap) and [MALSync](https://github.com/MALSync/MALSync).
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
