### PR TITLE
PowerToys@0.66+: Remove auto-update

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -37,17 +37,5 @@
             "PowerToys.exe",
             "PowerToys"
         ]
-    ],
-    "checkver": "github",
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe",
-                "hash": {
-                    "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
-                    "regex": ">$sha256<"
-                }
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

PowerToys adopted a strategy of creating links in the file system to share dependencies between utilities. The fact that the PowerToys Scoop package doesn't run the installer means that these dependencies don't get created except by doing extra steps.
This means that auto-updating the PowerToys manifest leads to installations that do not work properly at runtime. This has happened with 0.63 and 0.64. ( #9419 and #9643 , respectively).

This is bound to happen again in 0.66, set to release this week, since the inclusion of self-contained .NET binaries: https://github.com/microsoft/PowerToys/commit/6ac508fb933d0a30e1176baae34981f91e0984cf

This commit removes the auto-update feature, as the scoop manifest needs extra additions to have a working 0.66 installation.

Relates to #9419 and #9643

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
