### PR TITLE
lite-xl: Update to version 2.1.0

### DIFF
--- a/bucket/lite-xl.json
+++ b/bucket/lite-xl.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.0.5",
+    "version": "2.1.0",
     "description": "A lightweight text editor written in Lua, adapted from lite.",
     "homepage": "https://lite-xl.github.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lite-xl/lite-xl/releases/download/v2.0.5/lite-xl-windows-x86_64.zip",
-            "hash": "383005f6e45b102fdae6f6c0f1468cab916eded09aa6c548fb0eb07e94613044"
+            "url": "https://github.com/lite-xl/lite-xl/releases/download/v2.1.0/lite-xl-v2.1.0-windows-x86_64.zip",
+            "hash": "c9ecc452bdd24c2596532bb1034b1a340d30da7243c5ecb921e731470a02b803"
         },
         "32bit": {
-            "url": "https://github.com/lite-xl/lite-xl/releases/download/v2.0.5/lite-xl-windows-x86.zip",
-            "hash": "4587fe52b1b4e8a181f41b694f17867c265d31bc938d0c1c151883c985c48511"
+            "url": "https://github.com/lite-xl/lite-xl/releases/download/v2.1.0/lite-xl-v2.1.0-windows-i686.zip",
+            "hash": "6cff99fe707e3be4832de1584b2a44183b6039502f1ec815b87bc78a347fc5bf"
         }
     },
     "extract_dir": "lite-xl",
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lite-xl/lite-xl/releases/download/v$version/lite-xl-windows-x86_64.zip"
+                "url": "https://github.com/lite-xl/lite-xl/releases/download/v$version/lite-xl-v$version-windows-x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/lite-xl/lite-xl/releases/download/v$version/lite-xl-windows-x86.zip"
+                "url": "https://github.com/lite-xl/lite-xl/releases/download/v$version/lite-xl-v$version-windows-i686.zip"
             }
         }
     }


### PR DESCRIPTION
Update the lite-xl manifest to lite-xl v2.1.0

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
