### PR TITLE
firefox-esr: Add private browsing shortcut

### DIFF
--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -44,10 +44,10 @@
             "Mozilla Firefox ESR\\Firefox ESR Profile Manager",
             "-P"
         ],
-		[
-			"private_browsing.exe",
-			"Mozilla Firefox ESR\\Firefox ESR Private Browsing"
-		]
+        [
+            "private_browsing.exe",
+            "Mozilla Firefox ESR\\Firefox ESR Private Browsing"
+        ]
     ],
     "persist": [
         "distribution",

--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -37,13 +37,17 @@
     "shortcuts": [
         [
             "firefox.exe",
-            "Firefox ESR"
+            "Mozilla Firefox ESR\\Firefox ESR"
         ],
         [
             "firefox.exe",
-            "Firefox ESR Profile Manager",
+            "Mozilla Firefox ESR\\Firefox ESR Profile Manager",
             "-P"
-        ]
+        ],
+		[
+			"private_browsing.exe",
+			"Mozilla Firefox ESR\\Firefox ESR Private Browsing"
+		]
     ],
     "persist": [
         "distribution",


### PR DESCRIPTION
Add private browsing shortcut and places all shortcuts under a group folder in Scoop Apps.

Relates to #10777
Relates to #10778 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
