### PR TITLE
MPC-HC@2.0.0: change download location

### DIFF
--- a/bucket/mpc-hc.json
+++ b/bucket/mpc-hc.json
@@ -1,13 +1,12 @@
 {
-    "version": "1.7.13",
+    "version": "2.0.0",
     "description": "An extremely light-weight, open source media player for Windows.",
-    "homepage": "https://mpc-hc.org",
+    "homepage": "https://github.com/clsid2/mpc-hc",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binaries.mpc-hc.org/MPC%20HomeCinema%20-%20x64/MPC-HC_v1.7.13_x64/MPC-HC.1.7.13.x64.7z",
-            "hash": "1ce281b255ba4cd0762aed63c59e0cfa5be471422bd89676af07f2e3bfc6a5c4",
-            "extract_dir": "MPC-HC.1.7.13.x64",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.0.0/MPC-HC.2.0.0.x64.zip",
+            "hash": "2e24c05a4cf10ef37a589c02aea4d4f08daca6191fdf9da35b840ff9a4558809",
             "bin": [
                 "mpc-hc64.exe",
                 [
@@ -23,9 +22,8 @@
             ]
         },
         "32bit": {
-            "url": "https://binaries.mpc-hc.org/MPC%20HomeCinema%20-%20Win32/MPC-HC_v1.7.13_x86/MPC-HC.1.7.13.x86.7z",
-            "hash": "ae5f25f92f0586ce305fa909da98419e3ee3e0d55b08a7b7f246dec7b6a7d2f4",
-            "extract_dir": "MPC-HC.1.7.13.x86",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.0.0/MPC-HC.2.0.0.x86.zip",
+            "hash": "9e77432ad119098216dddda8aa615ba94247ebe9c666c69171c53369cd9e3a0f",
             "bin": "mpc-hc.exe",
             "shortcuts": [
                 [
@@ -36,13 +34,23 @@
         }
     },
     "pre_install": [
-        "@('mpc-hc64.ini', 'mpc-hc.ini', 'default.mpcpl') | ForEach-Object {",
+        "@('mpc-hc64.ini', 'mpc-hc.ini') | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
         "}"
     ],
     "persist": [
         "mpc-hc64.ini",
-        "mpc-hc.ini",
-        "default.mpcpl"
-    ]
+        "mpc-hc.ini"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/clsid2/mpc-hc/releases/download/$version/MPC-HC.$version.x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/clsid2/mpc-hc/releases/download/$version/MPC-HC.$version.x86.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
The old JSON downloads MPC-HC from the original project website, which has been out of development since 2017. This new JSON downloads from the GitHub page of the developer who took over maintenance and development for this project.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11483

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
