### PR TITLE
mpv(-git): Add to path instead of shimming

### DIFF
--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -21,7 +21,8 @@
             "hash": "sha1:4c1fa0e1ac0564d4793d173a5f7082617624ae1c"
         }
     },
-    "bin": "mpv.com",
+    "pre_install": "Remove-Item \"$dir\\updater.bat\"",
+    "env_add_path": ".",
     "shortcuts": [
         [
             "mpv.exe",
@@ -30,7 +31,7 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://sourceforge.net/projects/mpv-player-windows/rss?path=/64bit",
+        "sourceforge": "mpv-player-windows/64bit",
         "regex": "mpv-x86_64-(\\d+)-git-(?<commit>[\\da-f]+)\\.7z"
     },
     "autoupdate": {

--- a/bucket/mpv.json
+++ b/bucket/mpv.json
@@ -17,7 +17,8 @@
             "hash": "7c13e571f5e3c1c481d901245f657171775024fe10d0026026db7d5e55eb4b25"
         }
     },
-    "bin": "mpv.com",
+    "pre_install": "Remove-Item \"$dir\\updater.bat\"",
+    "env_add_path": ".",
     "shortcuts": [
         [
             "mpv.exe",
@@ -26,8 +27,8 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://sourceforge.net/projects/mpv-player-windows/rss?path=/release",
-        "regex": "mpv-([\\d.]+)-x86_64"
+        "sourceforge": "mpv-player-windows/release",
+        "regex": "mpv-([\\d.]+)-"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

[mpv.net](https://github.com/mpvnet-player/mpv.net) fails to terminate MPV subprocesses when using the shim. This was causing problems such as [thumbfast](https://github.com/po5/thumbfast) not displaying the thumbnails properly. Adding mpv directly to the path fixes the problem.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
