### PR TITLE
rufus: Add arm64 architecture

### DIFF
--- a/bucket/rufus.json
+++ b/bucket/rufus.json
@@ -3,8 +3,20 @@
     "description": "A utility that helps format and create bootable USB flash drives.",
     "homepage": "https://rufus.ie/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/pbatard/rufus/releases/download/v4.0/rufus-4.0p.exe#/rufus.exe",
-    "hash": "bfecf4dcf1a63d8b64b900906102edf666642316291c9bba42eb0fb9c7bccbd6",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/pbatard/rufus/releases/download/v4.0/rufus-4.0.exe#/rufus.exe",
+            "hash": "bfecf4dcf1a63d8b64b900906102edf666642316291c9bba42eb0fb9c7bccbd6"
+        },
+        "32bit": {
+            "url": "https://github.com/pbatard/rufus/releases/download/v4.0/rufus-4.0_x86.exe#/rufus.exe",
+            "hash": "d41d72c239c4561d86a4d4c0d76a0dca41bd8798bcfefb7bfcb7efd073a6f391"
+        },
+        "arm64": {
+            "url": "https://github.com/pbatard/rufus/releases/download/v4.0/rufus-4.0_arm64.exe#/rufus.exe",
+            "hash": "0496d29183fe30f00ab452249ae4afb358628258ab63bd9e85c077d162dbc6d7"
+        }
+    },
     "pre_install": "if (!(Test-Path \"$persist_dir\\rufus.ini\")) { New-Item \"$dir\\rufus.ini\" | Out-Null }",
     "bin": "rufus.exe",
     "shortcuts": [
@@ -21,6 +33,16 @@
         "github": "https://github.com/pbatard/rufus"
     },
     "autoupdate": {
-        "url": "https://github.com/pbatard/rufus/releases/download/v$version/rufus-$versionp.exe#/rufus.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/pbatard/rufus/releases/download/v$version/rufus-$version.exe#/rufus.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/pbatard/rufus/releases/download/v$version/rufus-$version_x86.exe#/rufus.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/pbatard/rufus/releases/download/v$version/rufus-$version_arm64.exe#/rufus.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The latest version changes the main binary to x64, so I added the x86 and arm64 binaries: https://github.com/pbatard/rufus/releases/tag/v4.0

Also dropped using the portable version that only exists for the main binary as the regular version functions identically when a config file is present as mentioned here: https://github.com/pbatard/rufus/wiki/FAQ#user-content-What_is_the_difference_between_the_portable_and_the_regular_version
>...the ONLY difference the "portable" version of Rufus has with the "regular" one, which is that the "portable" version will create a rufus.ini by default (so that you don't have to do it yourself, if you want to use Rufus in portable mode), whereas the regular version doesn't.

`pre_install` already creates the config file, so it should function the same.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
