### PR TITLE
linphone@4.4.10: Fix hash

### DIFF
--- a/bucket/linphone.json
+++ b/bucket/linphone.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.linphone.org/releases/windows/app/Linphone-4.4.10-win64.exe#/dl.7z",
-            "hash": "f62a32207b753d4b4e3d71e994cd1132687d4f223e12895f99f74e84ccc3f6dc"
+            "hash": "6bdc54dcdb53fdd4b485b04d1c5db574b441b53953d11c7e98a1b3fa8017ac08"
         }
     },
     "bin": "bin\\linphone.exe",


### PR DESCRIPTION
Change the hash to correct the correct hash of 6bdc54dcdb53fdd4b485b04d1c5db574b441b53953d11c7e98a1b3fa8017ac08
