### PR TITLE
kryptor@4.0.0: Update url, hash, and autoupdate

### DIFF
--- a/bucket/kryptor.json
+++ b/bucket/kryptor.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://www.kryptor.co.uk/",
     "description": "An open source encryption and signing tool.",
-    "version": "3.1.1",
+    "version": "4.0.0",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/samuel-lucas6/Kryptor/releases/download/v3.1.1/kryptor-windows.zip",
-            "hash": "e5278429c3c52ccf7fb5b8fa35289d505a3266c68cd7d65796b6699111f63815"
+            "url": "https://github.com/samuel-lucas6/Kryptor/releases/download/v4.0.0/kryptor-windows-x64.zip",
+            "hash": "5b8ff5581fffcd695eea055e36b97d838c218ccafdb6980a8154d1164e28d7b8"
         }
     },
     "bin": "kryptor.exe",
@@ -16,9 +16,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/samuel-lucas6/Kryptor/releases/download/v$version/kryptor-windows.zip",
+                "url": "https://github.com/samuel-lucas6/Kryptor/releases/download/v$version/kryptor-windows-x64.zip",
                 "hash": {
-                    "url": "$url.DIGEST"
+                    "url": "$url.digest"
                 }
             }
         }


### PR DESCRIPTION
The file names in the release changed (added -x64), therefore the auto update failed.
Also, newer versions use `.digest` (instead of `.DIGEST`) for the hash (although GitHub seems to be case insensitive here).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
