### PR TITLE
librewolf: Fix checkver script

### DIFF
--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -5,7 +5,7 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/57e8cb791892a99e5d426105d28f330a/librewolf-106.0.1-1.en-US.win64-portable.zip",
+            "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/d5e449b50517d8013f19c6693e3972d2/librewolf-106.0.1-1.en-US.win64-portable.zip",
             "hash": "3384fb546a7d868cf9519d00846632b2e583de883dba669b29029209b9a9d8ae"
         }
     },
@@ -37,7 +37,7 @@
             "# using checkver script because checksum URL can be either above or below file URL",
             "$url = 'https://gitlab.com/api/v4/projects/13852981/releases'",
             "$regex1 = '/uploads/([a-f0-9]+)/sha256sums\\.txt'",
-            "$regex2 = '/uploads/([a-f0-9]+)/librewolf-([\\d.-]+)\\.en-US\\.win64-portable\\.zip'",
+            "$regex2 = '/uploads/([a-f0-9]+)/librewolf-([\\d.-]+)\\.en-US\\.win64-portable\\.zip;'",
             "",
             "$cont = (Invoke-WebRequest $url).Content | ConvertFrom-Json",
             "$cont = $cont[0] | ConvertTo-Json",


### PR DESCRIPTION
The wrong URL is using the id of the signature file. 

```json
{
    "links": [
        "@{id=1034241; name=sha256sums.txt; url=https://gitlab.com/librewolf-community/browser/windows/uploads/86ff8c2bf9be973be4b1046b3a021c80/sha256sums.txt; direct_asset_url=https://gitlab.com/librewolf-community/browser/windows/uploads/86ff8c2bf9be973be4b1046b3a021c80/sha256sums.txt; external=False; link_type=other}",
        "@{id=1034240; name=librewolf-106.0.1-1.en-US.win64-portable.zip.sig; url=https://gitlab.com/librewolf-community/browser/windows/uploads/57e8cb791892a99e5d426105d28f330a/librewolf-106.0.1-1.en-US.win64-portable.zip.sig; direct_asset_url=https://gitlab.com/librewolf-community/browser/windows/uploads/57e8cb791892a99e5d426105d28f330a/librewolf-106.0.1-1.en-US.win64-portable.zip.sig; external=False; link_type=other}",
        "@{id=1034239; name=librewolf-106.0.1-1.en-US.win64-setup.exe.sig; url=https://gitlab.com/librewolf-community/browser/windows/uploads/cadc998ef568c53dd7c112a9d8bc1e45/librewolf-106.0.1-1.en-US.win64-setup.exe.sig; direct_asset_url=https://gitlab.com/librewolf-community/browser/windows/uploads/cadc998ef568c53dd7c112a9d8bc1e45/librewolf-106.0.1-1.en-US.win64-setup.exe.sig; external=False; link_type=other}",
        "@{id=1034238; name=librewolf-106.0.1-1.en-US.win64-portable.zip; url=https://gitlab.com/librewolf-community/browser/windows/uploads/d5e449b50517d8013f19c6693e3972d2/librewolf-106.0.1-1.en-US.win64-portable.zip; direct_asset_url=https://gitlab.com/librewolf-community/browser/windows/uploads/d5e449b50517d8013f19c6693e3972d2/librewolf-106.0.1-1.en-US.win64-portable.zip; external=False; link_type=package}",
        "@{id=1034237; name=librewolf-106.0.1-1.en-US.win64-setup.exe; url=https://gitlab.com/librewolf-community/browser/windows/uploads/84cd64c0f5d248fa26a9715496b97c89/librewolf-106.0.1-1.en-US.win64-setup.exe; direct_asset_url=https://gitlab.com/librewolf-community/browser/windows/uploads/84cd64c0f5d248fa26a9715496b97c89/librewolf-106.0.1-1.en-US.win64-setup.exe; external=False; link_type=package}"
    ]
}
```

When signature file url above file url, using the `.en-US.win64-portable.zip` regular expression will match the signature file url.


Closes #9523 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
