### PR TITLE
DNSBench: Add version 1.3.668.0

### DIFF
--- a/bucket/dnsbench.json
+++ b/bucket/dnsbench.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.3.6668.0",
+    "description": "Benchmark DNS servers",
+    "homepage": "https://www.grc.com/dns/benchmark.htm",
+    "license": "Freeware",
+    "url": "https://www.grc.com/files/DNSBench.exe",
+    "hash": "ab42c94fc03ddbf446319772518b229d7b2e2546fdddaae7c01abe0fa8a02be1",
+    "bin": "DNSBench.exe",
+    "shortcuts": [
+        [
+            "DNSBench.exe",
+            "DNSBench"
+        ]
+    ],
+    "autoupdate": {
+        "url": "https://www.grc.com/files/DNSBench.exe"
+    }
+}


### PR DESCRIPTION
New manifest for the freeware dns benchmark tool DNSBench


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
