### PR TITLE
dosbox-x: Update to version 2022.12.26, fix autoupdate, add `arm64` arch

### DIFF
--- a/bucket/dosbox-x.json
+++ b/bucket/dosbox-x.json
@@ -1,18 +1,23 @@
 {
-    "version": "0.84.2",
+    "version": "2022.12.26",
     "description": "Fork of DOSBox, an Intel x86-based PC emulator, complete with sound, graphics, mouse, joystick, modem, etc.",
     "homepage": "https://dosbox-x.com",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-windows-v2022.08.0/dosbox-x-vsbuild-win64-20220801203148.zip",
-            "hash": "4a29a5f7a52ca6ed953a20da8bd7328eda71cca7bf7f27bd3a25d27529e08304",
+            "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v2022.12.26/dosbox-x-vsbuild-win64-20221226190454.zip",
+            "hash": "f82c85058033288712ac8c36fbbd0888a6718bbb1e2934ccb4263943da3f0e20",
             "extract_dir": "bin\\x64\\Release SDL2"
         },
         "32bit": {
-            "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-windows-v2022.08.0/dosbox-x-vsbuild-win32-20220801203132.zip",
-            "hash": "63db4993b8fb63849ef1e78c6a2e7d2895b85507fbe357fe11f9e547d8d51e82",
+            "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v2022.12.26/dosbox-x-vsbuild-win32-20221226190454.zip",
+            "hash": "6ea8ed879ed5f95ca827fcad50724a0f64c01f9f81cb669c093ea402931ac326",
             "extract_dir": "bin\\Win32\\Release SDL2"
+        },
+        "arm64": {
+            "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v2022.12.26/dosbox-x-vsbuild-arm64-20221226190454.zip",
+            "hash": "08f49e2d11676ae0b024a1c173844772f51fc8c6053ea8739f30b2e58f0bb8ee",
+            "extract_dir": "bin\\ARM64\\Release SDL2"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\dosbox.conf\")) { Copy-Item \"$dir\\dosbox-x.reference.conf\" \"$dir\\dosbox.conf\" }",
@@ -25,16 +30,20 @@
     ],
     "persist": "dosbox.conf",
     "checkver": {
-        "github": "https://github.com/joncampbell123/dosbox-x",
-        "regex": "(?sm)DOSBox-X (?<dateversion>[\\d.]+) \\(([\\d.]+)\\).*?download/dosbox-x-windows-v[\\d.]+/dosbox-x-vsbuild-win32-(?<releasewin32>[\\d-]+).*?download/dosbox-x-windows-v[\\d.]+/dosbox-x-vsbuild-win64-(?<releasewin64>[\\d-]+)"
+        "url": "https://api.github.com/repos/joncampbell123/dosbox-x/releases/latest",
+        "jsonpath": "$.assets[*].browser_download_url",
+        "regex": "(?s)dosbox-x-v(?<version>[\\d.]+).*?vsbuild-arm64-(?<releasearm64>\\d+).*?vsbuild-win32-(?<releasewin32>\\d+).*?vsbuild-win64-(?<releasewin64>\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-windows-v$matchDateversion/dosbox-x-vsbuild-win64-$matchReleasewin64.zip"
+                "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v$matchVersion/dosbox-x-vsbuild-win64-$matchReleasewin64.zip"
             },
             "32bit": {
-                "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-windows-v$matchDateversion/dosbox-x-vsbuild-win32-$matchReleasewin32.zip"
+                "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v$matchVersion/dosbox-x-vsbuild-win32-$matchReleasewin32.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v$matchVersion/dosbox-x-vsbuild-arm64-$matchReleasearm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10474

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
