### PR TITLE
device-cleanup-tool: Add version 1.2.1

### DIFF
--- a/bucket/device-cleanup-tool.json
+++ b/bucket/device-cleanup-tool.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.2.1",
+    "description": "Cleanup non-present devices from Windows",
+    "homepage": "https://www.uwe-sieber.de/",
+    "license": "Freeware",
+    "url": "https://www.uwe-sieber.de/files/devicecleanup.zip",
+    "hash": "15008b6b5098846bfdb5a2262f7522d8958215b1bbfa1ade031e54bd08755ff1",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "x64"
+        },
+        "32bit": {
+            "extract_dir": "Win32"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\DeviceCleanup.ini\")) {",
+        "   New-Item \"$dir\\DeviceCleanup.ini\" | Out-Null",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "DeviceCleanup.exe",
+            "Device Cleanup Tool"
+        ]
+    ],
+    "persist": "DeviceCleanup.ini",
+    "checkver": "Device Cleanup Tool V([\\d.]+)",
+    "autoupdate": {
+        "url": "https://www.uwe-sieber.de/files/DeviceCleanup.zip"
+    }
+}

--- a/bucket/device-cleanup-tool.json
+++ b/bucket/device-cleanup-tool.json
@@ -25,7 +25,10 @@
         ]
     ],
     "persist": "DeviceCleanup.ini",
-    "checkver": "Device Cleanup Tool V([\\d.]+)",
+    "checkver": {
+        "url": "https://www.uwe-sieber.de/misc_tools_e.html",
+        "regex": "Device Cleanup Tool V([\\d.]+)"
+    },
     "autoupdate": {
         "url": "https://www.uwe-sieber.de/files/DeviceCleanup.zip"
     }

--- a/bucket/device-cleanup-tool.json
+++ b/bucket/device-cleanup-tool.json
@@ -3,7 +3,7 @@
     "description": "Cleanup non-present devices from Windows",
     "homepage": "https://www.uwe-sieber.de/",
     "license": "Freeware",
-    "url": "https://www.uwe-sieber.de/files/devicecleanup.zip",
+    "url": "https://www.uwe-sieber.de/files/DeviceCleanup.zip",
     "hash": "15008b6b5098846bfdb5a2262f7522d8958215b1bbfa1ade031e54bd08755ff1",
     "architecture": {
         "64bit": {
@@ -28,8 +28,5 @@
     "checkver": {
         "url": "https://www.uwe-sieber.de/misc_tools_e.html",
         "regex": "Device Cleanup Tool V([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "https://www.uwe-sieber.de/files/DeviceCleanup.zip"
     }
 }


### PR DESCRIPTION
App description: Cleanup non-present devices from Windows.

Credit goes to @Velgus for his manifest [here](https://github.com/Velgus/Scoop-Velgus/blob/master/bucket/device-cleanup-tool.json) which this is based on.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
