### PR TITLE
hwinfo: Fix persistence

### DIFF
--- a/bucket/hwinfo.json
+++ b/bucket/hwinfo.json
@@ -5,9 +5,13 @@
     "license": "Freeware",
     "url": "https://www.fosshub.com/HWiNFO.html/hwi_736.zip",
     "hash": "939ef51eed6536aff977e53529a7a75b7bff9bcc928350a83f0cdad0a3639330",
+    "pre_install": [
+        "foreach ($conf in 'HWiNFO64.INI', 'HWiNFO32.INI') {",
+        "    if (!(Test-Path \"$persist_dir\\$conf\")) { Set-Content \"$dir\\$conf\" '[Settings]', 'AutoUpdate=0' -Encoding ASCII }",
+        "}"
+    ],
     "architecture": {
         "64bit": {
-            "pre_install": "if (-not (Test-Path \"$persist_dir\\HWiNFO64.INI\")) { Set-Content \"$dir\\HWiNFO64.INI\" '[Settings]', 'AutoUpdate=0' -Encoding Ascii}",
             "bin": [
                 [
                     "HWiNFO64.exe",
@@ -22,7 +26,6 @@
             ]
         },
         "32bit": {
-            "pre_install": "if (-not (Test-Path \"$persist_dir\\HWiNFO32.INI\")) { Set-Content \"$dir\\HWiNFO32.INI\" '[Settings]', 'AutoUpdate=0' -Encoding Ascii}",
             "bin": [
                 [
                     "HWiNFO32.exe",


### PR DESCRIPTION
Since `persist` does not have conditional functionality, 32-bit profiles will generate invalid links when only 64bit scripts are executed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
