### PR TITLE
azurestorageexplorer@1.28.1 use new naming conventions

### DIFF
--- a/bucket/azurestorageexplorer.json
+++ b/bucket/azurestorageexplorer.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.28.0",
+    "version": "1.28.1",
     "description": "Easily manage the contents of Azure storage account.",
     "homepage": "https://azure.microsoft.com/en-us/features/storage-explorer/",
     "license": "CC-BY-4.0",
-    "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.28.0/Windows_StorageExplorer.exe",
-    "hash": "4078079e105fa1528506251d0a402fa9e209b1c5916df977a7ed0b7c9f75ccc5",
+    "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.28.1/StorageExplorer-windows-ia32.exe",
+    "hash": "b19d61a5ed4323e59ec35475f18c104ee41ebd81d6062346ffc4e83b99d4858e",
     "innosetup": true,
     "bin": "StorageExplorer.exe",
     "shortcuts": [
@@ -17,6 +17,6 @@
         "github": "https://github.com/microsoft/AzureStorageExplorer"
     },
     "autoupdate": {
-        "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/Windows_StorageExplorer.exe"
+        "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-ia32.exe"
     }
 }


### PR DESCRIPTION
Azure storage explorer from 1.30.0 onwards will only use the new naming convention. The current storage explorer manifest uses the old file name scheme for url download and autoupdate. This will break in the upcoming major releases.

I have updated the storage explorer manifest to use the new naming convention.

Closes #10747

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
