### PR TITLE
(fix) freeplane@1.10.6  java version

### DIFF
--- a/bucket/freeplane.json
+++ b/bucket/freeplane.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "suggest": {
         "JDK": [
-            "java/oraclejdk17",
+            "java/openjdk11",
             "java/openjdk17"
         ]
     },

--- a/bucket/freeplane.json
+++ b/bucket/freeplane.json
@@ -5,8 +5,8 @@
     "license": "GPL-2.0-or-later",
     "suggest": {
         "JDK": [
-            "java/oraclejdk",
-            "java/openjdk"
+            "java/oraclejdk17",
+            "java/openjdk17"
         ]
     },
     "url": "https://downloads.sourceforge.net/project/freeplane/freeplane%20stable/freeplane_bin-1.10.6.zip",


### PR DESCRIPTION
Freeplane [requires Java 11 to 17 to be installed](https://docs.freeplane.org/getting-started/Distributions.html), while openjdk/oraclejdk is 19.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

![dsBuffer](https://user-images.githubusercontent.com/67063101/209048075-1c84adcc-04ab-44d8-be3b-abc2adc50656.jpg)
