### PR TITLE
f3d: Update to version 2.0.0 and fix autoupdate

### DIFF
--- a/bucket/f3d.json
+++ b/bucket/f3d.json
@@ -1,6 +1,6 @@
 {
     "version": "2.0.0",
-    "description": "F3D, a fast and minimalist 3D viewer",
+    "description": "A fast and minimalist 3D viewer.",
     "homepage": "https://f3d.app/",
     "license": "BSD-3-Clause",
     "architecture": {

--- a/bucket/f3d.json
+++ b/bucket/f3d.json
@@ -1,12 +1,13 @@
 {
-    "version": "1.3.1",
+    "version": "2.0.0",
     "description": "F3D, a fast and minimalist 3D viewer",
-    "homepage": "https://f3d-app.github.io/f3d/",
+    "homepage": "https://f3d.app/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/f3d-app/f3d/releases/download/v1.3.1/f3d-1.3.1-win64.zip",
-            "hash": "e2ffa54bbab102e55b6cd0ee9d4d2e92cac8be1093e90dade61d17bd42f2af46"
+            "url": "https://github.com/f3d-app/f3d/releases/download/v2.0.0/F3D-2.0.0-Windows-x86_64.zip",
+            "extract_dir": "F3D-2.0.0-Windows-x86_64",
+            "hash": "md5:680f4238778cbd47fdbd5b4fa852dcc8"
         }
     },
     "bin": [
@@ -18,7 +19,7 @@
     "shortcuts": [
         [
             "bin\\f3d.exe",
-            "f3d"
+            "F3D"
         ]
     ],
     "persist": "config.json",
@@ -26,6 +27,14 @@
         "github": "https://github.com/f3d-app/f3d/"
     },
     "autoupdate": {
-        "url": "https://github.com/f3d-app/f3d/releases/download/v$version/f3d-$version-win64.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/f3d-app/f3d/releases/download/v$version/F3D-$version-Windows-x86_64.zip",
+                "extract_dir": "F3D-$version-Windows-x86_64"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/f3d-app/f3d/releases/download/v$version/F3D-$version-Windows-x86_64.zip.md5"
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

f3d: 2.0.0 (scoop version is 1.3.1) autoupdate available
Autoupdating f3d
Downloading f3d-2.0.0-win64.zip to compute hashes!
VERBOSE: GET with 0-byte payload
VERBOSE: received 6072-byte response of content type application/json
VERBOSE: Content encoding: utf-8
The remote server returned an error: (404) Not Found.
URL https://github.com/f3d-app/f3d/releases/download/v2.0.0/f3d-2.0.0-win64.zip is not valid
ERROR Could not update f3d, hash for f3d-2.0.0-win64.zip failed!


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
