### PR TITLE
detect-it-easy: switch to qt6 version

### DIFF
--- a/bucket/detect-it-easy.json
+++ b/bucket/detect-it-easy.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/horsicq/DIE-engine/releases/download/3.08/die_win64_portable_3.08_x64.zip",
-            "hash": "a6b9ea7ea2e06a048ac4aef3d27020fbc383bbad448da6c767118ebfd2449d5e"
+            "url": "https://github.com/horsicq/DIE-engine/releases/download/3.08/die_win64_qt6_portable_3.08_x64.zip",
+            "hash": "02da106bc09f6d2af6a08f5853ea3e2934fa011fd3f7f6e01bcfba0931488e43"
         },
         "32bit": {
             "url": "https://github.com/horsicq/DIE-engine/releases/download/3.08/die_win32_portable_3.08_x86.zip",
@@ -39,7 +39,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/horsicq/DIE-engine/releases/download/$version/die_win64_portable_$version_x64.zip"
+                "url": "https://github.com/horsicq/DIE-engine/releases/download/$version/die_win64_qt6_portable_$version_x64.zip"
             },
             "32bit": {
                 "url": "https://github.com/horsicq/DIE-engine/releases/download/$version/die_win32_portable_$version_x86.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Dark mode properly works in the qt6 version

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
