### PR TITLE
pterm|putty|puttytel: Add arm64

### DIFF
--- a/bucket/pterm.json
+++ b/bucket/pterm.json
@@ -1,6 +1,6 @@
 {
     "version": "0.78",
-    "description": "a PuTTY-like wrapper program for Windows command prompts (or anything else running in a Windows console) that is not included in putty all-in-one archive/installer",
+    "description": "A PuTTY-like wrapper program for Windows command prompts (or anything else running in a Windows console) that is not included in putty all-in-one archive/installer",
     "homepage": "https://www.chiark.greenend.org.uk/~sgtatham/putty/",
     "license": "MIT",
     "architecture": {
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://the.earth.li/~sgtatham/putty/0.78/w32/pterm.exe",
             "hash": "sha512:bb5e5c01df811209b0cdd9d97994056d2ce02e8da28e4642c09557b09076c23abc7383eae0ef42c5a6d421a7f8712c71d4de40e549ebd9807caa2c6edbda1022"
+        },
+        "arm64": {
+            "url": "https://the.earth.li/~sgtatham/putty/0.78/wa64/pterm.exe",
+            "hash": "sha512:52ebd36d068586a7685e678c83f903bac32f4d3654b9a563a44beef99c393a58826074cc232e8e2feca6752be423bf4179679ae7810fc8fb5a05f1f3fa7d5f52"
         }
     },
     "bin": "pterm.exe",
@@ -35,6 +39,13 @@
                 "hash": {
                     "url": "https://the.earth.li/~sgtatham/putty/$version/sha512sums",
                     "regex": "$sha512\\s+w32/pterm.exe"
+                }
+            },
+            "arm64": {
+                "url": "https://the.earth.li/~sgtatham/putty/$version/wa64/pterm.exe",
+                "hash": {
+                    "url": "https://the.earth.li/~sgtatham/putty/$version/sha512sums",
+                    "regex": "$sha512\\s+wa64/pterm.exe"
                 }
             }
         }

--- a/bucket/putty.json
+++ b/bucket/putty.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://the.earth.li/~sgtatham/putty/0.78/w32/putty.zip",
             "hash": "sha512:b72cdef83e26a50a0d2cd97738a997944bd649c68072c405b50738116547a84651cb7075be97af923a9bd4d812b0e9c9e172c73ad4fa41e2b9d7997974f5606e"
+        },
+        "arm64": {
+            "url": "https://the.earth.li/~sgtatham/putty/0.78/wa64/putty.zip",
+            "hash": "sha512:64602ddf7c73c116145776f323cb997cb6aecac1eb6379fdecca6d15ec4dd8cef172ec9cb8ea6d968d81e820f7a454c695cdac1752ad63f17c4b3a092e5f58d3"
         }
     },
     "bin": [
@@ -54,6 +58,13 @@
                 "hash": {
                     "url": "https://the.earth.li/~sgtatham/putty/$version/sha512sums",
                     "regex": "$sha512\\s+\\*?(?:w32/$basename)"
+                }
+            },
+            "arm64": {
+                "url": "https://the.earth.li/~sgtatham/putty/$version/wa64/putty.zip",
+                "hash": {
+                    "url": "https://the.earth.li/~sgtatham/putty/$version/sha512sums",
+                    "regex": "$sha512\\s+\\*?(?:wa64/$basename)"
                 }
             }
         }

--- a/bucket/puttytel.json
+++ b/bucket/puttytel.json
@@ -1,6 +1,6 @@
 {
     "version": "0.78",
-    "description": "a Telnet-only client that is not included in putty all-in-one archive/installer",
+    "description": "A Telnet-only client that is not included in putty all-in-one archive/installer",
     "homepage": "https://www.chiark.greenend.org.uk/~sgtatham/putty/",
     "license": "MIT",
     "architecture": {
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://the.earth.li/~sgtatham/putty/latest/w32/puttytel.exe",
             "hash": "sha512:f9eaf0f026b70631be9afea9a4292868e8f8359e97c93588ba2a3272ea8131b788445c628ee05283ff0761d2752f4504099af3972a65aa0625eb127df0ee1d83"
+        },
+        "arm64": {
+            "url": "https://the.earth.li/~sgtatham/putty/latest/wa64/puttytel.exe",
+            "hash": "sha512:4ea5c71b39320c0b706bc093a54980a14693fab84ea8ec6d756ca940191d5f359a4a6518ea77a7e2d34ff689794f59dff01888192044ffc4f81f2281ffd8576a"
         }
     },
     "bin": "puttytel.exe",
@@ -29,6 +33,13 @@
                 "hash": {
                     "url": "https://the.earth.li/~sgtatham/putty/latest/sha512sums",
                     "regex": "$sha512\\s+w32/puttytel.exe"
+                }
+            },
+            "arm64": {
+                "url": "https://the.earth.li/~sgtatham/putty/latest/wa64/puttytel.exe",
+                "hash": {
+                    "url": "https://the.earth.li/~sgtatham/putty/latest/sha512sums",
+                    "regex": "$sha512\\s+wa64/puttytel.exe"
                 }
             }
         }


### PR DESCRIPTION
Add arm64 version for:
- putty;
- puttytel;
- pterm.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
