### PR TITLE
crunchy-cli: Update to version 3.0.0

### DIFF
--- a/bucket/crunchy-cli.json
+++ b/bucket/crunchy-cli.json
@@ -1,25 +1,24 @@
 {
-    "version": "2.3.6",
-    "description": "A Crunchyroll cli client and downloader.",
+    "version": "3.0.0",
+    "description": "Command-line downloader for Crunchyroll",
     "homepage": "https://github.com/crunchy-labs/crunchy-cli",
-    "license": "GPL-3.0-or-later",
+    "license": "MIT",
     "suggest": {
-        "ffmpeg": "ffmpeg",
-        "vcredist": "extras/vcredist2010"
+        "ffmpeg": "ffmpeg"
     },
-    "notes": "You need a premium account for full access.",
+    "notes": "You need a Crunchyroll Premium subscription to access premium content",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/crunchy-labs/crunchy-cli/releases/download/v2.3.6/crunchy-v2.3.6_windows.exe#/crunchy.exe",
-            "hash": "8153cecf59d0ae1d9c71be3e5bd65c91fe6063eea2510da1f1a9b42171888122"
+            "url": "https://github.com/crunchy-labs/crunchy-cli/releases/download/v3.0.0/crunchy-cli-v3.0.0-windows-x86_64.exe#/crunchy-cli.exe",
+            "hash": "ef30883e5889020f6547131b65dcdc1a5257e5e24e415a30be66aa6153b3b0a8"
         }
     },
-    "bin": "crunchy.exe",
+    "bin": "crunchy-cli.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/crunchy-labs/crunchy-cli/releases/download/v$version/crunchy-v$version_windows.exe#/crunchy.exe"
+                "url": "https://github.com/crunchy-labs/crunchy-cli/releases/download/v$version/crunchy-cli-v$version-windows-x86_64.exe#/crunchy-cli.exe"
             }
         }
     }


### PR DESCRIPTION
With the [v3 release](https://github.com/crunchy-labs/crunchy-cli/releases/tag/v3.0.0) of [crunchy-cli](https://github.com/crunchy-labs/crunchy-cli), the naming scheme of the release binary got changed, as well as the license, description and required dependencies. This PR adjusts the crunchy-cli manifest to those changes.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).