### PR TITLE
ilspy: Update to version 8.1

### DIFF
--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.0.0.7345",
+    "version": "8.1.0.7455",
     "description": ".NET assembly browser and decompiler.",
     "homepage": "http://ilspy.net",
     "license": "MIT",
@@ -9,8 +9,8 @@
             "extras/windowsdesktop-runtime-lts"
         ]
     },
-    "url": "https://github.com/icsharpcode/ILSpy/releases/download/v8.0/ILSpy_binaries_8.0.0.7345.zip",
-    "hash": "2f3cb188eac706c08ea278201b4854030fd091697fb41f1b5654cb3a5835ae37",
+    "url": "https://github.com/icsharpcode/ILSpy/releases/download/v8.1/ILSpy_binaries_8.1.0.7455-x64.zip",
+    "hash": "2b7ad51638fd8886df795e63fe45b3fc848e0d90dfdb95a70bb3a32470d7ea8a",
     "bin": "ILSpy.exe",
     "shortcuts": [
         [
@@ -21,9 +21,9 @@
     "checkver": {
         "url": "https://api.github.com/repos/icsharpcode/ILSpy/releases/latest",
         "jsonpath": "$.assets[*].browser_download_url",
-        "regex": "download/v(?<tag>[\\d.]+)/ILSpy_binaries_([\\d.]+).zip"
+        "regex": "download/v(?<tag>[\\d.]+)/ILSpy_binaries_([\\d.]+)-x64.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$matchTag/ILSpy_binaries_$version.zip"
+        "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$matchTag/ILSpy_binaries_$version-x64.zip"
     }
 }


### PR DESCRIPTION
ilspy: Update to version 8.1

Also updated checkver regex and autoupdate url, as now there is -x64 suffix in the ILSpy zip.

There is also ARM build of ILSpy, I assume it is not relevant for scoop?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
