### PR TITLE
xc@0.3.0: Add arm64 architecture

### DIFF
--- a/bucket/xc.json
+++ b/bucket/xc.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/joerdav/xc/releases/download/v0.3.0/xc_0.3.0_windows_386.exe#/xc.exe",
             "hash": "f1eac51e3c185947fd64fa6deba72744c3d92a3535a1a0b3a6c60e2c93c98f5d"
+        },
+        "arm64": {
+            "url": "https://github.com/joerdav/xc/releases/download/v0.3.0/xc_0.3.0_windows_arm64.exe#/xc.exe",
+            "hash": "bbd6a0657635a92c782ce2f9084629d803d411e22c4a107bd1343fcc2226f161"
         }
     },
     "bin": "xc.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/joerdav/xc/releases/download/v$version/xc_$version_windows_386.exe#/xc.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/joerdav/xc/releases/download/v$version/xc_$version_windows_arm64.exe#/xc.exe"
             }
         },
         "hash": {

--- a/bucket/xc.json
+++ b/bucket/xc.json
@@ -1,7 +1,7 @@
 {
     "version": "0.3.0",
     "description": "Simple, Convenient, Markdown defined task runner.",
-    "homepage": "https://github.com/joerdav/xc",
+    "homepage": "https://xcfile.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
@@ -18,7 +18,9 @@
         }
     },
     "bin": "xc.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/joerdav/xc"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
- Add arm64 version.
- Update homepage.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
