### PR TITLE
kid3: fix autoupdate with releases

### DIFF
--- a/bucket/kid3.json
+++ b/bucket/kid3.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/kid3/kid3/3.9.3/kid3-3.9.3-1-win32-x64.zip",
             "hash": "sha1:a28468df977682a4263e0245fe15d963923291fe",
-            "extract_dir": "kid3-3.9.3-1-win32-x64"
+            "extract_dir": "kid3-3.9.3-win32-x64"
         }
     },
     "bin": [
@@ -23,12 +23,12 @@
             "Kid3"
         ]
     ],
-    "checkver": "kid3-([\\d.-]+)-win32-x64\\.zip",
+    "checkver": "kid3-(?<version>(?<short>[\\d.]+)(?:-\\d+)?)-win32-x64\\.zip",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/kid3/kid3/$matchHead/kid3-$version-win32-x64.zip",
-                "extract_dir": "kid3-$version-win32-x64"
+                "url": "https://downloads.sourceforge.net/project/kid3/kid3/$matchShort/kid3-$version-win32-x64.zip",
+                "extract_dir": "kid3-$matchShort-win32-x64"
             }
         }
     }


### PR DESCRIPTION
Relates to https://github.com/ScoopInstaller/Extras/pull/10970#issuecomment-1506782703

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

This should be a better fix to #10970 and #11040.
