### PR TITLE
openrgb: Fix download and autoupdate URLs

### DIFF
--- a/bucket/openrgb.json
+++ b/bucket/openrgb.json
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://openrgb.org/releases/release_0.7/OpenRGB_0.7_Windows_64_6128731.zip",
+            "url": "https://openrgb.org/up_/up_/static/releases/release_0.7/OpenRGB_0.7_Windows_64_6128731.zip",
             "hash": "4bee9c65c6eac32ea5472f7f68390e86f28ab12ba4250360413e257fd7f0778a",
             "extract_dir": "OpenRGB Windows 64-bit"
         },
         "32bit": {
-            "url": "https://openrgb.org/releases/release_0.7/OpenRGB_0.7_Windows_32_6128731.zip",
+            "url": "https://openrgb.org/up_/up_/static/releases/release_0.7/OpenRGB_0.7_Windows_32_6128731.zip",
             "hash": "f057b90bcf9f0f7b55d0e0dc7e63c34f80feb43f609f800c0a68ccc4b5370abd",
             "extract_dir": "OpenRGB Windows 32-bit"
         }
@@ -31,10 +31,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://openrgb.org/releases/release_$version/OpenRGB_$version_Windows_64_$matchCommit.zip"
+                "url": "https://openrgb.org/up_/up_/static/releases/release_$version/OpenRGB_$version_Windows_64_$matchCommit.zip"
             },
             "32bit": {
-                "url": "https://openrgb.org/releases/release_$version/OpenRGB_$version_Windows_32_$matchCommit.zip"
+                "url": "https://openrgb.org/up_/up_/static/releases/release_$version/OpenRGB_$version_Windows_32_$matchCommit.zip"
             }
         }
     }


### PR DESCRIPTION
Apparently, the download URLs changed.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
