### PR TITLE
powertoys: Update to version 0.70.0 and add hardlinks

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.69.1",
+    "version": "0.70.0",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysUserSetup-0.69.1-x64.exe",
-            "hash": "662e4082a788df808bfb34c8d922c8b15835632808ce8c93db7e13d9f2b984ba"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.70.0/PowerToysUserSetup-0.70.0-x64.exe",
+            "hash": "a2c45cc2ea953ff07246c85c7e106a403eaa5ed51e7c777452238ee280c9f6ea"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.69.1/PowerToysUserSetup-0.69.1-arm64.exe",
-            "hash": "cbd35e2f0dcef16e902c6f5110224618e0e272b8afdba3468f7ad32978603a51"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.70.0/PowerToysUserSetup-0.70.0-arm64.exe",
+            "hash": "2d9591a4752efa7603c56ebddc9cb4f70c5e938a4ef66adc46b72fc60779e82c"
         }
     },
     "installer": {
@@ -23,15 +23,15 @@
     },
     "post_install": [
         "foreach ($f in @('modules\\FileLocksmith', 'modules\\Hosts', 'modules\\MeasureTool', ",
-        "                 'modules\\PowerRename')) {",
+        "                 'modules\\PowerRename', 'modules\\RegistryPreview', 'modules\\Peek')) {",
         "    Get-ChildItem -Path \"$dir\\dll\\WinAppSDK\" | ForEach-Object {",
         "        New-Item -ItemType HardLink -Path \"$dir\\$f\\$($_.Name)\" -Value $_.FullName | Out-Null",
         "    }",
         "}",
         "foreach ($f in @('Settings', 'modules\\Awake', 'modules\\ColorPicker', 'modules\\FancyZones', ",
         "                 'modules\\FileExplorerPreview', 'modules\\FileLocksmith', 'modules\\Hosts', 'modules\\ImageResizer', ",
-        "                 'modules\\launcher', 'modules\\MeasureTool', 'modules\\MouseUtils\\MouseJumpUI', ",
-        "                 'modules\\PowerAccent', 'modules\\PowerOCR')) {",
+        "                 'modules\\launcher', 'modules\\MeasureTool', 'modules\\MouseUtils\\MouseJumpUI', 'modules\\MouseWithoutBorders', ",
+        "                 'modules\\Peek', 'modules\\PowerAccent', 'modules\\PowerOCR', 'modules\\RegistryPreview')) {",
         "    Get-ChildItem -Path \"$dir\\dll\\Interop\" | ForEach-Object {",
         "        New-Item -ItemType HardLink -Path \"$dir\\$f\\$($_.Name)\" -Value $_.FullName | Out-Null",
         "    }",


### PR DESCRIPTION
Updates PowerToys to 0.70.0 and adds missing hardlinks instructions for the new utilities.

Disclaimer: I'm the dev lead on PowerToys.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
