### PR TITLE
winmtr-live: Add version 1.1

### DIFF
--- a/bucket/winmtr-live.json
+++ b/bucket/winmtr-live.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.1",
+    "description": "An extended fork of Appnor's WinMTR - a Network diagnostic tool combining ping and traceroute, with IPv6 support and other different enhancements and bug fixes",
+    "homepage": "https://github.com/AUnited/WinMTR",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AUnited/WinMTR/releases/download/1.1/WinMTR1.1_x64.zip",
+            "hash": "5cbb846d88e7c90256cbb1d4dceb97dc38060912f614430da08a5494674b4ab2"
+        },
+        "32bit": {
+            "url": "https://github.com/AUnited/WinMTR/releases/download/1.1/WinMTR1.1_x32.zip",
+            "hash": "d8efb3168d08bb01f83936a2a28f83d0415eb76306a9091ddac4abae7915a8c1"
+        }
+    },
+    "bin": "mtr.exe",
+    "shortcuts": [
+        [
+            "WinMTR.exe",
+            "WinMTR"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/AUnited/WinMTR/releases/download/$version/WinMTR$version_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/AUnited/WinMTR/releases/download/$version/WinMTR$version_x32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
fork of a fork, even has a cli bin

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).