### PR TITLE
Win10_BrightnessSlider: add version 1.7.15

### DIFF
--- a/bucket/win10_brightnessslider.json
+++ b/bucket/win10_brightnessslider.json
@@ -6,7 +6,6 @@
     "url": "https://github.com/blackholeearth/Win10_BrightnessSlider/releases/download/v1.7.15/Win10_BrightnessSlider.exe",
     "hash": "55e4a4b53d6d34e19eb86ba27495b48339b57b573aef79682df86e3f72063c4d",
     "extract_dir": "Win10_BrightnessSlider",
-    "bin": "Win10_BrightnessSlider.exe",
     "shortcuts": [
         [
             "Win10_BrightnessSlider.exe",

--- a/bucket/win10_brightnessslider.json
+++ b/bucket/win10_brightnessslider.json
@@ -1,8 +1,8 @@
 {
     "version": "1.7.15",
-    "license": "Freeware",
     "description": "Puts a Monitor Brightness icon to on Taskbar Tray",
     "homepage": "https://github.com/blackholeearth/Win10_BrightnessSlider",
+    "license": "Freeware",
     "url": "https://github.com/blackholeearth/Win10_BrightnessSlider/releases/download/v1.7.15/Win10_BrightnessSlider.exe",
     "hash": "55e4a4b53d6d34e19eb86ba27495b48339b57b573aef79682df86e3f72063c4d",
     "extract_dir": "Win10_BrightnessSlider",

--- a/bucket/win10_brightnessslider.json
+++ b/bucket/win10_brightnessslider.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.7.15",
+    "license": "Freeware",
+    "description": "Puts a Monitor Brightness icon to on Taskbar Tray",
+    "homepage": "https://github.com/blackholeearth/Win10_BrightnessSlider",
+    "url": "https://github.com/blackholeearth/Win10_BrightnessSlider/releases/download/v1.7.15/Win10_BrightnessSlider.exe",
+    "hash": "55e4a4b53d6d34e19eb86ba27495b48339b57b573aef79682df86e3f72063c4d",
+    "extract_dir": "Win10_BrightnessSlider",
+    "bin": "Win10_BrightnessSlider.exe",
+    "shortcuts": [
+        [
+            "Win10_BrightnessSlider.exe",
+            "Win10_BrightnessSlider"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/blackholeearth/Win10_BrightnessSlider",
+        "regex": "v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/blackholeearth/Win10_BrightnessSlider/releases/download/v$version/Win10_BrightnessSlider.exe"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

This is a simple GUI utility. I've been running this package for a bit in my personal bucket and it works https://github.com/scowalt/scoop-apps/blob/main/bucket/win10_brightnessslider.json