### PR TITLE
snappy-driver-installer-origin: Remove `extract_dir`

### DIFF
--- a/bucket/snappy-driver-installer-origin.json
+++ b/bucket/snappy-driver-installer-origin.json
@@ -5,7 +5,6 @@
     "license": "GPL-3.0-or-later",
     "url": "https://www.glenn.delahoy.com/downloads/sdio/SDIO_1.12.12.753.zip",
     "hash": "c24c4d805947b473c5f9abf3fa3b2168b1aaf8b282d612d004fd60774da49193",
-    "extract_dir": "SDIO_1.12.12.753",
     "architecture": {
         "64bit": {
             "pre_install": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11181

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
