### PR TITLE
antimicrox: Add version 3.3.4

### DIFF
--- a/bucket/antimicrox.json
+++ b/bucket/antimicrox.json
@@ -1,0 +1,30 @@
+{
+    "version": "3.3.4",
+    "description": "Graphical program used to map keyboard buttons and mouse controls to a gamepad.",
+    "homepage": "https://github.com/AntiMicroX/antimicrox",
+    "license": "GPL-3.0-only",
+    "notes": "AntiMicroX is a fork of AntiMicro (https://github.com/AntiMicro/antimicro). The original project is no longer being developed.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AntiMicroX/antimicrox/releases/download/3.3.4/antimicrox-3.3.4-PortableWindows-AMD64.zip",
+            "hash": "2b05228cd2cc93b1025d352050e80953ebbecd10b6badadbc76370acb349a8cf"
+        }
+    },
+    "extract_dir": "antimicrox-3.3.4-PortableWindows-AMD64",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\antimicrox_settings.ini\")) { New-Item -ItemType File \"$dir\\bin\\antimicrox_settings.ini\" | Out-Null }",
+    "shortcuts": [
+        [
+            "bin\\antimicrox.exe",
+            "AntiMicroX"
+        ]
+    ],
+    "persist": [
+        "bin\\antimicrox_settings.ini",
+        "profiles"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "extract_dir": "antimicrox-$version-PortableWindows-AMD64",
+        "url": "https://github.com/AntiMicroX/antimicrox/releases/download/$version/antimicrox-$version-PortableWindows-AMD64.zip"
+    }
+}

--- a/bucket/antimicrox.json
+++ b/bucket/antimicrox.json
@@ -1,9 +1,8 @@
 {
     "version": "3.3.4",
-    "description": "Graphical program used to map keyboard buttons and mouse controls to a gamepad.",
+    "description": "Mapping keyboard buttons and mouse controls to a gamepad.",
     "homepage": "https://github.com/AntiMicroX/antimicrox",
     "license": "GPL-3.0-only",
-    "notes": "AntiMicroX is a fork of AntiMicro (https://github.com/AntiMicro/antimicro). The original project is no longer being developed.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/AntiMicroX/antimicrox/releases/download/3.3.4/antimicrox-3.3.4-PortableWindows-AMD64.zip",
@@ -11,7 +10,7 @@
         }
     },
     "extract_dir": "antimicrox-3.3.4-PortableWindows-AMD64",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\antimicrox_settings.ini\")) { New-Item -ItemType File \"$dir\\bin\\antimicrox_settings.ini\" | Out-Null }",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\bin\\antimicrox_settings.ini\")) { New-Item \"$dir\\bin\\antimicrox_settings.ini\" | Out-Null }",
     "shortcuts": [
         [
             "bin\\antimicrox.exe",
@@ -24,7 +23,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "extract_dir": "antimicrox-$version-PortableWindows-AMD64",
-        "url": "https://github.com/AntiMicroX/antimicrox/releases/download/$version/antimicrox-$version-PortableWindows-AMD64.zip"
+        "url": "https://github.com/AntiMicroX/antimicrox/releases/download/$version/antimicrox-$version-PortableWindows-AMD64.zip",
+        "extract_dir": "antimicrox-$version-PortableWindows-AMD64"
     }
 }


### PR DESCRIPTION
Graphical program used to map keyboard buttons and mouse controls to a gamepad.

AntiMicroX is a fork of AntiMicro (https://github.com/AntiMicro/antimicro). The original project is no longer being developed.

I'll leave the decision to the maintainers if this deprecates the existing antimicro manifest.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
