### PR TITLE
textadept: 11.4 fix extract_dir name ".win" vs ".win32"

### DIFF
--- a/bucket/textadept.json
+++ b/bucket/textadept.json
@@ -19,6 +19,6 @@
     "checkver": "Download \\(v([\\d.]+)\\)",
     "autoupdate": {
         "url": "https://github.com/orbitalquark/textadept/releases/download/textadept_$version/textadept_$version.win.zip",
-        "extract_dir": "textadept_$version.win32"
+        "extract_dir": "textadept_$version.win"
     }
 }

--- a/bucket/textadept.json
+++ b/bucket/textadept.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/orbitalquark/textadept/releases/download/textadept_11.4/textadept_11.4.win.zip",
     "hash": "a41c1a1c9b0098d6c84900aab9cffe2e481a24c533d2f6447f4e24ed99b71b27",
-    "extract_dir": "textadept_11.4.win32",
+    "extract_dir": "textadept_11.4.win",
     "bin": [
         "textadept.exe",
         "textadept-curses.exe"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes issue with renamed folder within provided zip
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11023 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
