### PR TITLE
Added HWiNFO key persistence

### DIFF
--- a/bucket/hwinfo.json
+++ b/bucket/hwinfo.json
@@ -42,7 +42,8 @@
     },
     "persist": [
         "HWiNFO64.INI",
-        "HWiNFO32.INI"
+        "HWiNFO32.INI",
+        "HWiNFO64_KEY.txt"
     ],
     "checkver": {
         "url": "https://www.hwinfo.com/ver.txt",


### PR DESCRIPTION
Added HWiNFO64_KEY.txt to the persist in HWiNFO so user's license key is saved between updates

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
