### PR TITLE
Fix mp3tag json, issue 10166

### DIFF
--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -50,7 +50,7 @@
         "mp3tag.cfg"
     ],
     "pre_uninstall": [
-        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
+        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
         "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
         "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
         "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -31,9 +31,9 @@
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
         "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",
-        "   Start-Process \"$dir\\mp3tag.exe\" -Verb 'Open' -WindowStyle 'Minimized'; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
+        "    Start-Process \"$dir\\mp3tag.exe\" -Verb Open -WindowStyle Minimized; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
         "}",
-        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
+        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction SilentlyContinue"
     ],
     "bin": "mp3tag.exe",
     "shortcuts": [
@@ -52,10 +52,9 @@
     "pre_uninstall": [
         "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
         "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
-        "   if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
-        "   Start-Sleep -Seconds 4",
+        "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
+        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
         "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -27,7 +27,7 @@
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
         "'mp3tag.cfg', 'data\\columns.ini' | ForEach-Object {",
-        "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
         "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -27,13 +27,13 @@
     "hash": "520e74932fd8e59ca5febacd12ef9f6719cdfb955aa1341ff253c5e792167293",
     "pre_install": [
         "'mp3tag.cfg', 'data\\columns.ini' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "   if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
         "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",
-        "    Start-Process \"$dir\\mp3tag.exe\" -Verb Open -WindowStyle Minimized; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
+        "   Start-Process \"$dir\\mp3tag.exe\" -Verb 'Open' -WindowStyle 'Minimized'; Start-Sleep -Seconds 3; Stop-Process -Name 'mp3tag'",
         "}",
-        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction SilentlyContinue"
+        "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'"
     ],
     "bin": "mp3tag.exe",
     "shortcuts": [
@@ -50,11 +50,12 @@
         "mp3tag.cfg"
     ],
     "pre_uninstall": [
-        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
-        "if (($cmd -eq 'uninstall') -and (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\')) {",
-        "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction 'SilentlyContinue'",
+        "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
+        "   if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
+        "   Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "   Start-Sleep -Seconds 4",
         "}"
     ],
     "checkver": "Mp3tag\\s+v([\\w.]+)",


### PR DESCRIPTION
Replace the contents of mp3tag.json with the corrected version, which I found here, https://raw.githubusercontent.com/anderlli0053/DEV-tools/master/added_to_official_repository/mp3tag_fixed.json As described in https://github.com/ScoopInstaller/Extras/issues/10166 mp3tag does not work correctly without this change. Thanks @anderlli0053 for including the fix in your repo.

Closes #10166 on the Extras repo.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
