### PR TITLE
firefox-eme-free: Add private browsing shortcut

### DIFF
--- a/bucket/firefox-eme-free.json
+++ b/bucket/firefox-eme-free.json
@@ -32,12 +32,16 @@
     "shortcuts": [
         [
             "firefox.exe",
-            "Firefox"
+            "Mozilla Firefox EME-free\\Firefox EME-free"
         ],
         [
             "firefox.exe",
-            "Firefox Profile Manager",
+            "Mozilla Firefox EME-free\\Firefox EME-free Profile Manager",
             "-P"
+        ],
+        [
+            "private_browsing.exe",
+            "Mozilla Firefox EME-free\\Firefox EME-free Private Browsing"
         ]
     ],
     "persist": [


### PR DESCRIPTION
Add private browsing shortcut and places all shortcuts under a group folder in Scoop Apps.

Relates to #10777
Relates to #10778

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
