### PR TITLE
MPC-QT: Restrict to 64-bit

### DIFF
--- a/bucket/mpc-qt.json
+++ b/bucket/mpc-qt.json
@@ -6,8 +6,12 @@
     "suggest": {
         "yt-dlp": "yt-dlp"
     },
-    "url": "https://github.com/mpc-qt/mpc-qt/releases/download/v22.02/mpc-qt-win-x64-2202.zip",
-    "hash": "sha512:221584b8dcc832bf637c29246151aabdca57da9f85c9cd03ad6432acb270da709582335332e02da113de850673410bb13c0a0631cddcac8c9696b6ecda163963",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mpc-qt/mpc-qt/releases/download/v22.02/mpc-qt-win-x64-2202.zip",
+            "hash": "sha512:221584b8dcc832bf637c29246151aabdca57da9f85c9cd03ad6432acb270da709582335332e02da113de850673410bb13c0a0631cddcac8c9696b6ecda163963",
+        }
+    },
     "bin": "mpc-qt.exe",
     "shortcuts": [
         [
@@ -17,6 +21,10 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mpc-qt/mpc-qt/releases/download/v$version/mpc-qt-win-x64-$cleanVersion.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mpc-qt/mpc-qt/releases/download/v$version/mpc-qt-win-x64-$cleanVersion.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
It works only on 64-bit Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
