### PR TITLE
kubelogin: add kubectl-oidc_login bin

### DIFF
--- a/bucket/kubelogin.json
+++ b/bucket/kubelogin.json
@@ -10,10 +10,7 @@
         }
     },
     "bin": [
-        [
-            "kubelogin.exe",
-            "kubelogin"
-        ],
+        "kubelogin.exe",
         [
             "kubelogin.exe",
             "kubectl-oidc_login"

--- a/bucket/kubelogin.json
+++ b/bucket/kubelogin.json
@@ -9,7 +9,16 @@
             "hash": "1d386343837ec0c67d53a39c224ac11b853b7262b307945d315f2eb71f49beb4"
         }
     },
-    "bin": "kubelogin.exe",
+    "bin": [
+        [
+            "kubelogin.exe",
+            "kubelogin"
+        ],
+        [
+            "kubelogin.exe",
+            "kubectl-oidc_login"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
`kubelogin` needs a binary called `kubectl-oidc_login`.

c.f. https://github.com/int128/kubelogin#setup
> If you install via GitHub releases, you need to put the kubelogin binary on your path under the name kubectl-oidc_login so that the [kubectl plugin mechanism](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/) can find it when you invoke kubectl oidc-login. The other install methods do this for you.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--Closes #XXXX-->
<!-- or -->
<!--Relates to #XXXX-->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
