### PR TITLE
kdeconnect: Fix checkver

### DIFF
--- a/bucket/kdeconnect.json
+++ b/bucket/kdeconnect.json
@@ -1,13 +1,13 @@
 {
-    "version": "22.08.0",
+    "version": "21.12.3-903",
     "description": "Communications and data transfer between devices over local networks",
     "homepage": "https://kdeconnect.kde.org/",
     "license": "GPL-3.0-or-later",
     "notes": "If you want to get the latest development branch-based installer, please install `kdeconnect-nightly` from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/release-service/22.08.0/windows/kdeconnect-kde-22.08.0-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "4f918ba88f947b81bbed7bc66d9d18a71eeafd4956667a4cf0769c5745f50c2c"
+            "url": "https://download.kde.org/stable/release-service/21.12.3/windows/kdeconnect-kde-21.12.3-903-windows-msvc2019_64-cl.exe#/dl.7z",
+            "hash": "ec7a9f5b3788fef774c49bc619a062a87b364e54099946a14a954637a4682318"
         }
     },
     "pre_install": [
@@ -23,13 +23,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://apps.kde.org/kdeconnect",
-        "regex": "kdeconnect-kde-([\\d.]+)-windows-(?<lib>\\w+)-cl\\.exe"
+        "url": "https://kdeconnect.kde.org/download.html",
+        "regex": "release-service/(?<release>[\\d.]+)/windows/kdeconnect-kde-(?<version>.*)-windows-(?<lib>.*)\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/release-service/$version/windows/kdeconnect-kde-$version-windows-$matchLib-cl.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$matchRelease/windows/kdeconnect-kde-$version-windows-$matchLib.exe#/dl.7z",
                 "hash": {
                     "url": "https://apps.kde.org/kdeconnect",
                     "regex": "sha256:</strong> $sha256</div>"


### PR DESCRIPTION
- Update to version 21.12.3-903
- `autoupdate.hash` not removed, even invalid now

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
