### PR TITLE
AnyBurn@5.6: Fix md5 hash

### DIFF
--- a/bucket/anyburn.json
+++ b/bucket/anyburn.json
@@ -7,7 +7,7 @@
         "url": "http://www.anyburn.com/tutorials/eula.htm"
     },
     "url": "http://www.anyburn.com/anyburn.zip",
-    "hash": "md5:87072db896e761375981c31cb2997162",
+    "hash": "md5:3D14878028A095379EABD2348FE62CC8",
     "architecture": {
         "64bit": {
             "extract_dir": "AnyBurn(64-bit)"


### PR DESCRIPTION
Although the version number hasn't changed, the available file has been updated and has a new hash. Manually fixing what checkver missed...

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
