### PR TITLE
monero: Add `monero-storage` to `persist`

### DIFF
--- a/bucket/monero.json
+++ b/bucket/monero.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.18.2.2",
+    "version": "0.18.3.1",
     "description": "The secure, private, untraceable cryptocurrency",
     "homepage": "https://getmonero.org",
     "license": "BSD-3-Clause",
@@ -10,7 +10,7 @@
             "hash": "f263ce5863fd87ea959f79420e28ef0002649fa02bd57ae34efda926bdcf1a70"
         }
     },
-    "extract_dir": "monero-gui-v0.18.2.2",
+    "extract_dir": "monero-gui-v0.18.3.1",
     "pre_install": "if (!(Test-Path \"$persist_dir$($p = '/monero-storage')\")) { New-Item -ItemType Directory \"$dir$p\" | Out-Null }",
     "persist": "monero-storage",
     "bin": [

--- a/bucket/monero.json
+++ b/bucket/monero.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.18.3.1",
+    "version": "0.18.2.2",
     "description": "The secure, private, untraceable cryptocurrency",
     "homepage": "https://getmonero.org",
     "license": "BSD-3-Clause",
@@ -10,7 +10,9 @@
             "hash": "f263ce5863fd87ea959f79420e28ef0002649fa02bd57ae34efda926bdcf1a70"
         }
     },
-    "extract_dir": "monero-gui-v0.18.3.1",
+    "extract_dir": "monero-gui-v0.18.2.2",
+    "pre_install": "if (!(Test-Path \"$persist_dir$($p = '/monero-storage')\")) { New-Item -ItemType Directory \"$dir$p\" | Out-Null }",
+    "persist": "monero-storage",
     "bin": [
         "monerod.exe",
         "monero-wallet-gui.exe",


### PR DESCRIPTION
Good to have an in-path persist option, as opposed to making scoop users have to choose a dir outside of the install dir, which makes their installs less portable
`settings.ini` and `monero-wallet-gui.log` are stored here regardless of where you store anything else

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).