### PR TITLE
arduino-old: Add version 1.8.19

### DIFF
--- a/bucket/arduino-old.json
+++ b/bucket/arduino-old.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.8.19",
+    "description": "Arduino is an open-source physical computing platform based on a simple I/O board and a development environment that implements the Processing/Wiring language.",
+    "homepage": "https://www.arduino.cc/en/Main/Software",
+    "license": "GPL-2.0-only",
+    "url": "https://downloads.arduino.cc/arduino-1.8.19-windows.zip",
+    "hash": "c704a821089eab2588f1deae775916219b1517febd1dd574ff29958dca873945",
+    "extract_dir": "arduino-1.8.19",
+    "bin": [
+        [
+            "arduino.exe",
+            "arduino-old"
+        ],
+        "arduino_debug.exe",
+        "arduino-builder.exe"
+    ],
+    "shortcuts": [
+        [
+            "arduino.exe",
+            "Arduino"
+        ],
+        [
+            "arduino_debug.exe",
+            "Arduino Debug"
+        ],
+        [
+            "arduino-builder.exe",
+            "Arduino Builder"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.arduino.cc/en/software",
+        "regex": "Arduino IDE ([\\d.]+)",
+        "reverse": "true"
+    },
+    "autoupdate": {
+        "url": "https://downloads.arduino.cc/arduino-$version-windows.zip",
+        "extract_dir": "arduino-$version"
+    }
+}

--- a/bucket/arduino-old.json
+++ b/bucket/arduino-old.json
@@ -22,10 +22,6 @@
         [
             "arduino_debug.exe",
             "Arduino Debug"
-        ],
-        [
-            "arduino-builder.exe",
-            "Arduino Builder"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Added arduino-old.json to the bucket

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
