### PR TITLE
xmedia-recode: Update to version 3.5.6.7

### DIFF
--- a/bucket/xmedia-recode.json
+++ b/bucket/xmedia-recode.json
@@ -36,10 +36,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_x64_setup.exe"
+                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion`_x64_setup.exe"
             },
             "32bit": {
-                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_setup.exe"
+                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion`_setup.exe"
             }
         }
     }

--- a/bucket/xmedia-recode.json
+++ b/bucket/xmedia-recode.json
@@ -36,10 +36,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion`_x64_setup.exe"
+                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_x64_setup.exe"
             },
             "32bit": {
-                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion`_setup.exe"
+                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_setup.exe"
             }
         }
     }

--- a/bucket/xmedia-recode.json
+++ b/bucket/xmedia-recode.json
@@ -15,9 +15,8 @@
     },
     "innosetup": true,
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\" -Include 'Fav.ini', 'XMediaRecode.json')) {",
-        "   New-Item \"$dir\\Fav.ini\" | Out-Null; Set-Content \"$dir\\XMediaRecode.json\" -Value '{}' -Encoding 'utf8' -Force",
-        "}"
+        "if (!(Test-Path \"$persist_dir\\Fav.ini\")) { New-Item \"$dir\\Fav.ini\" | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\XMediaRecode.json\")) { Set-Content \"$dir\\XMediaRecode.json\" -Value '{}' -Encoding 'utf8' -Force }"
     ],
     "shortcuts": [
         [

--- a/bucket/xmedia-recode.json
+++ b/bucket/xmedia-recode.json
@@ -1,22 +1,24 @@
 {
-    "version": "3.5.6.6",
+    "version": "3.5.6.7",
     "description": "An All-In-One video converter and audio converter tool.",
     "homepage": "https://www.xmedia-recode.de/en/",
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://www.xmedia-recode.de/download/XMediaRecode3566_x64.zip",
-            "hash": "c8767d4809ab0d867754e67306230df7c602eb431e4422bd6af737316169ab12",
-            "extract_dir": "XMediaRecode3566_x64"
+            "url": "https://www.xmedia-recode.de/download/XMediaRecode3567_x64_setup.exe",
+            "hash": "bdafeb2bb4127bb8b284e213e360f76adff1f350fd8f61300bfa3cd49d1cd269"
         },
         "32bit": {
-            "url": "https://www.xmedia-recode.de/download/XMediaRecode3566.zip",
-            "hash": "196b4a5d23b451b77b59829d4cadf9f46bfcfe594d461450af72d8a99eb78b03",
-            "extract_dir": "XMediaRecode3566"
+            "url": "https://www.xmedia-recode.de/download/XMediaRecode3567_setup.exe",
+            "hash": "033fb1b6f1f186785dcff5cd292fbd57bdf29bd82717e31f7371329ac6fe2c54"
         }
     },
-    "pre_install": "if(!(Test-Path \"$persist_dir\\Fav.ini\")) { New-Item \"$dir\\Fav.ini\" -ItemType File | Out-Null }",
-    "bin": "XMedia Recode.exe",
+    "innosetup": true,
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\" -Include 'Fav.ini', 'XMediaRecode.json')) {",
+        "   New-Item \"$dir\\Fav.ini\" | Out-Null; Set-Content \"$dir\\XMediaRecode.json\" -Value '{}' -Encoding 'utf8' -Force",
+        "}"
+    ],
     "shortcuts": [
         [
             "XMedia Recode.exe",
@@ -24,8 +26,9 @@
         ]
     ],
     "persist": [
-        "XMediaRecode.ini",
-        "Fav.ini"
+        "XMediaRecode.json",
+        "Fav.ini",
+        "XMedia Recode"
     ],
     "checkver": {
         "url": "https://www.xmedia-recode.de/update/version.txt",
@@ -34,12 +37,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_x64.zip",
-                "extract_dir": "XMediaRecode$cleanVersion_x64"
+                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_x64_setup.exe"
             },
             "32bit": {
-                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion.zip",
-                "extract_dir": "XMediaRecode$cleanVersion"
+                "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion_setup.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Updates **xmedia-recode** to the latest version. The manifest is using the setup files instead of the portable files. The reason for this is due to the developer discounting development for the portable 32bit version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).