### PR TITLE
chromium: latest (32bit support dropped)

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,18 +1,14 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "109.0.5414.120-r1070088",
+    "version": "111.0.5563.147-r1097615",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v109.0.5414.120-r1070088/chrome.sync.7z",
-            "hash": "sha1:e5109f3de1ede645f7088e35f7e4b3194f80aa36"
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v111.0.5563.147-r1097615/chrome.sync.7z",
+            "hash": "sha1:6ef8af4e0b6ddd8f903ba34910954b7a25db1218"
         },
-        "32bit": {
-            "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v109.0.5414.120-r1070088/chrome.sync.7z",
-            "hash": "sha1:0914ccdc66e8ebd58cbad511584bd23a8aea02e8"
-        }
     },
     "extract_dir": "Chrome-bin",
     "bin": [
@@ -50,13 +46,6 @@
                     "regex": "$sha1 \\.\\./out/x64/chrome.sync.7z"
                 }
             },
-            "32bit": {
-                "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v$version/chrome.sync.7z",
-                "hash": {
-                    "url": "https://github.com/Hibbiki/chromium-win32/releases/tag/v$version",
-                    "regex": "$sha1 \\.\\./out/x86/chrome.sync.7z"
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Update for latest Chromium version from https://github.com/Hibbiki/ (and https://chromium.woolyss.com/). There are no 32bit updates anymore (https://github.com/Hibbiki/chromium-win32 is public archive). Most likely why the autoupdate failed.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
