### PR TITLE
musikcube: Fix bin

### DIFF
--- a/bucket/musikcube.json
+++ b/bucket/musikcube.json
@@ -9,8 +9,8 @@
             "hash": "df3221a092c05d9911660d05a9493da45a95be2bf8abe22aebbad048791cd117"
         },
         "32bit": {
-            "url": "https://github.com/clangen/musikcube/releases/download/0.98.0/musikcube_win32_0.98.0.zip",
-            "hash": "aedbe3c7a7bf70f83ef52020b4ef1393a64a403b62536908e830676acf4d8c4c"
+            "url": "https://github.com/clangen/musikcube/releases/download/0.98.0/musikcube_win32_with_milkdrop2_0.98.0.zip",
+            "hash": "b0a0d79f23f934f6bc624a0c831f2616186f6ef186dcef14067b9a939e451cf2"
         }
     },
     "bin": [
@@ -26,8 +26,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/clangen/musikcube/releases",
-        "regex": "musikcube_win32_([\\d.]+)\\.zip"
+        "url": "https://api.github.com/repositories/32483164/releases/latest",
+        "jsonpath": "$.tag_name"
     },
     "autoupdate": {
         "architecture": {
@@ -35,7 +35,7 @@
                 "url": "https://github.com/clangen/musikcube/releases/download/$version/musikcube_win64_$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/clangen/musikcube/releases/download/$version/musikcube_win32_$version.zip"
+                "url": "https://github.com/clangen/musikcube/releases/download/$version/musikcube_win32_with_milkdrop2_$version.zip"
             }
         }
     }

--- a/bucket/musikcube.json
+++ b/bucket/musikcube.json
@@ -13,7 +13,12 @@
             "hash": "aedbe3c7a7bf70f83ef52020b4ef1393a64a403b62536908e830676acf4d8c4c"
         }
     },
-    "bin": "musikcube.exe",
+    "bin": [
+        [
+            "musikcube-cmd.exe",
+            "musikcube"
+        ]
+    ],
     "shortcuts": [
         [
             "musikcube.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
It was opening outside of the term, because the wrong bin was shimmed.
Now that I checked issues, I'll also change the `32bit` version to  use milkdrop

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #8658

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).