### PR TITLE
status: Update to version 0.11.0-621f0c and fix autoupdate

### DIFF
--- a/bucket/status.json
+++ b/bucket/status.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.10.0-9ae594",
+    "version": "0.11.0-621f0c",
     "description": "A messenger, crypto wallet, and Web3 browser.",
     "homepage": "https://status.im/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/status-im/status-desktop/releases/download/0.10.0/StatusIm-Desktop-v0.10.0-9ae594.7z ",
-            "hash": "14378fb9bb3078fab09d484dcb6ae1f19e6c6c2b9123d78e18cf267988a56ae7"
+            "url": "https://github.com/status-im/status-desktop/releases/download/0.11.0/StatusIm-Desktop-v0.11.0-621f0c-x86_64.7z ",
+            "hash": "f7e8d9b0849ece4d5e12f1e966a46a12f7282a0f61dde357e8c6e23fdacbb507"
         }
     },
     "extract_dir": "Status",
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/status-im/status-desktop/releases/download/$matchVer/StatusIm-Desktop-v$version.7z ",
+                "url": "https://github.com/status-im/status-desktop/releases/download/$matchVer/StatusIm-Desktop-v$version-x86_64.7z ",
                 "hash": {
                     "url": "$baseurl/StatusIm-Desktop-v$version.sha256",
                     "regex": "$sha256\\s+$fname"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

status: 0.11.0-621f0c (scoop version is 0.10.0-9ae594) autoupdate available
Autoupdating status
Searching hash for StatusIm-Desktop-v0.11.0-621f0c.7z in https://github.com/status-im/status-desktop/releases/download/0.11.0/StatusIm-Desktop-v0.11.0-621f0c.sha256
Could not find hash in https://github.com/status-im/status-desktop/releases/download/0.11.0/StatusIm-Desktop-v0.11.0-621f0c.sha256
Downloading StatusIm-Desktop-v0.11.0-621f0c.7z to compute hashes!
VERBOSE: GET with 0-byte payload
VERBOSE: received 6544-byte response of content type application/json
VERBOSE: Content encoding: utf-8
The remote server returned an error: (404) Not Found.
URL https://github.com/status-im/status-desktop/releases/download/0.11.0/StatusIm-Desktop-v0.11.0-621f0c.7z  is not valid
ERROR Could not update status, hash for StatusIm-Desktop-v0.11.0-621f0c.7z failed!


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
