### PR TITLE
reicon: Enhance `pre_install` script. Remove `architecture`, `notes`, and add `pre_uninstall` script

### DIFF
--- a/bucket/reicon.json
+++ b/bucket/reicon.json
@@ -13,8 +13,8 @@
         "ensure \"$persist_dir\" | Out-Null",
         "if ($architecture -eq '32bit') {Remove-Item \"$dir\\ReIcon_x64.exe\"}",
         "elseif ($architecture -eq '64bit') {Remove-Item \"$dir\\ReIcon.exe\"; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe'}",
-        "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\") {New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null}",
-        "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\""
+        "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\")) {New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null}",
+        "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\" -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "ReIcon.exe",
     "shortcuts": [
@@ -24,7 +24,7 @@
         ]
     ],
     "persist": "ReIcon.ini",
-    "pre_uninstall": "if (Test-Path \"$persist_dir\") {Copy-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\"}",
+    "pre_uninstall": "if (Test-Path \"$persist_dir\") {Copy-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" -ErrorAction 'SilentlyContinue'}",
     "checkver": "ReIcon\\sv([\\d.]+)",
     "autoupdate": {
         "url": "https://www.sordum.org/files/download/restore-desktop-icon-layouts/ReIcon.zip"

--- a/bucket/reicon.json
+++ b/bucket/reicon.json
@@ -11,8 +11,8 @@
     "extract_dir": "ReIcon",
     "pre_install": [
         "ensure \"$persist_dir\" | Out-Null",
-        "if ($architecture -eq '32bit') {Remove-Item \"$dir\\ReIcon_x64.exe\"}",
-        "elseif ($architecture -eq '64bit') {Remove-Item \"$dir\\ReIcon.exe\"; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe'}",
+        "if ($architecture -eq '32bit') { Remove-Item \"$dir\\ReIcon_x64.exe\" }",
+        "elseif ($architecture -eq '64bit') { Remove-Item \"$dir\\ReIcon.exe\"; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe' }",
         "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\")) {New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null}",
         "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],

--- a/bucket/reicon.json
+++ b/bucket/reicon.json
@@ -14,7 +14,7 @@
         "if ($architecture -eq '32bit') {Remove-Item \"$dir\\ReIcon_x64.exe\"}",
         "elseif ($architecture -eq '64bit') {Remove-Item \"$dir\\ReIcon.exe\"; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe'}",
         "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\")) {New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null}",
-        "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\" -ErrorAction 'SilentlyContinue'"
+        "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "ReIcon.exe",
     "shortcuts": [
@@ -24,7 +24,7 @@
         ]
     ],
     "persist": "ReIcon.ini",
-    "pre_uninstall": "if (Test-Path \"$persist_dir\") {Copy-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" -ErrorAction 'SilentlyContinue'}",
+    "pre_uninstall": "Copy-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" -Recurse -ErrorAction 'SilentlyContinue'",
     "checkver": "ReIcon\\sv([\\d.]+)",
     "autoupdate": {
         "url": "https://www.sordum.org/files/download/restore-desktop-icon-layouts/ReIcon.zip"

--- a/bucket/reicon.json
+++ b/bucket/reicon.json
@@ -13,7 +13,7 @@
         "ensure \"$persist_dir\" | Out-Null",
         "if ($architecture -eq '32bit') { Remove-Item \"$dir\\ReIcon_x64.exe\" }",
         "elseif ($architecture -eq '64bit') { Remove-Item \"$dir\\ReIcon.exe\"; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe' }",
-        "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\")) {New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null}",
+        "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\")) { New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null }",
         "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "ReIcon.exe",

--- a/bucket/reicon.json
+++ b/bucket/reicon.json
@@ -6,18 +6,16 @@
         "identifier": "Freeware",
         "url": "https://www.sordum.org/eula/"
     },
-    "notes": "Desktop icon layout Files created by the program are currenlty unable to be persisted in the app folder. So please place them somewhere else in your computer",
     "url": "https://www.sordum.org/files/download/restore-desktop-icon-layouts/ReIcon.zip",
     "hash": "0917519c64dcea763b9ef0b91737baecb195181f8bf3585ba3ed94b85c766acd",
     "extract_dir": "ReIcon",
-    "architecture": {
-        "64bit": {
-            "pre_install": "Remove-Item \"$dir\\ReIcon.exe\" | Out-Null; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe' | Out-Null"
-        },
-        "32bit": {
-            "pre_install": "Remove-Item \"$dir\\ReIcon_x64.exe\" | Out-Null"
-        }
-    },
+    "pre_install": [
+        "ensure \"$persist_dir\" | Out-Null",
+        "if ($architecture -eq '32bit') {Remove-Item \"$dir\\ReIcon_x64.exe\"}",
+        "elseif ($architecture -eq '64bit') {Remove-Item \"$dir\\ReIcon.exe\"; Rename-Item \"$dir\\ReIcon_x64.exe\" 'ReIcon.exe'}",
+        "if (!(Test-Path \"$dir\\IconLayoutsFor$env:USERNAME.ini\") {New-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" | Out-Null}",
+        "Copy-Item \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\" \"$dir\\IconLayoutsFor$env:USERNAME.ini\""
+    ],
     "bin": "ReIcon.exe",
     "shortcuts": [
         [
@@ -26,6 +24,7 @@
         ]
     ],
     "persist": "ReIcon.ini",
+    "pre_uninstall": "if (Test-Path \"$persist_dir\") {Copy-Item \"$dir\\IconLayoutsFor$env:USERNAME.ini\" \"$persist_dir\\IconLayoutsFor$env:USERNAME.ini\"}",
     "checkver": "ReIcon\\sv([\\d.]+)",
     "autoupdate": {
         "url": "https://www.sordum.org/files/download/restore-desktop-icon-layouts/ReIcon.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This should fix the commonly reoccurring issue that prevents user desktop icon layout's from being persisted. They will now persist with every update.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
