### PR TITLE
Fix #11740 - make persist work with v2.0.x migrated install paths

### DIFF
--- a/bucket/jetbrains-toolbox.json
+++ b/bucket/jetbrains-toolbox.json
@@ -15,7 +15,7 @@
     "post_install": [
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe\" -Recurse",
         "$config = \"$env:LOCALAPPDATA\\JetBrains\\Toolbox\\.settings.json\"",
-        "if (-not (Test-Path $config)) {",
+        "if (!(Test-Path $config)) {",
         "    $settings = @{",
         "        'autostart' = $false",
         "        'install_location' = \"$dir\\apps\"",
@@ -23,7 +23,14 @@
         "    }",
         "    New-Item $config -Type File -Force | Out-Null",
         "    Set-Content $config ($settings | ConvertToPrettyJson) -Encoding ASCII -Force",
-        "}"
+        "} else { # NOTE: Remove the migration script after 6 months (2024-02-15)",
+        "  $conf_content = (Get-Content $config | ConvertFrom-Json)",
+        "  if ($conf_content.'install_location' -eq \"$dir\") {",
+        "    $conf_content.'install_location' = \"$dir\\apps\"",
+        "    Set-Content $config ($conf_content | ConvertToPrettyJson) -Encoding ASCII -Force",
+        "  }",
+        "}",
+        "# NOTE END"
     ],
     "bin": "jetbrains-toolbox.exe",
     "shortcuts": [

--- a/bucket/jetbrains-toolbox.json
+++ b/bucket/jetbrains-toolbox.json
@@ -18,7 +18,7 @@
         "if (-not (Test-Path $config)) {",
         "    $settings = @{",
         "        'autostart' = $false",
-        "        'install_location' = \"$dir\"",
+        "        'install_location' = \"$dir\\apps\"",
         "        'update' = @{'install_automatically' = $false}",
         "    }",
         "    New-Item $config -Type File -Force | Out-Null",


### PR DESCRIPTION
JetBrains-toolbox v2.0.x changed the way how the install path is used.
 - Before apps are installed to `$current\apps`
 - Through migration, the apps are migrated to `$current`
   - Due to the app honoring the setting of `installation` path

So change the setting to `$current\apps` is the simple solution on code perspective. But a few manual setup is needed:
 - Clear the migrated apps directories from `$current`
   - Remove that particular version and reinstall is easier.
 - Back-up then clear persisted `apps` directory, then reinstall all tools.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #11740

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
