### PR TITLE
microsip: Change lite to full version

### DIFF
--- a/bucket/microsip.json
+++ b/bucket/microsip.json
@@ -3,8 +3,8 @@
     "description": "SIP softphone for Windows based on PJSIP stack",
     "homepage": "https://www.microsip.org",
     "license": "GPL-2.0-only",
-    "url": "https://www.microsip.org/download/MicroSIP-Lite-3.21.3.zip",
-    "hash": "856087fbb8fd124615f9af9081c9e7882dedd276ee639932bc58a929481feab1",
+    "url": "https://www.microsip.org/download/MicroSIP-3.21.3.zip",
+    "hash": "19e8d1820de0afdec5628ecba8409f607dd963deadd37dbb4479303acbab5eb2",
     "pre_install": "$manifest.persist | ForEach-Object { New-Item \"$dir\\$_\" -ItemType File -ErrorAction SilentlyContinue | Out-Null }",
     "bin": "MicroSIP.exe",
     "shortcuts": [
@@ -19,9 +19,9 @@
     ],
     "checkver": {
         "url": "https://www.microsip.org/downloads",
-        "regex": "MicroSIP-Lite-([\\d.]+)\\.zip"
+        "regex": "MicroSIP-([\\d.]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://www.microsip.org/download/MicroSIP-Lite-$version.zip"
+        "url": "https://www.microsip.org/download/MicroSIP-$version.zip"
     }
 }


### PR DESCRIPTION
Current microsip manifest uses the lite package instead of the full one.
They are both equally portable, and the difference in size is about 7MB which is minor, for gaining video support.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
