### PR TITLE
w64devkit: Add 32 bit and alternate versions

### DIFF
--- a/bucket/w64devkit-fortran.json
+++ b/bucket/w64devkit-fortran.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.19.0",
+    "description": "Portable C and C++ Development Kit for x64 Windows, including gfortran",
+    "homepage": "https://github.com/skeeto/w64devkit",
+    "license": "Unlicense",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/skeeto/w64devkit/releases/download/v1.19.0/w64devkit-fortran-1.19.0.zip",
+            "hash": "2cef625a7a5a85877533b4059c648344aca295bd100b79ce3c80fb2c2ad2d5f5"
+        },
+        "32bit": {
+            "url": "https://github.com/skeeto/w64devkit/releases/download/v1.19.0/w64devkit-i686-fortran-1.19.0.zip",
+            "hash": "3a3cbd20eba4a93cd1022c54668f7a4411ff8e14957588c50268ea74d9b19dc0"
+        }
+    },
+    "extract_dir": "w64devkit",
+    "bin": "w64devkit.exe",
+    "shortcuts": [
+        [
+            "w64devkit.exe",
+            "W64DevKit Command Prompt"
+        ]
+    ],
+    "env_add_path": "bin",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/skeeto/w64devkit/releases/download/v$version/w64devkit-fortran-$version.zip"
+    }
+}

--- a/bucket/w64devkit-mini.json
+++ b/bucket/w64devkit-mini.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.19.0",
+    "description": "Portable C and C++ Development Kit for x64 Windows, excluding C++",
+    "homepage": "https://github.com/skeeto/w64devkit",
+    "license": "Unlicense",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/skeeto/w64devkit/releases/download/v1.19.0/w64devkit-mini-1.19.0.zip",
+            "hash": "09ea23bc2b14b04fb1263653d1eb1931e9853d56c7e8c222b8053671d9792792"
+        },
+        "32bit": {
+            "url": "https://github.com/skeeto/w64devkit/releases/download/v1.19.0/w64devkit-i686-mini-1.19.0.zip",
+            "hash": "2d97d948023ca93acfe6d9ff258adac5225a078a754e4b5edd90f7a41444ed89"
+        }
+    },
+    "extract_dir": "w64devkit",
+    "bin": "w64devkit.exe",
+    "shortcuts": [
+        [
+            "w64devkit.exe",
+            "W64DevKit Command Prompt"
+        ]
+    ],
+    "env_add_path": "bin",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/skeeto/w64devkit/releases/download/v$version/w64devkit-mini-$version.zip"
+    }
+}

--- a/bucket/w64devkit.json
+++ b/bucket/w64devkit.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/skeeto/w64devkit/releases/download/v1.19.0/w64devkit-1.19.0.zip",
             "hash": "2862f388e1720b40026f2fd95c6100a9932e3b14fb13aac4f225a02b11e31ca9"
+        },
+        "32bit": {
+            "url": "https://github.com/skeeto/w64devkit/releases/download/v1.19.0/w64devkit-i686-1.19.0.zip",
+            "hash": "dc4f6984f7320b02fc057d19c23c06b2406d8133fb5b149c438dba1ee78a77e6"
         }
     },
     "extract_dir": "w64devkit",


### PR DESCRIPTION
Adds the -fortran and -mini variants of w64devkit, and the 32-bit builds of all three variants.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11239

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
