### PR TITLE
Update upscayl.json to 2.5.1

### DIFF
--- a/bucket/upscayl.json
+++ b/bucket/upscayl.json
@@ -1,7 +1,7 @@
 {
     "version": "2.5.1",
     "homepage": "https://github.com/upscayl/upscayl",
-    "description": "Free and Open Source AI Image Upscaler Using REAL-ESRGAN",
+    "description": "Free and Open Source AI Image Upscaler",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {

--- a/bucket/upscayl.json
+++ b/bucket/upscayl.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.0.1",
+    "version": "2.5.1",
     "homepage": "https://github.com/upscayl/upscayl",
-    "description": "A Free and Open Source AI Image Upscaler.",
+    "description": "Free and Open Source AI Image Upscaler Using REAL-ESRGAN",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/upscayl/upscayl/releases/download/v2.0.1/upscayl-2.0.1-win.exe#/dl.7z",
-            "hash": "sha512:828bebe5827bdeb5c0d50f445d2a3b9beee54c0b7689019f2e5ea5f5340203212acd828d08dce758fc4cc87113936fabff83310dfcd9185c7a115bba7faa02d7"
+            "url": "https://github.com/upscayl/upscayl/releases/download/v2.5.1/upscayl-2.5.1-win.exe#/dl.7z",
+            "hash": "sha512:1f8f870ee344cdd7f2d2e1b36732350634f19ec223a256fbf8652216d19562cd4d84cfead0f9bfa67241548f69d226c3ce09d1f1152251772317155f14032e8c"
         }
     },
     "extract_dir": "$PLUGINSDIR",

--- a/bucket/upscayl.json
+++ b/bucket/upscayl.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/upscayl/upscayl/releases/download/v2.5.1/upscayl-2.5.1-win.exe#/dl.7z",
-            "hash": "sha512:1f8f870ee344cdd7f2d2e1b36732350634f19ec223a256fbf8652216d19562cd4d84cfead0f9bfa67241548f69d226c3ce09d1f1152251772317155f14032e8c"
+            "hash": "sha512:e2a5a89554d4c7521069637add45cdf3f98f9a5ced8d5ee03a99beca2ebde4c000966ec116cd5a29af4f99a8472c8894899854eb1394fdad9875140c21d1f8a0"
         }
     },
     "extract_dir": "$PLUGINSDIR",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

For some reason the automatic updates don't work anymore?