### PR TITLE
fpcalc: Add version 1.5.1

### DIFF
--- a/bucket/fpcalc.json
+++ b/bucket/fpcalc.json
@@ -2,7 +2,7 @@
     "version": "1.5.1",
     "description": "fpcalc binary from Chromaprint for generating audio fingerprints used by AcoustID",
     "homepage": "https://acoustid.org/chromaprint",
-    "license": "MIT|LGPL-2.1-or-later",
+    "license": "LGPL-2.1-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/acoustid/chromaprint/releases/download/v1.5.1/chromaprint-fpcalc-1.5.1-windows-x86_64.zip",

--- a/bucket/fpcalc.json
+++ b/bucket/fpcalc.json
@@ -2,7 +2,7 @@
     "version": "1.5.1",
     "description": "fpcalc binary from Chromaprint for generating audio fingerprints used by AcoustID",
     "homepage": "https://acoustid.org/chromaprint",
-    "license": "LGPL-2.1-or-later",
+    "license": "MIT|LGPL-2.1-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/acoustid/chromaprint/releases/download/v1.5.1/chromaprint-fpcalc-1.5.1-windows-x86_64.zip",

--- a/bucket/fpcalc.json
+++ b/bucket/fpcalc.json
@@ -2,7 +2,7 @@
     "version": "1.5.1",
     "description": "fpcalc binary from Chromaprint for generating audio fingerprints used by AcoustID",
     "homepage": "https://acoustid.org/chromaprint",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.1-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/acoustid/chromaprint/releases/download/v1.5.1/chromaprint-fpcalc-1.5.1-windows-x86_64.zip",

--- a/bucket/fpcalc.json
+++ b/bucket/fpcalc.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.5.1",
+    "description": "fpcalc binary from Chromaprint for generating audio fingerprints used by AcoustID",
+    "homepage": "https://acoustid.org/chromaprint",
+    "license": "LGPL-2.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/acoustid/chromaprint/releases/download/v1.5.1/chromaprint-fpcalc-1.5.1-windows-x86_64.zip",
+            "hash": "36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc"
+        }
+    },
+    "extract_dir": "chromaprint-fpcalc-1.5.1-windows-x86_64",
+    "bin": "fpcalc.exe",
+    "checkver": {
+        "github": "https://github.com/acoustid/chromaprint"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/acoustid/chromaprint/releases/download/v$version/chromaprint-fpcalc-$version-windows-x86_64.zip"
+            }
+        },
+        "extract_dir": "chromaprint-fpcalc-$version-windows-x86_64"
+    }
+}


### PR DESCRIPTION
Adds fpcalc from [Chromaprint](https://acoustid.org/chromaprint).

Closes #11198

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
