### PR TITLE
ventoy: Copy altexes to root folder, Fix bin and shortcut, Update hash url

### DIFF
--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -9,14 +9,38 @@
     "pre_install": [
         "'log.txt', 'Ventoy2Disk.ini' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
-        "}"
+        "}",
+        "Copy-Item \"$dir\\altexe\\*\" \"$dir\""
     ],
-    "bin": "Ventoy2Disk.exe",
     "architecture": {
         "64bit": {
+            "bin": [
+                [
+                    "Ventoy2Disk_x64.exe",
+                    "Ventoy2Disk"
+                ]
+            ],
             "shortcuts": [
                 [
-                    "altexe\\Ventoy2Disk_X64.exe",
+                    "Ventoy2Disk_X64.exe",
+                    "Ventoy2Disk"
+                ],
+                [
+                    "VentoyPlugson_x64.exe",
+                    "VentoyPlugson"
+                ],
+                [
+                    "VentoyVlnk.exe",
+                    "VentoyVlnk",
+                    "-s"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "Ventoy2Disk.exe",
+            "shortcuts": [
+                [
+                    "Ventoy2Disk.exe",
                     "Ventoy2Disk"
                 ],
                 [
@@ -30,14 +54,20 @@
                 ]
             ]
         },
-        "32bit": {
+        "arm64": {
+            "bin": [
+                [
+                    "Ventoy2Disk_ARM64.exe",
+                    "Ventoy2Disk"
+                ]
+            ],
             "shortcuts": [
                 [
-                    "Ventoy2Disk.exe",
+                    "Ventoy2Disk_ARM64.exe",
                     "Ventoy2Disk"
                 ],
                 [
-                    "VentoyPlugson.exe",
+                    "VentoyPlugson_x64.exe",
                     "VentoyPlugson"
                 ],
                 [
@@ -58,8 +88,7 @@
     "autoupdate": {
         "url": "https://github.com/ventoy/Ventoy/releases/download/v$version/ventoy-$version-windows.zip",
         "hash": {
-            "url": "https://github.com/ventoy/Ventoy/releases/tag/v$version",
-            "regex": "$basename:\\s+$checksum"
+            "url": "$baseurl/sha256.txt"
         },
         "extract_dir": "ventoy-$version"
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://www.ventoy.net/en/doc_start.html
> `Ventoy2Disk.exe` is a x86_32 application and supports both 32-bit and 64-bit Windows PC with intel/amd processor.
> Since 1.0.58, Ventoy also provides `Ventoy2Disk_X64.exe/Ventoy2Disk_ARM.exe/Ventoy2Disk_ARM64.exe` you can use them if needed.
> These exe files are in `altexe` directory of the installation package.
> You must copy them to the upper directory to use them. (The same location with `Ventoy2Disk.exe`)

Closes #10452

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
