### PR TITLE
hwmonitor: use https to download

### DIFF
--- a/bucket/hwmonitor.json
+++ b/bucket/hwmonitor.json
@@ -5,7 +5,7 @@
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "http://download.cpuid.com/hwmonitor/hwmonitor_1.49.zip",
+            "url": "https://download.cpuid.com/hwmonitor/hwmonitor_1.49.zip",
             "hash": "980cae447886ce8f712bfc288febe18a17b939938769a020566233bc2baf36ff",
             "bin": [
                 [
@@ -21,7 +21,7 @@
             ]
         },
         "32bit": {
-            "url": "http://download.cpuid.com/hwmonitor/hwmonitor_1.49.zip",
+            "url": "https://download.cpuid.com/hwmonitor/hwmonitor_1.49.zip",
             "hash": "980cae447886ce8f712bfc288febe18a17b939938769a020566233bc2baf36ff",
             "bin": [
                 [
@@ -41,10 +41,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.cpuid.com/hwmonitor/hwmonitor_$version.zip"
+                "url": "https://download.cpuid.com/hwmonitor/hwmonitor_$version.zip"
             },
             "32bit": {
-                "url": "http://download.cpuid.com/hwmonitor/hwmonitor_$version.zip"
+                "url": "https://download.cpuid.com/hwmonitor/hwmonitor_$version.zip"
             }
         }
     }


### PR DESCRIPTION
Use HTTPS to download hwmonitor, like its cousin cpu-z.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
