### PR TITLE
wechat: Update to 3.8.0.41 / Fix checkver and autoupdate

### DIFF
--- a/bucket/wechat.json
+++ b/bucket/wechat.json
@@ -1,13 +1,12 @@
 {
-    "version": "3.7.6.44",
+    "version": "3.8.0.41",
     "description": "Free messaging and calling app by Tencent",
     "homepage": "https://pc.weixin.qq.com/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.wechat.com/en/service_terms.html"
     },
-    "url": "https://webcdn.m.qq.com/spcmgr/download/WeChat3.7.6.44.exe#/dl.7z",
-    "hash": "134646155a7d878d86de2333276e8fed68804928117609d31d44d2468b85418c",
+    "url": "https://webcdn.m.qq.com/spcmgr/download/WeChatSetup_3.8.0.41.exe#/dl.7z",
     "installer": {
         "script": [
             "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$_15_\", \"$dir\\`$R5\" -Force -Recurse",
@@ -36,9 +35,9 @@
     },
     "checkver": {
         "url": "https://pc.qq.com/detail/8/detail_11488.html",
-        "regex": "WeChat([\\d.]+)\\.exe"
+        "regex": "WeChat(\D*)([\d.]+)\.exe"
     },
     "autoupdate": {
-        "url": "https://webcdn.m.qq.com/spcmgr/download/WeChat$version.exe#/dl.7z"
+        "url": "https://dldir1.qq.com/weixin/Windows/WeChatSetup.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
I opened this pull request because I found that the version of `WeChat` is out-of-date because the source site changed their API to the former way (see [#9096](https://github.com/ScoopInstaller/Extras/pull/9196/commits/a42f707f6e3f59e592fa9ce490be4ab8d5c240a9)).

In order to avoid constantly changing autoupdate later, I updated the regex of checkver to make it more robust. However, I don't know how to add `hash` value to it, so I just simply deleted it. The `url` in autoupdate is the original download link in the homepage.
This is my first time opening a pull request in this project, so please let me know if there is anything to add.
