### PR TITLE
min: Add 32bit version

### DIFF
--- a/bucket/min.json
+++ b/bucket/min.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v1.26.0-windows.zip",
             "hash": "b3bf165f7e0b14e65c91b2d1ffb5a66e09b409b62b4dab6fb6c629e5aee98431"
+        },
+        "32bit": {
+            "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v1.26.0-windows-ia32.zip",
+            "hash": "2c2c338c0c49492d2943f478649350828677feb3eac249ea8123e04500cf1a8e"
         }
     },
     "extract_dir": "Min-v1.26.0",
@@ -22,6 +26,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v$version-windows.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v$version-windows-ia32.zip"
             }
         },
         "extract_dir": "Min-v$version"

--- a/bucket/min.json
+++ b/bucket/min.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v1.26.0-windows.zip",
-            "hash": "b3bf165f7e0b14e65c91b2d1ffb5a66e09b409b62b4dab6fb6c629e5aee98431",
-            "extract_dir": "Min-v1.26.0"
+            "hash": "b3bf165f7e0b14e65c91b2d1ffb5a66e09b409b62b4dab6fb6c629e5aee98431"
         }
     },
+    "extract_dir": "Min-v1.26.0",
     "bin": "Min.exe",
     "shortcuts": [
         [
@@ -21,9 +21,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v$version-windows.zip",
-                "extract_dir": "Min-v$version"
+                "url": "https://github.com/minbrowser/min/releases/latest/download/Min-v$version-windows.zip"
             }
-        }
+        },
+        "extract_dir": "Min-v$version"
     }
 }

--- a/bucket/min.json
+++ b/bucket/min.json
@@ -1,7 +1,7 @@
 {
     "version": "1.26.0",
     "description": "A fast, minimal browser that protects your privacy",
-    "homepage": "https://github.com/minbrowser/min",
+    "homepage": "https://minbrowser.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -21,7 +21,9 @@
             "Min"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/minbrowser/min"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Some updates for min:
- add 32bit (ia32) architecture;
- move `extract_dir` to higher level (since it equals for both 64bit/32bit versions);
- update homepage.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
