### PR TITLE
twine@2.6.0: Update to 2.6.0 and fix autoupdate url

### DIFF
--- a/bucket/twine.json
+++ b/bucket/twine.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.3.16",
+    "version": "2.6.0",
     "description": "Interactive, nonlinear story creator",
     "homepage": "https://twinery.org",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/klembot/twinejs/releases/download/2.3.16/twine_2.3.16_win.exe#/dl.7z",
-    "hash": "5d9369acf3243a6ef28545cc54ee938bdf322ae79eb78014cd8b47c0d9e67bd5",
+    "url": "https://github.com/klembot/twinejs/releases/download/2.6.0/Twine-2.6.0-Windows.exe#/dl.7z",
+    "hash": "43b7e08260895c860f3c9350e3b261d76a186ea18d7160e7fe178ec13a2fdc70",
     "architecture": {
         "64bit": {
             "pre_install": [
@@ -29,6 +29,6 @@
         "github": "https://github.com/klembot/twinejs"
     },
     "autoupdate": {
-        "url": "https://github.com/klembot/twinejs/releases/download/$version/twine_$version_win.exe#/dl.7z"
+        "url": "https://github.com/klembot/twinejs/releases/download/$version/Twine-$version-Windows.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Since the binary releases URLs changed on 2.4.x, the `autoupdate` `url` field was properly fixed. After running `.\bin\checkver.ps1` the version and its hash were automatically updated as well.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- Closes #XXXX -->
<!-- or -->
<!-- Relates to #XXXX -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
