### PR TITLE
emacs: Add cmdproxy.exe to shims

### DIFF
--- a/bucket/emacs.json
+++ b/bucket/emacs.json
@@ -16,7 +16,8 @@
         "bin\\emacs.exe",
         "bin\\emacsclientw.exe",
         "bin\\etags.exe",
-        "bin\\ctags.exe"
+        "bin\\ctags.exe",
+        "libexec\\emacs\\$version\\x86_64-w64-mingw32\\cmdproxy.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
Emacs on windows needs `shell-file-name` to be set to path of `cmdproxy.exe` manually, by adding this into bin paths, `cmdproxy.exe` is available directly without changing paths explicitly everytime on update.
