### PR TITLE
siyuan-note: Update to version 2.4.11, Remove 32bit

### DIFF
--- a/bucket/siyuan-note.json
+++ b/bucket/siyuan-note.json
@@ -1,22 +1,14 @@
 {
-    "version": "2.4.7",
-    "description": "SiYuan is a Markdown Block-Reference and Bidirectional-Link note-taking application",
+    "version": "2.4.11",
+    "description": "SiYuan is a local-first personal knowledge management system, supports fine-grained block-level reference, and Markdown WYSIWYG.",
     "homepage": "https://b3log.org/siyuan",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/siyuan-note/siyuan/releases/download/v2.4.7/siyuan-2.4.7-win.exe#/dl.7z",
-            "hash": "bc921a82f2d6bdebe4dcd2cf8a48e352c87338d263e3bec8625c92faeb5c5b8a",
+            "url": "https://github.com/siyuan-note/siyuan/releases/download/v2.4.11/siyuan-2.4.11-win.exe#/dl.7z",
+            "hash": "9b02672fe41af90b2c2dfe6d20761d34d249173514af0e9cb9e3871cb4737d1a",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$*\" -Recurse"
-            ]
-        },
-        "32bit": {
-            "url": "https://github.com/siyuan-note/siyuan/releases/download/v2.4.7/siyuan-2.4.7-win32.exe#/dl.7z",
-            "hash": "715402477089827ff9f6e0a4a2803561bfee16b3c902383e4eaaca7f5e034e38",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\" -Recurse"
             ]
         }
@@ -34,9 +26,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/siyuan-note/siyuan/releases/download/v$version/siyuan-$version-win.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/siyuan-note/siyuan/releases/download/v$version/siyuan-$version-win32.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

REF: [32-bit installations are no longer built on Windows · Issue #6386 · siyuan-note/siyuan](https://github.com/siyuan-note/siyuan/issues/6386)

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
