### PR TITLE
kate: Update to 22.08.1, fix `checkver`  & `autoupdate.hash`

### DIFF
--- a/bucket/kate.json
+++ b/bucket/kate.json
@@ -1,13 +1,13 @@
 {
-    "version": "22.08.0",
+    "version": "22.08.1",
     "description": "Multi-document editor",
     "homepage": "https://kate-editor.org",
     "license": "LGPL-2.0-only",
     "notes": "If you want to get the latest development branch-based installer, please install `kate-nightly` from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/release-service/22.08.0/windows/kate-22.08.0-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "3048b229e89f65dbfba63d64c5eae32c01f3ebfdeb98bd3cbd0339c70af3462d"
+            "url": "https://download.kde.org/stable/release-service/22.08.1/windows/kate-22.08.1-windows-msvc2019_64-cl.exe#/dl.7z",
+            "hash": "4d5a94a68c58317e16b0d349b81c5dead1669b4be318ec13246186788b552962"
         }
     },
     "pre_install": [
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://apps.kde.org/kate",
+        "url": "https://kate-editor.org/get-it/",
         "regex": "kate-([\\d.]+)-windows-(?<lib>\\w+)-cl\\.exe"
     },
     "autoupdate": {
@@ -31,8 +31,7 @@
             "64bit": {
                 "url": "https://download.kde.org/stable/release-service/$version/windows/kate-$version-windows-$matchLib-cl.exe#/dl.7z",
                 "hash": {
-                    "url": "https://apps.kde.org/kate",
-                    "regex": "sha256:</strong> $sha256</div>"
+                    "url": "$url.sha256"
                 }
             }
         }


### PR DESCRIPTION
Relates to https://github.com/ScoopInstaller/Extras/pull/9298#issuecomment-1281773912

The update info for the stable binary of https://apps.kde.org/kate is relatively outdated and has been changed to https://kate-editor.org/get-it

I also found that KDE provides direct hash verification, which is more accurate and stable.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


