### PR TITLE
xampp@8.1.12-0: Fix config and Add setup

### DIFF
--- a/bucket/xampp.json
+++ b/bucket/xampp.json
@@ -3,7 +3,6 @@
     "description": "Apache distribution containing MariaDB, PHP, and Perl",
     "homepage": "https://www.apachefriends.org/index.html",
     "license": "GPL-2.0-only",
-    "notes": "Follow the instructions on '$dir\\readme_en.txt' to set up XAMPP.",
     "suggest": {
         "Visual C++ 2019 Redistributable": "extras/vcredist2022"
     },
@@ -14,6 +13,12 @@
         }
     },
     "extract_dir": "xampp",
+    "pre_install": [
+        "if (-Not (Test-Path \"$dir\\xampp-control.ini\")) {",
+        "   New-Item \"$dir\\xampp-control.ini\"",
+        "}"
+    ],
+    "post_install": "Start-Process -FilePath \"$dir\\setup_xampp.bat\" -ArgumentList \"< nul\" -WorkingDirectory \"$dir\" -Wait",
     "bin": [
         "apache\\bin\\httpd.exe",
         "mysql\\bin\\mysql.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

File `xampp-control.ini` is not in archive by default, so we create it.
Scoop links it as directory, not a file, if it does not exist, which leads to incorrect start of application.
Also add automatic PHP setup (does not change system files).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
