### PR TITLE
localsend: Add version 1.6.2

### DIFF
--- a/bucket/localsend.json
+++ b/bucket/localsend.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.6.2",
+    "description": "Share files to nearby devices. An open source cross-platform alternative to AirDrop.",
+    "homepage": "https://localsend.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/localsend/localsend/releases/download/v1.6.2/LocalSend-1.6.2-windows.zip",
+            "hash": "b2456251077e7547bacab024582e8d9303c5bf0aff78dff0e5f43c5957c1bce6"
+        }
+    },
+    "shortcuts": [
+        [
+            "localsend_app.exe",
+            "LocalSend"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/localsend/localsend"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/localsend/localsend/releases/download/v$version/LocalSend-$version-windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

An open source cross-platform alternative to AirDrop similar to Sharik.

Settings are stored under `$env:APPDATA\org.localsend\localsend_app\shared_preferences.json`

 Closes #10368

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
