### PR TITLE
cloudcompare: add bin

### DIFF
--- a/bucket/cloudcompare.json
+++ b/bucket/cloudcompare.json
@@ -10,6 +10,7 @@
         }
     },
     "extract_dir": "CloudCompare_v2.12.4_bin_x64",
+    "bin": "CloudCompare.exe",
     "shortcuts": [
         [
             "CloudCompare.exe",


### PR DESCRIPTION
According to [Command line mode - CloudCompareWiki](https://www.cloudcompare.org/doc/wiki/index.php/Command_line_mode), CloudCompare.exe should be bin.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10902

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
