### PR TITLE
taiga: Make `persist` explicit

### DIFF
--- a/bucket/taiga.json
+++ b/bucket/taiga.json
@@ -7,7 +7,7 @@
     "hash": "22556aff39f20a88bde4f0b944d886dd729810477b6b97dab39a0c9a60ad43e0",
     "pre_install": [
         "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
-        "'user', 'feed' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
+        "'user', 'feed', 'db\\image' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
         "'settings', 'db\\anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
     ],
     "bin": "Taiga.exe",
@@ -21,6 +21,7 @@
         "data\\user",
         "data\\feed",
         "data\\settings.xml",
+        "data\\db\\image",
         "data\\db\\anime.xml"
     ],
     "checkver": {

--- a/bucket/taiga.json
+++ b/bucket/taiga.json
@@ -3,8 +3,13 @@
     "description": "Detects anime videos on computer and synchronizes progress with online services.",
     "homepage": "https://taiga.moe/",
     "license": "GPL-3.0-only",
-    "url": "https://taiga.moe/update/TaigaSetup.exe#/dl.7z",
+    "url": "https://github.com/erengy/taiga/releases/download/v1.4.0/TaigaSetup_1.4.0.exe#/dl.7z",
     "hash": "22556aff39f20a88bde4f0b944d886dd729810477b6b97dab39a0c9a60ad43e0",
+    "pre_install": [
+        "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
+        "'user', 'feed' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
+        "'settings', 'db\\anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
+    ],
     "bin": "Taiga.exe",
     "shortcuts": [
         [
@@ -12,11 +17,16 @@
             "Taiga"
         ]
     ],
-    "persist": "data",
+    "persist": [
+        "data\\user",
+        "data\\feed",
+        "data\\settings.xml",
+        "data\\db\\anime.xml"
+    ],
     "checkver": {
         "github": "https://github.com/erengy/taiga"
     },
     "autoupdate": {
-        "url": "https://taiga.moe/update/TaigaSetup.exe#/dl.7z"
+        "url": "https://github.com/erengy/taiga/releases/download/v$version/TaigaSetup_$version.exe#/dl.7z"
     }
 }

--- a/bucket/taiga.json
+++ b/bucket/taiga.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/erengy/taiga/releases/download/v1.4.0/TaigaSetup_1.4.0.exe#/dl.7z",
     "hash": "22556aff39f20a88bde4f0b944d886dd729810477b6b97dab39a0c9a60ad43e0",
     "pre_install": [
-        "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
-        "'user', 'feed', 'db\\image' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
-        "'settings', 'db\\anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
+        "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir/$_\" -Recurse }",
+        "'user', 'feed', 'db/image' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"/data/$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
+        "'settings', 'db/anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"/data/$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
     ],
     "bin": "Taiga.exe",
     "shortcuts": [
@@ -18,11 +18,11 @@
         ]
     ],
     "persist": [
-        "data\\user",
-        "data\\feed",
-        "data\\settings.xml",
-        "data\\db\\image",
-        "data\\db\\anime.xml"
+        "data/user",
+        "data/feed",
+        "data/settings.xml",
+        "data/db/image",
+        "data/db/anime.xml"
     ],
     "checkver": {
         "github": "https://github.com/erengy/taiga"


### PR DESCRIPTION
_also made the manifest match `versions` more._

The reason for this is because inside the `data` dir, `db\anime-relations.txt` (https://github.com/erengy/anime-relations) and `theme` can receive updates relatively often, and `theme` is not very user customizable.

Relates to [#1353](https://github.com/ScoopInstaller/Versions/pull/1353)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).