### PR TITLE
ubports-installer: Update to version 0.9.10-beta and fix autoupdate

### DIFF
--- a/bucket/ubports-installer.json
+++ b/bucket/ubports-installer.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.7-beta",
+    "version": "0.9.10-beta",
     "description": "A friendly cross-platform Installer for Ubuntu Touch.",
     "homepage": "https://ubuntu-touch.io//ubuntu-touch.io",
     "license": "GPL-3.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ubports/ubports-installer/releases/download/0.9.7-beta/ubports-installer_0.9.7-beta_win_x64.exe#/dl.7z",
-            "hash": "e610449ff0912a7940b67abc710f279e511ac017a3806e39859b7b291e5f484b"
+            "url": "https://github.com/ubports/ubports-installer/releases/download/0.9.10/ubports-installer_0.9.10-beta_win_x64.exe#/dl.7z",
+            "hash": "b2d85f8a55ed15b9fd84f5209a361508502bfe22d5dca3a076c4f1129ec72cc2"
         }
     },
     "pre_install": [
@@ -32,13 +32,14 @@
     ],
     "persist": "APPDATA",
     "checkver": {
-        "url": "https://github.com/ubports/ubports-installer/releases",
-        "regex": "ubports-installer_([\\w.-]+)_win_x64\\.exe"
+        "url": "https://api.github.com/repos/ubports/ubports-installer/releases",
+        "jsonpath": "$..browser_download_url",
+        "regex": "/download/(?<tag>[\\w.-]+)/ubports-installer_([\\w.-]+)_win_x64\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ubports/ubports-installer/releases/download/$version/ubports-installer_$version_win_x64.exe#/dl.7z",
+                "url": "https://github.com/ubports/ubports-installer/releases/download/$matchTag/ubports-installer_$version_win_x64.exe#/dl.7z",
                 "hash": {
                     "url": "$url.sha256"
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

ubports-installer: couldn't match 'ubports-installer_([\w.-]+)_win_x64\.exe' in https://github.com/ubports/ubports-installer/releases


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
