### PR TITLE
android-sdk@4333796: Fix shim path for emulator

### DIFF
--- a/bucket/android-sdk.json
+++ b/bucket/android-sdk.json
@@ -13,8 +13,8 @@
         "tools\\proguard\\bin\\proguard.bat",
         "tools\\proguard\\bin\\proguardgui.bat",
         "tools\\proguard\\bin\\retrace.bat",
-        "tools\\emulator.exe",
-        "tools\\emulator-check.exe",
+        "emulator\\emulator.exe",
+        "emulator\\emulator-check.exe",
         "tools\\mksdcard.exe",
         "tools\\monitor.bat"
     ],


### PR DESCRIPTION
The current version of 'emulator.exe' is installed into the folder 'emulator' and not 'tools'.

The executable in 'tools' either complains about using an old version or refuses to start with an error like this:
PANIC: Missing emulator engine program for 'x86' CPU.

Apparently this change of paths was made sometime in 2017:
https://developer.android.com/studio/releases/emulator#25-3

The date of 'tools/emulator.exe' is 2017-09-13, while emulator/emulator.exe is '2023-01-21'.

References:
https://stackoverflow.com/questions/51606128/windows-emulator-exe-panic-missing-emulator-engine-program-for-x86-cpu/51627009#51627009
https://developer.android.com/studio/run/emulator-commandline