### PR TITLE
jira-cli: Add version 1.1.0

### DIFF
--- a/bucket/jira-cli.json
+++ b/bucket/jira-cli.json
@@ -20,6 +20,6 @@
         "github": "https://github.com/ankitpokhrel/jira-cli"
     },
     "autoupdate": {
-        "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v$version/jira_1.1.0_windows_amd64.zip"
+        "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v$version/jira_$version_windows_amd64.zip"
     }
 }

--- a/bucket/jira-cli.json
+++ b/bucket/jira-cli.json
@@ -6,20 +6,16 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v1.1.0/jira_1.1.0_windows_amd64.zip",
-            "hash": "23DE92FF92C60A9FEF3E241951DFA579256C105D687E343502BAD7EDE13C1036"
+            "hash": "23de92ff92c60a9fef3e241951dfa579256c105d687e343502bad7ede13c1036"
         }
     },
     "extract_dir": "bin",
-    "bin": [
-        [
-            "jira.exe",
-            "jira"
-        ]
-    ],
-    "checkver": {
-        "github": "https://github.com/ankitpokhrel/jira-cli"
-    },
+    "bin": "jira.exe",
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v$version/jira_$version_windows_amd64.zip"
+        "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v$version/jira_$version_windows_amd64.zip",
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
     }
 }

--- a/bucket/jira-cli.json
+++ b/bucket/jira-cli.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.1.0",
+    "description": "Feature-rich Interactive Jira Command Line",
+    "homepage": "https://github.com/ankitpokhrel/jira-cli",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v1.1.0/jira_1.1.0_windows_amd64.zip",
+            "hash": "23DE92FF92C60A9FEF3E241951DFA579256C105D687E343502BAD7EDE13C1036"
+        }
+    },
+    "extract_dir": "bin",
+    "bin": [
+        [
+            "jira.exe",
+            "jira"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ankitpokhrel/jira-cli"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ankitpokhrel/jira-cli/releases/download/v$version/jira_1.1.0_windows_amd64.zip"
+    }
+}


### PR DESCRIPTION
Jira-CLI tool that actually works
Does support only ~/.config folder for config so no persist support can be done sadly