### PR TITLE
oranda: Add version 0.3.1

### DIFF
--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -4,7 +4,9 @@
     "homepage":"https://opensource.axo.dev/oranda/",
     "license":"MIT or Apache-2.0",
     "bin":"oranda.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/axodotdev/oranda",
+    },
     "autoupdate":{
         "architecture":{
             "64bit":{

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -6,7 +6,6 @@
     "suggest":{
         "Tailwind CLI":"tailwindcss"
     },
-    "hash":"1fbd33274a790500c5b69528ab22aa7eba5ff0297f9263f3f43ee53661f23e34",
     "bin":"oranda.exe",
     "checkver": "github",
     "autoupdate":{
@@ -24,6 +23,7 @@
     "architecture":{
         "64bit":{
             "url":"https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-x86_64-pc-windows-msvc.tar.gz",
+            "hash":"1fbd33274a790500c5b69528ab22aa7eba5ff0297f9263f3f43ee53661f23e34",
 			"extract_dir":"oranda-x86_64-pc-windows-msvc"
         }
     }

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -1,0 +1,32 @@
+{
+    "version":"v0.3.1",
+    "description":"Generate beautiful landing pages for your developer tools",
+    "homepage":"https://opensource.axo.dev/oranda/",
+    "license":"MIT or Apache-2.0",
+    "suggest":{
+        "Tailwind CLI":"tailwindcss"
+    },
+    "hash":"1fbd33274a790500c5b69528ab22aa7eba5ff0297f9263f3f43ee53661f23e34",
+    "bin":"oranda.exe",
+    "checkver":{
+        "github":"https://github.com/axodotdev/oranda/tags"
+    },
+    "autoupdate":{
+        "architecture":{
+            "64bit":{
+                "url":"https://github.com/axodotdev/oranda/releases/download/$version/oranda-x86_64-pc-windows-msvc.tar.gz",
+                "extract_dir":"oranda-x86_64-pc-windows-msvc"
+            }
+        },
+        "hash":{
+            "mode":"extract",
+            "url":"$url.sha256"
+        }
+    },
+    "architecture":{
+        "64bit":{
+            "url":"https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-x86_64-pc-windows-msvc.tar.gz",
+			"extract_dir":"oranda-x86_64-pc-windows-msvc"
+        }
+    }
+}

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -6,7 +6,7 @@
     "bin":"oranda.exe",
     "checkver": {
         "url": "https://github.com/axodotdev/oranda/tags",
-        "regex": "v(?<version>[\d.]+)\\.tar\\.gz"
+        "regex": "v(?<version>[\\d.]+)\\.tar\\.gz"
     },
     "autoupdate":{
         "architecture":{

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -17,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-x86_64-pc-windows-msvc.tar.gz"
+                "url": "https://github.com/axodotdev/oranda/releases/download/v$version/oranda-x86_64-pc-windows-msvc.tar.gz"
             }
         },
         "hash": {

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -8,9 +8,7 @@
     },
     "hash":"1fbd33274a790500c5b69528ab22aa7eba5ff0297f9263f3f43ee53661f23e34",
     "bin":"oranda.exe",
-    "checkver":{
-        "github":"https://github.com/axodotdev/oranda/tags"
-    },
+    "checkver": "github",
     "autoupdate":{
         "architecture":{
             "64bit":{

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -1,11 +1,12 @@
 {
-    "version":"v0.3.1",
+    "version":"0.3.1",
     "description":"Generate beautiful landing pages for your developer tools",
     "homepage":"https://opensource.axo.dev/oranda/",
     "license":"MIT or Apache-2.0",
     "bin":"oranda.exe",
     "checkver": {
-        "github": "https://github.com/axodotdev/oranda",
+        "url": "https://github.com/axodotdev/oranda/tags",
+        "regex": "v(?<version>[\d.]+)\\.tar\\.gz"
     },
     "autoupdate":{
         "architecture":{

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -1,30 +1,27 @@
 {
-    "version":"0.3.1",
-    "description":"Generate beautiful landing pages for your developer tools",
-    "homepage":"https://opensource.axo.dev/oranda/",
-    "license":"MIT or Apache-2.0",
-    "bin":"oranda.exe",
-    "checkver": {
-        "url": "https://github.com/axodotdev/oranda/tags",
-        "regex": "v(?<version>[\\d.]+)\\.tar\\.gz"
-    },
-    "autoupdate":{
-        "architecture":{
-            "64bit":{
-                "url":"https://github.com/axodotdev/oranda/releases/download/v$version/oranda-x86_64-pc-windows-msvc.tar.gz",
-                "extract_dir":"oranda-x86_64-pc-windows-msvc"
-            }
-        },
-        "hash":{
-            "mode":"extract",
-            "url":"$url.sha256"
+    "version": "0.3.1",
+    "description": "Generate beautiful landing pages for your developer tools",
+    "homepage": "https://opensource.axo.dev/oranda/",
+    "license": "MIT|Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "1fbd33274a790500c5b69528ab22aa7eba5ff0297f9263f3f43ee53661f23e34"
         }
     },
-    "architecture":{
-        "64bit":{
-            "url":"https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-x86_64-pc-windows-msvc.tar.gz",
-            "hash":"1fbd33274a790500c5b69528ab22aa7eba5ff0297f9263f3f43ee53661f23e34",
-			"extract_dir":"oranda-x86_64-pc-windows-msvc"
+    "extract_dir": "oranda-x86_64-pc-windows-msvc",
+    "bin": "oranda.exe",
+    "checkver": {
+        "github": "https://github.com/axodotdev/oranda"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/axodotdev/oranda/releases/download/v0.3.1/oranda-x86_64-pc-windows-msvc.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -11,7 +11,7 @@
     "autoupdate":{
         "architecture":{
             "64bit":{
-                "url":"https://github.com/axodotdev/oranda/releases/download/$version/oranda-x86_64-pc-windows-msvc.tar.gz",
+                "url":"https://github.com/axodotdev/oranda/releases/download/v$version/oranda-x86_64-pc-windows-msvc.tar.gz",
                 "extract_dir":"oranda-x86_64-pc-windows-msvc"
             }
         },

--- a/bucket/oranda.json
+++ b/bucket/oranda.json
@@ -3,9 +3,6 @@
     "description":"Generate beautiful landing pages for your developer tools",
     "homepage":"https://opensource.axo.dev/oranda/",
     "license":"MIT or Apache-2.0",
-    "suggest":{
-        "Tailwind CLI":"tailwindcss"
-    },
     "bin":"oranda.exe",
     "checkver": "github",
     "autoupdate":{


### PR DESCRIPTION
Adding `oranda`, a developer tool/static site generator to build landing pages for your projects fast.

Closes #11779

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
