### PR TITLE
(chore): Qalculate renamed a file.

### DIFF
--- a/bucket/qalculate.json
+++ b/bucket/qalculate.json
@@ -16,12 +16,12 @@
     "extract_dir": "qalculate",
     "bin": [
         "qalc.exe",
-        "qalculate-gtk.exe",
+        "qalculate.exe",
         "qalculate-qt.exe"
     ],
     "shortcuts": [
         [
-            "qalculate-gtk.exe",
+            "qalculate.exe",
             "Qalculate! (GTK)"
         ],
         [


### PR DESCRIPTION
Qalculate no longer includes a -gtk executable, it is now simply qalculate.exe.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
