### PR TITLE
vt-uploader: Fix `url`, `hash`, and remove `pre_install`.

### DIFF
--- a/bucket/vt-uploader.json
+++ b/bucket/vt-uploader.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.9",
+    "version": "0.2.1",
     "homepage": "https://github.com/SamuelTulach/VirusTotalUploader",
     "description": "A simple application written in C# that allows for file uploading to the VirusTotal website. (Requires a VirusTotal API Key)",
     "license": "GPL-3.0",

--- a/bucket/vt-uploader.json
+++ b/bucket/vt-uploader.json
@@ -1,20 +1,14 @@
 {
     "version": "0.1.9",
     "homepage": "https://github.com/SamuelTulach/VirusTotalUploader",
-    "description": "A simple application written in C# that allows for file uploading to the VirusTotal website. (Requires a Virustotal API Key)",
+    "description": "A simple application written in C# that allows for file uploading to the VirusTotal website. (Requires a VirusTotal API Key)",
     "license": "GPL-3.0",
     "notes": [
-        "For a guide on how to get your Virustotal API Key, visit:",
+        "For a guide on how to get your VirusTotal API Key, visit:",
         "https://github.com/SamuelTulach/VirusTotalUploader#how-to-get-api-key"
     ],
-    "url": "https://github.com/SamuelTulach/VirusTotalUploader/releases/download/0.1.9/setup_anycpu_signed.zip",
-    "hash": "142751060f6e68b989af65df8b16420e7d29979849f6aaa27e782d59901beae9",
-    "pre_install": [
-        "Rename-Item \"$dir\\uploader.exe\" 'setup.exe'; Expand-InnoArchive \"$dir\\setup.exe\" \"$dir\" -Removal",
-        "if (!(Test-Path \"$persist_dir\\vtu_settings.json\")) {",
-        "   New-Item \"$dir\\vtu_settings.json\" -ItemType 'File' -Value '{\"ApiKey\":\"\",\"Language\":\"\",\"DirectUpload\":false}' | Out-Null",
-        "}"
-    ],
+    "url": "https://github.com/SamuelTulach/VirusTotalUploader/releases/download/0.2.1/vt_portable.zip",
+    "hash": "77574fd3a16c1ec695a8b85fef05f813edfa8277e5f39cee38b286fc8c261419",
     "post_install": [
         "$registryPath = 'HKCU\\Software\\Classes\\*\\shell\\Upload to VirusTotal\\command'",
         "$registryValue = (\"\"\"$dir\\uploader.exe\"\" \"\"%1\"\"\").Replace('$dir', $dir)",
@@ -30,10 +24,9 @@
     "shortcuts": [
         [
             "uploader.exe",
-            "VirusTotal Uploader"
+            "VirusTotalUploader"
         ]
     ],
-    "persist": "vtu_settings.json",
     "post_uninstall": [
         "if ($cmd -eq 'uninstall') {",
         "    $registryPath = 'HKCU\\Software\\Classes\\*\\shell\\Upload to VirusTotal'",
@@ -43,6 +36,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/SamuelTulach/VirusTotalUploader/releases/download/$version/setup_anycpu_signed.zip"
+        "url": "https://github.com/SamuelTulach/VirusTotalUploader/releases/download/$version/vt_portable.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
