### PR TITLE
brave: Fix checkver

### DIFF
--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -42,8 +42,8 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://brave.com/latest/",
-        "regex": "Release Notes <strong>v([\\d.]+)"
+        "url": "https://brave-browser-downloads.s3.brave.com/latest/release.version",
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -42,18 +42,8 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "script": [
-            "# Using checkver script because sometimes Desktop and Mobile versions release at the same time,",
-            "# which causes autoupdate fail to catch up. See v1.43.89 and v1.43.90 for example",
-            "$url = 'https://api.github.com/repos/brave/brave-browser/releases'",
-            "$release_tags = (Invoke-WebRequest $url).Content | ConvertFrom-Json",
-            "$release_tags | ForEach-Object {",
-            "    if ($_.name.Contains('Release') -and ($_.assets -match 'brave-v([\\d.]+)-win32')) {",
-            "        Write-Output $_.tag_name.replace('v', '')",
-            "    }",
-            "}"
-        ],
-        "regex": "([\\d.]+)"
+        "url": "https://brave.com/latest/",
+        "regex": "Release Notes <strong>v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Brave's checkver keeps picking up versions that are very old and I can't work out why. It has picked up the following releases: [1.5.9](https://github.com/ScoopInstaller/Extras/commit/3e1999f1e2d6ad7ca97d4594b22997d3a8415e11), [1.9.2](https://github.com/ScoopInstaller/Extras/commit/a406a4dfbe0774e94e808df4260bdb5a4c689a64), [1.1.1](https://github.com/ScoopInstaller/Extras/commit/6866d4d74126eeb72e4dcc7cd0bcb556a45f0c16). I think this could be caused by the lack of any stable releases in the list that the GitHub API returns or maybe an occasional API error. Instead I suggest we use [Brave's release notes page](https://brave.com/latest/). I suggest we keep the checkver for the beta and nightly versions as that seems to be working fine.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
