### PR TITLE
Adding GO Feature Flag

### DIFF
--- a/bucket/go-feature-flag.json
+++ b/bucket/go-feature-flag.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.14.1",
+    "description": "Simple, complete, and lightweight feature flag solution",
+    "homepage": "https://gofeatureflag.org",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_i386.tar.gz",
+            "bin": [
+                "go-feature-flag.exe"
+            ],
+            "hash": "123a8933c1282537799f944b794d1173fc4a5564590efb9249a5228fa5a60690"
+        },
+        "64bit": {
+            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_x86_64.tar.gz",
+            "bin": [
+                "go-feature-flag.exe"
+            ],
+            "hash": "01995a43ed04c061b7efb8b64ee4c4a3ad9757b1a362df79c9064327929f1073"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz",
+                "bin": [
+                    "go-feature-flag.exe"
+                ]
+            },
+            "64bit": {
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz",
+                "bin": [
+                    "go-feature-flag.exe"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding GO Feature Flag inside the scoop extra bucket.
The project does not meet the requirement of the scoop official bucket (good with the stars not with the forks 😢)

fixes https://github.com/thomaspoignant/go-feature-flag/issues/817

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
