### PR TITLE
locale-remulator: add version 1.5.2

### DIFF
--- a/bucket/locale-remulator.json
+++ b/bucket/locale-remulator.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.5.2",
+    "description": "System Region and Language Simulator",
+    "homepage": "https://github.com/InWILL/Locale_Remulator",
+    "license": "LGPL-3.0-only,MS-PL",
+    "notes": "Please run Locale Remulator Installer to complete installation.",
+    "url": "https://github.com/InWILL/Locale_Remulator/releases/download/v1.5.2/Locale_Remulator.1.5.2.zip",
+    "hash": "b1aa495e3b192790162036dcde797d1e6ec0c9df3a1e4e63c69f0cbd86762641",
+    "extract_dir": "Locale_Remulator.1.5.2",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\LEConfig.xml\")) { New-Item \"$dir\\LRConfig.xml\" | Out-Null }",
+    "bin": [
+        [
+            "LREditor.exe",
+            "Locale-Remulator"
+        ],
+        "LRProc.exe"
+    ],
+    "shortcuts": [
+        [
+            "LREditor.exe",
+            "Locale Remulator",
+            "",
+            "LRProc.exe"
+        ],
+        [
+            "LRInstaller.exe",
+            "Locale Remulator Installer",
+            "",
+            "LRProc.exe"
+        ]
+    ],
+    "persist": "LRConfig.xml",
+    "checkver": {
+        "github": "https://github.com/InWILL/Locale_Remulator"
+    },
+    "autoupdate": {
+        "url": "https://github.com/InWILL/Locale_Remulator/releases/download/v$version/Locale_Remulator.$version.zip",
+        "extract_dir": "Locale_Remulator.$version"
+    }
+}


### PR DESCRIPTION
There is new fork of Locale Emulator named "Locale Remulator". Manifest looks pretty similar.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
