### PR TITLE
trafficmonitor, trafficmonitor-lite: fix missing dependency and typo

### DIFF
--- a/bucket/trafficmonitor-lite.json
+++ b/bucket/trafficmonitor-lite.json
@@ -3,9 +3,9 @@
     "description": "Network monitoring floating window software on Windows. It can display the current network speed, CPU and memory usage. It also supports being embedded into the taskbar, theme changing and traffic statistics. (Lite version, which does not contain GPU, Hard Disk or temperature monitoring. Administrator privilege is not required)",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
-    "suggest": [
+    "suggest": {
         "vcredist": "extras/vcredist2019"
-    ],
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.84.1/TrafficMonitor_V1.84.1_x64_Lite.zip",

--- a/bucket/trafficmonitor-lite.json
+++ b/bucket/trafficmonitor-lite.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
     "suggest": [
-        "vcredist2019"
+        "vcredist": "vcredist2019"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/trafficmonitor-lite.json
+++ b/bucket/trafficmonitor-lite.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
     "suggest": [
-        "vcredist": "vcredist2019"
+        "vcredist": "extras/vcredist2019"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/trafficmonitor-lite.json
+++ b/bucket/trafficmonitor-lite.json
@@ -1,6 +1,6 @@
 {
     "version": "1.84.1",
-    "description": "Network monitoring suspension window software in Windows platform. It can display the current network speed, CPU and memory usage. It also support the functions of display in the taskbar, change skin and historical traffic statistics. (Lite version, does not required Administrator to run, does not contain GPU, Hard Disk or temperature monitoring)",
+    "description": "Network monitoring floating window software on Windows. It can display the current network speed, CPU and memory usage. It also supports being embedded into the taskbar, theme changing and traffic statistics. (Lite version, which does not contain GPU, Hard Disk or temperature monitoring. Administrator privilege is not required)",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
     "architecture": {
@@ -41,6 +41,9 @@
     "checkver": {
         "github": "https://github.com/zhongyang219/TrafficMonitor"
     },
+    "depends": [
+        "vcredist2019"
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/trafficmonitor-lite.json
+++ b/bucket/trafficmonitor-lite.json
@@ -3,6 +3,9 @@
     "description": "Network monitoring floating window software on Windows. It can display the current network speed, CPU and memory usage. It also supports being embedded into the taskbar, theme changing and traffic statistics. (Lite version, which does not contain GPU, Hard Disk or temperature monitoring. Administrator privilege is not required)",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
+    "suggest": [
+        "vcredist2019"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.84.1/TrafficMonitor_V1.84.1_x64_Lite.zip",
@@ -41,9 +44,6 @@
     "checkver": {
         "github": "https://github.com/zhongyang219/TrafficMonitor"
     },
-    "depends": [
-        "vcredist2019"
-    ],
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
     "suggest": [
-        "vcredist2019"
+        "vcredist": "vcredist2019"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
     "suggest": [
-        "vcredist": "vcredist2019"
+        "vcredist": "extras/vcredist2019"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -3,9 +3,9 @@
     "description": "Network monitoring floating window software on Windows. It can display the current network speed, CPU and memory usage. It also supports being embedded into the taskbar, theme changing and traffic statistics.",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
-    "suggest": [
+    "suggest": {
         "vcredist": "extras/vcredist2019"
-    ],
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.84.1/TrafficMonitor_V1.84.1_x64.zip",

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -1,6 +1,6 @@
 {
     "version": "1.84.1",
-    "description": "Network monitoring suspension window software in Windows platform. It can display the current network speed, CPU and memory usage. It also support the functions of display in the taskbar, change skin and historical traffic statistics.",
+    "description": "Network monitoring floating window software on Windows. It can display the current network speed, CPU and memory usage. It also supports being embedded into the taskbar, theme changing and traffic statistics.",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
     "architecture": {
@@ -41,6 +41,9 @@
     "checkver": {
         "github": "https://github.com/zhongyang219/TrafficMonitor"
     },
+    "depends": [
+        "vcredist2019"
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/trafficmonitor.json
+++ b/bucket/trafficmonitor.json
@@ -3,6 +3,9 @@
     "description": "Network monitoring floating window software on Windows. It can display the current network speed, CPU and memory usage. It also supports being embedded into the taskbar, theme changing and traffic statistics.",
     "homepage": "https://github.com/zhongyang219/TrafficMonitor/blob/master/README_en-us.md",
     "license": "MIT",
+    "suggest": [
+        "vcredist2019"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/zhongyang219/TrafficMonitor/releases/download/V1.84.1/TrafficMonitor_V1.84.1_x64.zip",
@@ -41,9 +44,6 @@
     "checkver": {
         "github": "https://github.com/zhongyang219/TrafficMonitor"
     },
-    "depends": [
-        "vcredist2019"
-    ],
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
This package depends on `vcredist2019`, but this dependency was missing in the manifest file. Therefore, this commit adds it accordingly. It also changes the wording in description.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
