### PR TITLE
onefetch: Fix autoupdate

### DIFF
--- a/bucket/onefetch.json
+++ b/bucket/onefetch.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.13.2",
+    "version": "2.14.2",
     "description": "Git repository summary on terminal",
     "homepage": "https://github.com/o2sh/onefetch",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/o2sh/onefetch/releases/download/v2.13.2/onefetch-win.tar.gz",
-            "hash": "79a41220d96868edbf67aa534930d1ecd05edbc75b81956f9a0039fbd7a501a4"
+            "url": "https://github.com/o2sh/onefetch/releases/download/2.14.2/onefetch-win.tar.gz",
+            "hash": "97aa69e3d15b5e5f463b459522e5059d5828a410dc249aa20cc141e606466bd2"
         }
     },
     "bin": "onefetch.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/o2sh/onefetch/releases/download/v$version/onefetch-win.tar.gz"
+                "url": "https://github.com/o2sh/onefetch/releases/download/$version/onefetch-win.tar.gz"
             }
         }
     }


### PR DESCRIPTION
Since 2.14.0 the "v" in naming convention is dropped, so:
- `autoupdate` URL fixed accordingly;
- manifest updated to the actual version.

Relates to o2sh/onefetch#868.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
