### PR TITLE
yumi-exfat: Update to version 1.0.1.6a and fix checkver

### DIFF
--- a/bucket/yumi-exfat.json
+++ b/bucket/yumi-exfat.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.0.1.6",
+    "version": "1.0.1.6a",
     "description": "Multiboot USB Creator. Supports exFAT format, BIOS and UEFI USB boot.",
     "homepage": "https://www.pendrivelinux.com/yumi-multiboot-usb-creator/",
     "license": "GPL-2.0-or-later",
-    "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-exFAT-1.0.1.6.exe#/YUMI-exFAT.exe",
-    "hash": "413e7e0a6a5b55b7de1fae9d218a284e73b7e293de448b087b557cffde526bda",
+    "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-exFAT-1.0.1.6a.exe#/YUMI-exFAT.exe",
+    "hash": "424e455013500ec94a05dd8d33f82bda64f119956e66034adf0893c568b24200",
     "shortcuts": [
         [
             "YUMI-exFAT.exe",
             "YUMI-exFAT"
         ]
     ],
-    "checkver": "YUMI-exFAT-([\\d.]+)\\.exe",
+    "checkver": "YUMI-exFAT-([\\w\\d.]+)\\.exe",
     "autoupdate": {
         "url": "https://www.pendrivelinux.com/downloads/YUMI/YUMI-exFAT-$version.exe#/YUMI-exFAT.exe",
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

yumi-exfat: couldn't match 'YUMI-exFAT-([\d.]+)\.exe' in https://www.pendrivelinux.com/yumi-multiboot-usb-creator/

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
