### PR TITLE
prusaslicer: extract_dir uses _signed suffix again on version 2.5.1

### DIFF
--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.5.1/PrusaSlicer-2.5.1+win64-202303151108_signed.zip",
             "hash": "662bdee3480cb4d6984af734e37ee2a8ca49e4e2d3ce3c34fb2f0f3f55687e7e",
-            "extract_dir": "PrusaSlicer-2.5.1+win64-202303151108"
+            "extract_dir": "PrusaSlicer-2.5.1+win64-202303151108_signed"
         }
     },
     "bin": "prusa-slicer-console.exe",
@@ -25,7 +25,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_$version/PrusaSlicer-$version+win64-$matchTimestamp64_signed.zip",
-                "extract_dir": "PrusaSlicer-$version+win64-$matchTimestamp64"
+                "extract_dir": "PrusaSlicer-$version+win64-$matchTimestamp64_signed"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #10666
With Release of Prusaslicer 2.5.1 on GitHub, the _signed suffix of the extract_dir exists again.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
