### PR TITLE
kotlin-interactive-shell: Add version 0.5.2

### DIFF
--- a/bucket/kotlin-interactive-shell.json
+++ b/bucket/kotlin-interactive-shell.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.5.2",
+    "description": "This shell is an extensible implementation of Kotlin REPL.",
+    "homepage": "https://github.com/Kotlin/kotlin-interactive-shell",
+    "license": "Apache-2.0",
+    "url": "https://github.com/Kotlin/kotlin-interactive-shell/releases/download/v0.5.2/ki-archive.zip",
+    "hash": "9bd5697f9ec29cd63eaf0b503f46edce377bac73e46552aa12231ac5dbda21e4",
+    "extract_dir": "ki", 
+    "bin": "bin\\ki.bat",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Kotlin/kotlin-interactive-shell/releases/download/v$version/ki-archive.zip",
+        "hash": {
+            "url": "https://github.com/Kotlin/kotlin-interactive-shell/releases/download/v$version/checksums_sha256.txt"
+        }
+    }
+}


### PR DESCRIPTION
Added kotlin-interactive-shell.json to the bucket

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
