### PR TITLE
coretemp: plugins folder should be persistent

### DIFF
--- a/bucket/coretemp.json
+++ b/bucket/coretemp.json
@@ -36,7 +36,10 @@
             "Core Temp"
         ]
     ],
-    "persist": "languages",
+    "persist": [
+        "languages",
+        "plugins",
+        ]
     "checkver": {
         "url": "https://www.alcpu.com/CoreTemp/history.html",
         "regex": "Version ([\\d.]+)"

--- a/bucket/coretemp.json
+++ b/bucket/coretemp.json
@@ -38,8 +38,8 @@
     ],
     "persist": [
         "languages",
-        "plugins",
-        ]
+        "plugins"
+    ],
     "checkver": {
         "url": "https://www.alcpu.com/CoreTemp/history.html",
         "regex": "Version ([\\d.]+)"


### PR DESCRIPTION
the plugins folder should be persistent.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
