### PR TITLE
x64dbg: Change URL from Sourceforge to GitHub

### DIFF
--- a/bucket/x64dbg.json
+++ b/bucket/x64dbg.json
@@ -69,6 +69,6 @@
         "regex": "snapshot_([\\d-_]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2022-10-03_23-36.zip"
+        "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_$version.zip"
     }
 }

--- a/bucket/x64dbg.json
+++ b/bucket/x64dbg.json
@@ -3,7 +3,7 @@
     "description": "x64/x32 debugger",
     "homepage": "https://x64dbg.com/",
     "license": "GPL-3.0-only",
-    "url": "https://downloads.sourceforge.net/project/x64dbg/snapshots/snapshot_2022-10-03_23-36.zip",
+    "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2022-10-03_23-36.zip",
     "hash": "9b1db1574db05d86146fe022f30d7735b4de4b98c28207c3a2e7bb4208b38846",
     "pre_install": [
         "'release\\x96dbg.ini', 'release\\x32\\x32dbg.ini', 'release\\x64\\x64dbg.ini' | ForEach-Object {",
@@ -69,6 +69,6 @@
         "regex": "snapshot_([\\d-_]+)"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/x64dbg/snapshots/snapshot_$version.zip"
+        "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2022-10-03_23-36.zip"
     }
 }


### PR DESCRIPTION
This was done to avoid future hashing errors.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #8880

Log:
```
krist@DESKTOP-7E5L82P > scoop install x64dbg                                                                                06:24:05
Installing 'x64dbg' (2022-10-03_23-36) [64bit] from extras bucket
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: fe80be|OK  |   159KiB/s|C:/Users/krist/scoop/cache/x64dbg#2022-10-03_23-36#https_downloads.sourceforge.net_project_x64dbg_snapshots_snapshot_2022-10-03_23-36.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of snapshot_2022-10-03_23-36.zip ... ERROR Hash check failed!
App:         extras/x64dbg
URL:         https://downloads.sourceforge.net/project/x64dbg/snapshots/snapshot_2022-10-03_23-36.zip
First bytes: 3C 21 64 6F 63 74 79 70
Expected:    9b1db1574db05d86146fe022f30d7735b4de4b98c28207c3a2e7bb4208b38846
Actual:      2c0994d8a5c059c2cc55d82e8ef296ff3791f449120d01bd00e34f79f2ebc49f
SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.

Please try again or create a new issue by using the following link and paste your console output:
https:////
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
