### PR TITLE
kdiff3: Update to version 1.10.1

### DIFF
--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.9.6",
+    "version": "1.10.1",
     "description": "Utility for comparing and merging files and directories",
-    "homepage": "https://invent.kde.org/sdk/kdiff3",
+    "homepage": "https://apps.kde.org/kdiff3/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/kdiff3/kdiff3-1.9.6-windows-64-cl.exe#/dl.7z",
-            "hash": "5b56ebad1ab980fbc22404c2ae9dacfb674d7f46e2734dbfcf261ba4f991d133"
+            "url": "https://download.kde.org/stable/kdiff3/kdiff3-1.10.1-windows-x86_64.exe#/dl.7z",
+            "hash": "55dca4c7ac058a5eeac6b68c0bc88e37a329f2ccabe21b7baab78418e412f090"
         }
     },
     "pre_install": [
@@ -22,7 +22,7 @@
     ],
     "checkver": {
         "url": "https://download.kde.org/stable/kdiff3/?C=M;O=D",
-        "regex": "(?<file>kdiff3-((?<version>[\\d.]+\\w?))-windows[-_]64(-cl)?)\\.exe"
+        "regex": "(?<file>kdiff3-(?<version>[\\d.]+(\\w)?)-windows(-cl|-(x86_)?64)+)\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
KDE doesn't release with fixed filenames, thus the checkver regex needs to be updated to match also the latest file name.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
