### PR TITLE
firefoxpwa@2.7.3: Update the homepage

### DIFF
--- a/bucket/firefoxpwa.json
+++ b/bucket/firefoxpwa.json
@@ -1,7 +1,7 @@
 {
     "version": "2.7.3",
     "description": "A tool to install, manage and use Progressive Web Apps (PWAs) in Mozilla Firefox (native component)",
-    "homepage": "https://github.com/filips123/PWAsForFirefox",
+    "homepage": "https://pwasforfirefox.filips.si/",
     "license": "MPL-2.0",
     "notes": [
         "You have successfully installed the native part of the PWAsForFirefox project",


### PR DESCRIPTION
The PWAsForFirefox (firefoxpwa) project now has a new website. This PR updates the homepage URL in the Scoop package.

Because it's quite a simple change, I haven't created a new issue about this. I can create it if this is really needed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
