### PR TITLE
RabbitMQ is licensed under the MPL2

### DIFF
--- a/bucket/rabbitmq.json
+++ b/bucket/rabbitmq.json
@@ -2,7 +2,7 @@
     "version": "3.11.8",
     "description": "Message-broker",
     "homepage": "https://www.rabbitmq.com",
-    "license": "MPL-1.1",
+    "license": "MPL-2.0",
     "depends": "erlang",
     "url": "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.11.8/rabbitmq-server-windows-3.11.8.zip",
     "hash": "8220f62ab6e3cae1f595856dbfaff041e4cfcd0bfdd50373a5f4a581562f64d1",


### PR DESCRIPTION
has been since July 2020 [1].

1. https://github.com/rabbitmq/rabbitmq-server/blob/main/LICENSE