### PR TITLE
windows-terminal.json: fix typo

### DIFF
--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -9,7 +9,7 @@
         "",
         "Portable mode is enabled from version 1.17.11391.0, please migrate the settings manually:",
         "original settings dir: \"$env:LOCALAPPDATA\\Packages\\Microsoft.WindowsTerminal_8wekyb3d8bbwe\\LocalState\"",
-        "Portable settsing dir: \"$dir\\settings\""
+        "Portable settings dir: \"$dir\\settings\""
     ],
     "suggest": {
         "vcredist": "extras/vcredist2022"


### PR DESCRIPTION
Fix typo of "settsing" -> "settings"

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
