### PR TITLE
(chore): Update speedcrunch to allow persisting history

### DIFF
--- a/bucket/speedcrunch.json
+++ b/bucket/speedcrunch.json
@@ -6,6 +6,13 @@
     "url": "https://bitbucket.org/heldercorreia/speedcrunch/downloads/SpeedCrunch-0.12-win32.zip",
     "hash": "024362bccd7908b508192cd90c2f6a716b5aa4fa5c7ff2aea9a1bf49d6580175",
     "extract_dir": "SpeedCrunch-0.12-win32",
+    "pre_install": [
+        "# Manually create history and config files to allow to persist them (SpeedCrunch.ini is overwritten by Speedcrunch, so can't be persisted)",
+        "if (-not (Test-Path '$dir/history.json')) {",
+        "  set-content -path $dir/history.json    -value '{}' -encoding utf8 }",
+        "if (-not (Test-Path '$dir/SpeedCrunch.ini')) {",
+        "  set-content -path $dir/SpeedCrunch.ini -value ''   -encoding utf8 }"
+    ],
     "bin": "speedcrunch.exe",
     "shortcuts": [
         [
@@ -13,6 +20,7 @@
             "SpeedCrunch"
         ]
     ],
+    "persist": ["history.json"],
     "checkver": {
         "url": "https://heldercorreia.bitbucket.io/speedcrunch/download.html",
         "regex": "<h1>Version\\s+([\\d.]+)<\\/h1>"


### PR DESCRIPTION
Settings still can't be persisted due to the hardlink overwritten by the app

Closes #11801

- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
