### PR TITLE
fix emulator.exe shim dir of android-sdk.json

### DIFF
--- a/bucket/android-sdk.json
+++ b/bucket/android-sdk.json
@@ -13,8 +13,8 @@
         "tools\\proguard\\bin\\proguard.bat",
         "tools\\proguard\\bin\\proguardgui.bat",
         "tools\\proguard\\bin\\retrace.bat",
-        "emulator\\emulator.exe",
-        "emulator\\emulator-check.exe",
+        "tools\\emulator.exe",
+        "tools\\emulator-check.exe",
         "tools\\mksdcard.exe",
         "tools\\monitor.bat"
     ],


### PR DESCRIPTION
commit for fixing an installation failure bug of next package: Extras/android-sdk

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10335

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
