### PR TITLE
bluelife-keyfreeze: Add version 1.4

### DIFF
--- a/bucket/bluelife-keyfreeze.json
+++ b/bucket/bluelife-keyfreeze.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.4",
+    "homepage": "https://www.sordum.org/bluelife-keyfreeze",
+    "description": "A free Windows application that blocks your keyboard and mouse without “locking” the screen.",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.sordum.org/eula/"
+    },
+    "url": "https://www.sordum.org/files/bluelife-keyfreeze/KeyFreeze.zip",
+    "hash": "603844bad905b570a2bd57b0455357619d76642a057deb58f425d20f6002026d",
+    "extract_dir": "KeyFreeze",
+    "pre_install": [
+        "ensure \"$persist_dir\" | Out-Null",
+        "Copy-Item \"$persist_dir\\KeyFreeze.ini\" \"$dir\\KeyFreeze.ini\" -ErrorAction 'SilentlyContinue'",
+        "if ($architecture -eq '32bit') { Remove-Item \"$dir\\KeyFreeze_x64.exe\" }",
+        "elseif ($architecture -eq '64bit') { Remove-Item \"$dir\\KeyFreeze.exe\"; Rename-Item \"$dir\\KeyFreeze_x64.exe\" 'KeyFreeze.exe' }"
+    ],
+    "shortcuts": [
+        [
+            "KeyFreeze.exe",
+            "BlueLife KeyFreeze"
+        ]
+    ],
+    "pre_uninstall": "Copy-Item \"$dir\\KeyFreeze.ini\" \"$persist_dir\\KeyFreeze.ini\" -ErrorAction 'SilentlyContinue'",
+    "checkver": "BlueLife\\sKeyFreeze\\sv([\\d.]+)",
+    "autoupdate": {
+        "url": "https://www.sordum.org/files/bluelife-keyfreeze/KeyFreeze.zip"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

A helpful small utility app that allows for the freezing of keyboard and mouse, preventing them from being used until the lock/unlock shortcut keys are pressed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
