### PR TITLE
Update quiterss.json homepage link

### DIFF
--- a/bucket/quiterss.json
+++ b/bucket/quiterss.json
@@ -1,7 +1,7 @@
 {
     "version": "0.19.4",
     "description": "RSS/Atom news feeds reader",
-    "homepage": "https://quiterss.org/en",
+    "homepage": "https://quiterss.org/",
     "license": "GPL-3.0-only",
     "url": "https://quiterss.org/files/0.19.4_/QuiteRSS-0.19.4.zip",
     "hash": "md5:84e44cac789dea9dbf3746130c0ea02b",


### PR DESCRIPTION
Old link went to bad gateway.

I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
