### PR TITLE
obs-studio: Update to version 29.1 and fix autoupdate

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "29.0.2",
+    "version": "29.1",
     "description": "Video recording and live streaming software",
     "homepage": "https://obsproject.com",
     "license": "GPL-2.0-only",
@@ -9,8 +9,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-29.0.2-Full-x64.zip",
-            "hash": "1420b73b18afa766c6331725e12fb4cc8ce1a65843dff72c68e0030f9a82b6c1",
+            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-29.1-Full.zip",
+            "hash": "bb6c18f9a9bf0ca847e7d20b8afee76c39b2bbec0f7612c6fb899f773ee12f27",
             "shortcuts": [
                 [
                     "bin\\64bit\\obs64.exe",
@@ -32,12 +32,12 @@
     ],
     "checkver": {
         "url": "https://obsproject.com/download",
-        "regex": "OBS-Studio-([\\d.]+)-Full-x64\\.zip"
+        "regex": "OBS-Studio-([\\d.]+)-Full\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Full-x64.zip"
+                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Full.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

obs-studio: couldn't match 'OBS-Studio-([\d.]+)-Full-x64\.zip' in https://obsproject.com/download

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
