### PR TITLE
Add "res" to persist in registry-finder.json

### DIFF
--- a/bucket/registry-finder.json
+++ b/bucket/registry-finder.json
@@ -30,7 +30,10 @@
             "--dataFolder \"$dir\\config\""
         ]
     ],
-    "persist": "config",
+    "persist": [
+            "config",
+            "res"
+        ]
     "checkver": {
         "regex": "bin/([\\d.]+)/"
     },


### PR DESCRIPTION
The "res" folder contains custom icons for the app UI. Currently after every update, user has to manually copy the "res" folder to the "current" folder. Fixed by adding "res" to persist.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
