### PR TITLE
easy-context-menu: Fix `hash`

### DIFF
--- a/bucket/easy-context-menu.json
+++ b/bucket/easy-context-menu.json
@@ -7,7 +7,7 @@
         "url": "https://www.sordum.org/eula/"
     },
     "url": "https://www.sordum.org/files/easy-context-menu/ec_menu.zip",
-    "hash": "d3b16dc6606f51772af3dff90381a7f41321ceae6bd5d8f9eb0994373b5a9ca7",
+    "hash": "060d8bb2b6f1cea88f85230ccfe221f3fe7226b7ba5af927362ea4f195e328ee",
     "extract_dir": "EcMenu_v1.6",
     "pre_install": "New-Item \"$dir\\Files\\EcMenu.ini\" -ItemType 'File' | Out-Null",
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Fixes this error I had with this app,
![(WindowsTerminal)b2e1a3_11-25-2022](https://user-images.githubusercontent.com/101912712/204074643-e063e974-f7ee-4796-9373-da7643b3c3b1.jpg)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
