### PR TITLE
maple@0.8.1.0: fix path cannot be found error

### DIFF
--- a/bucket/maple.json
+++ b/bucket/maple.json
@@ -13,7 +13,7 @@
     },
     "pre_install": [
         "Get-ChildItem \"$dir\\*.cer\" | Rename-Item -NewName 'maple.cer'",
-        "Get-ChildItem \"$dir\\*.appxbundle\" | Rename-Item -NewName 'maple.appxbundle'",
+        "Get-ChildItem \"$dir\\*.msixbundle\" | Rename-Item -NewName 'maple.msixbundle'",
         "",
         "# Check if the certificate is installed",
         "$trusted = $false",
@@ -35,7 +35,7 @@
         "# Install Appx package",
         "# note: using '3>$null' to omit warning message. Also, '-SkipEditionCheck' does not work for Appx module",
         "if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell 3>$null }",
-        "Add-AppxPackage \"$dir\\maple.appxbundle\""
+        "Add-AppxPackage \"$dir\\maple.msixbundle\""
     ],
     "pre_uninstall": [
         "if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell 3>$null }",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The upstream has used new package format ```.msixbundle``` instead of ```.appxbundle```. Using the original manifest will cause error like ```Add-AppxPackage: Cannot find path 'path\to\scoop\apps\maple\0.8.1.0\maple.appxbundle' because it does not exist.```.
This PR changes all strings ```.appxbundle``` to ```.msixbundle``` and this app manifest can be normally installed and uninstalled.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10606

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
