### PR TITLE
streamlink: Update to version 5.3.1-1 and fix auto-update

### DIFF
--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -1,5 +1,5 @@
-{
-    "version": "5.1.2-1",
+
+    "version": "5.3.1-1",
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",
     "license": "BSD-2-Clause",
@@ -13,14 +13,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/streamlink/windows-builds/releases/download/5.1.2-1/streamlink-5.1.2-1-py310-x86_64.zip",
-            "hash": "40c0e22af8ba31df3de6d030428843092c10dc4cbb859cfa4ca8e0ad9f5b2b16",
-            "extract_dir": "streamlink-5.1.2-1-py310-x86_64"
+            "url": "https://github.com/streamlink/windows-builds/releases/download/5.3.1-1/streamlink-5.3.1-1-py311-x86_64.zip",
+            "hash": "4d51a46b7fb9bdf0b68ebfb27e6f70770a00f1538a7a54c20920c6ac452c6d6c",
+            "extract_dir": "streamlink-5.3.1-1-py311-x86_64"
         },
         "32bit": {
-            "url": "https://github.com/streamlink/windows-builds/releases/download/5.1.2-1/streamlink-5.1.2-1-py310-x86.zip",
-            "hash": "92f4e032a2b5f2ae47c860a4baf21a20c0104f5367ba6d0db928f3a66929db4c",
-            "extract_dir": "streamlink-5.1.2-1-py310-x86"
+            "url": "https://github.com/streamlink/windows-builds/releases/download/5.3.1-1/streamlink-5.3.1-1-py311-x86.zip",
+            "hash": "ed30bf929ccad9c96a859eaf2bae1e8402027012a04ed7b386b45de6b6caf901",
+            "extract_dir": "streamlink-5.3.1-1-py311-x86"
         }
     },
     "pre_install": [
@@ -49,12 +49,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py310-x86_64.zip",
-                "extract_dir": "streamlink-$version-py310-x86_64"
+                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py311-x86_64.zip",
+                "extract_dir": "streamlink-$version-py311-x86_64"
             },
             "32bit": {
-                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py310-x86.zip",
-                "extract_dir": "streamlink-$version-py310-x86"
+                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py311-x86.zip",
+                "extract_dir": "streamlink-$version-py311-x86"
             }
         }
     }

--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -1,4 +1,4 @@
-
+{
     "version": "5.3.1-1",
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",


### PR DESCRIPTION
Fixes streamlink that was stuck on 5.1.2-1 due to streamlink changing from `py310` naming to `py311` naming after an update to python version.

My first ever PR in GitHub, but it should be fine.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
