### PR TITLE
🐛 #10088: Bad extensions path when replacing versions

### DIFF
--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -54,7 +54,7 @@
         "$extensions_file = \"$dir\\data\\extensions\\extensions.json\"",
         "if ((Test-Path \"$extensions_file\")) {",
         "    info 'Adjusting path in extensions file...'",
-        "    (Get-Content \"$extensions_file\") -replace '(?<=vscode(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
+        "    (Get-Content \"$extensions_file\") -replace '(?<=vscodium(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
         "}"
     ],
     "persist": "data",


### PR DESCRIPTION
I made a mistake in the PR #10074 when copy pasting my fix for vscode. I didn't take into account the fact that the paths are not the same. Sorry about that.

Closes #10088

- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
