### PR TITLE
update install script, for mambaforge 22.11.1-2

### DIFF
--- a/bucket/mambaforge.json
+++ b/bucket/mambaforge.json
@@ -15,8 +15,11 @@
     },
     "installer": {
         "script": [
-            "Start-Process -Wait \"$dir\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
-            "Remove-Item \"$dir\\$fname\""
+            "$TempFilePath = Join-Path -Path $env:TEMP -ChildPath $fname",
+            "if (Test-Path -Path $TempFilePath){throw 'Temporary file path already exists. Please remove ' + $TempFilePath}",
+            "Move-Item -Path \"$dir\\$fname\" -Destination $TempFilePath",
+            "Start-Process -Wait \"$TempFilePath\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
+            "Remove-Item \"$TempFilePath\""
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
As the 22.11.1-2 version of the mambaforge installer only installs into an empty directory, the installer is moved to the $env:TEMP directory befor installation. If the temporary path for the installer already exists, an error is thrown. After installation the installer is deleted as before.

Closes #10420

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
