### PR TITLE
vesktop: Add version 1.5.0

### DIFF
--- a/bucket/vesktop.json
+++ b/bucket/vesktop.json
@@ -1,23 +1,23 @@
 {
-    "version": "0.3.3",
+    "version": "1.5.0",
     "description": "A cross platform electron-based desktop app aiming to give you a snappier Discord experience with Vencord pre-installed",
     "homepage": "https://github.com/Vencord/Vesktop",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Vencord/Vesktop/releases/download/v0.3.3/Vesktop-0.3.3-win.zip",
-            "hash": "faca0728ee67c31469f532412c30c5c21aa3aa41283111a62c210313acb5b2c3"
+            "url": "https://github.com/Vencord/Vesktop/releases/download/v1.5.0/Vesktop-1.5.0-win.zip",
+            "hash": "305bba02fa13afc1bee9d617d3a4651268416edab14ae45d6d1e136fa8d55264"
         }
     },
     "bin": "Vesktop.exe",
-    "shortcuts":  [[
-        "Vesktop.exe",
-        "Vesktop",
-        "Vencord Desktop"
-    ]],
-    "checkver": {
-        "github": "https://github.com/Vencord/Vesktop"
-    },
+    "shortcuts": [
+        [
+            "Vesktop.exe",
+            "Vesktop",
+            "Vencord Desktop"
+        ]
+    ],
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/vesktop.json
+++ b/bucket/vesktop.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.3.1",
+    "description": "A cross platform electron-based desktop app aiming to give you a snappier Discord experience with Vencord pre-installed",
+    "homepage": "https://vencord.dev/",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Vencord/Vesktop/releases/download/v0.3.1/Vesktop-Setup-0.3.1.exe#/dl.7z",
+            "hash": "2b777365eb5aacb0285ea8a4f8819938b669979db1f85fdd5eabb51c32988af4"
+        }
+    },
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+        ]
+    },
+    "bin": "vesktop.exe",
+    "shortcuts": [
+        [
+            "vesktop.exe",
+            "Vencord Desktop"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Vencord/Vesktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Vencord/Vesktop/releases/download/v$version/Vesktop-Setup-$version.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/vesktop.json
+++ b/bucket/vesktop.json
@@ -1,34 +1,27 @@
 {
-    "version": "0.3.1",
+    "version": "0.3.3",
     "description": "A cross platform electron-based desktop app aiming to give you a snappier Discord experience with Vencord pre-installed",
-    "homepage": "https://vencord.dev/",
+    "homepage": "https://github.com/Vencord/Vesktop",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Vencord/Vesktop/releases/download/v0.3.1/Vesktop-Setup-0.3.1.exe#/dl.7z",
-            "hash": "2b777365eb5aacb0285ea8a4f8819938b669979db1f85fdd5eabb51c32988af4"
+            "url": "https://github.com/Vencord/Vesktop/releases/download/v0.3.3/Vesktop-0.3.3-win.zip",
+            "hash": "faca0728ee67c31469f532412c30c5c21aa3aa41283111a62c210313acb5b2c3"
         }
     },
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
-        ]
-    },
-    "bin": "vesktop.exe",
-    "shortcuts": [
-        [
-            "vesktop.exe",
-            "Vencord Desktop"
-        ]
-    ],
+    "bin": "Vesktop.exe",
+    "shortcuts":  [[
+        "Vesktop.exe",
+        "Vesktop",
+        "Vencord Desktop"
+    ]],
     "checkver": {
         "github": "https://github.com/Vencord/Vesktop"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Vencord/Vesktop/releases/download/v$version/Vesktop-Setup-$version.exe#/dl.7z"
+                "url": "https://github.com/Vencord/Vesktop/releases/download/v$version/Vesktop-$version-win.zip"
             }
         }
     }


### PR DESCRIPTION
this PR adds the [Vesktop App](https://github.com/Vencord/Vesktop) to this bucket

this json file is basically just mirrored from https://github.com/anderlli0053/DEV-tools/blob/master/bucket/vesktop.json and https://github.com/okibcn/ScoopMaster/blob/master/bucket/vesktop.json 
as I think Vesktop should be in one of the official repos; Extras being the most fitting.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/Vencord/Vesktop/issues/82

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
