### PR TITLE
autohotkey: Download from Github Release

### DIFF
--- a/bucket/autohotkey.json
+++ b/bucket/autohotkey.json
@@ -10,7 +10,7 @@
         "  - 'autohotkey /script \"$dir\\UX\\ui-uninstall.ahk\"'",
         "See also: https://github.com/ScoopInstaller/Extras/issues/10066"
     ],
-    "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_2.0.2.zip",
+    "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v2.0.2/AutoHotkey_2.0.2.zip",
     "hash": "8f28c38a0b2af6ac96c4a7e1a2c0f296b2410f845d9aca8487843a1edac4271d",
     "extract_to": "installer",
     "installer": {
@@ -78,9 +78,9 @@
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_$version.zip",
+        "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v$version/AutoHotkey_$version.zip",
         "hash": {
-            "url": "$url.sha256"
+            "url": "https://www.autohotkey.com/download/2.0/AutoHotkey_$version.zip.sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #10270
<!-- or -->

It looks like https://www.autohotkey.com is using Cloudflare as the CDN provider, which may cause the download to fail, so we go to Github Release to download the file and get the hash from the original URL


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
