### PR TITLE
Revert "micmute: Update to version 1.2.7" to 1.2.6 due to bug with mute behavior

### DIFF
--- a/bucket/micmute.json
+++ b/bucket/micmute.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.2.7",
+    "version": "1.2.6",
     "description": "Microphone controller using keyboard/mouse shortcuts",
     "homepage": "https://github.com/SaifAqqad/AHK_MicMute",
     "license": "Unlicense",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SaifAqqad/AHK_MicMute/releases/download/1.2.7/MicMute.exe",
-            "hash": "e2017c76b8b62180c80cac6f98fbfdb222c0058966b9c2f09b477f6298d76494"
+            "url": "https://github.com/SaifAqqad/AHK_MicMute/releases/download/1.2.6/MicMute.exe",
+            "hash": "ce932c49c7287ed410924c1c71f95a4d76d305640309920545420bcf465380df"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\config.json\")) { New-Item \"$dir\\config.json\" | Out-Null }",


### PR DESCRIPTION
This reverts commit 4b5cec08653ad4ccd880f18fb0ef5199d0d3fe7e due to https://github.com/SaifAqqad/AHK_MicMute/issues/82

<!-- Provide a general summary of your changes in the title above -->

Revert the update to 1.2.7 for MicMute back to the previous version 1.2.6 because of a bug making mute behavior inconsistent

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
