### PR TITLE
akelpad: Fix download url

### DIFF
--- a/bucket/akelpad.json
+++ b/bucket/akelpad.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": [
                 "https://downloads.sourceforge.net/project/akelpad/AkelPad%204/4.9.8/x64/AkelPad-4.9.8-x64-bin-eng.zip",
-                "http://akelpad.sourceforge.net/files/tools/AkelUpdater.zip"
+                "https://akelpad.sourceforge.net/files/tools/AkelUpdater.zip"
             ],
             "hash": [
                 "sha1:bf31285377fd70627b1dc93ebfb3f7cb88fe913b",
@@ -17,7 +17,7 @@
         "32bit": {
             "url": [
                 "https://downloads.sourceforge.net/project/akelpad/AkelPad%204/4.9.8/AkelPad-4.9.8-bin-eng.zip",
-                "http://akelpad.sourceforge.net/files/tools/AkelUpdater.zip"
+                "https://akelpad.sourceforge.net/files/tools/AkelUpdater.zip"
             ],
             "hash": [
                 "sha1:b95c8bd7c9c05c431cc9233af4c3bd698a1f5ec5",

--- a/bucket/akelpad.json
+++ b/bucket/akelpad.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://downloads.sourceforge.net/project/akelpad/files/AkelPad%204/4.9.8/x64/AkelPad-4.9.8-x64-bin-eng.zip",
+                "https://downloads.sourceforge.net/project/akelpad/AkelPad%204/4.9.8/x64/AkelPad-4.9.8-x64-bin-eng.zip",
                 "http://akelpad.sourceforge.net/files/tools/AkelUpdater.zip"
             ],
             "hash": [
@@ -16,7 +16,7 @@
         },
         "32bit": {
             "url": [
-                "https://downloads.sourceforge.net/project/akelpad/files/AkelPad%204/4.9.8/AkelPad-4.9.8-bin-eng.zip",
+                "https://downloads.sourceforge.net/project/akelpad/AkelPad%204/4.9.8/AkelPad-4.9.8-bin-eng.zip",
                 "http://akelpad.sourceforge.net/files/tools/AkelUpdater.zip"
             ],
             "hash": [
@@ -53,10 +53,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/akelpad/files/AkelPad%20$majorVersion/$version/x64/AkelPad-$version-x64-bin-eng.zip"
+                "url": "https://downloads.sourceforge.net/project/akelpad/AkelPad%20$majorVersion/$version/x64/AkelPad-$version-x64-bin-eng.zip"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/akelpad/files/AkelPad%20$majorVersion/$version/AkelPad-$version-bin-eng.zip"
+                "url": "https://downloads.sourceforge.net/project/akelpad/AkelPad%20$majorVersion/$version/AkelPad-$version-bin-eng.zip"
             }
         }
     }


### PR DESCRIPTION

Relates to https://repology.org/repository/scoop/problems


Project | Package name | Maintainer | Problem
-- | -- | -- | --
akelpad | akelpad | - | Download link https://downloads.sourceforge.net/project/akelpad/files/AkelPad%204/4.9.8/AkelPad-4.9.8-bin-eng.zip is dead (HTTP 404) 				for more than a month and should be replaced by alive link (see other packages for hints).
akelpad | akelpad | - | Download link https://downloads.sourceforge.net/project/akelpad/files/AkelPad%204/4.9.8/x64/AkelPad-4.9.8-x64-bin-eng.zip is dead (HTTP 404) 				for more than a month and should be replaced by alive link (see other packages for hints).
akelpad | akelpad | - | Download link http://akelpad.sourceforge.net/files/tools/AkelUpdater.zip is a permanent redirect to its HTTPS counterpart https://akelpad.sourceforge.net/files/tools/AkelUpdater.zip and should be updated.




- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
