### PR TITLE
playnite: Silence theme copying errors

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -20,8 +20,8 @@
     ],
     "pre_uninstall": [
         "Stop-Process -Name 'Playnite.DesktopApp' -ErrorAction SilentlyContinue",
-        "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force",
-        "Copy-Item \"$dir\\themes\" \"$persist_dir\\\" -Recurse -Force"
+        "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
+        "Copy-Item \"$dir\\themes\" \"$persist_dir\\\" -Recurse -Force -ErrorAction SilentlyContinue"
     ],
     "bin": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Silences overwriting errors when the installer is persisting the themes folder.
```
Updating 'playnite' (10.14 -> 10.15)
Downloading new version
Playnite1015.zip (141.9 MB) [=================================================================================] 100%
Checking hash of Playnite1015.zip ... ok.
Running pre_uninstall script...
Copy-Item:
Line |
   3 |  Copy-Item "$dir\themes" "$persist_dir\" -Recurse -Force
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot overwrite the item C:\Users\synthtech\scoop\persist\playnite\Themes\Desktop\Default\Common.xaml with itself.
```
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
