### PR TITLE
clash-mini: Update to version 0.2.1

### DIFF
--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A simple GUI for Clash.",
     "homepage": "https://github.com/MetaCubeX/Clash.Mini",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.0/Clash.Mini_v0.2.0_x64.7z",
-            "hash": "a5007c479c10be6929aa11fa6efb11c30bb990774babed9e374807320e339908"
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.1/Clash.Mini_v0.2.1_x64.zip",
+            "hash": "86f9707de315f6ec6d0a28851798e9fa119a1dae948e65656b361b2c3da6b070"
         },
         "32bit": {
-            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.0/Clash.Mini_v0.2.0_x86.7z",
-            "hash": "ad1f5e3c017497b964c943ac5ce0f74aa8ecfe6aa1d7507ca1ca924185a78bdc"
+            "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v0.2.1/Clash.Mini_v0.2.1_x86.zip",
+            "hash": "a699159d3034d0451dc87ce737a90c4a688230e6000dfa4790583ff283c5875f"
         }
     },
     "shortcuts": [
@@ -28,15 +28,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x64.7z"
+                "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x86.7z"
+                "url": "https://github.com/MetaCubeX/Clash.Mini/releases/download/v$version/Clash.Mini_v$version_x86.zip"
             }
-        },
-        "hash": {
-            "url": "$url.sha256",
-            "regex": "([\\S]+)"
         }
     }
 }


### PR DESCRIPTION
* Fix 'autoupdate'

* Remove 'hash'

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
