### PR TITLE
zoom: Fix missing DLLs

### DIFF
--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -24,6 +24,7 @@
         }
     },
     "post_install": [
+        "Expand-7zipArchive \"$dir\\win10rt.7z\" -Removal",
         "Remove-Item \"$dir\\Install*\"",
         "Write-Host \"Registering zoommtg:// protocol handler\"",
         "$regpath = \"HKCU:\\SOFTWARE\\Classes\\zoommtg\"",


### PR DESCRIPTION
Close #10427
By emulating the way the official installer unpacks the runtime library, it makes Zoom ready to run out of the box without the need to install the runtime library.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
