### PR TITLE
discord@1.0.9010-15: update homepage url

### DIFF
--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,10 +1,10 @@
 {
     "version": "1.0.9010-15",
     "description": "Free Voice and Text Chat",
-    "homepage": "https://discordapp.com/",
+    "homepage": "https://discord.com/",
     "license": {
         "identifier": "Freeware",
-        "url": "https://discordapp.com/terms"
+        "url": "https://discord.com/terms"
     },
     "url": "https://github.com/portapps/discord-portable/releases/download/1.0.9010-15/discord-portable-win32-1.0.9010-15.7z",
     "hash": "07e8fb39f18c55c3ee5fc47c1d0a86522ae71c039ce50421b5d7b7a8567c4731",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

The URL in the manifest uses the domain `discordapp.com` which redirects to `discord.com`, probably an old domain.