### PR TITLE
dosbox-staging: Update to version 0.79.1

### DIFF
--- a/bucket/dosbox-staging.json
+++ b/bucket/dosbox-staging.json
@@ -1,18 +1,11 @@
 {
-    "version": "0.78.1",
+    "version": "0.79.1",
     "description": "A DOS/x86 emulator based on DOSBox which focuses on ease of use.",
     "homepage": "https://dosbox-staging.github.io/",
     "license": "GPL-2.0-or-later",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-x86_64-v0.78.1.zip",
-            "hash": "3c2f408125351154a37e93de8a4bd05d0c722bbf53e1f583909e4ca6c3eb9204"
-        },
-        "32bit": {
-            "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-i686-v0.78.1.zip",
-            "hash": "8ffd54502f2411f49d7b9f8e74a7a1861f008fcd1192ed4441262f829c05a608"
-        }
-    },
+    "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-windows-x86_64-v0.79.1.zip",
+    "hash": "8c7045dfea6dc20bb985cff516d2faee51d2ecaf054db60632857b6941d3d648",
+    "extract_dir": "dosbox-staging-windows-x86_64-v0.79.1",
     "pre_install": "if (!(Test-Path \"$persist_dir\\dosbox-staging.conf\")) { New-Item -ItemType File \"$dir\\dosbox-staging.conf\" | Out-Null }",
     "bin": [
         "dosbox.exe",
@@ -34,14 +27,8 @@
         "github": "https://github.com/dosbox-staging/dosbox-staging"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-x86_64-v$version.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-msys2-i686-v$version.zip"
-            }
-        }
+        "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-x86_64-v$version.zip",
+        "extract_dir": "dosbox-staging-windows-x86_64-v$version"
     },
-    "notes": "For config file examples see: https://github.com/dosbox-staging/dosbox-staging/wiki/Config-file-examples"
+    "notes": "For config file examples, see: https://github.com/dosbox-staging/dosbox-staging/wiki/Config-file-examples"
 }


### PR DESCRIPTION
The app is no longer compiled for 32-bit – 64-bit only, seemingly; removing `architecture`.

Adds `extract_dir` as needed, including in `autoupdate`.



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
