### PR TITLE
megasync: updated checkver regex AND add post_install script for shell extension

### DIFF
--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -41,7 +41,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/meganz/MEGAsync"
+        "url": "https://api.github.com/repos/meganz/MEGAsync/releases",
+        "regex": "v(\d+.\d+.\d+).\d+_Win"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -4,7 +4,7 @@
         "https://github.com/meganz/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGAUpdater/Preferences.h#L9",
         "https://github.com/meganz/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/control/UpdateTask.cpp#L93-L111"
     ],
-    "version": "4.9.0",
+    "version": "4.9.0.0",
     "description": "Client for automated synchronization between local folder and MEGA cloud",
     "homepage": "https://mega.nz",
     "license": {
@@ -42,7 +42,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/meganz/MEGAsync/releases",
-        "regex": "v(\\d+.\\d+.\\d+).\\d+_Win"
+        "regex": "v(\\d+.\\d+.\\d+.\\d+)_Win"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -27,8 +27,8 @@
         "7z e -bso0 -bse0 -bsp0 -aou -o\"$dir\" \"$cachedir\\megasync#$version#https_mega.nz_MEGAsyncSetup$bit.exe_dl.7z\" `$R0",
         "if (Test-Path \"$dir\\`$R0\") { if ((7z l -bse0 \"$dir\\`$R0\") -like \"*CPU = x64*\") { Rename-Item \"$dir\\`$R0\" \"$dir\\ShellExtX64.dll\" } else { Rename-Item \"$dir\\`$R0\" \"$dir\\ShellExtX32.dll\" } }",
         "if (Test-Path \"$dir\\`$R0_1\") { if ((7z l -bse0 \"$dir\\`$R0_1\") -like \"*CPU = x64*\") { Rename-Item \"$dir\\`$R0_1\" \"$dir\\ShellExtX64.dll\" } else { Rename-Item \"$dir\\`$R0_1\" \"$dir\\ShellExtX32.dll\" } }",
-        "Write-Host -ForegroundColor Blue 'To enable MEGAsync''s context menu and sync indicator icon for files, run the following command as administrator:'",
-        "Write-Host -ForegroundColor Yellow \"regsvr32 \"\"$dir\\ShellExtX$bit.dll\"\"\""
+        "Write-Host -ForegroundColor Yellow -BackgroundColor Black 'To enable MEGAsync''s context menu and sync indicator icon for files, run the following command as administrator:'",
+        "Write-Host -ForegroundColor Yellow -BackgroundColor Black \"regsvr32 \"\"$dir\\ShellExtX$bit.dll\"\"\""
     ],
     "uninstaller": {
         "script": "shortcut_folder $global | Split-Path | Join-Path -ChildPath 'MEGAsync' | Remove-Item -ErrorAction 'SilentlyContinue' -Force -Recurse"

--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -4,7 +4,7 @@
         "https://github.com/meganz/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGAUpdater/Preferences.h#L9",
         "https://github.com/meganz/MEGAsync/blob/58d3ed7f4a10d08b0fa908639a65deac6a6bde1b/src/MEGASync/control/UpdateTask.cpp#L93-L111"
     ],
-    "version": "4.7.3.0",
+    "version": "4.9.0",
     "description": "Client for automated synchronization between local folder and MEGA cloud",
     "homepage": "https://mega.nz",
     "license": {
@@ -14,11 +14,11 @@
     "architecture": {
         "64bit": {
             "url": "https://mega.nz/MEGAsyncSetup64.exe#/dl.7z",
-            "hash": "3c5db4f98ce373725edf4b8ffb83fdedc7341f08c8514aa339e4ce44f4953e80"
+            "hash": "6532e3cbe3af7011a0fbee6b0de47f41d886b9fc00d9d07de3e055aa7ef1e285"
         },
         "32bit": {
             "url": "https://mega.nz/MEGAsyncSetup32.exe#/dl.7z",
-            "hash": "eff82de45d729ff5c0d78528e9a3a5a6b851bc059e48a86e277ac9df5487c0eb"
+            "hash": "3bc205d7edd7fa55828cc45aaa1eb73c9cdcb705c945e6ef1d8284467c28b7e9"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Megaupdater.exe\", \"$dir\\uninst*\" -Recurse",

--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -42,7 +42,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/meganz/MEGAsync/releases",
-        "regex": "v(\d+.\d+.\d+).\d+_Win"
+        "regex": "v(\\d+.\\d+.\\d+).\\d+_Win"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -22,6 +22,14 @@
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Megaupdater.exe\", \"$dir\\uninst*\" -Recurse",
+    "post_install": [
+        "$bit = \"$architecture\".Substring(0,2)",
+        "7z e -bso0 -bse0 -bsp0 -aou -o\"$dir\" \"$cachedir\\megasync#$version#https_mega.nz_MEGAsyncSetup$bit.exe_dl.7z\" `$R0",
+        "if (Test-Path \"$dir\\`$R0\") { if ((7z l -bse0 \"$dir\\`$R0\") -like \"*CPU = x64*\") { Rename-Item \"$dir\\`$R0\" \"$dir\\ShellExtX64.dll\" } else { Rename-Item \"$dir\\`$R0\" \"$dir\\ShellExtX32.dll\" } }",
+        "if (Test-Path \"$dir\\`$R0_1\") { if ((7z l -bse0 \"$dir\\`$R0_1\") -like \"*CPU = x64*\") { Rename-Item \"$dir\\`$R0_1\" \"$dir\\ShellExtX64.dll\" } else { Rename-Item \"$dir\\`$R0_1\" \"$dir\\ShellExtX32.dll\" } }",
+        "Write-Host -ForegroundColor Blue 'To enable MEGAsync''s context menu and sync indicator icon for files, run the following command as administrator:'",
+        "Write-Host -ForegroundColor Yellow \"regsvr32 \"\"$dir\\ShellExtX$bit.dll\"\"\""
+    ],
     "uninstaller": {
         "script": "shortcut_folder $global | Split-Path | Join-Path -ChildPath 'MEGAsync' | Remove-Item -ErrorAction 'SilentlyContinue' -Force -Recurse"
     },


### PR DESCRIPTION
**This update adds a post_install script for MEGAsync's context menu and sync indicator icons.**

The MEGAsync installers have a unique case regarding how it register the shell extension responsible for the context menu and sync indicator icons.

In the original installation process, MEGAsync installer will dynamically create the ShellExtX64.dll using the $R0 file of the installer.

To make it more complicated, the 32-bit installer has 2 "$R0" file inside the installer. The original install process will dynamically extract this as ShellExtX32.dll and ShellExtX64.dll accordingly.

However, the Scoop installation process extracts these files in the $dir, then deletes the "dollar files" using the pre_install script
```
"Remove-Item \"$dir\\`$*\", \"$dir\\Megaupdater.exe\", \"$dir\\uninst*\" -Recurse"
```

While this deletes all the dollar-files and dollar-folders that are not necessary, it also deletes the $R0 file that should have been renamed to ShellExtX64.dll.

Another complication is for 32-bit installer where 2 "$R0" files are extracted in $dir causing it to overwrite the other. The order of the overwrite is unpredictable which can cause the $R0 that is 32bit to be overwritten by the 64-bit version and thus will not register correctly in a 32-bit machine.

**So the proposed changes does the following to solve these issues:**

1. Let the pre_install script to run as is, deleting all the dollar-files and dollar-folders. Why? Because there's no use of retaining $R0 in pre_install given that in 32-bit systems it might be the wrong overwritten file out of the two.
2. Determine the bit using the $architecture variable. $bit will be used later in the script.
```
"$bit = \"$architecture\".Substring(0,2)",
```
3. A post_install script was added that will extract the $R0 files from the cached installer.
4. The 7z command uses the -aou flag to auto-rename duplicate files. This will create $R0 and $R0_1 for 32-bit installer. For the 64-bit installer only $R0 exists.
```
"7z e -bso0 -bse0 -bsp0 -aou -o\"$dir\" \"$cachedir\\megasync#$version#https_mega.nz_MEGAsyncSetup$bit.exe_dl.7z\" `$R0",
```
5. Once extracted, we let 7z determine the file by listing its details. Since the dll files are compressed and can be read by 7z, it will output the string "CPU = x64" for 64-bit dll, while none for 32-bit dll. This allows us to rename $R0 and $R0_1 appropriately depending on their bit. Remember that we can't know which is 32 or 64-bit among both $R0 and $R0_1 due to the installer compilation, hence this step is necessary.
```
"if (Test-Path \"$dir\\`$R0\") { if ((7z l -bse0 \"$dir\\`$R0\") -like \"*CPU = x64*\") { Rename-Item \"$dir\\`$R0\" \"$dir\\ShellExtX64.dll\" } else { Rename-Item \"$dir\\`$R0\" \"$dir\\ShellExtX32.dll\" } }",
"if (Test-Path \"$dir\\`$R0_1\") { if ((7z l -bse0 \"$dir\\`$R0_1\") -like \"*CPU = x64*\") { Rename-Item \"$dir\\`$R0_1\" \"$dir\\ShellExtX64.dll\" } else { Rename-Item \"$dir\\`$R0_1\" \"$dir\\ShellExtX32.dll\" } }",
```
6. An instruction on how to enable the shell extension is printed in the screen.

I have tested this for both 32-bit and 64-bit systems and it works.

- I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
