### PR TITLE
inkscape: fix bin

### DIFF
--- a/bucket/inkscape.json
+++ b/bucket/inkscape.json
@@ -16,8 +16,8 @@
         }
     },
     "bin": [
-        "bin\\inkscape.com",
-        "bin\\inkview.com"
+        "bin\\inkscapecom.com",
+        "bin\\inkviewcom.com"
     ],
     "shortcuts": [
         [

--- a/bucket/inkscape.json
+++ b/bucket/inkscape.json
@@ -16,8 +16,14 @@
         }
     },
     "bin": [
-        "bin\\inkscapecom.com",
-        "bin\\inkviewcom.com"
+        [
+            "bin\\inkscapecom.com",
+            "inkscape"
+        ],
+        [
+            "bin\\inkviewcom.com",
+            "inkview"
+        ]
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
`Can't shim 'bin\inkscape.com': File doesn't exist.`

It had been renamed to `inkscapecom.com`

![image](https://github.com/ScoopInstaller/Extras/assets/19755727/89fad44a-75db-4343-97e0-f8af86bb5325)


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
