### PR TITLE
mcomix: Update to version 3.0.0, Remove `extract_dir`

### DIFF
--- a/bucket/mcomix.json
+++ b/bucket/mcomix.json
@@ -1,19 +1,18 @@
 {
-    "version": "2.3.0",
+    "version": "3.0.0",
     "description": "User-friendly and customizable image viewer",
     "homepage": "https://sourceforge.net/projects/mcomix/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/mcomix/MComix-2.3.0/mcomix-2.3.0-win64-all-in-one.zip",
-            "hash": "sha1:f8268f919dd87f138f4ce0f7b450da08a331b619",
-            "extract_dir": "MComix-2.3.0"
+            "url": "https://sourceforge.net/projects/mcomix/files/MComix-3.0.0/mcomix-win64-3.0.0.zip/download",
+            "hash": "sha1:FE8A930AA08F7CDCDAF3D4A114DD9A28A401E704",
         }
     },
-    "bin": "mcomix.exe",
+    "bin": "MComix.exe",
     "shortcuts": [
         [
-            "mcomix.exe",
+            "MComix.exe",
             "MComix"
         ]
     ],
@@ -24,8 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/mcomix/MComix-$version/mcomix-$version-win64-all-in-one.zip",
-                "extract_dir": "MComix-$version"
+                "url": "https://downloads.sourceforge.net/project/mcomix/MComix-$version/mcomix-win64-$version.zip",
             }
         }
     }


### PR DESCRIPTION
This merge request updates MComix to the newest version. The new version's ZIP file no longer contains a MComix-x.x.x subfolder, so the manifest is slightly simplified.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
