### PR TITLE
v2rayn: Fix `pre_install`

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -11,8 +11,7 @@
     "url": "https://github.com/2dust/v2rayN/releases/download/6.21/v2rayN.zip",
     "hash": "4d1cd20eaadcbea498f67f3ff7419c5cd84d78136077bf3ce1a8d722a5c141e2",
     "extract_dir": "v2rayN",
-    "pre_install": [
-        "}",
+    "pre_install":
         "foreach ($form in @('*.exe', '*.dat')) {",
         "    foreach ($_ in Get-ChildItem \"$(appdir xray $global)\\current\" -File) {",
         "        $name = $_.Name",


### PR DESCRIPTION
v2rayn: Fix `pre_install` Unexpected token '}' in expression

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
