### PR TITLE
apifox: Update hash url and uninstall scripts

### DIFF
--- a/bucket/apifox.json
+++ b/bucket/apifox.json
@@ -28,6 +28,7 @@
             "--user-data-dir=\"$dir\\UserData\""
         ]
     ],
+    "pre_uninstall": "Stop-Process -Name 'ApifoxAppAgent' -ErrorAction SilentlyContinue; Start-Sleep -Seconds 3;",
     "persist": "UserData",
     "checkver": {
         "url": "https://cdn.apifox.cn/download/latest.yml",
@@ -38,14 +39,14 @@
             "64bit": {
                 "url": "https://cdn.apifox.cn/download/$version/Apifox-$version.exe#/dl.7z",
                 "hash": {
-                    "url": "https://cdn.apifox.cn/download/latest.yml",
+                    "url": "$baseurl/latest.yml",
                     "regex": "sha512: $base64"
                 }
             },
             "32bit": {
                 "url": "https://cdn.apifox.cn/download/$version/Apifox-windows-x86-$version.exe#/dl.7z",
                 "hash": {
-                    "url": "https://cdn.apifox.cn/download/x32/latest.yml",
+                    "url": "$baseurl/x32/latest.yml",
                     "regex": "sha512: $base64"
                 }
             }


### PR DESCRIPTION
1. After exiting the application, a background process called ApifoxAppAgent will be started.
2. Update the url to use the hash of a specified version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
