### PR TITLE
Use "Sublime Text" in context menu entry

### DIFF
--- a/scripts/sublime-text/install-context.reg
+++ b/scripts/sublime-text/install-context.reg
@@ -1,19 +1,26 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime]
-@="Open with &Sublime"
+[-HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime]
+[-HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime\command]
+
+[HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime Text]
+@="Open with &Sublime Text"
 "Icon"="$sublime"
-[HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime\command]
+[HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime Text\command]
 @="\"$sublime\" \"%1\""
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime]
-@="Open with &Sublime"
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime Text]
+@="Open with &Sublime Text"
 "Icon"="$sublime"
-[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime\command]
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime Text\command]
 @="\"$sublime\" \"%1\""
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime]
-@="Open with &Sublime"
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime Text]
+@="Open with &Sublime Text"
 "Icon"="$sublime"
-[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime\command]
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime Text\command]
 @="\"$sublime\" \"%V\""

--- a/scripts/sublime-text/uninstall-context.reg
+++ b/scripts/sublime-text/uninstall-context.reg
@@ -6,3 +6,10 @@ Windows Registry Editor Version 5.00
 [-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime\command]
 [-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime]
 [-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime\command]
+
+[-HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime Text]
+[-HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Sublime Text\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime Text]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Sublime Text\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime Text]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime Text\command]


### PR DESCRIPTION
Use "Sublime Text" rather than just "Sublime" in the optional context menu entry for Sublime Text.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
