### PR TITLE
archi@5.1.0: fix download URL

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/archi.php?/5.1.0/Archi-Win64-5.1.0.zip",
+            "url": "https://www.archimatetool.com/downloads/archi5.php?/5.1.0/Archi-Win64-5.1.0.zip",
             "hash": "sha1:0048230b72fb1774a64b2b6ed3c2c14b123db7a0"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.archimatetool.com/downloads/archi.php?/$version/Archi-Win64-$version.zip"
+                "url": "https://www.archimatetool.com/downloads/archi5.php?/$version/Archi-Win64-$version.zip"
             }
         },
         "hash": {

--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/archi5.php?/5.1.0/Archi-Win64-5.1.0.zip",
+            "url": "https://www.archimatetool.com/downloads/archi-5.php?/5.1.0/Archi-Win64-5.1.0.zip",
             "hash": "sha1:0048230b72fb1774a64b2b6ed3c2c14b123db7a0"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.archimatetool.com/downloads/archi5.php?/$version/Archi-Win64-$version.zip"
+                "url": "https://www.archimatetool.com/downloads/archi-5.php?/$version/Archi-Win64-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Archi download url fix, based on the following error:
```
> scoop install archi
WARN  Purging previous failed installation of archi.
ERROR 'archi' isn't installed correctly.
Removing older version (5.1.0).
'archi' was uninstalled.
Installing 'archi' (5.1.0) [64bit] from extras bucket
The remote server returned an error: (404) Not Found.
URL https://www.archimatetool.com/downloads/archi.php?/5.1.0/Archi-Win64-5.1.0.zip is not valid
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
