### PR TITLE
RidNacs: update to 3.0.0

### DIFF
--- a/bucket/ridnacs.json
+++ b/bucket/ridnacs.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.0.3",
+    "version": "3.0.0",
     "description": "Disk space usage analyzer",
     "homepage": "https://www.splashsoft.de/ridnacs-disk-space-usage-analyzer/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.splashsoft.de/ridnacs-freeware-license/"
     },
-    "url": "https://www.splashsoft.de/?download=276#/dl.zip",
-    "hash": "b3d6f743ec73388d8c425edf8b29d381a10a0fe6b58ad7e2955494b5646b1cbb",
+    "url": "https://www.splashsoft.de/?download=520#/dl.zip",
+    "hash": "e25052121994423edd757dc549ff8520dad87092bd1bba57c573dbdc59a38f9a",
     "bin": "RidNacs.exe",
     "shortcuts": [
         [

--- a/bucket/ridnacs.json
+++ b/bucket/ridnacs.json
@@ -20,6 +20,6 @@
         "regex": "download=(?<page>\\d+)\" title=\"RidNacs ([\\d.]+) \\(zip, portable"
     },
     "autoupdate": {
-        "url": "https://www.splashsoft.de/?download=520#/dl.zip"
+        "url": "https://www.splashsoft.de/?download=$matchPage#/dl.zip"
     }
 }

--- a/bucket/ridnacs.json
+++ b/bucket/ridnacs.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.0",
+    "version": "3.0",
     "description": "Disk space usage analyzer",
     "homepage": "https://www.splashsoft.de/ridnacs-disk-space-usage-analyzer/",
     "license": {
@@ -14,5 +14,12 @@
             "RidNacs.exe",
             "RidNacs"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://www.splashsoft.de/ridnacs-download/",
+        "regex": "download=(?<page>\\d+)\" title=\"RidNacs ([\\d.]+) \\(zip, portable"
+    },
+    "autoupdate": {
+        "url": "https://www.splashsoft.de/?download=520#/dl.zip"
+    }
 }


### PR DESCRIPTION
This PR updates the manifest for RidNacs to the version 3.0 of the application. I did not create an issue beforehand as I didn't find a correct template for it, so please let me know if I should do that.

There hasn't been any updates for this application in many years and they have slightly changed the layout of the download page after releasing 3.0, so I didn't add a checkver.

Also, I am kinda lost in their versioning now, cause they used to do proper semver before, now they're using two numbers for the version, and the application says it's actually 1.0.8053, so in the manifest I just set 3.0.0.

![image](https://github.com/ScoopInstaller/Extras/assets/26277478/3f2a73ed-a2e0-485d-bad2-a430c95b35bb)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
