### PR TITLE
ahkpm: Add version 0.3.0

### DIFF
--- a/bucket/ahkpm.json
+++ b/bucket/ahkpm.json
@@ -1,15 +1,23 @@
 {
-    "homepage": "https://ahkpm.dev/",
-    "description": "The AutoHotKey Package Manager",
-    "url": "https://github.com/joshuacc/ahkpm/releases/download/0.3.0/ahkpm-0.3.0.msi",
-    "hash": "7db1822d52142f6fc651ba65afcb5fa7d63b3ffb4afedcd64753504031ad24bc",
     "version": "0.3.0",
+    "description": "The AutoHotKey Package Manager",
+    "homepage": "https://ahkpm.dev/",
     "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/joshuacc/ahkpm/releases/download/0.3.0/ahkpm-0.3.0.msi",
+            "hash": "7db1822d52142f6fc651ba65afcb5fa7d63b3ffb4afedcd64753504031ad24bc"
+        }
+    },
     "bin": "ahkpm.exe",
     "checkver": {
         "github": "https://github.com/joshuacc/ahkpm"
     },
     "autoupdate": {
-        "url": "https://github.com/joshuacc/ahkpm/releases/download/$version/ahkpm-$version.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/joshuacc/ahkpm/releases/download/$version/ahkpm-$version.msi"
+            }
+        }
     }
 }

--- a/bucket/ahkpm.json
+++ b/bucket/ahkpm.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://ahkpm.dev/",
+    "description": "The AutoHotKey Package Manager",
+    "url": "https://github.com/joshuacc/ahkpm/releases/download/0.3.0/ahkpm-0.3.0.msi",
+    "hash": "7db1822d52142f6fc651ba65afcb5fa7d63b3ffb4afedcd64753504031ad24bc",
+    "version": "0.3.0",
+    "license": "MIT",
+    "bin": "ahkpm.exe",
+    "checkver": {
+        "github": "https://github.com/joshuacc/ahkpm"
+    },
+    "autoupdate": {
+        "url": "https://github.com/joshuacc/ahkpm/releases/download/$version/ahkpm-$version.msi"
+    }
+}


### PR DESCRIPTION
ahkpm is a new package manager for autohotkey, this PR adds a manifest for version 0.3.0

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
