### PR TITLE
ventoy: use altexes directly from directory

### DIFF
--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -9,24 +9,23 @@
     "pre_install": [
         "'log.txt', 'Ventoy2Disk.ini' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
-        "}",
-        "Copy-Item \"$dir\\altexe\\*\" \"$dir\""
+        "}"
     ],
     "architecture": {
         "64bit": {
             "bin": [
                 [
-                    "Ventoy2Disk_x64.exe",
+                    "altexe\\Ventoy2Disk_x64.exe",
                     "Ventoy2Disk"
                 ]
             ],
             "shortcuts": [
                 [
-                    "Ventoy2Disk_X64.exe",
+                    "altexe\\Ventoy2Disk_X64.exe",
                     "Ventoy2Disk"
                 ],
                 [
-                    "VentoyPlugson_x64.exe",
+                    "altexe\\VentoyPlugson_x64.exe",
                     "VentoyPlugson"
                 ],
                 [
@@ -57,17 +56,17 @@
         "arm64": {
             "bin": [
                 [
-                    "Ventoy2Disk_ARM64.exe",
+                    "altexe\\Ventoy2Disk_ARM64.exe",
                     "Ventoy2Disk"
                 ]
             ],
             "shortcuts": [
                 [
-                    "Ventoy2Disk_ARM64.exe",
+                    "altexe\\Ventoy2Disk_ARM64.exe",
                     "Ventoy2Disk"
                 ],
                 [
-                    "VentoyPlugson_x64.exe",
+                    "altexe\\VentoyPlugson_x64.exe",
                     "VentoyPlugson"
                 ],
                 [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://github.com/ventoy/Ventoy/releases/tag/v1.0.89
> 2. Fix the issue that Ventoy2Disk_X64.exe can not run under altexe directory.
> 3. Fix the issue that VentoyPlugson_X64.exe exit silently.

Closes #10682

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
