### PR TITLE
vscodium: Add 32bit architecture & disable in-app update and more

### DIFF
--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -21,12 +21,15 @@
             "hash": "ae9e47c5d9fab5318cf8756ee663d2d682f0408f3a31e12f346aca02928c828a"
         }
     },
-    "env_add_path": "bin",
-    "shortcuts": [
-        [
-            "VSCodium.exe",
-            "VSCodium"
-        ]
+    "pre_install": [
+        "$product_path = \"$dir\\resources\\app\\product.json\"",
+        "if (Test-Path -Path $product_path) {",
+        "    $product = Get-Content -Path $product_path -Raw -Encoding UTF8 | ConvertFrom-Json",
+        "    if (![string]::IsNullOrEmpty($product.updateUrl)) {",
+        "        Get-Content -Path $product_path | Where-Object {$_ -notmatch \"updateurl\"} | Set-Content temp.json",
+        "        Move-Item -Path temp.json -Destination $product_path -Force",
+        "    }",
+        "}"
     ],
     "post_install": [
         "$dirpath = \"$dir\".Replace('\\', '\\\\')",

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -4,7 +4,7 @@
     "homepage": "https://vscodium.com/",
     "license": "MIT",
     "notes": [
-        "Add VSCodium as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
+        "Add VSCodium as a context menu option by running 'reg import \"$dir\\install-context.reg\"'",
         "For file associations, run 'reg import \"$dir\\install-associations.reg\"'"
     ],
     "architecture": {

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -1,6 +1,6 @@
 {
     "version": "1.79.2.23166",
-    "description": "VSCodium is a community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
+    "description": "A community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
     "homepage": "https://vscodium.com/",
     "license": "MIT",
     "notes": [

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -1,7 +1,7 @@
 {
     "version": "1.80.0.23188",
     "description": "A community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
-    "homepage": "https://github.com/VSCodium/vscodium",
+    "homepage": "https://vscodium.com/",
     "license": "MIT",
     "notes": [
         "Add VSCodium as a context menu option by running 'reg import \"$dir\\install-context.reg\"'",

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -1,7 +1,7 @@
 {
     "version": "1.79.2.23166",
-    "description": "Binary releases of VS Code without MS branding/telemetry/licensing.",
-    "homepage": "https://github.com/VSCodium/vscodium",
+    "description": "VSCodium is a community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
+    "homepage": "https://vscodium.com/",
     "license": "MIT",
     "notes": [
         "Add VSCodium as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
@@ -58,7 +58,9 @@
         "}"
     ],
     "persist": "data",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/VSCodium/vscodium"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -12,6 +12,10 @@
             "url": "https://github.com/VSCodium/vscodium/releases/download/1.79.2.23166/VSCodium-win32-x64-1.79.2.23166.zip",
             "hash": "687fac21f667954fce8f0821223d27177486c4e68114ff02eec7214d1960e2c5"
         },
+        "32bit": {
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.79.2.23166/VSCodium-win32-ia32-1.79.2.23166.zip",
+            "hash": "4240ebeeaab69f6e32534c284ff5c1dc4efd9f2a96e3cbb840bae8631a9e84a4"
+        },
         "arm64": {
             "url": "https://github.com/VSCodium/vscodium/releases/download/1.79.2.23166/VSCodium-win32-arm64-1.79.2.23166.zip",
             "hash": "ae9e47c5d9fab5318cf8756ee663d2d682f0408f3a31e12f346aca02928c828a"
@@ -59,6 +63,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-x64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-ia32-$version.zip"
             },
             "arm64": {
                 "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-arm64-$version.zip"

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -57,6 +57,19 @@
         "    (Get-Content \"$extensions_file\") -replace '(?<=vscodium(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
         "}"
     ],
+    "env_add_path": "bin",
+    "bin": [
+        [
+            "bin/codium.cmd",
+            "vscodium"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "VSCodium.exe",
+            "VSCodium"
+        ]
+    ],
     "persist": "data",
     "checkver": {
         "github": "https://github.com/VSCodium/vscodium"

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -13,7 +13,7 @@
             "hash": "856398e61a023918bac344827df1848fb74833a6fe62fc0de30343fd749e95ee"
         },
         "32bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.79.2.23166/VSCodium-win32-ia32-1.79.2.23166.zip",
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.80.0.23188/VSCodium-win32-ia32-1.80.0.23188.zip",
             "hash": "4240ebeeaab69f6e32534c284ff5c1dc4efd9f2a96e3cbb840bae8631a9e84a4"
         },
         "arm64": {


### PR DESCRIPTION
This PR includes various updates and refactoring to the VSCodium manifest, here are the details.

1.  Description and Homepage: The description and homepage have been updated.
2. Architecture: The architecture now includes an entry for 32bit versions.
3. pre_install: and a new "pre_install" section has been added to prevent in-app updates.
4. Bin: A new "bin" section has been introduced, which allows users to type and employ the actual product name vscodium.
5.  Checkver: The "checkver" field has been updated.
6. Autoupdate: The "autoupdate" field now includes an entry for 32bit versions.

Closes https://github.com/ScoopInstaller/Extras/issues/11529

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Attribution
PR title and body provided by @StarsbySea .