### PR TITLE
vidiot: Update to version 0.3.38 and fix autoupdate

### DIFF
--- a/bucket/vidiot.json
+++ b/bucket/vidiot.json
@@ -8,11 +8,6 @@
             "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-0.3.38-win64.zip",
             "hash": "sha1:41e1a28fa3ac8861aee57d46be57cabe4872f47d",
             "extract_dir": "Vidiot-0.3.38-win64"
-        },
-        "32bit": {
-            "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-0.3.37-win32.zip",
-            "hash": "sha1:fb7396f291c1abb5add59f3bc9ddba7520dec3d0",
-            "extract_dir": "Vidiot-0.3.37-win32"
         }
     },
     "bin": "vidiot.exe",
@@ -23,28 +18,14 @@
         ]
     ],
     "checkver": {
-        "script": [
-            "$url = 'https://sourceforge.net/projects/vidiot/rss?path=/'",
-            "$cont = (Invoke-WebRequest $url).Content",
-            "$r = 'Vidiot-([\\d.]+)-win64.zip'",
-            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; continue }",
-            "$version = $matches[1]",
-            "$r = 'Vidiot-([\\d.]+)-win32.zip'",
-            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; continue }",
-            "$version32 = $matches[1]",
-            "Write-Output $version $version32"
-        ],
-        "regex": "([\\d.]+) (?<version32>[\\d.]+)"
+        "url": "https://sourceforge.net/projects/vidiot/files/",
+        "regex": "Release\\s+([\\d.]+)\\s+\\(r"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-$version-win64.zip",
                 "extract_dir": "Vidiot-$version-win64"
-            },
-            "32bit": {
-                "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-$matchVersion32-win32.zip",
-                "extract_dir": "Vidiot-$matchVersion32-win32"
             }
         }
     }

--- a/bucket/vidiot.json
+++ b/bucket/vidiot.json
@@ -1,17 +1,17 @@
 {
-    "version": "0.3.37",
+    "version": "0.3.38",
     "description": "A non-linear video editor targeted for home video editing.",
     "homepage": "https://sourceforge.net/projects/vidiot",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-0.3.37-win64.zip",
-            "hash": "8f015a725db0ba36e8c102c62ef2e158729a08ded70e8960f820fb1a41f589f0",
-            "extract_dir": "Vidiot-0.3.37-win64"
+            "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-0.3.38-win64.zip",
+            "hash": "sha1:41e1a28fa3ac8861aee57d46be57cabe4872f47d",
+            "extract_dir": "Vidiot-0.3.38-win64"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-0.3.37-win32.zip",
-            "hash": "e82ec32ee141414f2c1d72334440b5f10cb8000236674a87642baf5819aa0660",
+            "hash": "sha1:fb7396f291c1abb5add59f3bc9ddba7520dec3d0",
             "extract_dir": "Vidiot-0.3.37-win32"
         }
     },
@@ -23,8 +23,18 @@
         ]
     ],
     "checkver": {
-        "url": "https://sourceforge.net/projects/vidiot/files/",
-        "regex": "Release\\s+([\\d.]+)\\s+\\(r"
+        "script": [
+            "$url = 'https://sourceforge.net/projects/vidiot/rss?path=/'",
+            "$cont = (Invoke-WebRequest $url).Content",
+            "$r = 'Vidiot-([\\d.]+)-win64.zip'",
+            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; continue }",
+            "$version = $matches[1]",
+            "$r = 'Vidiot-([\\d.]+)-win32.zip'",
+            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; continue }",
+            "$version32 = $matches[1]",
+            "Write-Output $version $version32"
+        ],
+        "regex": "([\\d.]+) (?<version32>[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -33,8 +43,8 @@
                 "extract_dir": "Vidiot-$version-win64"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-$version-win32.zip",
-                "extract_dir": "Vidiot-$version-win32"
+                "url": "https://downloads.sourceforge.net/project/vidiot/Vidiot-$matchVersion32-win32.zip",
+                "extract_dir": "Vidiot-$matchVersion32-win32"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

vidiot: 0.3.38 (scoop version is 0.3.37) autoupdate available
Autoupdating vidiot
Could not find hash in https://sourceforge.net/projects/vidiot/files
Downloading Vidiot-0.3.38-win32.zip to compute hashes!
The remote server returned an error: (404) Not Found.


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
