### PR TITLE
ios-webkit-debug-proxy: Update to version 1.9.0 and fix autoupdate

### DIFF
--- a/bucket/ios-webkit-debug-proxy.json
+++ b/bucket/ios-webkit-debug-proxy.json
@@ -1,19 +1,16 @@
 {
-    "version": "1.8.8",
+    "version": "1.9.0",
     "description": "A DevTools proxy (Chrome Remote Debugging Protocol) for iOS devices (Safari Remote Web Inspector).",
     "homepage": "https://github.com/google/ios-webkit-debug-proxy",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.8.8/ios-webkit-debug-proxy-1.8.8-win64-bin.zip",
-            "hash": "f630a632d33f8bc9fb9b402afafecd42a5de486df7b42fd720827da065658e95"
+            "url": "https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.9.0/ios-webkit-debug-proxy-1.9.0-win64-bin.zip",
+            "hash": "2d4ca676a0cb10cb94d9b641eb1f4cee20102d500feda1389e1814eec464690e"
         }
     },
     "bin": "ios_webkit_debug_proxy.exe",
-    "checkver": {
-        "url": "https://github.com/google/ios-webkit-debug-proxy/releases",
-        "regex": "/ios-webkit-debug-proxy-([\\d.]+)-win64-bin.zip"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
