### PR TITLE
Add git-credential-manager.exe shim

### DIFF
--- a/bucket/git-credential-manager.json
+++ b/bucket/git-credential-manager.json
@@ -5,10 +5,13 @@
     "license": "MIT",
     "url": "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v2.0.886/gcm-win-x86-2.0.886.zip",
     "hash": "12a85baf27461d9597f4bba5ad7dd1840c4e58f97e50379f53b9a8410a75d5ce",
-    "bin": "git-credential-manager-core.exe",
+    "bin": [
+        "git-credential-manager-core.exe",
+        "git-credential-manager.exe"
+    ],
     "shortcuts": [
         [
-            "git-credential-manager-core.exe",
+            "git-credential-manager.exe",
             "GCM"
         ]
     ],


### PR DESCRIPTION
Microsoft renamed the exe. The old one still works, but outputs a nag message:

> git-credential-manager-core --version
warning: git-credential-manager-core was renamed to git-credential-manager warning: see https://aka.ms/gcm/rename for more information 2.0.886+ea93cb5158

The [rename explainer page][1] says they'll keep the symlinks for two major Git versions, so maybe scoop should do the same? I kept the core.exe. I don't see any reason to link to the old exe for the start menu shortcut, so that's just pointing to the new one.

[1]: https://github.com/GitCredentialManager/git-credential-manager/blob/main/docs/rename.md

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10382

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
