### PR TITLE
qview: Add possible plugin persists

### DIFF
--- a/bucket/qview.json
+++ b/bucket/qview.json
@@ -15,6 +15,13 @@
             "extract_dir": "qView-win32"
         }
     },
+    "pre_install": "'apng', 'apngd', 'avif', 'jpegxl' | ForEach-Object { $_ = \"imageformats\\q$_.dll\"; if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null } }",
+    "persist": [
+        "imageformats\\qapng.dll",
+        "imageformats\\qapngd.dll",
+        "imageformats\\qavif.dll",
+        "imageformats\\qjpegxl.dll"
+    ],
     "bin": "qView.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
This allows people to add `imageformats` plugins if they so choose

These are common ones, I'm open to adding more on request, but it's better to at least support these as it's a pretty large amount of functionality.

Relates to https://github.com/ScoopInstaller/Versions/pull/899

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).