### PR TITLE
rsgain: Add version 3.3

### DIFF
--- a/bucket/rsgain.json
+++ b/bucket/rsgain.json
@@ -1,0 +1,26 @@
+{
+    "version": "3.3",
+    "description": "A simple, but powerful ReplayGain 2.0 tagging utility",
+    "homepage": "https://github.com/complexlogic/rsgain",
+    "license": "BSD-2-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/complexlogic/rsgain/releases/download/v3.3/rsgain-3.3-win64.zip",
+            "hash": "94e8fa1eb7fafd4860f5c07c3efabda6e81f692bc178892a89d65b5699e5126a",
+            "extract_dir": "rsgain-3.3-win64"
+        }
+    },
+    "bin": "rsgain.exe",
+    "persist": [
+        "presets"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/complexlogic/rsgain/releases/download/v$version/rsgain-$version-win64.zip",
+                "extract_dir": "rsgain-$version-win64"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an initial manifest for [rsgain](https://github.com/complexlogic/rsgain), which is currently only available in a few [community buckets](https://scoop.sh/#/apps?q=rsgain&s=0&d=1&o=false).

There are [no existing issues or PRs](https://github.com/search?q=org%3AScoopInstaller%20rsgain&type=code) for rsgain.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
