### PR TITLE
ventoy: Add bin for CLI mode

### DIFF
--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -11,6 +11,7 @@
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
         "}"
     ],
+    "bin": "Ventoy2Disk.exe",
     "architecture": {
         "64bit": {
             "shortcuts": [


### PR DESCRIPTION
Ventoy supports Windows command line mode since 1.0.86. https://www.ventoy.net/en/doc_windows_cli.html

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
