### PR TITLE
pycharm: Run a batch file in a completely hidden way 

### DIFF
--- a/bucket/pycharm-professional.json
+++ b/bucket/pycharm-professional.json
@@ -13,20 +13,21 @@
         "script": [
             "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse",
-            "Set-Content \"$dir\\run_pycharm.bat\" \"start `\"`\" `\"$dir\\IDE\\bin\\pycharm64.exe`\"\" -Encoding ascii | Out-Null"
+            "Set-Content \"$dir\\run_pycharm.vbs\" \"WScript.CreateObject(`\"Wscript.Shell`\").Run `\"`\"`\"$dir\\IDE\\bin\\pycharm64.exe`\"`\"`\"\" -Encoding ascii | Out-Null"
         ]
     },
     "architecture": {
         "64bit": {
             "bin": [
                 [
-                    "run_pycharm.bat",
-                    "pycharm"
+                    "wscript.exe",
+                    "pycharm",
+                    "$dir\\run_pycharm.vbs"
                 ]
             ],
             "shortcuts": [
                 [
-                    "run_pycharm.bat",
+                    "run_pycharm.vbs",
                     "JetBrains\\PyCharm Professional",
                     "",
                     "IDE\\bin\\pycharm64.exe"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
#8359 fix pycharm creation of virtualenv by introduce a batch file as shims to  launch the executable for true path(not hardlink path), which makes command prompt splash screen every time execute pycharm by shortcuts or terminal. To address this, I had change bat to vbs. The idea come from [https://superuser.com/a/62646/1802860](https://superuser.com/a/62646/1802860)

<!-- or -->
Relates to #8359

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
