### PR TITLE
hydrus-network: update to 501

### DIFF
--- a/bucket/hydrus-network.json
+++ b/bucket/hydrus-network.json
@@ -1,12 +1,12 @@
 {
-    "version": "499",
+    "version": "501",
     "description": "A personal booru-style media tagger",
     "homepage": "https://hydrusnetwork.github.io/hydrus/",
     "license": "WTFPL",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hydrusnetwork/hydrus/releases/download/v499/Hydrus.Network.499.-.Windows.Qt6.-.Extract.only.zip",
-            "hash": "62c9b3a23c0d938a5e336bd9e73acc3276d8b6e975d16ab876d9d7a9aa853417"
+            "url": "https://github.com/hydrusnetwork/hydrus/releases/download/v501/Hydrus.Network.501.-.Windows.Qt6.-.Extract.only.zip",
+            "hash": "6ae075e029700494f256d52d9d46c223ecaedad34aab575f29a0543182e47c81"
         }
     },
     "extract_dir": "Hydrus Network",


### PR DESCRIPTION
Update hydrus-network to v501


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
