### PR TITLE
mp3tag: Fix `pre_(un)install` script

### DIFF
--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -30,7 +30,9 @@
         "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
-        "Start-Process \"$dir\\mp3tag.exe\" -Verb 'Open' -WindowStyle 'Minimized'; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
+        "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",
+        "   Start-Process \"$dir\\mp3tag.exe\" -Verb 'Open' -WindowStyle 'Minimized'; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
+        "}",
         "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "mp3tag.exe",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -52,7 +52,7 @@
     "pre_uninstall": [
         "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
         "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
-        "   if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
+        "   if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
         "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
         "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
         "   Start-Sleep -Seconds 4",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -55,7 +55,7 @@
         "   if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
         "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
-        "   Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 2",
+        "   Start-Sleep -Seconds 4",
         "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -1,4 +1,5 @@
 {
+    "##": "An external script is needs to (un)install the context menu.",
     "version": "3.18",
     "description": "Powerful and easy-to-use tool to edit metadata of audio files.",
     "homepage": "https://www.mp3tag.de",
@@ -26,14 +27,10 @@
     "url": "https://download.mp3tag.de/mp3tagv318setup.exe#/dl.7z",
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
-        "'mp3tag.cfg', 'data\\columns.ini' | ForEach-Object {",
+        "'mp3tag.cfg', 'data\\columns.ini', 'data\\usrfields.ini' | ForEach-Object {",
         "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
-        "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",
-        "   Start-Process \"$dir\\mp3tag.exe\" -Verb 'Open' -WindowStyle 'Minimized'; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
-        "}",
-        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse"
     ],
     "bin": "mp3tag.exe",
     "shortcuts": [
@@ -47,16 +44,8 @@
         "data\\columns",
         "data\\columns.ini",
         "data\\usrfields.ini",
+        "export",
         "mp3tag.cfg"
-    ],
-    "pre_uninstall": [
-        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
-        "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
-        "   if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
-        "   Start-Sleep -Seconds 4",
-        "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",
     "autoupdate": {

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -52,6 +52,7 @@
         "   if (!(is_admin)) {error \"$app requires admin rights to $cmd\"; break}",
         "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
         "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "   Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 2",
         "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -1,6 +1,5 @@
 {
-    "##": "An external script is needs to (un)install the context menu.",
-    "version": "3.18",
+    "version": "3.28",
     "description": "Powerful and easy-to-use tool to edit metadata of audio files.",
     "homepage": "https://www.mp3tag.de",
     "license": {
@@ -27,10 +26,14 @@
     "url": "https://download.mp3tag.de/mp3tagv318setup.exe#/dl.7z",
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
-        "'mp3tag.cfg', 'data\\columns.ini', 'data\\usrfields.ini' | ForEach-Object {",
-        "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "'mp3tag.cfg', 'data\\columns.ini' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse"
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
+        "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",
+        "    Start-Process \"$dir\\mp3tag.exe\" -Verb Open -WindowStyle Minimized; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
+        "}",
+        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction SilentlyContinue"
     ],
     "bin": "mp3tag.exe",
     "shortcuts": [
@@ -44,8 +47,15 @@
         "data\\columns",
         "data\\columns.ini",
         "data\\usrfields.ini",
-        "export",
         "mp3tag.cfg"
+    ],
+    "pre_uninstall": [
+        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
+        "if (($cmd -eq 'uninstall') -and (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\')) {",
+        "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "    Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
+        "    Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",
     "autoupdate": {

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -26,10 +26,11 @@
     "url": "https://download.mp3tag.de/mp3tagv318setup.exe#/dl.7z",
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
-        "'mp3tag.cfg', 'data\\columns.ini', 'data\\usrfields.ini' | ForEach-Object {",
+        "'mp3tag.cfg', 'data\\columns.ini' | ForEach-Object {",
         "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
+        "Start-Process \"$dir\\mp3tag.exe\" -Verb 'Open' -WindowStyle 'Minimized'; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
         "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "mp3tag.exe",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.28",
+    "version": "3.18",
     "description": "Powerful and easy-to-use tool to edit metadata of audio files.",
     "homepage": "https://www.mp3tag.de",
     "license": {
@@ -53,8 +53,8 @@
         "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
         "if (($cmd -eq 'uninstall') -and (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\')) {",
         "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "    Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "    Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
+        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
         "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

**mp3tag** has a problem where the program will not uninstall if the context menu is installed. This edit should fix that issue.
![(WindowsTerminal)Z9J2w1_12-08-2022](https://user-images.githubusercontent.com/101912712/206567711-89dd0dd2-b4b0-4a12-8325-67b5ae817227.jpg)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
