### PR TITLE
wireshark: Update to version 4.0.0

### DIFF
--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.6.8",
+    "version": "4.0.0",
     "description": "A network protocol analyzer that lets you see what’s happening on your network at a microscopic level.",
     "homepage": "https://www.wireshark.org/",
     "license": "GPL-2.0-or-later",
@@ -12,17 +12,13 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://1.eu.dl.wireshark.org/win64/all-versions/Wireshark-win64-3.6.8.exe#/dl.7z",
-            "hash": "17ce19def77592d4c0fb0b680e77e4712dd6c8c4af79c6d58a281eb509a4f34b"
-        },
-        "32bit": {
-            "url": "https://1.eu.dl.wireshark.org/win32/all-versions/Wireshark-win32-3.6.8.exe#/dl.7z",
-            "hash": "332aff4889f73ee1daf656e3411554685796a51f8059e2cd531bb60fb754799c"
+            "url": "https://www.wireshark.org/download/win64/Wireshark-win64-4.0.0.exe#/dl.7z",
+            "hash": "aa4c3ae9d50113785c83b441cfdfdf484a308aa7d37bacb5803561e4d1c12902"
         }
     },
     "installer": {
         "script": [
-            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\vcredist_x*\", \"$dir\\uninstall.exe\" -Recurse",
+            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\vc_redist*\", \"$dir\\uninstall-wireshark.exe\" -Recurse",
             "Get-ChildItem \"$dir\\npcap-*.exe\" | Rename-Item -NewName 'npcap-installer.exe'",
             "Get-ChildItem \"$dir\\USBPcapSetup-*.exe\" | Rename-Item -NewName 'USBPcapSetup-installer.exe'"
         ]
@@ -51,20 +47,13 @@
     },
     "persist": "Data",
     "checkver": {
-        "url": "https://www.wireshark.org/update/0/Wireshark/0.0.0/Windows/x86/en-US/stable.xml",
+        "url": "https://www.wireshark.org/update/0/Wireshark/0.0.0/Windows/x86-64/en-US/stable.xml",
         "regex": "Version ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://1.eu.dl.wireshark.org/win64/all-versions/Wireshark-win64-$version.exe#/dl.7z",
-                "hash": {
-                    "url": "https://www.wireshark.org/download/SIGNATURES-$version.txt",
-                    "regex": "SHA256\\($basename\\)=$sha256"
-                }
-            },
-            "32bit": {
-                "url": "https://1.eu.dl.wireshark.org/win32/all-versions/Wireshark-win32-$version.exe#/dl.7z",
+                "url": "https://www.wireshark.org/download/win64/Wireshark-win64-$version.exe#/dl.7z",
                 "hash": {
                     "url": "https://www.wireshark.org/download/SIGNATURES-$version.txt",
                     "regex": "SHA256\\($basename\\)=$sha256"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #9468

The version 4 no longer supports 32-bit OS.

Version 3.6.8: https://github.com/ScoopInstaller/Versions/pull/706 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
