### PR TITLE
hterm: Add version 0.8.9

### DIFF
--- a/bucket/hterm.json
+++ b/bucket/hterm.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.8.9",
+    "description": "terminal program for serial communication running on Windows and Linux",
+    "homepage": "https://www.der-hammer.info/pages/terminal.html",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.der-hammer.info/terminal/LICENSE.txt"
+    },
+    "url": "https://www.der-hammer.info/terminal/hterm089-windows.zip",
+    "hash": "33fbaf228a5bee7db04913b0f5d14b22126c3e7ba965d82ca0f2958dd0db56e0",
+    "shortcuts": [
+        [
+            "hterm.exe",
+            "HTerm"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.der-hammer.info/terminal/CHANGELOG.txt",
+        "regex": "Version\\s+([\\d.]+)"
+    },
+    "autoupdate": {
+		"url": "https://www.der-hammer.info/terminal/hterm$cleanVersion-windows.zip"
+    }
+}

--- a/bucket/hterm.json
+++ b/bucket/hterm.json
@@ -1,6 +1,6 @@
 {
     "version": "0.8.9",
-    "description": "terminal program for serial communication running on Windows and Linux",
+    "description": "A terminal program for serial communication.",
     "homepage": "https://www.der-hammer.info/pages/terminal.html",
     "license": {
         "identifier": "Freeware",
@@ -19,6 +19,6 @@
         "regex": "Version\\s+([\\d.]+)"
     },
     "autoupdate": {
-		"url": "https://www.der-hammer.info/terminal/hterm$cleanVersion-windows.zip"
+        "url": "https://www.der-hammer.info/terminal/hterm$cleanVersion-windows.zip"
     }
 }


### PR DESCRIPTION
Adding hterm in its current version 0.8.9 to the bucket

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
