### PR TITLE
arcadedb: Add version 23.6.1

### DIFF
--- a/bucket/arcadedb.json
+++ b/bucket/arcadedb.json
@@ -3,12 +3,6 @@
     "description": "Multi-model database, one DBMS that supports SQL, Cypher, Gremlin, HTTP/JSON, MongoDB and Redis",
     "homepage": "https://arcadedb.com",
     "license": "Apache-2.0",
-    "notes": [
-        "After an installation or update please close all your terminal sessions before interacting with ArcadeDB commands.",
-        "Available commands:",
-        "  arcadedb-console",
-        "  arcadedb-server"
-    ],
     "suggest": {
         "JDK": [
             "java/openjdk11",

--- a/bucket/arcadedb.json
+++ b/bucket/arcadedb.json
@@ -1,0 +1,46 @@
+{
+    "version": "23.6.1",
+    "description": "Multi-model database, one DBMS that supports SQL, Cypher, Gremlin, HTTP/JSON, MongoDB and Redis.",
+    "homepage": "https://arcadedb.com",
+    "license": "Apache-2.0",
+    "notes": [
+        "After an installation or update please close all your terminal sessions before interacting with ArcadeDB commands.",
+        "Available commands:",
+        "  arcadedb-console",
+        "  arcadedb-server"
+    ],
+    "suggest": {
+        "JDK": [
+            "java/openjdk11",
+            "java/graalvm-jdk11"
+        ]
+    },
+    "url": "https://github.com/ArcadeData/arcadedb/releases/download/23.6.1/arcadedb-23.6.1.tar.gz",
+    "hash": "049ec7393ae8b0d2c9fd0523dd26fe20d68fa888297ff9b193aaa71a5915d169",
+    "extract_dir": "arcadedb-23.6.1",
+    "persist": [
+        "config",
+        "databases",
+        "log"
+    ],
+    "env_set": {
+        "ARCADEDB_HOME": "$dir"
+    },
+    "bin": [
+        [
+            "bin\\console.bat",
+            "arcadedb-console"
+        ],
+        [
+            "bin\\server.bat",
+            "arcadedb-server"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ArcadeData/arcadedb"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ArcadeData/arcadedb/releases/download/$version/arcadedb-$version.tar.gz",
+        "extract_dir": "arcadedb-$version"
+    }
+}

--- a/bucket/arcadedb.json
+++ b/bucket/arcadedb.json
@@ -1,6 +1,6 @@
 {
     "version": "23.6.1",
-    "description": "Multi-model database, one DBMS that supports SQL, Cypher, Gremlin, HTTP/JSON, MongoDB and Redis.",
+    "description": "Multi-model database, one DBMS that supports SQL, Cypher, Gremlin, HTTP/JSON, MongoDB and Redis",
     "homepage": "https://arcadedb.com",
     "license": "Apache-2.0",
     "notes": [


### PR DESCRIPTION
This PR adds ArcadeDB, an OSS successor to OrientDB, multimodal high-performance database with HA capabilities.

Closes #11638

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Comments on manifest

ArcadeDB is written in Java and comes with a structure that's similar to a lot of Java projects.
It contains two scripts `console.bat` and `server.bat` that are unfortunately very generic names, that's why I decided to come up with two shims with `arcadedb-` prefix. Also set `ARCADEDB_HOME` environment variable is a huge convenience required by launch scripts and position of following folders.
Folders `config`, `database` and `log` are persisted so they don't disapper between updates.
