### PR TITLE
b1: Downgrade to http

### DIFF
--- a/bucket/b1.json
+++ b/bucket/b1.json
@@ -1,12 +1,12 @@
 {
     "version": "1.7.120",
-    "homepage": "https://b1.org/",
+    "homepage": "http://b1.org/",
     "description": "A user-friendly and free file archiver.",
     "license": {
         "identifier": "Freeware",
-        "url": "https://b1.org/eula.jsp"
+        "url": "http://b1.org/eula.jsp"
     },
-    "url": "https://b1.org/smart-download/0/os=windows&standalone=true/B1FreeArchiver_1.7.120.exe#/dl.7z",
+    "url": "http://b1.org/smart-download/0/os=windows&standalone=true/B1FreeArchiver_1.7.120.exe#/dl.7z",
     "hash": "D07836EE5CA6D6EB9F501F3F5484AC5D49B8F0914F31A669AE5EE40670DDC5BE",
     "bin": "b1.exe",
     "shortcuts": [
@@ -16,10 +16,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://b1.org/download",
+        "url": "http://b1.org/download",
         "regex": "B1FreeArchiver_([\\d.]+).exe"
     },
     "autoupdate": {
-        "url": "https://b1.org/smart-download/0/os=windows&standalone=true/B1FreeArchiver_$version.exe#/dl.7z"
+        "url": "http://b1.org/smart-download/0/os=windows&standalone=true/B1FreeArchiver_$version.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

As the upstream SSL certificate has expired for more than 1 month, switch to http to ensure proper update and download of the software.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
