### PR TITLE
picocrypt@1.32: fix autoupdate

### DIFF
--- a/bucket/picocrypt.json
+++ b/bucket/picocrypt.json
@@ -5,8 +5,8 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/HACKERALERT/Picocrypt/releases/download/1.29/Picocrypt.exe",
-            "hash": "a3968be664c0f86baa174fd0f8cbca339be156ee808c80a3c09a0146277283ad"
+            "url": "https://github.com/HACKERALERT/Picocrypt/releases/download/1.32/Picocrypt.exe",
+            "hash": "08982183b7b410c060e6de636b0bbaf92443ab2759cac7ee7a0583a261be7c26"
         }
     },
     "shortcuts": [
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/HACKERALERT/Picocrypt/releases/download/1.29/Picocrypt.exe"
+                "url": "https://github.com/HACKERALERT/Picocrypt/releases/download/$version/Picocrypt.exe"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

App was stuck on 1.29 version
Update to 1.32
Fix autoupdate