### PR TITLE
restish: Add arm64 architecture

### DIFF
--- a/bucket/restish.json
+++ b/bucket/restish.json
@@ -32,6 +32,9 @@
             "arm64": {
                 "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/restish.json
+++ b/bucket/restish.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/danielgtaylor/restish/releases/download/v0.15.1/restish-0.15.1-windows-i386.zip",
             "hash": "c81f83aac93b95a88bfae098676eeeb85dd16d8afa130228cf38b630a0097f45"
+        },
+        "arm64": {
+            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.15.1/restish-0.15.1-windows-arm64.zip",
+            "hash": "78e1e8f809a03b74e0d4d64af39534af7a25aeb543334c25b639d81d1ff3265d"
         }
     },
     "bin": "restish.exe",
@@ -24,6 +28,9 @@
             },
             "32bit": {
                 "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
Some updates for restish:
- add arm64 architecture;
- add autoupdate hash extraction.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).