### PR TITLE
fastcopy: Update manifest

### DIFF
--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -1,31 +1,21 @@
 {
-    "version": "4.2.2",
+    "version": "5.0.2",
     "description": "The Fastest copy/backup software.",
-    "homepage": "https://fastcopy.jp",
+    "homepage": "https://fastcopy.jp/",
     "license": {
         "identifier": "Freeware",
         "url": "https://fastcopy.jp/help/fastcopy_eng.htm#license"
     },
-    "url": "https://fastcopy.jp/archive/FastCopy4.2.2_installer.exe",
-    "hash": "1192ff6459440840df651c2e4049a6db3fbafa0d6809637db3092a7c0f19ba33",
-    "pre_install": [
-        "if ($architecture -eq '64bit') {Invoke-ExternalCommand \"$dir\\$fname\" '/EXTRACT64' | Out-Null }",
-        "elseif ($architecture -eq '32bit') {Invoke-ExternalCommand \"$dir\\$fname\" '/EXTRACT32' | Out-Null }",
-        "Get-ChildItem \"$dir\\FastCopy$version*\\*\" -Recurse | Move-Item -Destination $dir",
-        "Remove-Item \"$dir\\$fname\", \"$dir\\FastCopy$version*\", \"$dir\\setup.exe\"",
-        "",
-        "if (!(Test-Path \"$persist_dir\\FastCopy.log\")) { New-Item \"$dir\\FastCopy.log\" | Out-Null }",
-        "if (!(Test-Path \"$persist_dir\\FastCopy2.ini\")) {",
-        "   Set-Content \"$dir\\FastCopy2.ini\" '[main]' -Encoding ASCII",
-        "}"
+    "notes": [
+        "If an error occurs when updating or uninstalling, execute the following command then retry:",
+        "`Stop-Process -Name 'explorer'`"
     ],
-    "pre_uninstall": [
-        "'FastEx64.dll', 'FastExt1.dll' | ForEach-Object {",
-        "    Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\$_\", '/s') | Out-Null",
-        "}",
-        "# restart explorer to avoid 'file in use' error",
-        "Stop-Process -Name 'explorer'; Start-Sleep -Seconds 2",
-        "if (!(Get-Process 'explorer' -ErrorAction SilentlyContinue)) { explorer }"
+    "url": "https://fastcopy.jp/archive/FastCopy5.0.2_installer.exe",
+    "hash": "b15ed66a8e5b88b81899bf2c161dc7fa9e8827866139589855ab9391044c859b",
+    "pre_install": [
+        "Start-Process \"$dir\\$fname\" -Args @('/SILENT', \"/DIR=$dir\", '/NOPROG', '/NODESK') -Wait",
+        "Copy-Item \"$persist_dir\\FastCopy.log\", \"$persist_dir\\FastCopy2.ini\" -Destination \"$dir\" -ErrorAction SilentlyContinue",
+        "Remove-Item \"$dir\\$fname\""
     ],
     "bin": [
         "FastCopy.exe",
@@ -43,11 +33,13 @@
         ]
     ],
     "persist": [
-        "Log",
-        "FastCopy.log",
-        "FastCopy2.ini"
+        "Log"
     ],
-    "checkver": "FastCopy ver ([\\d.]+)",
+    "pre_uninstall": [
+        "Copy-Item \"$dir\\FastCopy.log\", \"$dir\\FastCopy2.ini\" -Destination \"$persist_dir\" -ErrorAction SilentlyContinue",
+        "Start-Process \"$dir\\setup.exe\" -Args @('/SILENT', '/r') -Wait"
+    ],
+    "checkver": "Download v([\\d.]+)",
     "autoupdate": {
         "url": "https://fastcopy.jp/archive/FastCopy$version_installer.exe"
     }


### PR DESCRIPTION
- Update to version 5.0.2
- Update (un)install scripts
  1. Concise
  2. Remove `tskill explorer`-like as it may interrupt what the user doing
  3. Use (un)install functions of the program itself


`checkver` temporarily invalidated, probably accessed the cache.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11069

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
