### PR TITLE
zeal: Update to version 0.7.0

### DIFF
--- a/bucket/zeal.json
+++ b/bucket/zeal.json
@@ -1,18 +1,13 @@
 {
-    "version": "0.6.1",
+    "version": "0.7.0",
     "description": "An offline documentation browser for software developers",
     "homepage": "https://zealdocs.org/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zealdocs/zeal/releases/download/v0.6.1/zeal-portable-0.6.1-windows-x64.7z",
-            "hash": "08e9992f620ba0a5ea348471d8ac9c85059e95eedd950118928be639746e3f94",
-            "extract_dir": "zeal-portable-0.6.1-windows-x64"
-        },
-        "32bit": {
-            "url": "https://github.com/zealdocs/zeal/releases/download/v0.6.1/zeal-portable-0.6.1-windows-x86.7z",
-            "hash": "9ab3fd0c15101afe3e6be18afe892868c37784d4bf556a81311b3544621501ae",
-            "extract_dir": "zeal-portable-0.6.1-windows-x86"
+            "url": "https://github.com/zealdocs/zeal/releases/download/v0.7.0/zeal-0.7.0-portable-windows-x64.7z",
+            "hash": "e99a11a5692f8ca93da55589b23d20bf40edc9a3f9d78f7d58e0c55f8bd0acac",
+            "extract_dir": "zeal-0.7.0-portable-windows-x64"
         }
     },
     "pre_install": [
@@ -43,12 +38,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zealdocs/zeal/releases/download/v$version/zeal-portable-$version-windows-x64.7z",
-                "extract_dir": "zeal-portable-$version-windows-x64"
-            },
-            "32bit": {
-                "url": "https://github.com/zealdocs/zeal/releases/download/v$version/zeal-portable-$version-windows-x86.7z",
-                "extract_dir": "zeal-portable-$version-windows-x86"
+                "url": "https://github.com/zealdocs/zeal/releases/download/v$version/zeal-$version-portable-windows-x64.7z",
+                "extract_dir": "zeal-$version-portable-windows-x64"
             }
         }
     }


### PR DESCRIPTION
Zeal v0.7.0 has been released. It has different file name format for portable builds, and there will be no 32-bit builds.

P.S. I am maintainer of Zeal. 

~Closes #XXXX~ I can create an issue, but feels like an overkill.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
