### PR TITLE
sweethome3d: fix decompress error

### DIFF
--- a/bucket/sweethome3d.json
+++ b/bucket/sweethome3d.json
@@ -3,10 +3,10 @@
     "description": "A free interior design application that helps you draw the plan of your house, arrange furniture on it and visit the results in 3D.",
     "homepage": "http://www.sweethome3d.com/",
     "license": "GPL-2.0-or-later",
+    "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z#/dl.7z_",
+    "hash": "sha1:b4f2997b831f254e0448363d43021cbec6dd7645",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z#/dl.7z_",
-            "hash": "sha1:b4f2997b831f254e0448363d43021cbec6dd7645",
             "bin": [
                 [
                     "SweetHome3D-windows-x64.exe",
@@ -21,8 +21,6 @@
             ]
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z#/dl.7z_",
-            "hash": "sha1:b4f2997b831f254e0448363d43021cbec6dd7645",
             "bin": [
                 [
                     "SweetHome3D-windows-x86.exe",
@@ -41,10 +39,10 @@
         "script": [
             "Expand-7zipArchive \"$dir\\$fname\" \"$dir\" -Switch \"-xr!SweetHome3D-macosx.app\" -Removal",
             "Move-Item \"$dir\\SweetHome3D-$version-portable\\*\" \"$dir\"",
-            "Remove-Item \"$dir\\SweetHome3D-$version-portable\" "
+            "Remove-Item \"$dir\\SweetHome3D-$version-portable\""
         ]
     },
-    "post_install": "if (!(Test-Path \"$persist_dir\\data\\preferences.xml\")) {New-Item \"$dir\\data\\preferences.xml\" | Out-Null}",
+    "post_install": "if (!(Test-Path \"$persist_dir\\data\\preferences.xml\")) { New-Item \"$dir\\data\\preferences.xml\" | Out-Null }",
     "persist": [
         "data\\preferences.xml",
         "data\\plugins",
@@ -56,14 +54,7 @@
         "regex": "id=\"SweetHome3D#Portable\"\\s+version=\"([\\d.]+)\""
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z#/dl.7z_"
-            },
-            "32bit": {
-                "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z#/dl.7z_"
-            }
-        },
+        "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z#/dl.7z_",
         "extract_dir": "SweetHome3D-$version-portable"
     }
 }

--- a/bucket/sweethome3d.json
+++ b/bucket/sweethome3d.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z",
+            "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z#/dl.7z_",
             "hash": "sha1:b4f2997b831f254e0448363d43021cbec6dd7645",
             "bin": [
                 [
@@ -21,7 +21,7 @@
             ]
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z",
+            "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-7.1/SweetHome3D-7.1-portable.7z#/dl.7z_",
             "hash": "sha1:b4f2997b831f254e0448363d43021cbec6dd7645",
             "bin": [
                 [
@@ -37,8 +37,14 @@
             ]
         }
     },
-    "extract_dir": "SweetHome3D-7.1-portable",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\data\\preferences.xml\")) {New-Item \"$dir\\data\\preferences.xml\" | Out-Null}",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\$fname\" \"$dir\" -Switch \"-xr!SweetHome3D-macosx.app\" -Removal",
+            "Move-Item \"$dir\\SweetHome3D-$version-portable\\*\" \"$dir\"",
+            "Remove-Item \"$dir\\SweetHome3D-$version-portable\" "
+        ]
+    },
+    "post_install": "if (!(Test-Path \"$persist_dir\\data\\preferences.xml\")) {New-Item \"$dir\\data\\preferences.xml\" | Out-Null}",
     "persist": [
         "data\\preferences.xml",
         "data\\plugins",
@@ -52,10 +58,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z"
+                "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z#/dl.7z_"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z"
+                "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-portable.7z#/dl.7z_"
             }
         },
         "extract_dir": "SweetHome3D-$version-portable"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10937 #10547

Problem solved by not unzipping the folder SweetHome3D-macosx.app.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
