### PR TITLE
usb-tree-view: Add version 3.8.1

### DIFF
--- a/bucket/usb-tree-view.json
+++ b/bucket/usb-tree-view.json
@@ -13,6 +13,11 @@
             "hash": "405e6d9ffb145fa76f35a2ff9a4b4ff520d16f70cfa559852c21872c73a18f85"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\UsbTreeView.ini\")) {",
+        "   New-Item \"$dir\\UsbTreeView.ini\" | Out-Null",
+        "}"
+    ],
     "bin": [
         [
             "UsbTreeView.exe",
@@ -25,6 +30,7 @@
             "USB Device Tree Viewer"
         ]
     ],
+    "persist": "UsbTreeView.ini",
     "checkver": {
         "url": "https://www.uwe-sieber.de/usbtreeview_e.html",
         "regex": "USB Device Tree Viewer V([\\d.]+)"

--- a/bucket/usb-tree-view.json
+++ b/bucket/usb-tree-view.json
@@ -1,0 +1,32 @@
+{
+    "version": "3.8.1",
+    "description": "View USB devices in a tree-like structure",
+    "homepage": "https://www.uwe-sieber.de/usbtreeview_e.html",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.uwe-sieber.de/files/UsbTreeView_x64.zip",
+            "hash": "43f33cf1bf9b6ea41e36840923a85791b06803cb9f588a4c3b288e2539d0c63b"
+        },
+        "32bit": {
+            "url": "https://www.uwe-sieber.de/files/UsbTreeView_Win32.zip",
+            "hash": "405e6d9ffb145fa76f35a2ff9a4b4ff520d16f70cfa559852c21872c73a18f85"
+        }
+    },
+    "bin": [
+        [
+            "UsbTreeView.exe",
+            "usbtreeview"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "UsbTreeView.exe",
+            "USB Device Tree Viewer"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.uwe-sieber.de/usbtreeview_e.html",
+        "regex": "USB Device Tree Viewer V([\\d.]+)"
+    }
+}


### PR DESCRIPTION
App description: View USB devices in a tree-like structure.

Credit goes to @404NetworkError for his manifest [here](https://github.com/404NetworkError/scoop-bucket/blob/main/bucket/usbtreeview.json) which this is based on.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
