### PR TITLE
sophiapp: Remove "SophiApp.exe.config" from `persist`

### DIFF
--- a/bucket/sophiapp.json
+++ b/bucket/sophiapp.json
@@ -12,10 +12,7 @@
             "SophiApp"
         ]
     ],
-    "persist": [
-        "SophiApp.exe.config",
-        "Logs"
-    ],
+    "persist": "Logs",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Sophia-Community/SophiApp/releases/download/$version/SophiApp.zip",


### PR DESCRIPTION
Reason: This file is already included inside the zip file, and only exists to help the **SophiApp.exe** file. There is no need to persist it.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
