### PR TITLE
mp3tag: Enhance `pre_install` script, add `pre_uninstall` script, and change `persist`

### DIFF
--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -47,11 +47,12 @@
         "mp3tag.cfg"
     ],
     "pre_uninstall": [
-        "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
-        "if (![System.Environment]::Is64BitOperatingSystem) { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') }",
-        "elseif ([System.Environment]::Is64BitOperatingSystem) { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') }",
-        "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 4"
+        "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
+        "   if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
+        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
+        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",
     "autoupdate": {

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -48,7 +48,7 @@
     ],
     "pre_uninstall": [
         "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
-        "Copy-Item \"$dir\\export\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
+        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
         "if (![System.Environment]::Is64BitOperatingSystem) { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') }",
         "elseif ([System.Environment]::Is64BitOperatingSystem) { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') }",
         "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 4"

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -6,17 +6,31 @@
         "identifier": "Freeware",
         "url": "http://help.mp3tag.de/misc_license.html"
     },
+    "notes": [
+        "If you want 'mp3tag' as a context menu option run the following commands:",
+        "For 64bit Windows OS users run,",
+        "To Install:",
+        "start 'regsvr32' -Verb 'RunAs' -Args @(\"$dir\\Mp3tagShell.dll\", '/s')",
+        "To Uninstall:",
+        "start 'regsvr32' -Verb 'RunAs' -Args @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "",
+        "For 32bit Windows OS users run,",
+        "To Install:",
+        "start 'regsvr32' -Verb 'RunAs' -Args @(\"$dir\\Mp3tagShell32.dll\", '/s')",
+        "To Uninstall:",
+        "start 'regsvr32' -Verb 'RunAs' -Args @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
+        "",
+        "To find out if you have a have 32bit or 64bit Windows OS, run the following command:",
+        "(Get-CimInstance win32_operatingsystem).OSArchitecture"
+    ],
     "url": "https://download.mp3tag.de/mp3tagv318setup.exe#/dl.7z",
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
-        "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "'mp3tag.cfg', 'data\\columns.ini', 'data\\usrfields.ini' | ForEach-Object {",
         "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
-        "if ($architecture -eq '32bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @(\"$dir\\Mp3tagShell32.dll\", '/s') }",
-        "elseif ($architecture -eq '64bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @(\"$dir\\Mp3tagShell.dll\", '/s') }",
-        "Copy-Item \"$persist_dir\\export\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
+        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "mp3tag.exe",
     "shortcuts": [
@@ -35,9 +49,9 @@
     "pre_uninstall": [
         "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "Copy-Item \"$dir\\export\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
-        "if ($architecture -eq '32bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') }",
-        "elseif ($architecture -eq '64bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') }",
-        "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 2"
+        "if (![System.Environment]::Is64BitOperatingSystem) { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') }",
+        "elseif ([System.Environment]::Is64BitOperatingSystem) { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') }",
+        "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 4"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",
     "autoupdate": {

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -9,8 +9,14 @@
     "url": "https://download.mp3tag.de/mp3tagv318setup.exe#/dl.7z",
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\mp3tag.cfg\")) { New-Item \"$dir\\mp3tag.cfg\" | Out-Null }",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse"
+        "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
+        "'mp3tag.cfg', 'data\\columns.ini', 'data\\usrfields.ini' | ForEach-Object {",
+        "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "}",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
+        "if ($architecture -eq '32bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @(\"$dir\\Mp3tagShell32.dll\", '/s') }",
+        "elseif ($architecture -eq '64bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @(\"$dir\\Mp3tagShell.dll\", '/s') }",
+        "Copy-Item \"$persist_dir\\export\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "mp3tag.exe",
     "shortcuts": [
@@ -20,9 +26,18 @@
         ]
     ],
     "persist": [
-        "data",
-        "export",
+        "data\\panels",
+        "data\\columns",
+        "data\\columns.ini",
+        "data\\usrfields.ini",
         "mp3tag.cfg"
+    ],
+    "pre_uninstall": [
+        "if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
+        "Copy-Item \"$dir\\export\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
+        "if ($architecture -eq '32bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') }",
+        "elseif ($architecture -eq '64bit') { Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') }",
+        "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 2"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",
     "autoupdate": {


### PR DESCRIPTION
This allows for mp3tag to be added as a shell extension when the user installs this app.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
