### PR TITLE
ImHex autoupdate url pattern fix + upgrade

### DIFF
--- a/bucket/imhex.json
+++ b/bucket/imhex.json
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/WerWolv/ImHex/releases/download/v$version/ImHex-$version-Windows-Portable.zip"
+                "url": "https://github.com/WerWolv/ImHex/releases/download/v$version/imhex-$version-Windows-Portable-x86_64.zip"
             }
         }
     }

--- a/bucket/imhex.json
+++ b/bucket/imhex.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.26.2",
+    "version": "1.27.1",
     "description": "Hex editor",
     "homepage": "https://github.com/WerWolv/ImHex",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/WerWolv/ImHex/releases/download/v1.26.2/ImHex-1.26.2-Windows-Portable.zip",
-            "hash": "4f58097c3ccee88d8dff0d48da0f239af8a9d444903cc19a3369f63caa8d77e6"
+            "url": "https://github.com/WerWolv/ImHex/releases/download/v1.27.1/imhex-1.27.1-Windows-Portable-x86_64.zip",
+            "hash": "d59e2212e4e909292f1f25c19a209e7fbfdb90bb5da801924bdfa41ca1335c55"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
This fixes the url pattern for ImHex releases and uses the new pattern to update to version 1.27.1.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
