### PR TITLE
archisteamfarm: Add bin

### DIFF
--- a/bucket/archisteamfarm.json
+++ b/bucket/archisteamfarm.json
@@ -19,6 +19,7 @@
             "hash": "f9aa773127adc25a4196da692eb04a37027a5c4433d7bd937f2e3f781e477905"
         }
     },
+    "bin": "ArchiSteamFarm.exe",
     "shortcuts": [
         [
             "ArchiSteamFarm.exe",


### PR DESCRIPTION
Although ArchiSteamFarm comes with its own interactive console, you may want to run it directly from a console window you already have open instead.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).