### PR TITLE
Update sqlitestudio.json

### DIFF
--- a/bucket/sqlitestudio.json
+++ b/bucket/sqlitestudio.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "A SQLite database manager",
     "homepage": "https://sqlitestudio.pl",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.4.0/sqlitestudio_x64-3.4.0.zip",
-            "hash": "02eea73f0488a45fffa7af902e1605ec06bd57f30418a3f88ca5e40335913c95"
+            "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.4.1/sqlitestudio_x64-3.4.1.zip",
+            "hash": "cbb7481f072afa5cfbbc2c9dcded0fef347a0c18bf6257a311f876c2fa35b006"
         },
         "32bit": {
-            "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.4.0/sqlitestudio_i386-3.4.0.zip",
-            "hash": "177a3dcdf2e298cdaf3eb187d5e3645e8fdda2ad15e0670a2da58e73625847b6"
+            "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.4.1/sqlitestudio_i386-3.4.1.zip",
+            "hash": "4dc8662bf7aadfa47181cbf633601340dff7ac261310b543f27d69b4a5841da2"
         }
     },
     "extract_dir": "SQLiteStudio",
@@ -27,12 +27,19 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/sqlitestudio_x64-$version.zip"
+                "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/sqlitestudio_x64-$version.zip",
+                "hash": {
+                    "url": "https://github.com/pawelsalawa/sqlitestudio/releases/tag/$version",
+                    "find": "<td>Windows\\s+?x64<\\/td>\\s*?<td>Portable<\\/td>[\\s\\S]*?<code>(.*?)<\\/code>"
+                }
             },
             "32bit": {
-                "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/sqlitestudio_i386-$version.zip"
+                "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/sqlitestudio_i386-$version.zip",
+                "hash": {
+                    "url": "https://github.com/pawelsalawa/sqlitestudio/releases/tag/$version",
+                    "find": "<td>Windows\\s+?i386<\\/td>\\s*?<td>Portable<\\/td>[\\s\\S]*?<code>(.*?)<\\/code>"
+                }
             }
         }
     }
 }
-

--- a/bucket/sqlitestudio.json
+++ b/bucket/sqlitestudio.json
@@ -1,10 +1,18 @@
 {
-    "version": "3.3.3",
+    "version": "3.4.0",
     "description": "A SQLite database manager",
-    "homepage": "https://sqlitestudio.pl/index.rvt",
+    "homepage": "https://sqlitestudio.pl",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.3.3/SQLiteStudio-3.3.3.zip",
-    "hash": "da888b08b075c71999002b903757d7842746925d8092c00efbd11fc594192494",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.4.0/sqlitestudio_x64-3.4.0.zip",
+            "hash": "02eea73f0488a45fffa7af902e1605ec06bd57f30418a3f88ca5e40335913c95"
+        },
+        "32bit": {
+            "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.4.0/sqlitestudio_i386-3.4.0.zip",
+            "hash": "177a3dcdf2e298cdaf3eb187d5e3645e8fdda2ad15e0670a2da58e73625847b6"
+        }
+    },
     "extract_dir": "SQLiteStudio",
     "bin": "SQLiteStudio.exe",
     "shortcuts": [
@@ -17,6 +25,14 @@
         "github": "https://github.com/pawelsalawa/sqlitestudio"
     },
     "autoupdate": {
-        "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/SQLiteStudio-$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/sqlitestudio_x64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/$version/sqlitestudio_i386-$version.zip"
+            }
+        }
     }
 }
+


### PR DESCRIPTION
sqlite studio changes windows release name and seperates 64 bit and 32bit. current check can not check new updates.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
