### PR TITLE
viddy: Add arm64 architecture

### DIFF
--- a/bucket/viddy.json
+++ b/bucket/viddy.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/sachaos/viddy/releases/download/v0.3.6/viddy_0.3.6_Windows_i386.tar.gz",
             "hash": "b03f1725fb8b8327cf588960514e0a5396305f706713ca58395c75e8f0d08442"
+        },
+        "arm64": {
+            "url": "https://github.com/sachaos/viddy/releases/download/v0.3.6/viddy_0.3.6_Windows_arm64.tar.gz",
+            "hash": "d6b2238295ad3b25fe06bd45c25e3bf0939a3e9c8dde860d6e889beb37290319"
         }
     },
     "bin": "viddy.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_i386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/sachaos/viddy/releases/download/v$version/viddy_$version_Windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).