### PR TITLE
jenv: Add version 2.1.0

### DIFF
--- a/bucket/jenv.json
+++ b/bucket/jenv.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.1.0",
+    "description": "Change your current Java version with one line",
+    "homepage": "https://github.com/FelixSelter/JEnv-for-Windows",
+    "license": "Apache-2.0",
+    "url": "https://github.com/FelixSelter/JEnv-for-Windows/releases/download/v2.1.0/JEnv.zip",
+    "hash": "f9a03bdd5d6d8328f49cef6ba781639e75e007851d75f9b6676cb32c3d244e71",
+    "bin": [
+        "jenv.bat",
+        "java.bat"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/FelixSelter/JEnv-for-Windows/releases/download/v$version/JEnv.zip"
+    }
+}


### PR DESCRIPTION
Adds https://github.com/FelixSelter/JEnv-for-Windows for managing Java versions.

It was recommended to move this to Extras [here](https://github.com/ScoopInstaller/Java/pull/378).