### PR TITLE
Tracy: Add version 0.9.1

### DIFF
--- a/bucket/tracy.json
+++ b/bucket/tracy.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.9.1",
+    "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
+    "homepage": "https://github.com/wolfpld/tracy",
+    "license": "BSD-3-Clause",
+    "notes": "",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wolfpld/tracy/releases/download/v0.9.1/Tracy-0.9.1.7z",
+            "hash": "755cf8933b22d5e1a94f4ce641896851026da982c4bff54203d4d7146d2f49a7"
+        }
+    },
+    "bin": "Tracy.exe",
+    "shortcuts": [
+        [
+            "Tracy.exe",
+            "Tracy"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wolfpld/tracy/releases/download/v$version/Tracy-$version.7z"
+            }
+        }
+    }
+}

--- a/bucket/tracy.json
+++ b/bucket/tracy.json
@@ -1,16 +1,17 @@
 {
     "version": "0.9.1",
-    "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
+    "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications",
     "homepage": "https://github.com/wolfpld/tracy",
     "license": "BSD-3-Clause",
-    "notes": "",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/wolfpld/tracy/releases/download/v0.9.1/Tracy-0.9.1.7z",
             "hash": "755cf8933b22d5e1a94f4ce641896851026da982c4bff54203d4d7146d2f49a7"
         }
     },
-    "bin": "Tracy.exe",
     "shortcuts": [
         [
             "Tracy.exe",


### PR DESCRIPTION
Tracy is a profiler that I personally use for analyzing video game performance. The client library can already be found on vcpkg so making the graphical tool available on scoop is a big help.

- [✔️ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
