### PR TITLE
Update wavosaur to 1.8.0.0, fix checkver regex in manifest

### DIFF
--- a/bucket/wavosaur.json
+++ b/bucket/wavosaur.json
@@ -1,18 +1,18 @@
 {
-    "version": "1.7.0.0",
+    "version": "1.8.0.0",
     "homepage": "https://www.wavosaur.com/",
     "description": "A free sound editor, audio editor, wav editor software for editing, processing and recording sounds, wav and mp3 files.",
     "license": "Freeware",
     "architecture": {
         "32bit": {
-            "url": "https://www.wavosaur.com/download/files/Wavosaur.1.7.0.0-x86.zip",
-            "hash": "25dc82a9d92c4b0c785898fbab35bc2444669d3999778e5317eb566a5b98db5d",
-            "extract_dir": "Wavosaur.1.7.0.0-x86"
+            "url": "https://www.wavosaur.com/download/files/Wavosaur.1.8.0.0-x86.zip",
+            "hash": "779484337e2ecb6aeaf81f5c7d7c5dbf89b29b0a43921c8a22934853491c79c5",
+            "extract_dir": "Wavosaur.1.8.0.0-x86"
         },
         "64bit": {
-            "url": "https://www.wavosaur.com/download/files/Wavosaur.1.7.0.0-x64.zip",
-            "hash": "ccd0cf0a468fa53b56adf3309bf0d82d34bca541de308c69927d67b5a2842c63",
-            "extract_dir": "Wavosaur.1.7.0.0-x64"
+            "url": "https://www.wavosaur.com/download/files/Wavosaur.1.8.0.0-x64.zip",
+            "hash": "5807d9b719b27504739c7ca8daa2a652229a503be5e0df2723dea0967f4b58e0",
+            "extract_dir": "Wavosaur.1.8.0.0-x64"
         }
     },
     "pre_install": [
@@ -34,7 +34,7 @@
         "wavosaur.skin",
         "wavosaur.vst"
     ],
-    "checkver": "Wavosaur\\.([\\d.]+)-*",
+    "checkver": "Wavosaur\\.([\\d.]+)\\.-*",
     "autoupdate": {
         "architecture": {
             "32bit": {


### PR DESCRIPTION
Also update regex for checkver to remove the dot from app version that prevents "checkver.ps1 -u wavosaur" to generate a working url.

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
