### PR TITLE
kdenlive: Update to version 23.04.0a and fix checkver

### DIFF
--- a/bucket/kdenlive.json
+++ b/bucket/kdenlive.json
@@ -1,15 +1,15 @@
 {
-    "version": "23.04.0",
+    "version": "23.04.0a",
     "description": "Video editing software based on the MLT Framework, KDE and Qt",
     "homepage": "https://kdenlive.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/kdenlive/23.04/windows/kdenlive-23.04.0_standalone.exe#/dl.7z",
-            "hash": "c946abec45efd009d8da9361ecd3c08f2a7637d801e24365d3c3680f0455865d"
+            "url": "https://download.kde.org/stable/kdenlive/23.04/windows/kdenlive-23.04.0a_standalone.exe#/dl.7z",
+            "hash": "35ce608223a1c2833eeccf4031ffaa8672ee59f894f5e3ed90bd8bb80032e7c8"
         }
     },
-    "extract_dir": "kdenlive-23.04.0_standalone",
+    "extract_dir": "kdenlive-23.04.0a_standalone",
     "bin": "bin\\kdenlive.exe",
     "shortcuts": [
         [
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://kdenlive.org/en/download/",
-        "regex": "kdenlive-([\\d.\\-]+)_standalone\\.exe"
+        "regex": "kdenlive-([\\d\\w.-]+)_standalone\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

kdenlive: couldn't match 'kdenlive-([\d.\-]+)_standalone\.exe' in https://kdenlive.org/en/download/

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
