### PR TITLE
bitwarden: Changed `pre_install`, added `architecture`, and added `autoupdate` hash extraction

### DIFF
--- a/bucket/bitwarden.json
+++ b/bucket/bitwarden.json
@@ -3,29 +3,52 @@
     "description": "Password management solutions for individuals, teams, and business organizations",
     "homepage": "https://bitwarden.com",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/Bitwarden-Portable-2023.2.0.exe",
-    "hash": "c2c391971eac66efa87981c881771819e6e142c27e70ace035af2ea6c6bdd8f2",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/bitwarden-2023.2.0-ia32.nsis.7z",
+            "hash": "7b03deb193c70ac88182fff2d166a1a1836272b8a5e002f5adb87010b1d5cacb"
+        },
+        "64bit": {
+            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/bitwarden-2023.2.0-x64.nsis.7z",
+            "hash": "adb6ecf8ddba4cf2f80e2e531060ca6d4593e1be535f8c0e46cdb6bb5a77a944"
+        },
+        "arm64": {
+            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/bitwarden-2023.2.0-arm64.nsis.7z",
+            "hash": "c3b668c2998b1d3c88f6c195f13a53d048b5fbbb4278cc40e60e067f92b5be73"
+        }
+    },
     "pre_install": [
-        "Rename-Item \"$dir\\Bitwarden-Portable-$version.exe\" 'Bitwarden.exe'",
-        "# copy config from non-portable version",
-        "if (!(Test-Path \"$dir\\bitwarden-appdata\\*\") -and (Test-Path \"$env:Appdata\\Bitwarden\")) {",
-        "    if (!(Test-Path \"$dir\\bitwarden-appdata\")) { New-Item \"$dir\\bitwarden-appdata\" -ItemType Directory | Out-Null }",
-        "    Copy-Item \"$env:Appdata\\Bitwarden\\*\" \"$dir\\bitwarden-appdata\\\" -Recurse -Force",
+        "# copy config from portable data folder to Appdata folder",
+        "if (Test-Path \"$persist_dir\\bitwarden-appdata\") {",
+        "   Copy-Item \"$persist_dir\\bitwarden-appdata\\*\" \"$env:Appdata\\Bitwarden\" -Recurse -ErrorAction 'SilentlyContinue'",
+        "   Remove-Item $persist_dir -Recurse",
         "}"
     ],
-    "bin": "Bitwarden.exe",
     "shortcuts": [
         [
             "Bitwarden.exe",
             "Bitwarden"
         ]
     ],
-    "persist": "bitwarden-appdata",
     "checkver": {
         "url": "https://api.github.com/repos/bitwarden/clients/releases",
         "regex": "tag/desktop-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/bitwarden/clients/releases/download/desktop-v$version/Bitwarden-Portable-$version.exe"
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/bitwarden/clients/releases/download/desktop-v$version/bitwarden-$version-ia32.nsis.7z"
+            },
+            "64bit": {
+                "url": "https://github.com/bitwarden/clients/releases/download/desktop-v$version/bitwarden-$version-x64.nsis.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/bitwarden/clients/releases/download/desktop-v$version/bitwarden-$version-arm64.nsis.7z"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256-checksums.txt",
+            "regex": "$sha256\\s+$basename"
+        }
     }
 }

--- a/bucket/bitwarden.json
+++ b/bucket/bitwarden.json
@@ -1,20 +1,20 @@
 {
-    "version": "2023.2.0",
+    "version": "2023.4.0",
     "description": "Password management solutions for individuals, teams, and business organizations",
     "homepage": "https://bitwarden.com",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/bitwarden-2023.2.0-ia32.nsis.7z",
-            "hash": "7b03deb193c70ac88182fff2d166a1a1836272b8a5e002f5adb87010b1d5cacb"
+            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.4.0/bitwarden-2023.4.0-ia32.nsis.7z",
+            "hash": "64bc22f0a4b9369a47812ffdd444eb04425545b5c5617eaa3bf7a4404a3c7910"
         },
         "64bit": {
-            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/bitwarden-2023.2.0-x64.nsis.7z",
-            "hash": "adb6ecf8ddba4cf2f80e2e531060ca6d4593e1be535f8c0e46cdb6bb5a77a944"
+            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.4.0/bitwarden-2023.4.0-x64.nsis.7z",
+            "hash": "2c6ce2f729805b08e15e4b6c9c1b21253b5b582311c377d5a833727a3a2a36df"
         },
         "arm64": {
-            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.2.0/bitwarden-2023.2.0-arm64.nsis.7z",
-            "hash": "c3b668c2998b1d3c88f6c195f13a53d048b5fbbb4278cc40e60e067f92b5be73"
+            "url": "https://github.com/bitwarden/clients/releases/download/desktop-v2023.4.0/bitwarden-2023.4.0-arm64.nsis.7z",
+            "hash": "cad7f3ac31822d6362bd6b3ba7be3ef90baa4b36f5197ffcaca8f00e46e7a497"
         }
     },
     "pre_install": [
@@ -22,7 +22,8 @@
         "if (Test-Path \"$persist_dir\\bitwarden-appdata\") {",
         "   Copy-Item \"$persist_dir\\bitwarden-appdata\\*\" \"$env:Appdata\\Bitwarden\" -Recurse -ErrorAction 'SilentlyContinue'",
         "   Remove-Item $persist_dir -Recurse",
-        "}"
+        "}",
+        "Remove-Item \"$dir\\resources\\app-update.yml\""
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
This was done, because the Bitwarden electron app was NOT made to be portable. This change was made so the portable config folder's contents will be copied over to the `Appdata\Roaming` directory.

See #10651 if you want to know more of what I am talking about.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
