### PR TITLE
gitextensions: Update to version 4.0.1 & fix autoupdate

### DIFF
--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -5,7 +5,6 @@
     "license": "GPL-3.0-only",
     "url": "https://github.com/gitextensions/gitextensions/releases/download/v4.0.1/GitExtensions-Portable-4.0.1.15887-f2567dea2.zip",
     "hash": "a06719c829623ec457fbd9dfa69eeebee2987cb31b2aa1b66c162839cf10ae2c",
-    "extract_dir": "GitExtensions",
     "pre_install": "if (!(Test-Path \"$persist_dir\\GitExtensions.settings\")) { New-Item \"$dir\\GitExtensions.settings\" | Out-Null }",
     "bin": [
         "GitExtensions.exe",

--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -1,10 +1,11 @@
 {
-    "version": "4.0.0",
+    "version": "4.0.1.15887",
     "description": "A graphical user interface for Git that allows you to control Git without using the commandline.",
     "homepage": "https://gitextensions.github.io/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/gitextensions/gitextensions/releases/download/v4/GitExtensions-Portable-4.0.0-cba315df5.zip",
-    "hash": "51a30d461e1a24beb89b15e63e8d8426ab0bf2eac3b6ebcc4034f55d8ea461bf",
+    "url": "https://github.com/gitextensions/gitextensions/releases/download/v4.0.1/GitExtensions-Portable-4.0.1.15887-f2567dea2.zip",
+    "hash": "a06719c829623ec457fbd9dfa69eeebee2987cb31b2aa1b66c162839cf10ae2c",
+    "extract_dir": "GitExtensions",
     "pre_install": "if (!(Test-Path \"$persist_dir\\GitExtensions.settings\")) { New-Item \"$dir\\GitExtensions.settings\" | Out-Null }",
     "bin": [
         "GitExtensions.exe",
@@ -21,10 +22,10 @@
     ],
     "persist": "GitExtensions.settings",
     "checkver": {
-        "url": "https://github.com/gitextensions/gitextensions/releases/expanded_assets/v4",
+        "github": "https://github.com/gitextensions/gitextensions",
         "regex": "/GitExtensions-Portable-([\\d.]+)-(?<commit>[\\w]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/gitextensions/gitextensions/releases/download/v$majorVersion/GitExtensions-Portable-$version-$matchCommit.zip"
+        "url": "https://github.com/gitextensions/gitextensions/releases/download/v$matchHead/GitExtensions-Portable-$version-$matchCommit.zip"
     }
 }


### PR DESCRIPTION
GitExtensions v4.0.0 has a blocking issue which prevents it from being able to [pull with git 2.39](https://github.com/gitextensions/gitextensions/pull/10521).

This PR updates gitextensions to v4.0.1 and revert the autoupdate to the previous versions because it is [working for v4.0.1](https://github.com/val1984/scoop-main-alternative-location/commit/e9af58d13067a14579d8579f99a5eb147170ae8c) as well and https://github.com/gitextensions/gitextensions/releases/expanded_assets/v4 is always showing v4.0.0 which is why v4.0.1 isn't offered.

I found a similar PR but this autoupdate fix is far simpler and I was able to test that it works with Excavator on my small private bucket.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).