### PR TITLE
megasync: Update to version 4.8.1.0

### DIFF
--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -4,7 +4,7 @@
         "https://github.com/meganz/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGAUpdater/Preferences.h#L9",
         "https://github.com/meganz/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/control/UpdateTask.cpp#L93-L111"
     ],
-    "version": "4.7.3.0",
+    "version": "4.8.1.0",
     "description": "Client for automated synchronization between local folder and MEGA cloud",
     "homepage": "https://mega.nz",
     "license": {


### PR DESCRIPTION

Recently the hash of the installer was change (Issue #9877) but the program version was not changed. This pull request just bumps it to the correct version.

![Screenshot_20221130_041806](https://user-images.githubusercontent.com/36266783/204743642-d72c0e99-ec23-4cbe-a16c-4d4acb20847f.png)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #9877

- I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
