### PR TITLE
vcredist & vcredist2022: add arm64 archictecture

### DIFF
--- a/bucket/vcredist.json
+++ b/bucket/vcredist.json
@@ -14,21 +14,59 @@
         "vcredist2012",
         "vcredist2013"
     ],
-    "url": [
-        "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9/VC_redist.x64.exe",
-        "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe"
-    ],
-    "hash": [
-        "2257b3fbe3c7559de8b31170155a433faf5b83829e67c589d5674ff086b868b9",
-        "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875"
-    ],
-    "post_install": [
-        "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
-        "$ec = @{",
-        "    1638 = 'This product is already installed';",
-        "    3010 = 'A restart is required to complete the installation';",
-        "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
-    ]
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9/VC_redist.x64.exe",
+                "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe"
+            ],
+            "hash": [
+                "2257b3fbe3c7559de8b31170155a433faf5b83829e67c589d5674ff086b868b9",
+                "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875"
+            ],
+            "post_install": [
+                "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
+                "$ec = @{",
+                "    1638 = 'This product is already installed';",
+                "    3010 = 'A restart is required to complete the installation';",
+                "}",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+            ]
+        },
+        "32bit": {
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe",
+            "hash": "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875",
+            "post_install": [
+                "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
+                "$ec = @{",
+                "    1638 = 'This product is already installed';",
+                "    3010 = 'A restart is required to complete the installation';",
+                "}",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+            ]
+        },
+        "arm64": {
+            "url": [
+                "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/85759E1CA11B0DB71C9DC9D825ACC68AF0E6D74415A4D4BA5BAB2DEDEFB65628/VC_redist.arm64.exe",
+                "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9/VC_redist.x64.exe",
+                "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe"
+            ],
+            "hash": [
+                "85759e1ca11b0db71c9dc9d825acc68af0e6d74415a4d4ba5bab2dedefb65628",
+                "2257b3fbe3c7559de8b31170155a433faf5b83829e67c589d5674ff086b868b9",
+                "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875"
+            ],
+            "post_install": [
+                "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
+                "$ec = @{",
+                "    1638 = 'This product is already installed';",
+                "    3010 = 'A restart is required to complete the installation';",
+                "}",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.arm64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+            ]
+        }
+    }
 }

--- a/bucket/vcredist2022.json
+++ b/bucket/vcredist2022.json
@@ -7,21 +7,59 @@
         "url": "https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx"
     },
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2022'",
-    "url": [
-        "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9/VC_redist.x64.exe",
-        "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe"
-    ],
-    "hash": [
-        "2257b3fbe3c7559de8b31170155a433faf5b83829e67c589d5674ff086b868b9",
-        "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875"
-    ],
-    "post_install": [
-        "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
-        "$ec = @{",
-        "    1638 = 'This product is already installed';",
-        "    3010 = 'A restart is required to complete the installation';",
-        "}",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
-        "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
-    ]
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9/VC_redist.x64.exe",
+                "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe"
+            ],
+            "hash": [
+                "2257b3fbe3c7559de8b31170155a433faf5b83829e67c589d5674ff086b868b9",
+                "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875"
+            ],
+            "post_install": [
+                "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
+                "$ec = @{",
+                "    1638 = 'This product is already installed';",
+                "    3010 = 'A restart is required to complete the installation';",
+                "}",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+            ]
+        },
+        "32bit": {
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe",
+            "hash": "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875",
+            "post_install": [
+                "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
+                "$ec = @{",
+                "    1638 = 'This product is already installed';",
+                "    3010 = 'A restart is required to complete the installation';",
+                "}",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+            ]
+        },
+        "arm64": {
+            "url": [
+                "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/85759E1CA11B0DB71C9DC9D825ACC68AF0E6D74415A4D4BA5BAB2DEDEFB65628/VC_redist.arm64.exe",
+                "https://download.visualstudio.microsoft.com/download/pr/bcb0cef1-f8cb-4311-8a5c-650a5b694eab/2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9/VC_redist.x64.exe",
+                "https://download.visualstudio.microsoft.com/download/pr/6a4c74cd-8ee0-4757-9620-a11a5b48b1a7/CE4843A946EE3732EB2BFC098DB5741DC5495C7BEA204E11D379336DCC68E875/VC_redist.x86.exe"
+            ],
+            "hash": [
+                "85759e1ca11b0db71c9dc9d825acc68af0e6d74415a4d4ba5bab2dedefb65628",
+                "2257b3fbe3c7559de8b31170155a433faf5b83829e67c589d5674ff086b868b9",
+                "ce4843a946ee3732eb2bfc098db5741dc5495c7bea204e11d379336dcc68e875"
+            ],
+            "post_install": [
+                "# For error codes, see https://docs.microsoft.com/en-us/windows/win32/msi/error-codes",
+                "$ec = @{",
+                "    1638 = 'This product is already installed';",
+                "    3010 = 'A restart is required to complete the installation';",
+                "}",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x86.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null",
+                "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.arm64.exe\" -ArgumentList '/fo', '/quiet', '/norestart' -ContinueExitCodes $ec -RunAs | Out-Null"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

----

This adds specializations to vcredist & vcredist2022 for x86 (32-bit) and ARM64 architectures.  They installs a different set of redistributables for each architecture:

- x86 (64-bit): both *VC_redist.x64.exe* and *VC_redist.x86.exe* as it's done so far.
- x86 (32-bit): only *VC_redist.x86.exe*.
- ARM64: all of *VC_redist.arm64.exe*, *VC_redist.x64.exe*, and *VC_redist.x86.exe* for compatibility with non-arm64 executables.

I am not sure if this change is appropriate.  Please tell me if I did something wrong!