### PR TITLE
skaffold@2.0.2: Fix hash

### DIFF
--- a/bucket/skaffold.json
+++ b/bucket/skaffold.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/GoogleCloudPlatform/skaffold/releases/download/v2.0.2/skaffold-windows-amd64.exe#/skaffold.exe",
-            "hash": "5ab3107c54242b39ea6f8d0c36f653f90e9dc0b5c37717e777e7b2475340a1f4"
+            "hash": "7a1202a0674c7600d16b9f05c96185aaec01b6a1108b56891d0344dbf2dbd3a0"
         }
     },
     "bin": "skaffold.exe",


### PR DESCRIPTION
The skaffold team republished the `v2.0.2` windows binary due to an issue with signing the binary which was later resolved.  The sha256 value that the github action picked up is no longer correct as a result of this.  This PR contains the correct hash.

Skaffold `v2.0.2` windows binary from our release page has the value in this PR:
https://github.com/GoogleContainerTools/skaffold/releases/download/v2.0.2/skaffold-windows-amd64.exe
https://github.com/GoogleContainerTools/skaffold/releases/download/v2.0.2/skaffold-windows-amd64.exe.sha256

```
aprindle@aprindle-ssd ~/Downloads $ sha256sum skaffold-windows-amd64.exe
7a1202a0674c7600d16b9f05c96185aaec01b6a1108b56891d0344dbf2dbd3a0  skaffold-windows-amd64.exe
aprindle@aprindle-ssd ~/Downloads $ cat skaffold-windows-amd64.exe.sha256 
7a1202a0674c7600d16b9f05c96185aaec01b6a1108b56891d0344dbf2dbd3a0  skaffold-windows-amd64.exe
```