### PR TITLE
ipfilter-updater.json: Fix `extract_dir`

### DIFF
--- a/bucket/ipfilter-updater.json
+++ b/bucket/ipfilter-updater.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/DavidMoore/ipfilter/releases/download/3.0.3-beta/IPFilter.msi",
     "hash": "146d6130f619dec8c0dc584c90127ae57e71be33a70cbf20755dc7f2bb09bac2",
-    "extract_dir": "AppData\\IPFilter",
+    "extract_dir": "LocalApp\\IPFilter",
     "bin": "ipfilter.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Fixes `Could not find 'IPFilter'! (error 16)` for v3.0.3-beta.

```
Installing 'ipfilter-updater' (3.0.3-beta) [64bit] from extras bucket
Loading IPFilter.msi from cache
Checking hash of IPFilter.msi ... ok.
Extracting IPFilter.msi ... Exception: D:\Scoop\apps\scoop\current\lib\core.ps1:638
Line |
 638 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'IPFilter'! (error 16)
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
