### PR TITLE
ditto: use github releases

### DIFF
--- a/bucket/ditto.json
+++ b/bucket/ditto.json
@@ -1,7 +1,7 @@
 {
     "version": "3.24.238.0",
     "description": "An enhanced clipboard manager",
-    "homepage": "https://github.com/sabrogden/Ditto",
+    "homepage": "https://ditto-cp.sourceforge.io",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/ditto.json
+++ b/bucket/ditto.json
@@ -42,7 +42,9 @@
         "Ditto.db",
         "Ditto.Settings"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/sabrogden/Ditto"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/ditto.json
+++ b/bucket/ditto.json
@@ -1,15 +1,15 @@
 {
     "version": "3.24.238.0",
     "description": "An enhanced clipboard manager",
-    "homepage": "https://ditto-cp.sourceforge.io/",
+    "homepage": "https://github.com/sabrogden/Ditto",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/3.24.238.0/DittoPortable_64bit_3_24_238_0.zip",
+            "url": "https://github.com/sabrogden/Ditto/releases/download/3.24.238.0/DittoPortable_64bit_3_24_238_0.zip",
             "hash": "d0f2399ef52df3af3013abe4ef93adc4602e2e8f10593e5ffcbf9a4a5c898dd0"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/3.24.238.0/DittoPortable_3_24_238_0.zip",
+            "url": "https://github.com/sabrogden/Ditto/releases/download/3.24.238.0/DittoPortable_3_24_238_0.zip",
             "hash": "3fe011b0ac474c4ec9f7149aa3c7267588547a05bf23474beb6621c58f3a3746"
         }
     },
@@ -42,14 +42,14 @@
         "Ditto.db",
         "Ditto.Settings"
     ],
-    "checkver": "var versionDots=\"([\\d.]+)\"",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoPortable_64bit_$underscoreVersion.zip"
+                "url": "https://github.com/sabrogden/Ditto/releases/download/$version/DittoPortable_64bit_$underscoreVersion.zip"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoPortable_$underscoreVersion.zip"
+                "url": "https://github.com/sabrogden/Ditto/releases/download/$version/DittoPortable_$underscoreVersion.zip"
             }
         }
     }


### PR DESCRIPTION
Sourceforge downloads are slow and the project development moved to github. Even the sourceforge homepage links to github releases as the download links.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
