### PR TITLE
qbittorrent-enhanced@4.5.0.10: Update manifest

### DIFF
--- a/bucket/qbittorrent-enhanced.json
+++ b/bucket/qbittorrent-enhanced.json
@@ -5,8 +5,12 @@
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.5.0.10/qbittorrent_enhanced_4.5.0.10_qt6_setup.exe#/dl.7z",
-            "hash": "ff8d0df14bf79b3f09eef69179440a56c3dd616ea55047dadd519ae6f341ae75"
+            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.5.0.10/qbittorrent_enhanced_4.5.0.10_x64_setup.exe#/dl.7z",
+            "hash": "3ddb9373df93397f5b64109da6f52a1190b2df6d4335d17993a7a788633e6d16"
+        },
+        "32bit": {
+            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.5.0.10/qbittorrent_enhanced_4.5.0.10_setup.exe#/dl.7z",
+            "hash": "263f5a4991805cdb0ec81767de69c1548dcd1b56310a0be2a20ec4ea6fafba82"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
@@ -25,7 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_qt6_setup.exe#/dl.7z"
+                "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_x64_setup.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-$version/qbittorrent_enhanced_$version_setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
- Use standard version instead of qt6
- 32bit
- Update `autoupdate`

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #9930 #9931 #9914

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
