### PR TITLE
Kicad@7.0.1: Update manifest to use github release (Closes #10573)

### DIFF
--- a/bucket/kicad.json
+++ b/bucket/kicad.json
@@ -1,12 +1,12 @@
 {
-    "version": "7.0.0",
+    "version": "7.0.1",
     "description": "Electronics Design Automation Suite",
     "homepage": "https://www.kicad.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.0/kicad-7.0.0-x86_64.exe#/dl.7z",
-            "hash": "6b32bfce38bb03852cd25fe9c2174bf80091cb130d3721475fd14b2f0bfc8f8f"
+            "url": "https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.1/kicad-7.0.1-x86_64.exe#/dl.7z",
+            "hash": "f452f71df13c7d1d253fcd7c07813bc2ad362fc38a75c7f779b0d3971ed561ff"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",

--- a/bucket/kicad.json
+++ b/bucket/kicad.json
@@ -10,10 +10,7 @@
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
-    "bin": [
-        "bin\\kicad.exe",
-        "bin\\kicad-cli.exe"
-    ],
+    "bin": "bin\\kicad-cli.exe",
     "shortcuts": [
         [
             "bin\\kicad.exe",

--- a/bucket/kicad.json
+++ b/bucket/kicad.json
@@ -1,20 +1,19 @@
 {
-    "version": "6.0.11",
+    "version": "7.0.0",
     "description": "Electronics Design Automation Suite",
     "homepage": "https://www.kicad.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://kicad-downloads.s3.cern.ch/windows/stable/kicad-6.0.11-x86_64.exe#/dl.7z",
-            "hash": "41d89f8bd141be2efce68f667f6cbf030191198fa517fd189f4ba6dc129e4ac7"
-        },
-        "32bit": {
-            "url": "https://kicad-downloads.s3.cern.ch/windows/stable/kicad-6.0.11-i686.exe#/dl.7z",
-            "hash": "9d128e9c09783b2c97142d6cba15cc5866a8f6ff3680b13f9578bed7dc4fbeb1"
+            "url": "https://github.com/KiCad/kicad-source-mirror/releases/download/7.0.0/kicad-7.0.0-x86_64.exe#/dl.7z",
+            "hash": "6b32bfce38bb03852cd25fe9c2174bf80091cb130d3721475fd14b2f0bfc8f8f"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
-    "bin": "bin\\kicad.exe",
+    "bin": [
+        "bin\\kicad.exe",
+        "bin\\kicad-cli.exe"
+    ],
     "shortcuts": [
         [
             "bin\\kicad.exe",
@@ -22,16 +21,12 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.kicad.org/download/windows/",
-        "regex": "kicad-([\\d._]+)-"
+        "github": "https://github.com/KiCad/kicad-source-mirror/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://kicad-downloads.s3.cern.ch/windows/stable/kicad-$version-x86_64.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://kicad-downloads.s3.cern.ch/windows/stable/kicad-$version-i686.exe#/dl.7z"
+                "url": "https://github.com/KiCad/kicad-source-mirror/releases/download/$version/kicad-$version-x86_64.exe#/dl.7z"
             }
         }
     }

--- a/deprecated/kicad-lite.json
+++ b/deprecated/kicad-lite.json
@@ -3,7 +3,7 @@
     "description": "Electronics Design Automation Suite, stable build without libraries",
     "homepage": "https://www.kicad.org",
     "license": "GPL-3.0-only",
-    "notes": "To configure KiCad's environment variables, visit https://docs.kicad.org/5.1/en/kicad/kicad.html#paths_configuration",
+    "notes": "Depreciated. Lite version no longer offered by KiCad developers. Install extras/kicad for the most recent version. To configure KiCad's environment variables, visit https://docs.kicad.org/5.1/en/kicad/kicad.html#paths_configuration",
     "architecture": {
         "64bit": {
             "url": "https://kicad-downloads.s3.cern.ch/windows/stable/kicad-5.1.12_1-x86_64-lite.exe#/dl.7z",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
KiCad version 7.0.0 onwards will not support 32bit architecture. They are no longer releasing builds targeting i686. This breaks the autoupdate and checkver fields of the KiCad manifest.
The current [KiCad ](https://www.kicad.org/download/)manifest uses a regex based checkver on the kicad.org downloads page. This seems to have broken for version 7.0.0, which was just released. The download URL also uses the European mirror from CERN which can be quite slow.

I updated the KiCad manifest to take advantage of the Github app release feature built into Scoop for version checking and auto-updating.
KiCad releases are published on the GitHub source code mirror repository https://github.com/KiCad/kicad-source-mirror/
This will allow checkver to use the "github" key.

I also made the new cli utility available by scoop (`kicad-cli.exe`)

KiCad lite is no longer offered in recent versions of the software, so that manifest has been marked depreciated.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10573 
Closes #10865
<!-- or -->

- [ x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
