### PR TITLE
universal-ctags: Update to version 6.0.0 and Add checkver

### DIFF
--- a/bucket/universal-ctags.json
+++ b/bucket/universal-ctags.json
@@ -1,29 +1,32 @@
 {
-    "version": "2020-10-11",
+    "version": "6.0.0",
     "description": "Generates an index (or tag) file of language objects found in source files for many popular programming languages.",
     "homepage": "https://ctags.io",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/universal-ctags/ctags-win32/releases/download/2020-10-11/952bd1e9/ctags-2020-10-11_952bd1e9-x64.zip",
-            "hash": "fa8165fda14622048b37e525242628afbaa98cf8dce84e9032d9a3a50d3c886f"
+            "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v6.0.0/ctags-v6.0.0-x64.zip",
+            "hash": "dea14e95c68294e16e884971afef1a65cefc9efe4cdec2d70fdb0a2405fd801f"
         },
         "32bit": {
-            "url": "https://github.com/universal-ctags/ctags-win32/releases/download/2020-10-11/952bd1e9/ctags-2020-10-11_952bd1e9-x86.zip",
-            "hash": "5a2a39fe2622c45dd5c8fea13130ffeb8f35e46581cd5d6ca1b60c777f71f64d"
+            "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v6.0.0/ctags-v6.0.0-x86.zip",
+            "hash": "0b38dbbe9f8497a99be24054518128da6042f6eb111eb2ad2e1082c7dd184aea"
         }
     },
     "bin": [
         "ctags.exe",
         "readtags.exe"
     ],
+    "checkver": {
+        "github": "https://github.com/universal-ctags/ctags-win32/"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/$version/$matchSha/ctags-$version_$matchSha-x64.zip"
+                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v$version/ctags-v$version_x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/$version/$matchSha/ctags-$version_$matchSha-x86.zip"
+                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v$version/ctags-v$version_x86.zip"
             }
         }
     }

--- a/bucket/universal-ctags.json
+++ b/bucket/universal-ctags.json
@@ -23,10 +23,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v$version/ctags-v$version_x64.zip"
+                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v$version/ctags-v$version-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v$version/ctags-v$version_x86.zip"
+                "url": "https://github.com/universal-ctags/ctags-win32/releases/download/v$version/ctags-v$version-x86.zip"
             }
         }
     }


### PR DESCRIPTION
Previously this was on build 2020-10-11, I've updated it to use the `"github"` autoupdate and to v6.0.0.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
