### PR TITLE
conda-series: fix installation error, update to the latest version

### DIFF
--- a/bucket/mambaforge.json
+++ b/bucket/mambaforge.json
@@ -15,8 +15,9 @@
     },
     "installer": {
         "script": [
-            "Start-Process -Wait \"$dir\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
-            "Remove-Item \"$dir\\$fname\""
+            "Move-Item \"$dir\\$fname\" \"$dir\\..\\$fname\"",
+            "Start-Process -Wait \"$dir\\..\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
+            "Remove-Item \"$dir\\..\\$fname\""
         ]
     },
     "uninstaller": {

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -9,16 +9,21 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe",
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe#/setup.exe",
             "hash": "d4517212c8ac44fd8b5ccc2d4d9f38c2dd924c77a81c2be92c3a72e70dd3e907"
         }
     },
     "installer": {
         "script": [
             "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
-            "Start-Process \"$dir\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+            "# Move the installer to the upper directory to avoid the error \"The installatiom directory is not empty.\"",
+            "Move-Item \"$dir\\setup.exe\" \"$dir\\..\\setup.exe\" | Out-Null",
+            "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
         ]
     },
+    "post_install": [
+        "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null"
+    ],
     "uninstaller": {
         "script": [
             "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
@@ -36,7 +41,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_$version-Windows-x86_64.exe"
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_$version-Windows-x86_64.exe#/setup.exe"
             }
         },
         "hash": {

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -6,7 +6,7 @@
     "notes": [
         "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
         "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
-        """",
+        "",
         "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
 
     ],

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.12.0",
+    "version": "23.1.0-1",
     "description": "A cross-platform, Python-agnostic binary package manager",
     "homepage": "https://conda.io/miniconda.html",
     "license": "BSD-3-Clause",
@@ -9,12 +9,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Windows-x86_64.exe#/setup.exe",
-            "hash": "1acbc2e8277ddd54a5f724896c7edee112d068529588d944702966c867e7e9cc"
-        },
-        "32bit": {
-            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Windows-x86.exe#/setup.exe",
-            "hash": "4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe",
+            "hash": "d4517212c8ac44fd8b5ccc2d4d9f38c2dd924c77a81c2be92c3a72e70dd3e907"
         }
     },
     "installer": {
@@ -30,30 +26,17 @@
             "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
         ]
     },
-    "bin": [
-        "python.exe",
-        "pythonw.exe",
-        [
-            "python.exe",
-            "python3"
-        ]
-    ],
-    "env_add_path": [
-        "scripts",
-        "Library\\bin"
-    ],
+    "bin": ["python.exe", "pythonw.exe", ["python.exe", "python3"]],
+    "env_add_path": ["scripts", "Library\\bin"],
     "persist": "envs",
     "checkver": {
         "url": "https://docs.conda.io/en/latest/miniconda.html",
-        "regex": "Miniconda3-py39_([\\d.]+)-Windows"
+        "regex": "Miniconda3-py310_([\\d.-]+)-Windows"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_$version-Windows-x86_64.exe"
-            },
-            "32bit": {
-                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_$version-Windows-x86.exe"
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_$version-Windows-x86_64.exe"
             }
         },
         "hash": {

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -5,7 +5,10 @@
     "license": "BSD-3-Clause",
     "notes": [
         "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
-        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\""
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
+        """",
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.14.0 from the Versions bucket."
+
     ],
     "architecture": {
         "64bit": {

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -21,9 +21,7 @@
             "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
         ]
     },
-    "post_install": [
-        "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null"
-    ],
+    "post_install": "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null",
     "uninstaller": {
         "script": [
             "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
@@ -31,8 +29,18 @@
             "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
         ]
     },
-    "bin": ["python.exe", "pythonw.exe", ["python.exe", "python3"]],
-    "env_add_path": ["scripts", "Library\\bin"],
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
     "persist": "envs",
     "checkver": {
         "url": "https://docs.conda.io/en/latest/miniconda.html",

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -7,7 +7,7 @@
         "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
         "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
         """",
-        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.14.0 from the Versions bucket."
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
 
     ],
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

## Miniconda3: update to version 23.1.0

Closes #10522

note that this version drops support with 32bit. same with anaconda. I have created a corresponding PR in versions bucket to reflect changes.

## Mambaforge: fix installation failed error

Closes #10498 
Closes #10420
Closes #10572 

the newest conda installer requires the installation directory to be empty. so I temporarily moves the installer to the upper directory (same with "current" link) to solve the issue

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
