### PR TITLE
octant: Add arm64 architecture

### DIFF
--- a/bucket/octant.json
+++ b/bucket/octant.json
@@ -1,7 +1,7 @@
 {
     "version": "0.25.1",
     "description": "A web-based, highly extensible platform for developers to better understand the complexity of Kubernetes clusters.",
-    "homepage": "https://github.com/vmware/octant",
+    "homepage": "https://octant.dev/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -16,7 +16,9 @@
         }
     },
     "bin": "octant.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/vmware/octant"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/octant.json
+++ b/bucket/octant.json
@@ -8,6 +8,11 @@
             "url": "https://github.com/vmware/octant/releases/download/v0.25.1/octant_0.25.1_Windows-64bit.zip",
             "hash": "b1e8f372f64c79ff04d69d19f11773936b67447a3abd5a496fbdfef10b6b6d19",
             "extract_dir": "octant_0.25.1_Windows-64bit"
+        },
+        "arm64": {
+            "url": "https://github.com/vmware/octant/releases/download/v0.25.1/octant_0.25.1_Windows-arm64.zip",
+            "hash": "d871f2b5e9e048983c19e72e1e1f36806ef16819ec2344b4e60e0c5db8356a8e",
+            "extract_dir": "octant_0.25.1_Windows-arm64"
         }
     },
     "bin": "octant.exe",
@@ -17,6 +22,10 @@
             "64bit": {
                 "url": "https://github.com/vmware/octant/releases/download/v$version/octant_$version_Windows-64bit.zip",
                 "extract_dir": "octant_$version_Windows-64bit"
+            },
+            "arm64": {
+                "url": "https://github.com/vmware/octant/releases/download/v$version/octant_$version_Windows-arm64.zip",
+                "extract_dir": "octant_$version_Windows-arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
Some updates for octant:
- add arm64 architecture;
- update `homepage`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
