### PR TITLE
vt-uploader: Update manifest

### DIFF
--- a/bucket/vt-uploader.json
+++ b/bucket/vt-uploader.json
@@ -4,7 +4,7 @@
     "description": "A simple application written in C# that allows for file uploading to the VirusTotal website. (Requires a Virustotal API Key)",
     "license": "GPL-3.0",
     "notes": [
-        "For a guide on how to get your Virustotal API Key, visit,",
+        "For a guide on how to get your Virustotal API Key, visit:",
         "https://github.com/SamuelTulach/VirusTotalUploader#how-to-get-api-key"
     ],
     "url": "https://github.com/SamuelTulach/VirusTotalUploader/releases/download/0.1.9/setup_anycpu_signed.zip",
@@ -16,11 +16,10 @@
         "}"
     ],
     "post_install": [
-        "$vtPath = $dir.Replace('\\', '\\\\')",
-        "$regContent = (Get-Content \"$bucketsdir\\extras\\scripts\\vt-uploader\\install-context.reg\").Replace('$dir', \"$vtPath\")",
-        "if ($global) { $regContent = $regContent.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
-        "Set-Content \"$dir\\install-context.reg\" -Value $regContent -Encoding 'Ascii'",
-        "reg import \"$dir\\install-context.reg\""
+        "$registryPath = 'HKCU\\Software\\Classes\\*\\shell\\Upload to VirusTotal\\command'",
+        "$registryValue = '\"\"$dir\\uploader.exe\\\" \\\"%1\"\"'.Replace('$dir', $dir)",
+        "if ($global) { REG ADD $registryPath.Replace('HKCU', 'HKLM') /f /d $registryValue }",
+        "else { REG ADD $registryPath /f /d $registryValue }"
     ],
     "bin": [
         [
@@ -35,11 +34,11 @@
         ]
     ],
     "persist": "vtu_settings.json",
-    "pre_uninstall": [
+    "post_uninstall": [
         "if ($cmd -eq 'uninstall') {",
-        "    $registry = \"HKCU\\Software\\Classes\\*\\shell\\Upload to VirusTotal\"",
-        "    if ($global) { reg delete $registry.Replace('HKCU', 'HKLM') /f }",
-        "    else { reg delete $registry /f }",
+        "    $registryPath = 'HKCU\\Software\\Classes\\*\\shell\\Upload to VirusTotal'",
+        "    if ($global) { REG DELETE $registryPath.Replace('HKCU', 'HKLM') /f }",
+        "    else { REG DELETE $registryPath /f }",
         "}"
     ],
     "checkver": "github",

--- a/scripts/vt-uploader/install-context.reg
+++ b/scripts/vt-uploader/install-context.reg
@@ -1,4 +1,0 @@
-Windows Registry Editor Version 5.00
-
-[HKEY_CURRENT_USER\Software\Classes\*\shell\Upload to VirusTotal\command]
-@="\"$dir\\uploader.exe\" \"%1\""


### PR DESCRIPTION
- Use `REG` command instead of registry file
- Move `pre_uninstall` to `post_uninstall`

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
