### PR TITLE
qrscan: Fix the extract_dir

### DIFF
--- a/bucket/qrscan.json
+++ b/bucket/qrscan.json
@@ -13,10 +13,11 @@
             "hash": "e905291fafe2c2c108c5f23fb98e1032e74a118e4e1793e6ddb5b66372547181"
         }
     },
-    "extract_dir": "qrscan-0.1.6",
+    "extract_dir": "qrscan-0.1.7",
     "bin": "qrscan.exe",
     "checkver": "github",
     "autoupdate": {
+        "extract_dir": "qrscan-$version",
         "architecture": {
             "64bit": {
                 "url": "https://github.com/sayanarijit/qrscan/releases/download/v$version/qrscan-$version-x86_64-pc-windows-msvc.zip"


### PR DESCRIPTION
This fixes the qrscan manifest. Also, by adding `"extract_dir": "qrscan-$version"` under the `autoupdate` key this should fix automatic updates in the future if I understand correctly.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
