### PR TITLE
firefoxpwa: add version 2.1.2

### DIFF
--- a/bucket/firefoxpwa.json
+++ b/bucket/firefoxpwa.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.1.2",
+    "description": "A tool to install, manage and use Progressive Web Apps (PWAs) in Mozilla Firefox.",
+    "homepage": "https://github.com/filips123/PWAsForFirefox",
+    "license": "MPL-2.0 license",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.1.2/firefoxpwa-2.1.2-x86_64.msi",
+            "hash": "ff7ffc9ce002a8f36bfbe98c9b3654e70dc93bd9ba97de68003ac2b1abfb701b"
+        },
+        "32bit": {
+            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.1.2/firefoxpwa-2.1.2-x86.msi",
+            "hash": "e0ee7485b817d0a0aab39b993b7364962be5bf1f7340e54482c0bf88b43a4db5"
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v$version/firefoxpwa-$version-x86_64.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v$version/firefoxpwa-$version-x86.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds the PWA for firefox app to allow firefox users to run web apps on their computers
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
