### PR TITLE
nicotine-plus: Update homepage

### DIFF
--- a/bucket/nicotine-plus.json
+++ b/bucket/nicotine-plus.json
@@ -1,7 +1,7 @@
 {
     "version": "3.2.8",
     "description": "Graphical client for the Soulseek file sharing network",
-    "homepage": "https://nicotine-plus.github.io/nicotine-plus/",
+    "homepage": "https://nicotine-plus.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
The current homepage for Nicotine+ is https://nicotine-plus.org.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
