### PR TITLE
jpegview: Add version 1.1.43

### DIFF
--- a/bucket/jpegview.json
+++ b/bucket/jpegview.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.0.37",
+    "version": "1.1.43",
     "description": "Fast and highly configurable image viewer/editor with a minimal GUI.",
-    "homepage": "https://sourceforge.net/projects/jpegview/",
-    "license": "GPL-2.0-only",
-    "url": "https://downloads.sourceforge.net/project/jpegview/jpegview/1.0.37/JPEGView_1.0.37.zip",
-    "hash": "sha1:fb394fdbff070749956f830bac40d533aa0b4713",
+    "homepage": "https://github.com/sylikc/jpegview",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/sylikc/jpegview/releases/download/v1.1.43/JPEGView_1.1.43.7z",
+    "hash": "e2eeb5dab25c9cdb743a7f98c743435cc4885c8594b15ed0cf5e861d8e818acd",
     "architecture": {
         "64bit": {
             "extract_dir": "JPEGView64"
@@ -18,10 +18,14 @@
             "$cont = (Get-Content \"$dir\\JPEGView.ini\").Replace('StoreToEXEPath=false', 'StoreToEXEPath=true')",
             "Set-Content \"$dir\\JPEGView.ini\" $cont",
         "}",
-        "if (Test-Path \"$persist_dir\\ParamDB.db\") { Copy-Item \"$persist_dir\\ParamDB.db\" \"$dir\" | Out-Null }"
+        "if (Test-Path \"$persist_dir\\ParamDB.db\") { Copy-Item \"$persist_dir\\ParamDB.db\" \"$dir\" | Out-Null }",
+        "if (Test-Path \"$persist_dir\\KeyMap.txt\") { Copy-Item \"$persist_dir\\KeyMap.txt\" \"$dir\" | Out-Null }"
     ],
     "uninstaller": {
-        "script": "if (Test-Path \"$dir\\ParamDB.db\") { Copy-Item \"$dir\\ParamDB.db\" \"$persist_dir\" | Out-Null }"
+        "script": [
+            "if (Test-Path \"$dir\\ParamDB.db\") { Copy-Item \"$dir\\ParamDB.db\" \"$persist_dir\" | Out-Null }",
+            "if (Test-Path \"$dir\\KeyMap.txt\") { Copy-Item \"$dir\\KeyMap.txt\" \"$persist_dir\" | Out-Null }"
+        ]
     },
     "bin": "JPEGView.exe",
     "shortcuts": [
@@ -31,14 +35,12 @@
         ]
     ],
     "checkver": {
-        "url": "https://sourceforge.net/projects/jpegview/rss?path=/",
-        "regex": "/jpegview/([\\d.]+)/JPEGView_"
+        "github": "https://github.com/sylikc/jpegview"
     },
     "persist": [
-        "JPEGView.ini",
-        "KeyMap.txt"
+        "JPEGView.ini"
     ],
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/jpegview/jpegview/$version/JPEGView_$version.zip"
+        "url": "https://github.com/sylikc/jpegview/releases/download/v$version/JPEGView_$version.7z"
     }
 }


### PR DESCRIPTION
* Update JPEGView from the abandoned SF project's 1.0.37 to GH's semi-official fork 1.1.43
* new in 1.1.43 is that KeyMap.txt now operates the same way ParamDB does, it's optional.  It's backwards compatible with the old KeyMap.txt file, so the pre_install copies it back
* fixed the license.  the original project was GPL v2 or later as per the LICENSE.txt
* This is an update of the existing jpegview.json, I've verified and tested the manifest

Closes #10478

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
