### PR TITLE
registry-finder: preserve all config files

### DIFF
--- a/bucket/registry-finder.json
+++ b/bucket/registry-finder.json
@@ -17,8 +17,8 @@
         }
     },
     "post_install": [
-        "$persist = \"favorites.txt\", \"RegistryFinder.config\", \"UndoHistory\", \"VisitationHistory\"",
-        "$persist.ForEach({ Copy-Item \"$persist_dir\\$_\" \"$dir\" -Recurse -ea 0 })"
+        "'favorites.txt', 'RegistryFinder.config', 'UndoHistory', 'VisitationHistory' | ForEach-Object {",
+        "Copy-Item \"$persist_dir\\$_\" \"$dir\" -Recurse -ErrorAction SilentlyContinue }"
     ],
     "bin": "registryfinder.exe",
     "shortcuts": [

--- a/bucket/registry-finder.json
+++ b/bucket/registry-finder.json
@@ -16,24 +16,25 @@
             "hash": "56ebfc80eb32f5893b83df427606d5a9e70867271ad05438007bdd1f27ace455"
         }
     },
-    "bin": [
-        [
-            "registryfinder.exe",
-            "registry-finder",
-            "--dataFolder \"$dir\\config\""
-        ]
+    "post_install": [
+        "$persist = \"favorites.txt\", \"RegistryFinder.config\", \"UndoHistory\", \"VisitationHistory\"",
+        "$persist.ForEach({ Copy-Item \"$persist_dir\\$_\" \"$dir\" -Recurse -ea 0 })"
     ],
+    "bin": "registryfinder.exe",
     "shortcuts": [
         [
             "RegistryFinder.exe",
-            "Registry Finder",
-            "--dataFolder \"$dir\\config\""
+            "Registry Finder"
         ]
     ],
-    "persist": "config",
+    "persist": "res",
     "checkver": {
         "regex": "bin/([\\d.]+)/"
     },
+    "pre_uninstall": [
+        "$persist = \"favorites.txt\", \"RegistryFinder.config\", \"UndoHistory\", \"VisitationHistory\"",
+        "$persist.ForEach({ Copy-Item \"$dir\\$_\" \"$persist_dir\" -Recurse -ea 0 })"
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/registry-finder.json
+++ b/bucket/registry-finder.json
@@ -32,8 +32,8 @@
         "regex": "bin/([\\d.]+)/"
     },
     "pre_uninstall": [
-        "$persist = \"favorites.txt\", \"RegistryFinder.config\", \"UndoHistory\", \"VisitationHistory\"",
-        "$persist.ForEach({ Copy-Item \"$dir\\$_\" \"$persist_dir\" -Recurse -ea 0 })"
+        "'favorites.txt', 'RegistryFinder.config', 'UndoHistory', 'VisitationHistory' | ForEach-Object {",
+        "Copy-Item \"$dir\\$_\" \"$persist_dir\" -Recurse -ErrorAction SilentlyContinue }"
     ],
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This PR implements a better backup method and eliminates the purpose for creating an alias shim.

Closes #9809, #9769

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
