### PR TITLE
vt-uploader: Fix `post_install` script

### DIFF
--- a/bucket/vt-uploader.json
+++ b/bucket/vt-uploader.json
@@ -17,7 +17,7 @@
     ],
     "post_install": [
         "$registryPath = 'HKCU\\Software\\Classes\\*\\shell\\Upload to VirusTotal\\command'",
-        "$registryValue = '\"\"$dir\\uploader.exe\\\" \\\"%1\"\"'.Replace('$dir', $dir)",
+        "$registryValue = (\"\"\"$dir\\uploader.exe\"\" \"\"%1\"\"\").Replace('$dir', $dir)",
         "if ($global) { REG ADD $registryPath.Replace('HKCU', 'HKLM') /f /d $registryValue }",
         "else { REG ADD $registryPath /f /d $registryValue }"
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes this issue I had with the app. The issue was when you used the context menu option, it would pull up the **Open With…** menu instead of the **VirusTotalUploader** app.
![(explorer)N3u368_11-29-2022](https://user-images.githubusercontent.com/101912712/204663172-576ef982-55f4-45ee-a475-6d50c497c5f7.jpg)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
