### PR TITLE
rtss@7.3.4: Add wildcard for decompression

### DIFF
--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -10,7 +10,7 @@
     "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D.com%5D-RTSS.zip",
     "hash": "c38a21238536270078bb3f425192375f001e721ffd26346a6db5e6365aca47c5",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\RTSSSetup*.exe\" -Removal",
+        "Expand-7zipArchive \"$dir\\*RTSSSetup*.exe\" -Removal",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Guru3D.com\", \"$dir\\Uninstall*\" -Recurse",
         "Move-Item \"$dir\\RTSSHooks.dll.copy\" \"$dir\\RTSSHooks.dll\"",
         "Move-Item \"$dir\\RTSSHooks64.dll.copy\" \"$dir\\RTSSHooks64.dll\"",


### PR DESCRIPTION
Newer versions of RTSS (seemingly 7.3.4 and onwards) append "Guru3D.com" or equivalent to the beginning of the file name (for attribution or similar).

This change simply accounts for that to make sure decompression works as intended.

Closes #10886.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
