### PR TITLE
roundedtb: Update `url`

### DIFF
--- a/bucket/roundedtb.json
+++ b/bucket/roundedtb.json
@@ -1,11 +1,11 @@
 {
     "version": "3.1",
     "description": "A tool to add margins, rounded corners and segments to the taskbar",
-    "homepage": "https://github.com/Erisa/RoundedTB",
+    "homepage": "https://github.com/RoundedTB/RoundedTB",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Erisa/RoundedTB/releases/download/R3.1/RoundedTB_R3.1.zip",
+            "url": "https://github.com/RoundedTB/RoundedTB/releases/download/R3.1/RoundedTB_R3.1.zip",
             "hash": "1fb9fe40bceb39d681df733c2822165a78ff0b7d627be1c0eba0f73be5376f5b"
         }
     },
@@ -16,13 +16,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/Erisa/RoundedTB",
+        "url": "https://github.com/RoundedTB/RoundedTB",
         "regex": "/releases/tag/R([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Erisa/RoundedTB/releases/download/R$version/RoundedTB_R$version.zip"
+                "url": "https://github.com/RoundedTB/RoundedTB/releases/download/R$version/RoundedTB_R$version.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Repo URL has moved once again to https://github.com/RoundedTB/RoundedTB

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
