### PR TITLE
fspy: Add version 1.0.3

### DIFF
--- a/bucket/fspy.json
+++ b/bucket/fspy.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0.3",
+    "description": "Open source still image camera matching",
+    "homepage": "https://fspy.io/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/stuffmatic/fSpy/releases/download/v1.0.3/fSpy-1.0.3-win.zip",
+            "hash": "e9694824de5c663e8fd89713ccf30dc95ec00a2cb3df1c97b61c989f85d39a5d"
+        },
+        "32bit": {
+            "url": "https://github.com/stuffmatic/fSpy/releases/download/v1.0.3/fSpy-1.0.3-ia32-win.zip",
+            "hash": "e4d84010c5c14b18563f13703118f3eac382871f5e62d001c68950f2953aba53"
+        }
+    },
+    "bin": "fspy.exe",
+    "shortcuts": [
+        [
+            "fspy.exe",
+            "fspy"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/stuffmatic/fSpy"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/stuffmatic/fSpy/releases/download/v$version/fSpy-$version-win.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/stuffmatic/fSpy/releases/download/v$version/fSpy-$version-ia32-win.zip"
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add version 1.0.3 of `fspy`, an open source still image camera matching tool.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11814 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
