### PR TITLE
cryptomator: Add WinFsp as a suggestion/requirement

### DIFF
--- a/bucket/cryptomator.json
+++ b/bucket/cryptomator.json
@@ -3,6 +3,9 @@
     "description": "Multi-platform transparent client-side encryption of files in the cloud",
     "homepage": "https://cryptomator.org",
     "license": "GPL-3.0-only",
+    "suggest": {
+        "WinFSP": "nonportable/winfsp-np", 
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/cryptomator/cryptomator/releases/download/1.7.5/Cryptomator-1.7.5-x64.msi",

--- a/bucket/cryptomator.json
+++ b/bucket/cryptomator.json
@@ -4,7 +4,7 @@
     "homepage": "https://cryptomator.org",
     "license": "GPL-3.0-only",
     "suggest": {
-        "WinFSP": "nonportable/winfsp-np", 
+        "WinFSP": "nonportable/winfsp-np"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above -->
Cryptomator doesn't work without WinFsp. It runs but unlocking vaults crashes the app. The official website's download includes it as a third-party driver. I'd even lean towards using the `depends` instead of `suggest` prop. 

To be discussed.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
