### PR TITLE
azurestorageexplorer@1.30.0 use 64-bit installer with 1.30.0

### DIFF
--- a/bucket/azurestorageexplorer.json
+++ b/bucket/azurestorageexplorer.json
@@ -3,8 +3,12 @@
     "description": "Easily manage the contents of Azure storage account.",
     "homepage": "https://azure.microsoft.com/en-us/features/storage-explorer/",
     "license": "CC-BY-4.0",
-    "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.30.0/StorageExplorer-windows-x64.exe",
-    "hash": "ea1643ed48622d34b497dbf9a9534eca2d4c8c0e2c3d740845074f6270a112c4",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.30.0/StorageExplorer-windows-x64.exe",
+            "hash": "ea1643ed48622d34b497dbf9a9534eca2d4c8c0e2c3d740845074f6270a112c4"
+        }
+    },
     "innosetup": true,
     "bin": "StorageExplorer.exe",
     "shortcuts": [
@@ -17,6 +21,10 @@
         "github": "https://github.com/microsoft/AzureStorageExplorer"
     },
     "autoupdate": {
-        "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-x64.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-x64.exe"
+            }
+        }
     }
 }

--- a/bucket/azurestorageexplorer.json
+++ b/bucket/azurestorageexplorer.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.29.2",
+    "version": "1.30.0",
     "description": "Easily manage the contents of Azure storage account.",
     "homepage": "https://azure.microsoft.com/en-us/features/storage-explorer/",
     "license": "CC-BY-4.0",
-    "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.29.2/StorageExplorer-windows-ia32.exe",
-    "hash": "3de6cf31a971b2ec19dda57b1d75f8c850ac329ea8aed31e67746d9c5cafcf55",
+    "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.30.0/StorageExplorer-windows-x64.exe",
+    "hash": "ea1643ed48622d34b497dbf9a9534eca2d4c8c0e2c3d740845074f6270a112c4",
     "innosetup": true,
     "bin": "StorageExplorer.exe",
     "shortcuts": [
@@ -17,6 +17,6 @@
         "github": "https://github.com/microsoft/AzureStorageExplorer"
     },
     "autoupdate": {
-        "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-ia32.exe"
+        "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-x64.exe"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
With 1.30.0, Storage Explorer for Windows is now a 64-bit application. The current storage explorer manifest uses the 32-bit name for url download and autoupdate. This PR updates the url with the new 64-bit installer name for 1.30.0.

I have updated the storage explorer manifest to use the new naming convention.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
