### PR TITLE
apache-directory-studio: Update urls

### DIFF
--- a/bucket/apache-directory-studio.json
+++ b/bucket/apache-directory-studio.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.0.v20210717-M17",
     "description": "LDAP browser and directory client",
-    "homepage": "http://directory.apache.org/studio/",
+    "homepage": "https://directory.apache.org/studio/",
     "license": "Apache-2.0",
     "suggest": {
         "JDK": [
@@ -11,7 +11,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.apache.org/dist/directory/studio/2.0.0.v20210717-M17/ApacheDirectoryStudio-2.0.0.v20210717-M17-win32.win32.x86_64.zip",
+            "url": "https://downloads.apache.org/directory/studio/2.0.0.v20210717-M17/ApacheDirectoryStudio-2.0.0.v20210717-M17-win32.win32.x86_64.zip",
             "hash": "sha512:dced42bd1995bf328a86d5eec72f08a96b0ccd7f1b8104772bd0a7c360580e6c6654cd0e5f0a8b92c42e0022a4fa81745ed02ad16d32091349358fbd002a15d9"
         }
     },
@@ -24,13 +24,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.apache.org/dist/directory/studio/?C=M;O=D",
+        "url": "https://downloads.apache.org/directory/studio/?C=M;O=D",
         "regex": ">([\\dvM.-]+)/<"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.apache.org/dist/directory/studio/$version/ApacheDirectoryStudio-$version-win32.win32.x86_64.zip"
+                "url": "https://downloads.apache.org/directory/studio/$version/ApacheDirectoryStudio-$version-win32.win32.x86_64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relate to https://repology.org/repository/scoop/problems

1. Homepage link http://directory.apache.org/studio/ is a permanent redirect to its HTTPS counterpart https://directory.apache.org/studio/ and should be updated. 

2. https://www.apache.org/dist redirect to https://downloads.apache.org


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
