### PR TITLE
librehardwaremonitor@0.9.1: use github checkver

### DIFF
--- a/bucket/librehardwaremonitor.json
+++ b/bucket/librehardwaremonitor.json
@@ -1,21 +1,18 @@
 {
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "A fork of Open Hardware Monitor, a free software that can monitor the temperature sensors, fan speeds, voltages, load and clock speeds of your computer.",
     "homepage": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor",
     "license": "MPL-2.0",
-    "url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/download/v0.9.0/LibreHardwareMonitor-net472.zip",
-    "hash": "7a334846adc3f3b84243f25b6fceefeeddcd0c47e5ef5f91283da412f4d7408d",
+    "url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/download/v0.9.1/LibreHardwareMonitor-net472.zip",
+    "hash": "718e940e1851d8a9c6f21f02512d1415994476c7c187239234568e431c4f9a35",
     "shortcuts": [
         [
             "LibreHardwareMonitor.exe",
             "Libre Hardware Monitor"
         ]
     ],
-    "checkver": {
-        "url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases",
-        "regex": "([\\d.]+)/LibreHardwareMonitor-net(?<netver>[\\d]+).zip"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/download/v$version/LibreHardwareMonitor-net$matchNetver.zip"
+        "url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/download/v$version/LibreHardwareMonitor-net472.zip"
     }
 }


### PR DESCRIPTION
Assets listed under GitHub releases are not parseable from HTML anymore. Values are populated from API through JavaScript.

For example, the `0.9.1` assets listed on https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases are populated from the API https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/expanded_assets/v0.9.1.

This PR reverts the `checkver` changes from #8416, and uses `github` again. This also updates librehardwaremonitor to version `0.9.1`.

Relates to #8416 and ScoopInstaller/Scoop#5190.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
