### PR TITLE
thisiswin11: Remove `extract_dir`

### DIFF
--- a/bucket/thisiswin11.json
+++ b/bucket/thisiswin11.json
@@ -9,7 +9,6 @@
             "hash": "70aee4a021c2c11d58045a52712e73770385eeb1cb96743988040516e1e69b4b"
         }
     },
-    "extract_dir": "TIW11",
     "shortcuts": [
         [
             "ThisIsWin11.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
