### PR TITLE
fix-print-spooler: Fix extract_dir and autoupdate

### DIFF
--- a/bucket/fix-print-spooler.json
+++ b/bucket/fix-print-spooler.json
@@ -8,6 +8,7 @@
     },
     "url": "https://www.sordum.org/files/download/fix-print-spooler/FixPrintSpooler.zip",
     "hash": "9eee635e93d55763a461ac6afcf0d9c9759dd0f4134df6b3217a8b7d8e8c0f36",
+    "extract_dir": "FixPrintSpooler_v1.3",  
     "pre_install": [
         "if ($architecture -eq '32bit') {Remove-Item \"$dir\\FixSpooler_x64.exe\"}",
         "elseif ($architecture -eq '64bit') {Remove-Item \"$dir\\FixSpooler.exe\"; Rename-Item \"$dir\\FixSpooler_x64.exe\" 'FixSpooler.exe'}"
@@ -22,6 +23,7 @@
     "persist": "FixSpooler.ini",
     "checkver": "Fix\\sPrint\\sSpooler\\sv([\\d.]+)",
     "autoupdate": {
-        "url": "https://www.sordum.org/files/download/restart-explorer/Rexplorer.zip"
+        "url": "https://www.sordum.org/files/download/fix-print-spooler/FixPrintSpooler.zip",
+        "extract_dir": "FixPrintSpooler_v$version"
     }
 }

--- a/bucket/fix-print-spooler.json
+++ b/bucket/fix-print-spooler.json
@@ -8,7 +8,7 @@
     },
     "url": "https://www.sordum.org/files/download/fix-print-spooler/FixPrintSpooler.zip",
     "hash": "9eee635e93d55763a461ac6afcf0d9c9759dd0f4134df6b3217a8b7d8e8c0f36",
-    "extract_dir": "FixPrintSpooler_v1.3",  
+    "extract_dir": "FixPrintSpooler_v1.3",
     "pre_install": [
         "if ($architecture -eq '32bit') {Remove-Item \"$dir\\FixSpooler_x64.exe\"}",
         "elseif ($architecture -eq '64bit') {Remove-Item \"$dir\\FixSpooler.exe\"; Rename-Item \"$dir\\FixSpooler_x64.exe\" 'FixSpooler.exe'}"


### PR DESCRIPTION
fix autoupdate and extract_dir

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/ScoopInstaller/Extras/issues/9660

Relates to https://github.com/ScoopInstaller/Extras/pull/9701

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
