### PR TITLE
filezilla: Update manifests and change source

### DIFF
--- a/bucket/filezilla-server.json
+++ b/bucket/filezilla-server.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.6.6",
+    "version": "1.7.0",
     "description": "Open-source FTP server software",
     "homepage": "https://filezilla-project.org/",
     "license": "GPL-2.0-or-later",
@@ -10,15 +10,17 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/filezilla-server/FileZilla_Server_1.6.6_win64-setup.exe#/dl.7z",
-            "hash": "sha512:a1547119436936f592ffc84c57ec9d82df889d2eb3d8532c7acbf151b2a87eec2bb0a2607b4b165fa3d5c45500e09afe26294094bc3893fecf92e19da7a8346b"
+            "url": "https://packages.chocolatey.org/filezilla.server.1.7.0.nupkg",
+            "hash": "ff1e9a1f932af6d4a00a1eecd6a0edac8fca82459692e8372070c32e707477a7"
         }
     },
+    "extract_dir": "tools",
     "pre_install": [
         "if (!(is_admin)) {error 'This package requires admin rights to install'; break}",
+        "Expand-7zipArchive \"$dir\\FileZilla_Server_*_win64-setup.exe\" \"$dir\" -Removal",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe.nsis\", \"$dir\\*.ps1\", \"$dir\\*.xml\" -Force -Recurse",
         "Set-Content \"$dir\\start-filezilla-server.bat\" \"net start `\"FileZilla Server`\"\" -Encoding ascii",
-        "Set-Content \"$dir\\stop-filezilla-server.bat\" \"net stop `\"FileZilla Server`\"\" -Encoding ascii",
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse"
+        "Set-Content \"$dir\\stop-filezilla-server.bat\" \"net stop `\"FileZilla Server`\"\" -Encoding ascii"
     ],
     "post_install": [
         "Write-Host 'Installing FileZilla Server service...'",
@@ -57,5 +59,20 @@
             "",
             "filezilla-server.exe"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://community.chocolatey.org/packages/filezilla.server",
+        "regex": "<meta property=\"og:title\" content=\"FileZilla Server ([\\d.]+)\">"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://packages.chocolatey.org/filezilla.server.$version.nupkg",
+                "hash": {
+                    "url": "https://community.chocolatey.org/packages/filezilla.server/$version",
+                    "regex": "$sha256.*?$basename"
+                }
+            }
+        }
+    }
 }

--- a/bucket/filezilla.json
+++ b/bucket/filezilla.json
@@ -1,21 +1,17 @@
 {
     "##": "This package should be updated manually. See #9179 for details",
-    "version": "3.63.1",
+    "version": "3.64.0",
     "description": "Fast and reliable cross-platform FTP, FTPS and SFTP client with lots of useful features and an intuitive graphical user interface.",
     "homepage": "https://filezilla-project.org/",
     "license": "GPL-2.0-or-later",
-    "architecture": {
-        "64bit": {
-            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/filezilla/FileZilla_3.63.1_win64.zip",
-            "hash": "sha512:67add3c597d2d65c3616409322fcfa0b156a66432d9a51fbe9334e775d1fca68fe2c841f90e77e0427e3bdbd1d4b069e1b5aec91e8ecd79d4017ee1c2cf31fe4"
-        },
-        "32bit": {
-            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/filezilla/FileZilla_3.63.1_win32.zip",
-            "hash": "sha512:321d0154dca0ac02c2d3065ed417b235151bd284c89bd6c45a527362041b8805e949b6fdaa2ce7ba662d13b94a34dca35cfc0eb93ac48741b7e0623348d44bb5"
-        }
-    },
-    "extract_dir": "filezilla-3.63.1",
+    "url": "https://packages.chocolatey.org/filezilla.3.64.0.nupkg",
+    "hash": "aab0a7c76cf51f60b583786679169a8aca576a949e49caa5a77c5718e9b18e01",
+    "extract_dir": "tools",
     "pre_install": [
+        "$arch = 'x86'",
+        "if (\"$architecture\" -Match '64bit' -or \"$architecture\" -Match 'arm64') { $arch = 'x64' }",
+        "Expand-7zipArchive \"$dir\\FileZilla_*_$arch.exe\" \"$dir\" -Removal",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe.nsis\", \"$dir\\*.ps1\", \"$dir\\FileZilla_*.exe\" -Recurse -Force",
         "@'",
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>",
         "<FileZilla3>",
@@ -49,5 +45,16 @@
             "FileZilla"
         ]
     ],
-    "persist": "config"
+    "persist": "config",
+    "checkver": {
+        "url": "https://community.chocolatey.org/packages/filezilla",
+        "regex": "<meta property=\"og:title\" content=\"FileZilla ([\\d.]+)\">"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/filezilla.$version.nupkg",
+        "hash": {
+            "url": "https://community.chocolatey.org/packages/filezilla/$version",
+            "regex": "$sha256.*?$basename"
+        }
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Readd checkver/autoupdate by switching the sources to Chocolatey. This would remove the need for someone to actively upload the binaries to the Binary repo.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Binary/issues/20

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
