### PR TITLE
uniextract2: Fix checkver

### DIFF
--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -29,7 +29,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/Bioruebe/UniExtract2/releases",
+        "url": "https://api.github.com/repos/Bioruebe/UniExtract2/releases",
+        "jsonpath": "$..browser_download_url",
         "regex": "download/v([\\w.-]+)/(?<filename>\\w+\\.zip)"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

uniextract2: couldn't match 'download/v([\w.-]+)/(?<filename>\w+\.zip)' in https://github.com/Bioruebe/UniExtract2/releases


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
