### PR TITLE
okular: Fix `regex` and update to version 22.12.1

### DIFF
--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/release-service/$version/windows/okular-$version-$matchBuild.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$matchRelease/windows/okular-$version-windows-$matchLib.exe#/dl.7z",
                 "hash": {
                     "url": "https://apps.kde.org/okular",
                     "regex": "sha256:</strong>\\s$sha256</div>"

--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -24,7 +24,7 @@
     ],
     "checkver": {
         "url": "https://apps.kde.org/okular",
-        "regex": "windows/okular-(?<version>[\\d.]+)-(?<build>[\\w-]+)\\.exe"
+        "regex": "release-service/(?<release>[\\d.]+)/windows/okular-(?<version>.*)-windows-(?<lib>.*)\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -1,5 +1,5 @@
 {
-    "version": "22.12.1",
+    "version": "22.12.1-1265",
     "description": "Universal document viewer",
     "homepage": "https://okular.kde.org",
     "license": "LGPL-2.0-only",

--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -1,13 +1,13 @@
 {
-    "version": "22.08.1",
+    "version": "22.12.1",
     "description": "Universal document viewer",
     "homepage": "https://okular.kde.org",
     "license": "LGPL-2.0-only",
     "notes": "If you want to get the latest development branch-based installer, please install `okular-nightly` from Versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/release-service/22.08.1/windows/okular-22.08.1-windows-msvc2019_64-cl.exe#/dl.7z",
-            "hash": "3497f9dd3e136715a89f7e63d76e06fecd0bef96272b27ac34337e8cb61cd876"
+            "url": "https://download.kde.org/stable/release-service/22.12.1/windows/okular-22.12.1-1265-windows-cl-msvc2019-x86_64.exe#/dl.7z",
+            "hash": "73a891661ffe9f67772ca5116d50add54d1a827cebca921b797ae334d18ec75f"
         }
     },
     "pre_install": [
@@ -24,15 +24,15 @@
     ],
     "checkver": {
         "url": "https://apps.kde.org/okular",
-        "regex": "okular-([\\d.]+)-windows-(?<lib>\\w+)-cl\\.exe"
+        "regex": "windows/okular-(?<version>[\\d.]+)-(?<build>[\\w-]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/release-service/$version/windows/okular-$version-windows-$matchLib-cl.exe#/dl.7z",
+                "url": "https://download.kde.org/stable/release-service/$version/windows/okular-$version-$matchBuild.exe#/dl.7z",
                 "hash": {
                     "url": "https://apps.kde.org/okular",
-                    "regex": "sha256:</strong> $sha256</div>"
+                    "regex": "sha256:</strong>\\s$sha256</div>"
                 }
             }
         }


### PR DESCRIPTION
- Fixed Okular's `checkver.regex` (wasn't working).
- Ran `checkver.ps1 -app "okular.json" -update`.
- Small adjustment to `autoupdate`'s `regex`.
<!---->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).