### PR TITLE
darktable@4.2.0: Extract via 7zip instead of run installer

### DIFF
--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -5,16 +5,11 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/darktable-org/darktable/releases/download/release-4.2.0/darktable-4.2.0-win64.exe",
+            "url": "https://github.com/darktable-org/darktable/releases/download/release-4.2.0/darktable-4.2.0-win64.exe#/dl.7z",
             "hash": "748e617d36f810890fcc7829fdf0e9999da2906b20293a2ac919808f80709e27"
         }
     },
-    "installer": {
-        "script": [
-            "$Env:__COMPAT_LAYER='RunAsInvoker'",
-            "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList @('/S', \"/D=$dir\") | Out-Null"
-        ]
-    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst*\" -Force -Recurse",
     "bin": "bin\\darktable.exe",
     "shortcuts": [
         [
@@ -29,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-win64.exe",
+                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-win64.exe#/dl.7z",
                 "hash": {
                     "url": "https://github.com/darktable-org/darktable/releases/tag/release-$matchHead"
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10220

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
