### PR TITLE
Freeplane: Update to version 1.10.6u1 & Fix checkver

### DIFF
--- a/bucket/freeplane.json
+++ b/bucket/freeplane.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.10.6",
+    "version": "1.10.6u1",
     "description": "Freeplane is a free and open source software application that supports thinking, sharing information and getting things done at work, in school and at home. The software can be used for mind mapping and analyzing the information contained in mind maps.",
     "homepage": "https://www.freeplane.org",
     "license": "GPL-2.0-or-later",
@@ -9,9 +9,9 @@
             "java/openjdk17"
         ]
     },
-    "url": "https://downloads.sourceforge.net/project/freeplane/freeplane%20stable/freeplane_bin-1.10.6.zip",
-    "hash": "sha1:69310b253646235a18b025e0d2a60c8dff84303e",
-    "extract_dir": "freeplane-1.10.6",
+    "url": "https://downloads.sourceforge.net/project/freeplane/freeplane%20stable/freeplane_bin-1.10.6u1.zip",
+    "hash": "sha1:e7548978a52a668d912756c16588a296365e9dba",
+    "extract_dir": "freeplane-1.10.6u1",
     "bin": "freeplane.exe",
     "shortcuts": [
         [

--- a/bucket/freeplane.json
+++ b/bucket/freeplane.json
@@ -20,8 +20,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.freeplane.org/info/history/history_en.txt",
-        "regex": "={3,}\\n(\\d+\\.\\d+\\.\\d+)\\n={3,}"
+        "sourceforge": "freeplane/freeplane stable",
+        "regex": "freeplane_bin-(.*)\\.zip"
     },
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/freeplane/freeplane%20stable/freeplane_bin-$version.zip",

--- a/bucket/freeplane.json
+++ b/bucket/freeplane.json
@@ -21,7 +21,7 @@
     ],
     "checkver": {
         "url": "https://www.freeplane.org/info/history/history_en.txt",
-        "regex": "=\\s+([\\d.]+)\\s+="
+        "regex": "={3,}\\n(\\d+\\.\\d+\\.\\d+)\\n={3,}"
     },
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/freeplane/freeplane%20stable/freeplane_bin-$version.zip",


### PR DESCRIPTION
there was a minor update from `1.10.6` to `1.10.6u1`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
