### PR TITLE
gcc-arm-none-eabi: Update notes and regex of checkver

### DIFF
--- a/bucket/gcc-arm-none-eabi.json
+++ b/bucket/gcc-arm-none-eabi.json
@@ -3,10 +3,6 @@
     "description": "Pre-built GNU Toolchain for the Arm Architecture",
     "homepage": "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain",
     "license": "GPL-3.0-only",
-    "notes": [
-        "For GDB support, a 32bit Python 2.7 install is required",
-        "It can be installed from the Versions bucket via `scoop install versions/python27 -a 32bit`"
-    ],
     "url": "https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi.zip",
     "hash": "ad1427496cde9bbe7604bc448ec6e115c6538e04af1c8275795ebb1c2b7b2830",
     "extract_dir": "arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi",
@@ -16,7 +12,7 @@
     },
     "checkver": {
         "url": "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads",
-        "regex": "arm-gnu-toolchain-([\\d.rel]+)-mingw-w64-i686-arm-none-eabi.zip"
+        "regex": "arm-gnu-toolchain-([\\d.]+(rel\\d+)?)-mingw-w64-i686-arm-none-eabi.zip"
     },
     "autoupdate": {
         "url": "https://developer.arm.com/-/media/Files/downloads/gnu/$version/binrel/arm-gnu-toolchain-$version-mingw-w64-i686-arm-none-eabi.zip",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Release Note for Downloads 12.2.Rel1:
> Known Limitations and Issues
> 
> In the Linux hosted toolchains, GDB is provided with Python support. In the Windows and macOS hosted toolchains, GDB is provided without Python support.
> 