### PR TITLE
Update Powertoys 0.69.0 to use User Installer

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -16,13 +16,13 @@
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\.tmp\"",
-            "Get-ChildItem \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup*.msi\" | Rename-Item -NewName 'PowerToysSetup.msi' -Force",
+            "Get-ChildItem \"$dir\\.tmp\\AttachedContainer\\PowerToysUserSetup*.msi\" | Rename-Item -NewName 'PowerToysSetup.msi' -Force",
             "Expand-MsiArchive \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup.msi\" \"$dir\" -ExtractDir 'PowerToys'",
             "Remove-Item \"$dir\\.tmp\", \"$dir\\$fname\" -Force -Recurse"
         ]
     },
     "post_install": [
-        "foreach ($f in @('Settings', 'modules\\FileLocksmith', 'modules\\Hosts', 'modules\\MeasureTool', ",
+        "foreach ($f in @('modules\\FileLocksmith', 'modules\\Hosts', 'modules\\MeasureTool', ",
         "                 'modules\\PowerRename')) {",
         "    Get-ChildItem -Path \"$dir\\dll\\WinAppSDK\" | ForEach-Object {",
         "        New-Item -ItemType HardLink -Path \"$dir\\$f\\$($_.Name)\" -Value $_.FullName | Out-Null",

--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.69.0/PowerToysSetup-0.69.0-x64.exe",
-            "hash": "ade1e56df8cc52839fbd9db6a0bcf34e38b88aaa52544eead3c1bb023fdaf29a"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.69.0/PowerToysUserSetup-0.69.0-x64.exe",
+            "hash": "d05fc31f137718516c1d792765aafec51551fc172064bc3ee170911e455053ac"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.69.0/PowerToysSetup-0.69.0-arm64.exe",
-            "hash": "cf13f75f93462be68ca3e4c90b23f3828bbcaa44e7aa987503e73652dcb9fdf8"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.69.0/PowerToysUserSetup-0.69.0-arm64.exe",
+            "hash": "0b113eaf17eeea86299def7f73e7af15a9cbfb8033c7f9218e33bda276f37727"
         }
     },
     "installer": {
@@ -50,17 +50,17 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe",
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysUserSetup-$version-x64.exe",
                 "hash": {
                     "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
                     "regex": ">$sha256<"
                 }
             },
             "arm64": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-arm64.exe",
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysUserSetup-$version-arm64.exe",
                 "hash": {
                     "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
-                    "regex": "ARM64 Installer Hash[\\s\\S]*>$sha256<"
+                    "regex": ">(?:[a-fA-F0-9]{64})<[\\s\\S]*?>([a-fA-F0-9]{64})<"
                 }
             }
         }


### PR DESCRIPTION
Power Toys 0.69 now supports a User Only installation, which Scoop should use by default. This does not require admin privileges to install and should avoid a UAC popup when installing by Scoop.

This requires updating the hash check regex and the downloaded filename.

I will work on a PR for this, updating the powertoys.json manifest.
Relates to #10912 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
