### PR TITLE
typora: Update to 1.4.8, remove 32-bit

### DIFF
--- a/bucket/typora.json
+++ b/bucket/typora.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.4",
+    "version": "1.4.8",
     "description": "A truly minimal markdown editor",
     "homepage": "https://typora.io",
     "license": {
@@ -8,17 +8,13 @@
     },
     "notes": [
         "This package has a 15-day free trial",
-        "For free version (old beta version), install: versions/typora0.11.18"
+        "For old beta version, install: versions/typora0.11.18"
     ],
     "architecture": {
         "64bit": {
-            "url": "https://download.typora.io/windows/typora-setup-x64-1.4.4.exe",
-            "hash": "9d015818bf789306511ca7091e18afb5105accce2b3f4090b455345a60094c3a"
+            "url": "https://download.typora.io/windows/typora-setup-x64-1.4.8.exe",
+            "hash": "023c8cbfaad87aecea188b7add0857756ed89cf1f3fd584e7de5fb4ed94c8a56"
         },
-        "32bit": {
-            "url": "https://download.typora.io/windows/typora-setup-ia32-1.4.4.exe",
-            "hash": "c1300ac9705fae71d09805c26509f85057118b31b5dce255ddcd7ba31a96f70e"
-        }
     },
     "innosetup": true,
     "bin": "Typora.exe",
@@ -37,9 +33,6 @@
             "64bit": {
                 "url": "https://download.typora.io/windows/typora-setup-x64-$version.exe"
             },
-            "32bit": {
-                "url": "https://download.typora.io/windows/typora-setup-ia32-$version.exe"
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX


typora: Update to 1.4.8
and
remove 32-bit because [there is not](https://typora.io/releases/stable)
and delete `free version` description due to https://github.com/ScoopInstaller/Extras/commit/bbaafc2ea220e8f26dacb8b104268cbcbef6a1ee#commitcomment-77092710

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
