### PR TITLE
kanata: add version 1.3.0

### DIFF
--- a/bucket/kanata-cmd.json
+++ b/bucket/kanata-cmd.json
@@ -4,8 +4,8 @@
     "homepage": "https://github.com/jtroo/kanata",
     "license": "LGPL-3.0-only",
     "notes": [
-        "This version of Kanata is compiled with cmd support."
-        "More info about security concerns and cmd support here: https://github.com/jtroo/kanata/blob/main/docs/config.adoc#danger-enable-cmd"
+        "This version of Kanata is compiled with cmd support.",
+        "More info about security concerns and cmd support here: https://github.com/jtroo/kanata/blob/main/docs/config.adoc#danger-enable-cmd",
         "Configuration Guide: https://github.com/jtroo/kanata/blob/main/docs/config.adoc"
     ],
     "architecture": {
@@ -14,9 +14,7 @@
             "hash": "df2cab04eab5cb4fbd57e8ab72b7808e2bb3b93321f9c15a8e4f06dea3e5439d"
         }
     },
-    "bin": [
-        "kanata-cmd.exe"
-    ],
+    "bin": "kanata-cmd.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/kanata-cmd.json
+++ b/bucket/kanata-cmd.json
@@ -10,18 +10,18 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jtroo/kanata/releases/download/v1.3.0/kanata_cmd_allowed.exe",
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.3.0/kanata_cmd_allowed.exe#/kanata-cmd.exe",
             "hash": "df2cab04eab5cb4fbd57e8ab72b7808e2bb3b93321f9c15a8e4f06dea3e5439d"
         }
     },
     "bin": [
-        "kanata_cmd_allowed.exe"
+        "kanata-cmd.exe"
     ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jtroo/kanata/releases/download/v$version/kanata_cmd_allowed.exe"
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/kanata_cmd_allowed.exe#/kanata-cmd.exe"
             }
         }
     }

--- a/bucket/kanata-with-cmd.json
+++ b/bucket/kanata-with-cmd.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.3.0",
+    "description": "A software keyboard remapper, compiled with cmd support.",
+    "homepage": "https://github.com/jtroo/kanata",
+    "license": "LGPL-3.0-only",
+    "notes": [
+        "This version of Kanata is compiled with cmd support."
+        "More info about security concerns and cmd support here: https://github.com/jtroo/kanata/blob/main/docs/config.adoc#danger-enable-cmd"
+        "Configuration Guide: https://github.com/jtroo/kanata/blob/main/docs/config.adoc"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.3.0/kanata_cmd_allowed.exe",
+            "hash": "df2cab04eab5cb4fbd57e8ab72b7808e2bb3b93321f9c15a8e4f06dea3e5439d"
+        }
+    },
+    "bin": [
+        "kanata_cmd_allowed.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/kanata_cmd_allowed.exe"
+            }
+        }
+    }
+}

--- a/bucket/kanata.json
+++ b/bucket/kanata.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/jtroo/kanata",
     "license": "LGPL-3.0-only",
     "notes": [
-        "See sample config here: https://github.com/jtroo/kanata/blob/main/cfg_samples/kanata.kbd"
+        "Configuration Guide: https://github.com/jtroo/kanata/blob/main/docs/config.adoc"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/kanata.json
+++ b/bucket/kanata.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.3.0",
+    "description": "A software keyboard remapper.",
+    "homepage": "https://github.com/jtroo/kanata",
+    "license": "LGPL-3.0-only",
+    "notes": [
+        "See sample config here: https://github.com/jtroo/kanata/blob/main/cfg_samples/kanata.kbd"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.3.0/kanata.exe",
+            "hash": "a2848d43067de517855ca4321a90d6f3ff3bd0ea221aec52d0d6973df28c8760"
+        }
+    },
+    "bin": [
+        "kanata.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/kanata.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add kanata version 1.3.0 to Extras. Kananta is a software keyboard remapper written in Rust. 

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
