### PR TITLE
qalculate@4.8.1: fix GTK executable name

### DIFF
--- a/bucket/qalculate.json
+++ b/bucket/qalculate.json
@@ -16,12 +16,12 @@
     "extract_dir": "qalculate",
     "bin": [
         "qalc.exe",
-        "qalculate-gtk.exe",
+        "qalculate.exe",
         "qalculate-qt.exe"
     ],
     "shortcuts": [
         [
-            "qalculate-gtk.exe",
+            "qalculate.exe",
             "Qalculate! (GTK)"
         ],
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
