### PR TITLE
freecad@0.20.2-2: Fix subfolder reversal typo in recent change

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -9,10 +9,10 @@
             "hash": "d8af7454f43f1753fd6141fd2172aa9bc7513b4b9cbbac4cd7cee0567a1bca7f"
         }
     },
-    "bin": "bin\\FreeCAD-portable\\FreeCADCmd.exe",
+    "bin": "FreeCAD-portable\\bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
-            "bin\\FreeCAD-portable\\FreeCAD.exe",
+            "FreeCAD-portable\\bin\\FreeCAD.exe",
             "FreeCAD"
         ]
     ],


### PR DESCRIPTION
My PR #10257 had exactly the right description but my code had the subfolders reversed and of course I broke rule 4... didn't test it first. So the manifest remains broken.

This PR fixes the typo and HAS BEEN TESTED on my local machine. Maintainers, feel free to double-check my sanity.