### PR TITLE
manifold(-viewer): Fix url, shortcuts and autoupdate

### DIFF
--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -6,7 +6,7 @@
     "suggest": {
         "Microsoft Visual C++ Redistributable 2015-2022": "extras/vcredist2022"
     },
-    "url": "https://www.manifold.net/updates/manifold-viewer-9.0.178.zip",
+    "url": "https://manifold.net/updates/manifold-viewer-9.0.178.zip",
     "hash": "7a348a9780d7eb532ce6e1c33ce5a8542e15c4fd4f453d3f2c570e731b443d88",
     "extract_dir": "manifold-viewer-9.0.178",
     "architecture": {
@@ -21,11 +21,11 @@
         }
     },
     "checkver": {
-        "url": "https://wingetgui.com/apps?id=ManifoldSoftware.Manifold.9",
-        "regex": "Release version: ([\\d.]+)"
+        "url": "https://manifold.net/updates/download_viewer.shtml",
+        "regex": "https://manifold.net/updates/manifold-viewer-([\\d.]+).zip"
     },
     "autoupdate": {
-        "url": "https://www.manifold.net/updates/manifold-viewer-$version.zip",
+        "url": "https://manifold.net/updates/manifold-viewer-$version.zip",
         "extract_dir": "manifold-viewer-$version"
     }
 }

--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -1,29 +1,20 @@
 {
-    "version": "9.0.177",
+    "version": "9.0.178",
     "description": "File viewer for Manifold - a parallel GIS, ETL, data science and DBMS tool",
     "homepage": "https://manifold.net/",
     "license": "Freeware",
     "suggest": {
         "Microsoft Visual C++ Redistributable 2015-2022": "extras/vcredist2022"
     },
-    "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-9.0.177-x64.zip",
-    "hash": "6a861fffb2b6827d43f1d2b30d3c722eb09f28a999e37c14d70cc02b416704b8",
-    "extract_dir": "manifold-viewer-9.0.177-x64",
+    "url": "https://www.manifold.net/updates/manifold-viewer-9.0.178.zip",
+    "hash": "7a348a9780d7eb532ce6e1c33ce5a8542e15c4fd4f453d3f2c570e731b443d88",
+    "extract_dir": "manifold-viewer-9.0.178",
     "architecture": {
         "64bit": {
             "bin": "bin64\\manifold.exe",
             "shortcuts": [
                 [
                     "bin64\\manifold.exe",
-                    "Manifold 9 Viewer"
-                ]
-            ]
-        },
-        "32bit": {
-            "bin": "bin\\manifold.exe",
-            "shortcuts": [
-                [
-                    "bin\\manifold.exe",
                     "Manifold 9 Viewer"
                 ]
             ]
@@ -34,7 +25,7 @@
         "regex": "Release version: ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.manifoldgis.com/updates/working/manifold-viewer-$version-x64.zip",
-        "extract_dir": "manifold-viewer-$version-x64"
+        "url": "https://www.manifold.net/updates/manifold-viewer-$version.zip",
+        "extract_dir": "manifold-viewer-$version"
     }
 }

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -6,7 +6,7 @@
     "suggest": {
         "Microsoft Visual C++ Redistributable 2015-2022": "extras/vcredist2022"
     },
-    "url": "https://www.manifold.net/updates/manifold-9.0.178.zip",
+    "url": "https://manifold.net/updates/manifold-9.0.178.zip",
     "hash": "54c3afebc1cc0ffb699720f433a5dc9dc9bcfe638bce62dd028cee5b4a7fad32",
     "extract_dir": "manifold-9.0.178",
     "architecture": {
@@ -21,11 +21,11 @@
         }
     },
     "checkver": {
-        "url": "https://wingetgui.com/apps?id=ManifoldSoftware.Manifold.9",
-        "regex": "Release version: ([\\d.]+)"
+        "url": "https://manifold.net/updates/download_9.shtml",
+        "regex": "https://manifold.net/updates/manifold-([\\d.]+).zip"
     },
     "autoupdate": {
-        "url": "https://www.manifold.net/updates/manifold-$version.zip",
+        "url": "https://manifold.net/updates/manifold-$version.zip",
         "extract_dir": "manifold-$version"
     }
 }

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -1,29 +1,20 @@
 {
-    "version": "9.0.177",
+    "version": "9.0.178",
     "description": "Parallel GIS, ETL, data science and DBMS tool",
     "homepage": "https://manifold.net/",
     "license": "Proprietary",
     "suggest": {
         "Microsoft Visual C++ Redistributable 2015-2022": "extras/vcredist2022"
     },
-    "url": "https://www.manifoldgis.com/updates/working/manifold-9.0.177-x64.zip",
-    "hash": "3d074cbd63ee8189c8fde87d4a0807890ac80ab6441cae215a679208a6ec8b64",
-    "extract_dir": "manifold-9.0.177-x64",
+    "url": "https://www.manifold.net/updates/manifold-9.0.178.zip",
+    "hash": "54c3afebc1cc0ffb699720f433a5dc9dc9bcfe638bce62dd028cee5b4a7fad32",
+    "extract_dir": "manifold-9.0.178",
     "architecture": {
         "64bit": {
             "bin": "bin64\\manifold.exe",
             "shortcuts": [
                 [
                     "bin64\\manifold.exe",
-                    "Manifold 9"
-                ]
-            ]
-        },
-        "32bit": {
-            "bin": "bin\\manifold.exe",
-            "shortcuts": [
-                [
-                    "bin\\manifold.exe",
                     "Manifold 9"
                 ]
             ]
@@ -34,7 +25,7 @@
         "regex": "Release version: ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.manifoldgis.com/updates/working/manifold-$version-x64.zip",
-        "extract_dir": "manifold-$version-x64"
+        "url": "https://www.manifold.net/updates/manifold-$version.zip",
+        "extract_dir": "manifold-$version"
     }
 }


### PR DESCRIPTION
Close #9430

* Manifold no longer have 32bit mode executables. 
* URLs are changed
* extract_dir does not have -x64
* autoupdate changed



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
