### PR TITLE
rider: Add arm64 support and Switch to zip

### DIFF
--- a/bucket/rider.json
+++ b/bucket/rider.json
@@ -9,19 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.1.exe#/dl.7z",
-            "hash": "1649bce335a136dea0ed97aaf5c70fb13cd9c061e7e8d96edcdc392f71a82a86",
-            "bin": [
-                [
-                    "IDE\\bin\\rider64.exe",
-                    "rider"
-                ]
-            ],
-            "shortcuts": [
-                [
-                    "IDE\\bin\\rider64.exe",
-                    "JetBrains\\Rider"
-                ]
-            ]
+            "hash": "1649bce335a136dea0ed97aaf5c70fb13cd9c061e7e8d96edcdc392f71a82a86"
+        },
+        "arm64": {
+            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.1-aarch64.exe#/dl.7z",
+            "hash": "941e2073226d68693d38b1daad86fb5ccc0007ba9aeb8f3d30ebd7ab2f1bba10"
         }
     },
     "extract_to": "IDE",
@@ -31,6 +23,18 @@
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },
+    "bin": [
+        [
+            "IDE\\bin\\rider64.exe",
+            "rider"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "IDE\\bin\\rider64.exe",
+            "JetBrains\\Rider"
+        ]
+    ],
     "persist": [
         "IDE\\bin\\idea.properties",
         "profile"
@@ -44,6 +48,12 @@
         "architecture": {
             "64bit": {
                 "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead.exe#/dl.7z",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            },
+            "arm64": {
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead-aarch64.exe#/dl.7z",
                 "hash": {
                     "url": "$url.sha256"
                 }

--- a/bucket/rider.json
+++ b/bucket/rider.json
@@ -8,20 +8,17 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.1.exe#/dl.7z",
-            "hash": "1649bce335a136dea0ed97aaf5c70fb13cd9c061e7e8d96edcdc392f71a82a86"
+            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.1.win.zip",
+            "hash": "688ec16ced3472dfbe2d6a2b7a9d3ed15e62ed8d6c65daeeee26f98fa33f6292"
         },
         "arm64": {
-            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.1-aarch64.exe#/dl.7z",
-            "hash": "941e2073226d68693d38b1daad86fb5ccc0007ba9aeb8f3d30ebd7ab2f1bba10"
+            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2023.1.1-aarch64.win.zip",
+            "hash": "27ce7091d9c72b71227ede64e2b6c58b0ec623884d4b87fb61f3171c24510957"
         }
     },
     "extract_to": "IDE",
     "installer": {
-        "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
-            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
-        ]
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" \"$dir\" \"$persist_dir\""
     },
     "bin": [
         [
@@ -47,17 +44,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead.exe#/dl.7z",
-                "hash": {
-                    "url": "$url.sha256"
-                }
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead.win.zip"
             },
             "arm64": {
-                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead-aarch64.exe#/dl.7z",
-                "hash": {
-                    "url": "$url.sha256"
-                }
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead-aarch64.win.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
Adds support the ARM64 version of Rider for Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
