### PR TITLE
clash-mini: fix `shortcuts`

### DIFF
--- a/bucket/clash-mini.json
+++ b/bucket/clash-mini.json
@@ -15,7 +15,11 @@
     },
     "shortcuts": [
         [
-            "Clash.Mini.exe",
+            "Clash.Mini_x64.exe",
+            "Clash.Mini"
+        ],
+        [
+            "Clash.Mini_x86.exe",
             "Clash.Mini"
         ]
     ],


### PR DESCRIPTION
clash-mini: fix `shortcuts`

```
Creating shortcut for Clash.Mini (Clash.Mini.exe) failed: Couldn't find \scoop\apps\clash-mini\current\Clash.Mini.exe
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
