### PR TITLE
mpv: Remove `pre_install`

### DIFF
--- a/bucket/mpv.json
+++ b/bucket/mpv.json
@@ -17,7 +17,6 @@
             "hash": "7c13e571f5e3c1c481d901245f657171775024fe10d0026026db7d5e55eb4b25"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\updater.bat\"",
     "env_add_path": ".",
     "shortcuts": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

`mpv` does not have an `updater.bat`, my bad.

Related to #9662

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
