### PR TITLE
ngspice: Update to version 39

### DIFF
--- a/bucket/ngspice.json
+++ b/bucket/ngspice.json
@@ -1,12 +1,12 @@
 {
-    "version": "38",
+    "version": "39",
     "description": "SPICE simulator for electric and electronic circuits",
     "homepage": "http://ngspice.sourceforge.net",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/38/ngspice-38_64.zip",
-            "hash": "39e5809e55409733a37386cf056f3eb532b9c9b0f63b648df8e02ecd5a594d29",
+            "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/39/ngspice-39_64.7z",
+            "hash": "70ff13c996b6e2d940fae1edfa32a262a0082ebb54604bcb715f91c6b72e8ea0",
             "extract_dir": "Spice64"
         }
     },
@@ -30,7 +30,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/$version/ngspice-$version_64.zip"
+                "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/$version/ngspice-$version_64.7z"
             }
         }
     }


### PR DESCRIPTION
ngspice v39 switch zip to 7z

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
