### PR TITLE
obs-studio: Update to version 29.1.1 and fix autoupdate

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "29.1",
+    "version": "29.1.1",
     "description": "Video recording and live streaming software",
     "homepage": "https://obsproject.com",
     "license": "GPL-2.0-only",
@@ -9,8 +9,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-29.1-Full.zip",
-            "hash": "bb6c18f9a9bf0ca847e7d20b8afee76c39b2bbec0f7612c6fb899f773ee12f27",
+            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-29.1.1.zip",
+            "hash": "2fc156b3debe0ab79a9bf5e100a1d27a3ec551b5ac50a97d1330d8a224f0c86a",
             "shortcuts": [
                 [
                     "bin\\64bit\\obs64.exe",
@@ -32,12 +32,12 @@
     ],
     "checkver": {
         "url": "https://obsproject.com/download",
-        "regex": "OBS-Studio-([\\d.]+)-Full\\.zip"
+        "regex": "OBS-Studio-([\\d.]+)(-Full)?\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Full.zip"
+                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- obs-studio: couldn't match `OBS-Studio-([\d.]+)-Full.zip` in [obsproject.com/download](https://obsproject.com/download)
  changed it to `OBS-Studio-([\d.]+)(-Full)?.zip` in case they change the naming scheme back to include `-Full`
- Updated to `29.1.1`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
