### PR TITLE
textadept: Update to version 11.4 & fix autoupdate

### DIFF
--- a/bucket/textadept.json
+++ b/bucket/textadept.json
@@ -1,11 +1,11 @@
 {
-    "version": "11.3",
+    "version": "11.4",
     "description": "A fast, minimalist, and remarkably extensible cross-platform text editor",
     "homepage": "https://orbitalquark.github.io/textadept/",
     "license": "MIT",
-    "url": "https://github.com/orbitalquark/textadept/releases/download/textadept_11.3/textadept_11.3.win32.zip",
-    "hash": "60245a37fc4ea66251fe4636ca01f0747b636a2a0047ba58284a730d65fa6bd2",
-    "extract_dir": "textadept_11.3.win32",
+    "url": "https://github.com/orbitalquark/textadept/releases/download/textadept_11.4/textadept_11.4.win.zip",
+    "hash": "a41c1a1c9b0098d6c84900aab9cffe2e481a24c533d2f6447f4e24ed99b71b27",
+    "extract_dir": "textadept_11.4.win32",
     "bin": [
         "textadept.exe",
         "textadept-curses.exe"
@@ -18,7 +18,7 @@
     ],
     "checkver": "Download \\(v([\\d.]+)\\)",
     "autoupdate": {
-        "url": "https://github.com/orbitalquark/textadept/releases/download/textadept_$version/textadept_$version.win32.zip",
+        "url": "https://github.com/orbitalquark/textadept/releases/download/textadept_$version/textadept_$version.win.zip",
         "extract_dir": "textadept_$version.win32"
     }
 }


### PR DESCRIPTION


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
