### PR TITLE
hunt-and-peck: Add version 1.7

### DIFF
--- a/bucket/hunt-and-peck.json
+++ b/bucket/hunt-and-peck.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.7",
+  "description": "Simple vimium/vimperator style navigation for Windows applications based on the UI Automation framework.",
+  "homepage": "https://github.com/zsims/hunt-and-peck",
+  "license": "Unknown",
+  "notes": [
+    "Press Alt + ; to navigate within the focused window",
+    "Press Ctrl + ; to navigate within the tray"
+  ],
+  "url": "https://github.com/zsims/hunt-and-peck/releases/download/release%2F1.7/HuntAndPeck-1.7.zip",
+  "shortcuts": [
+    [
+      "hap.exe",
+      "HuntAndPeck"
+    ]
+  ],
+  "hash": "752a959d985f30654b27551a103adb56f47ef1e7dfb76819bcf20d29a76691ee",
+  "extract_dir": "",
+  "checkver": {
+    "url": "https://github.com/zsims/hunt-and-peck/releases/latest",
+    "regex": "release/([\\d.]+)"
+  },
+  "autoupdate": {
+    "url": "https://github.com/zsims/hunt-and-peck/releases/download/release%2F$version/HuntAndPeck-$version.zip"
+  }
+}

--- a/bucket/hunt-and-peck.json
+++ b/bucket/hunt-and-peck.json
@@ -1,26 +1,33 @@
 {
-  "version": "1.7",
-  "description": "Simple vimium/vimperator style navigation for Windows applications based on the UI Automation framework.",
-  "homepage": "https://github.com/zsims/hunt-and-peck",
-  "license": "Unknown",
-  "notes": [
-    "Press Alt + ; to navigate within the focused window",
-    "Press Ctrl + ; to navigate within the tray"
-  ],
-  "url": "https://github.com/zsims/hunt-and-peck/releases/download/release%2F1.7/HuntAndPeck-1.7.zip",
-  "shortcuts": [
-    [
-      "hap.exe",
-      "HuntAndPeck"
-    ]
-  ],
-  "hash": "752a959d985f30654b27551a103adb56f47ef1e7dfb76819bcf20d29a76691ee",
-  "extract_dir": "",
-  "checkver": {
-    "url": "https://github.com/zsims/hunt-and-peck/releases/latest",
-    "regex": "release/([\\d.]+)"
-  },
-  "autoupdate": {
-    "url": "https://github.com/zsims/hunt-and-peck/releases/download/release%2F$version/HuntAndPeck-$version.zip"
-  }
+    "version": "1.7",
+    "description": "Simple vimium/vimperator style navigation for Windows applications based on the UI Automation framework.",
+    "homepage": "https://github.com/zsims/hunt-and-peck",
+    "license": "Unknown",
+    "notes": [
+        "Press Alt + ; to navigate within the focused window",
+        "Press Ctrl + ; to navigate within the tray"
+    ],
+    "url": [
+        "https://github.com/zsims/hunt-and-peck/releases/download/release%2F1.7/HuntAndPeck-1.7.zip",
+        "https://raw.githubusercontent.com/zsims/hunt-and-peck/master/src/HuntAndPeck/Resources/originalbird.ico#/icon.ico"
+    ],
+    "hash": [
+        "752a959d985f30654b27551a103adb56f47ef1e7dfb76819bcf20d29a76691ee",
+        "20f9cc7093d3e5e8007b02f816ef814a26b2b7a0127200caa74803f197813df7"
+    ],
+    "shortcuts": [
+        [
+            "hap.exe",
+            "HuntAndPeck",
+            "",
+            "icon.ico"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/zsims/hunt-and-peck/releases/latest",
+        "regex": "release/([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/zsims/hunt-and-peck/releases/download/release%2F$version/HuntAndPeck-$version.zip"
+    }
 }


### PR DESCRIPTION
-  [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

I didn't use "checkver": "github" because the release page doesn't contain "v..." and the default regex doesn't fit.