### PR TITLE
FreeCAD@0.20.2-2: Fix shim/shortcut

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -9,10 +9,10 @@
             "hash": "d8af7454f43f1753fd6141fd2172aa9bc7513b4b9cbbac4cd7cee0567a1bca7f"
         }
     },
-    "bin": "bin\\FreeCADCmd.exe",
+    "bin": "bin\\FreeCAD-portable\\FreeCADCmd.exe",
     "shortcuts": [
         [
-            "bin\\FreeCAD.exe",
+            "bin\\FreeCAD-portable\\FreeCAD.exe",
             "FreeCAD"
         ]
     ],


### PR DESCRIPTION
This PR fixes broken a shim/shortcut caused by a change in the extracted folder structure since version 20.1.

Previously, the program executables resided in `\\bin`, but now they are in `\\FreeCAD-portable\bin`. I don't know if this change was intentional by the developers but until/unless they change it back, this fix is required for the scoop manifest...
