### PR TITLE
tor-browser: Update to 12.0, fix AU URLs

### DIFF
--- a/bucket/tor-browser.json
+++ b/bucket/tor-browser.json
@@ -1,17 +1,17 @@
 {
     "##": "Multiple components under various open source licenses. Included HTTPS Everywhere extension is the strictest.",
-    "version": "11.5.8",
+    "version": "12.0",
     "description": "Web browser that connects to the internet via the Tor anonymity network",
     "homepage": "https://www.torproject.org/",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://dist.torproject.org/torbrowser/11.5.8/torbrowser-install-win64-11.5.8_en-US.exe",
-            "hash": "4fdf6e39dc45455887d6674d630f0eeae238766fc476f83fa1807a3d93648676"
+            "url": "https://dist.torproject.org/torbrowser/12.0/torbrowser-install-win64-12.0_ALL.exe",
+            "hash": "f496cc0219c8b73f1f100124d6514bad55f503ff76202747f23620a6677e83c2"
         },
         "32bit": {
-            "url": "https://dist.torproject.org/torbrowser/11.5.8/torbrowser-install-11.5.8_en-US.exe",
-            "hash": "e0c94264ff06076d95a7b769b1de22e97790ca402341adff96e5a472345ade8a"
+            "url": "https://dist.torproject.org/torbrowser/12.0/torbrowser-install-12.0_ALL.exe",
+            "hash": "a9cc0f0af2ce8ca0d7a27d65c7efa37f6419cfc793fa80371e7db73d44b4cc02"
         }
     },
     "installer": {
@@ -48,10 +48,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dist.torproject.org/torbrowser/$version/torbrowser-install-win64-$version_en-US.exe"
+                "url": "https://dist.torproject.org/torbrowser/$version/torbrowser-install-win64-$version_ALL.exe"
             },
             "32bit": {
-                "url": "https://dist.torproject.org/torbrowser/$version/torbrowser-install-$version_en-US.exe"
+                "url": "https://dist.torproject.org/torbrowser/$version/torbrowser-install-$version_ALL.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Tor browser installer's file name has changed from using suffix en-US to ALL. As a result auto-update has been failing (version check still works fine).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
