### PR TITLE
peazip: Fix persist.

### DIFF
--- a/bucket/peazip.json
+++ b/bucket/peazip.json
@@ -30,11 +30,11 @@
         ]
     ],
     "persist": [
-        "res\\altconf.txt",
-        "res\\bookmarks.txt",
-        "res\\conf.txt",
-        "res\\conf-lastgood.txt",
-        "res\\custedit.txt"
+        "res\\conf\\altconf.txt",
+        "res\\conf\\bookmarks.txt",
+        "res\\conf\\conf.txt",
+        "res\\conf\\conf-lastgood.txt",
+        "res\\conf\\custedit.txt"
     ],
     "checkver": {
         "url": "https://osdn.net/projects/peazip/",


### PR DESCRIPTION
fixes #9046 again.

It seems that the last fix by @issaclin32 in Aug 15, 2022 doesn't take effect which actually fix the problem that the Scoop creates the folders not the files.

What I see is that peazip uses the configuration files 'res/conf/*.txt' rather than 'res/*.txt'.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- Closes #XXXX -->
<!-- or -->
Relates to #9046

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
