### PR TITLE
psiphon3: fix hash

### DIFF
--- a/bucket/psiphon3.json
+++ b/bucket/psiphon3.json
@@ -8,7 +8,7 @@
         "Privacy Policy:    https://psiphon.ca/en/privacy.html"
     ],
     "url": "https://psiphon.ca/psiphon3.exe",
-    "hash": "245b0533310427bc2df09f3a589606ee602293255d54aa207797bab9fe7e8ae8",
+    "hash": "b75ad9afdb23272f4fd4e5ade24a527c79b8c2c143524660c575afdb85c587ba",
     "shortcuts": [
         [
             "psiphon3.exe",


### PR DESCRIPTION

Relates to #9661 
hash of psiphon3 changed again
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
