### PR TITLE
ausweisapp2: Update homepage

### DIFF
--- a/bucket/ausweisapp2.json
+++ b/bucket/ausweisapp2.json
@@ -1,7 +1,7 @@
 {
     "version": "1.26.3",
     "description": "Authenticate to websites with german ID.",
-    "homepage": "https://www.ausweisapp.bund.de/en/ausweisapp2-home/",
+    "homepage": "https://www.ausweisapp.bund.de/",
     "license": "EUPL-1.2",
     "url": "https://github.com/Governikus/AusweisApp2/releases/download/1.26.3/AusweisApp2-1.26.3.msi",
     "hash": "5d1a17faaa68cb0df293908d1e6f29b69c3e2b1b0a9e118d4f5de71e156068c2",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://repology.org/repository/scoop/problems

Homepage link https://www.ausweisapp.bund.de/en/ausweisapp2-home/ is [dead](https://repology.org/link/https://www.ausweisapp.bund.de/en/ausweisapp2-home/) (Connect timeout (60 seconds)) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
