### PR TITLE
vscode: Add line break for note

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -7,8 +7,10 @@
         "url": "https://code.visualstudio.com/License/"
     },
     "notes": [
-        "Add Visual Studio Code as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
-        "For file associations, run 'reg import \"$dir\\install-associations.reg\"'"
+        "Add Visual Studio Code as a context menu option by running:"
+        "'reg import \"$dir\\install-context.reg\"'",
+        "For file associations, run:"
+        "'reg import \"$dir\\install-associations.reg\"'"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -7,9 +7,9 @@
         "url": "https://code.visualstudio.com/License/"
     },
     "notes": [
-        "Add Visual Studio Code as a context menu option by running:"
+        "Add Visual Studio Code as a context menu option by running:",
         "'reg import \"$dir\\install-context.reg\"'",
-        "For file associations, run:"
+        "For file associations, run:",
         "'reg import \"$dir\\install-associations.reg\"'"
     ],
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Every time I reinstall, I want to use reg to add VSCode to the right-click menu. However, the terminal always breaks at inconvenient places, making this operation particularly cumbersome. So I hope to add appropriate line breaks to fix this problem.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10710
<!-- or -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
