### PR TITLE
raspberry-pi-imager@1.7.4: Revert file name change

### DIFF
--- a/bucket/raspberry-pi-imager.json
+++ b/bucket/raspberry-pi-imager.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "Tool for writing an Raspberry Pi OS images to SD cards.",
     "homepage": "https://www.raspberrypi.org/software",
     "license": "Apache-2.0",
-    "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v1.7.3/imager_1.7.3.exe#/dl.7z",
-    "hash": "88db6e02dbca0bf49e859b89656c9d35c48653c31ca4492dadf7836149f2d854",
+    "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v1.7.4/imager-1.7.4.exe#/dl.7z",
+    "hash": "44e6f70412f0430a372c04d3bd60162d175600ab4da38da8efe20d9be3f37fac",
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninst*\" -Recurse",
     "bin": "rpi-imager.exe",
     "shortcuts": [
@@ -17,6 +17,6 @@
         "github": "https://github.com/raspberrypi/rpi-imager"
     },
     "autoupdate": {
-        "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v$version/imager_$version.exe#/dl.7z"
+        "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v$version/imager-$version.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
In #9680 the executable name was changed from a `-` separator to a `_`. It looks like this was just a typo in the release process of that specific version. Now we are back to `-`.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
