### PR TITLE
vieb: Add version 9.4.0 for arm64

### DIFF
--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/Jelmerro/Vieb/releases/download/9.4.0/Vieb-9.4.0-win.zip",
             "hash": "c26e657977c0eea0dc05a0bcfd2665c6bb14ff15f45779cd91c02bcf4984563b"
+        },
+        "arm64": {
+            "url": "https://github.com/Jelmerro/Vieb/releases/download/9.4.0/Vieb-9.4.0-arm64-win.zip",
+            "hash": "f385bb4c68cbaa77916bf65f5a64467dbae2347bfd55926480db698d8943a1ff"
         }
     },
     "bin": "Vieb.exe",
@@ -23,6 +27,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb-$version-win.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb-$version-arm64-win.zip"
             }
         }
     }


### PR DESCRIPTION
This PR provides updates manifest of Vieb and adds support for ARM64 binaries.

Contains url to artifact and hash.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
