### PR TITLE
archi: fix URL and hash

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -11,10 +11,15 @@
     },
     "extract_dir": "Archi",
     "bin": "archi.exe",
-    "shortcuts": [["archi.exe", "Archi"]],
+    "shortcuts": [
+        [
+            "archi.exe",
+            "Archi"
+        ]
+    ],
     "checkver": {
         "url": "https://www.archimatetool.com/download/",
-        "regex": "Archi ([\\d.]+)"
+        "regex": "Archi-Win64-([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -1,22 +1,17 @@
 {
-    "version": "5.1",
+    "version": "5.1.0",
     "description": "A tool and editor to create ArchiMate models",
     "homepage": "https://www.archimatetool.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/archi.php?/5.1/Archi-Win64-5.1.zip",
-            "hash": "356fe3ad8c67361c35aaae13e3b0d612608d3b70dadaba666e5abd04941a1308"
+            "url": "https://www.archimatetool.com/downloads/archi.php?/5.1.0/Archi-Win64-5.1.0.zip",
+            "hash": "sha1:0048230b72fb1774a64b2b6ed3c2c14b123db7a0"
         }
     },
     "extract_dir": "Archi",
     "bin": "archi.exe",
-    "shortcuts": [
-        [
-            "archi.exe",
-            "Archi"
-        ]
-    ],
+    "shortcuts": [["archi.exe", "Archi"]],
     "checkver": {
         "url": "https://www.archimatetool.com/download/",
         "regex": "Archi ([\\d.]+)"


### PR DESCRIPTION
It seemed like the zip file could be downloaded with just the `major.minor` version but the `.SUMSSHA1` file can't, and the hash is was wrong anyway.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
