### PR TITLE
aegisubdc: Fix shortcuts

### DIFF
--- a/bucket/aegisubdc.json
+++ b/bucket/aegisubdc.json
@@ -19,10 +19,6 @@
         [
             "Aegisub.exe",
             "Aegisub"
-        ],
-        [
-            "AssDraw3.exe",
-            "AssDraw3"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Remove AssDraw3 from shortcut list as it no longer exists.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
