### PR TITLE
sfsu: Fix `notes` and `bin`

### DIFF
--- a/bucket/sfsu.json
+++ b/bucket/sfsu.json
@@ -13,12 +13,8 @@
             "hash": "1eea038a79c2be772fb7e9b42502568d5a8387d488a9e6956d1945e8badd58b8"
         }
     },
-    "notes": "In order to replace scoop commands use `Invoke-Expression (&sfst-hook)` in your Powershell profile.",
-    "bin": [
-        "sfss.exe",
-        "sfsl.exe",
-        "sfst-hook.exe"
-    ],
+    "notes": "In order to replace scoop commands use `Invoke-Expression (sfsu.exe hook)` in your Powershell profile.",
+    "bin": "sfsu.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
**sfsu** has recently been changed to become a single binary instead of three. This fix was made to accommodate that.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
