### PR TITLE
hashcheck: Enhance the `installer` and `uninstaller` scripts.

### DIFF
--- a/bucket/hashcheck.json
+++ b/bucket/hashcheck.json
@@ -23,7 +23,7 @@
             "if ($architecture -eq '64bit') {",
             "   Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\HashCheck64.dll\", '/s') -Wait",
             "}",
-            "Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\HashCheck64.dll\", '/s') -Wait",
+            "Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\HashCheck32.dll\", '/s') -Wait",
             "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 3;"
         ]
     },

--- a/bucket/hashcheck.json
+++ b/bucket/hashcheck.json
@@ -24,7 +24,7 @@
             "if ($architecture -eq '64bit') {",
             "   sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck64.dll\"\"",
             "}",
-            "sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck32.dll\"\""
+            "sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck32.dll\"\"",
             "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 3;"
         ]
     },

--- a/bucket/hashcheck.json
+++ b/bucket/hashcheck.json
@@ -25,6 +25,7 @@
             "   sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck64.dll\"\"",
             "}",
             "sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck32.dll\"\""
+            "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 3;"
         ]
     },
     "checkver": "github",

--- a/bucket/hashcheck.json
+++ b/bucket/hashcheck.json
@@ -4,7 +4,6 @@
     "homepage": "https://github.com/gurnec/HashCheck",
     "license": "BSD-3-Clause",
     "notes": "Before uninstallation, please close Explorer (or other files management tool, e.g., Total Commander) windows where you've used HashCheck from.",
-    "depends": "sudo",
     "url": "https://github.com/gurnec/HashCheck/releases/download/v2.4.0/HashCheckSetup-v2.4.0.exe",
     "hash": "2d6067f00bbb93526d146d2228a46dc4851f0fa866e69250279c6b2f00b8f1b7",
     "installer": {
@@ -13,18 +12,18 @@
             "Rename-Item \"$dir\\`$0_1\" 'HashCheck32.dll' -Force",
             "Rename-Item \"$dir\\`$0\" 'HashCheck64.dll' -Force",
             "if ($architecture -eq '64bit') {",
-            "   sudo \"$env:COMSPEC\" /c \"regsvr32 /s \"$dir\\HashCheck64.dll\"\"",
+            "   Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @(\"$dir\\HashCheck64.dll\", '/s') -Wait",
             "}",
-            "sudo \"$env:COMSPEC\" /c \"regsvr32 /s \"$dir\\HashCheck32.dll\"\"",
+            "Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @(\"$dir\\HashCheck32.dll\", '/s') -Wait",
             "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force"
         ]
     },
     "uninstaller": {
         "script": [
             "if ($architecture -eq '64bit') {",
-            "   sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck64.dll\"\"",
+            "   Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\HashCheck64.dll\", '/s') -Wait",
             "}",
-            "sudo \"$env:COMSPEC\" /c \"regsvr32 /u /s \"$dir\\HashCheck32.dll\"\"",
+            "Start-Process 'regsvr32' -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\HashCheck64.dll\", '/s') -Wait",
             "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 3;"
         ]
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
This should solve the problem of the **hashcheck** Windows shell extension not being removed by the uninstaller script.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
