### PR TITLE
Correct extract_dir value for prusaslicer 2.6.0-alpha3 win64 version

### DIFF
--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -25,7 +25,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_$version/PrusaSlicer-$version+win64-$matchTimestamp64_signed.zip",
-                "extract_dir": "PrusaSlicer-$version+win64-$matchTimestamp64"
+                "extract_dir": "PrusaSlicer-$version+win64-$matchTimestamp64_signed"
             }
         }
     }

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.6.0-alpha3/PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed.zip",
             "hash": "2326a9a1ef47e233fb5d5d8fe291ad41723ea17ccaf132d670cd1bd4e7d614e2",
-            "extract_dir": "PrusaSlicer-2.6.0-alpha3+win64-202302031521"
+            "extract_dir": "PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed"
         }
     },
     "bin": "prusa-slicer-console.exe",


### PR DESCRIPTION
Correct the extract_dir value with "PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed" with a "_signed" suffix.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Without this suffix there is the following problem:
````
Installing 'prusaslicer' (2.6.0-alpha3) [64bit] from extras bucket
Loading PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed.zip from cache.
Checking hash of PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed.zip ... ok.
Extracting PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed.zip ... Could not find 'PrusaSlicer-2.6.0-alpha3+win64-202302031521'! (error 16)
Au caractère D:\Applications\Scoop\apps\scoop\current\lib\core.ps1:638 : 9
+         throw "Could not find '$(fname $from)'! (error $($proc.ExitCo ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (Could not find ...21'! (error 16):String) [], RuntimeException
+ FullyQualifiedErrorId : Could not find 'PrusaSlicer-2.6.0-alpha3+win64-202302031521'! (error 16)
````
after the extraction of the archive file, the installation script is looking for "PrusaSlicer-2.6.0-alpha3+win64-202302031521" but the extracted folder is "PrusaSlicer-2.6.0-alpha3+win64-202302031521_signed" (with "_signed" suffix)

I've made this correction in my Scoop\buckets\extras\bucket\prusaslicer.json and the installation works fine :)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
