### PR TITLE
MComix: Restrict to 64-bit

### DIFF
--- a/bucket/mcomix.json
+++ b/bucket/mcomix.json
@@ -3,9 +3,13 @@
     "description": "User-friendly and customizable image viewer",
     "homepage": "https://sourceforge.net/projects/mcomix/",
     "license": "GPL-2.0-only",
-    "url": "https://downloads.sourceforge.net/project/mcomix/MComix-2.1.0/mcomix-2.1.0.win64.all-in-one.zip",
-    "hash": "sha1:d284706da5cccb21dbc8aed0e3e690c75eb037ca",
-    "extract_dir": "MComix-2.1.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/mcomix/MComix-2.1.0/mcomix-2.1.0.win64.all-in-one.zip",
+            "hash": "sha1:d284706da5cccb21dbc8aed0e3e690c75eb037ca",
+            "extract_dir": "MComix-2.1.0",
+        }
+    },
     "bin": "mcomix.exe",
     "shortcuts": [
         [
@@ -18,7 +22,11 @@
         "regex": "files/MComix-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/mcomix/MComix-$version/mcomix-$version.win64.all-in-one.zip",
-        "extract_dir": "MComix-$version"
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/mcomix/MComix-$version/mcomix-$version.win64.all-in-one.zip",
+                "extract_dir": "MComix-$version"
+            }
+        }
     }
 }


### PR DESCRIPTION
It works only on 64-bit Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
