### PR TITLE
manifold|-viewer: no more bin64 subdirectory

### DIFF
--- a/bucket/manifold-viewer.json
+++ b/bucket/manifold-viewer.json
@@ -11,10 +11,10 @@
     "extract_dir": "manifold-viewer-9.0.179",
     "architecture": {
         "64bit": {
-            "bin": "bin64\\manifold.exe",
+            "bin": "manifold.exe",
             "shortcuts": [
                 [
-                    "bin64\\manifold.exe",
+                    "manifold.exe",
                     "Manifold 9 Viewer"
                 ]
             ]

--- a/bucket/manifold.json
+++ b/bucket/manifold.json
@@ -11,10 +11,10 @@
     "extract_dir": "manifold-9.0.179",
     "architecture": {
         "64bit": {
-            "bin": "bin64\\manifold.exe",
+            "bin": "manifold.exe",
             "shortcuts": [
                 [
-                    "bin64\\manifold.exe",
+                    "manifold.exe",
                     "Manifold 9"
                 ]
             ]


### PR DESCRIPTION

Fixes error:
Can't shim 'bin64\manifold.exe': File doesn't exist.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).