### PR TITLE
obs-studio: Persist and preserve plugins

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -22,7 +22,13 @@
     "pre_install": "if (!(Test-Path \"$persist_dir\\portable_mode.txt\")) { New-Item \"$dir\\portable_mode.txt\" | Out-Null }",
     "persist": [
         "config",
-        "portable_mode.txt"
+        "portable_mode.txt",
+        "obs-plugins"
+    ],
+    "post_install": [
+        "if (!(Test-Path \"$dir\\obs-plugins.original\")) { return }",
+        "Copy-Item \"$dir\\obs-plugins.original\\*\" \"$dir\\obs-plugins\" -Recurse -Force",
+        "Remove-Item \"$dir\\obs-plugins.original\" -Recurse -Force"
     ],
     "checkver": {
         "url": "https://obsproject.com/download",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10441

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

OBS's functionality can be extended using plugins located in `$dir\obs-plugins`. Since the folder is not persisted, users have to manually copy their custom plugins to the new location on each update.

The problem is this folder also contains files that do need to be updated and merely persisting the folder effectively keeps these files outdated.

A possible solution is persisting `obs-plugins` and implicitly forcing Scoop to place new files in `obs-plugins.original` whose contents are then copied back to `obs-plugins`, overwriting older versions.