### PR TITLE
musicplayer2@2.75: Set portable mode to default configuration

### DIFF
--- a/bucket/musicplayer2.json
+++ b/bucket/musicplayer2.json
@@ -21,7 +21,13 @@
             "MusicPlayer2"
         ]
     ],
-    "pre_install": "'recent_path.dat', 'song_data.dat', 'config.ini', 'global_cfg.ini' | ForEach-Object { if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File -Force | Out-Null } }",
+    "pre_install": [
+        "$GLOBAL_CFG = 'global_cfg.ini'",
+        "if (!(Test-Path \"$persist_dir\\$GLOBAL_CFG\")) {",
+        "    Set-Content \"$dir\\$GLOBAL_CFG\" @('[config]', 'portable_mode = true') -Encoding Ascii",
+        "}",
+        "'recent_path.dat', 'song_data.dat', 'config.ini' | ForEach-Object { if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File -Force | Out-Null } }"
+    ],
     "persist": [
         "playlist",
         "recent_path.dat",


### PR DESCRIPTION
Add a default configuration to enable the profile to be portable and persistent

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
