### PR TITLE
jpegview-fork: Add version 1.2.45

### DIFF
--- a/bucket/jpegview-fork.json
+++ b/bucket/jpegview-fork.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "1.2.45",
+    "description": "This is the official re-release of JPEGView. JPEGView is a lean, fast and highly configurable image viewer/editor with a minimal GUI.",
+    "homepage": "https://github.com/sylikc/jpegview",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/sylikc/jpegview/releases/download/v1.2.45/JPEGView_1.2.45.7z",
+    "hash": "d18d2e04eb7c9919199f76a0a0c303f05dda810b55e1d678870a0de006a3f393",
+    "architecture": {
+        "32bit": {
+            "extract_dir": "JPEGView32"
+        },
+        "64bit": {
+            "extract_dir": "JPEGView64"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\JPEGView.ini\")) {",
+        "    $cont = (Get-Content \"$dir\\JPEGView.ini\").Replace('StoreToEXEPath=false', 'StoreToEXEPath=true')",
+        "    Set-Content \"$dir\\JPEGView.ini\" $cont",
+        "}",
+        "if (Test-Path \"$persist_dir\\ParamDB.db\") { Copy-Item \"$persist_dir\\ParamDB.db\" \"$dir\" | Out-Null }",
+        "if (Test-Path \"$persist_dir\\KeyMap.txt\") { Copy-Item \"$persist_dir\\KeyMap.txt\" \"$dir\" | Out-Null }"
+    ],
+    "uninstaller": {
+        "script": [
+            "if (Test-Path \"$dir\\ParamDB.db\") { Copy-Item \"$dir\\ParamDB.db\" \"$persist_dir\" | Out-Null }",
+            "if (Test-Path \"$dir\\KeyMap.txt\") { Copy-Item \"$dir\\KeyMap.txt\" \"$persist_dir\" | Out-Null }"
+        ]
+    },
+    "bin": "JPEGView.exe",
+    "shortcuts": [
+        [
+            "JPEGView.exe",
+            "JPEGView"
+        ]
+    ],
+    "persist": "JPEGView.ini",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/sylikc/jpegview/releases/download/v$version/JPEGView_$version.7z",
+        "hash": {
+            "url": "https://github.com/sylikc/jpegview/releases/tag/v$version",
+            "regex": "$sha256 \\*$basename"
+        }
+    }
+}

--- a/bucket/jpegview-fork.json
+++ b/bucket/jpegview-fork.json
@@ -1,17 +1,16 @@
 {
-    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
     "version": "1.2.45",
-    "description": "This is the official re-release of JPEGView. JPEGView is a lean, fast and highly configurable image viewer/editor with a minimal GUI.",
+    "description": "Fork of JPEGView, a fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images with a minimal GUI.",
     "homepage": "https://github.com/sylikc/jpegview",
     "license": "GPL-2.0-or-later",
     "url": "https://github.com/sylikc/jpegview/releases/download/v1.2.45/JPEGView_1.2.45.7z",
     "hash": "d18d2e04eb7c9919199f76a0a0c303f05dda810b55e1d678870a0de006a3f393",
     "architecture": {
-        "32bit": {
-            "extract_dir": "JPEGView32"
-        },
         "64bit": {
             "extract_dir": "JPEGView64"
+        },
+        "32bit": {
+            "extract_dir": "JPEGView32"
         }
     },
     "pre_install": [
@@ -22,12 +21,6 @@
         "if (Test-Path \"$persist_dir\\ParamDB.db\") { Copy-Item \"$persist_dir\\ParamDB.db\" \"$dir\" | Out-Null }",
         "if (Test-Path \"$persist_dir\\KeyMap.txt\") { Copy-Item \"$persist_dir\\KeyMap.txt\" \"$dir\" | Out-Null }"
     ],
-    "uninstaller": {
-        "script": [
-            "if (Test-Path \"$dir\\ParamDB.db\") { Copy-Item \"$dir\\ParamDB.db\" \"$persist_dir\" | Out-Null }",
-            "if (Test-Path \"$dir\\KeyMap.txt\") { Copy-Item \"$dir\\KeyMap.txt\" \"$persist_dir\" | Out-Null }"
-        ]
-    },
     "bin": "JPEGView.exe",
     "shortcuts": [
         [
@@ -36,6 +29,12 @@
         ]
     ],
     "persist": "JPEGView.ini",
+    "uninstaller": {
+        "script": [
+            "if (Test-Path \"$dir\\ParamDB.db\") { Copy-Item \"$dir\\ParamDB.db\" \"$persist_dir\" | Out-Null }",
+            "if (Test-Path \"$dir\\KeyMap.txt\") { Copy-Item \"$dir\\KeyMap.txt\" \"$persist_dir\" | Out-Null }"
+        ]
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/sylikc/jpegview/releases/download/v$version/JPEGView_$version.7z",


### PR DESCRIPTION
Adds a [fork of JPEGView](https://github.com/sylikc/jpegview) to the bucket.

JPEGView is a lean, fast and highly configurable image viewer/editor with a minimal GUI. 

This fork is the de facto successor to the original project. It adds new features (such as support for new image formats), bug fixes, translations, and more. Additionally, this project is active, with 1.1k stars, 380 commits (roughly just as many as the original), and 11 releases since it started around 3 years ago in November 2020.

The original project had its [last release in 2018-02-24](https://sourceforge.net/projects/jpegview/files/jpegview/), and is widely considered to be abandoned. There has been no communication from the original developer. Note that this original project is also in this bucket at [`jpegview.json`](https://github.com/ScoopInstaller/Extras/blob/master/bucket/jpegview.json). Therefore, this app is `jpegview-fork`.

This manifest is based on the [original](https://github.com/ScoopInstaller/Extras/blob/master/bucket/jpegview.json). Additionally, changes have been incorporated from #10479, which was written by the fork author, @sylikc, but is now out of date and has not acknowledged a request for change to `jpegview-fork` — I have fixed both of these issues. Furthermore, I add the `autoupdate.hash` property.

Closes #10478, #10479.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
