### PR TITLE
vcxsrv: Add .xlaunch file associations script

### DIFF
--- a/bucket/vcxsrv.json
+++ b/bucket/vcxsrv.json
@@ -3,6 +3,9 @@
     "description": "Windows X-server based on the xorg git sources (like xming or cygwin's xwin)",
     "homepage": "https://vcxsrv.sourceforge.io/",
     "license": "GPL-3.0-only",
+    "notes": [
+        "To add file associations (.xlaunch), run 'reg import \"$dir\\install-associations.reg\"'"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.20.14.0/vcxsrv-64.1.20.14.0.installer.exe#/dl.7z",
@@ -33,6 +36,20 @@
             "xlaunch.exe",
             "XLauncher"
         ]
+    ],
+    "post_install": [
+        "$dirpath = \"$dir\".Replace('\\', '\\\\')",
+        "$xlaunchexepath = \"$dir\\xlaunch.exe\".Replace('\\', '\\\\')",
+        "'install-associations', 'uninstall-associations' | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\vcxsrv\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\vcxsrv\\$_.reg\"",
+        "    $content = $content.Replace('$xlaunch_exe_path', $xlaunchexepath)",
+        "    if ($global) {",
+        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
+        "  }",
+        "}"
     ],
     "checkver": {
         "url": "https://sourceforge.net/projects/vcxsrv/rss?path=/vcxsrv/",

--- a/scripts/vcxsrv/install-associations.reg
+++ b/scripts/vcxsrv/install-associations.reg
@@ -1,0 +1,73 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.xlaunch]
+@="XLaunchFile"
+
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile]
+@="XLaunch Configuration"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\DefaultIcon]
+@="$xlaunch_exe_path,0"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell]
+@="open"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\open\command]
+@="\"$xlaunch_exe_path\" -run \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\open\ddeexec\Application]
+@="XLaunch"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\open\ddeexec\Topic]
+@="System"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\edit\command]
+@="\"$xlaunch_exe_path\" -load \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\edit\ddeexec\Application]
+@="XLaunch"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\edit\ddeexec\Topic]
+@="System"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\Validate\command]
+@="\"$xlaunch_exe_path\" -validate \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\Validate\ddeexec\Application]
+@="XLaunch"
+
+[HKEY_CURRENT_USER\Software\Classes\XLaunchFile\shell\Validate\ddeexec\Topic]
+@="System"
+
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell]
+@="open"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\open\command]
+@="\"$xlaunch_exe_path\" -run \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\open\ddeexec\Application]
+@="XLaunch"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\open\ddeexec\Topic]
+@="System"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\edit\command]
+@="\"$xlaunch_exe_path\" -load \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\edit\ddeexec\Application]
+@="XLaunch"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\edit\ddeexec\Topic]
+@="System"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\Validate\command]
+@="\"$xlaunch_exe_path\" -validate \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\Validate\ddeexec\Application]
+@="XLaunch"
+
+[HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe\shell\Validate\ddeexec\Topic]
+@="System"
+

--- a/scripts/vcxsrv/uninstall-associations.reg
+++ b/scripts/vcxsrv/uninstall-associations.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\.xlaunch]
+[-HKEY_CURRENT_USER\Software\Classes\XLaunchFile]
+[-HKEY_CURRENT_USER\Software\Classes\Applications\xlaunch.exe]
+


### PR DESCRIPTION
Adds .xlaunch file associations scripts on vcxsrv installer.

The registry keys were obtained from the vcxsrv installer script source code (<https://sourceforge.net/p/vcxsrv/code/ci/master/tree/xorg-server/installer/vcxsrv-64.nsi#l166>), and adapted to user context using vscode manifest and reg scripts as references.