### PR TITLE
geode-sdk-cli: Add version 2.7.1

### DIFF
--- a/bucket/geode-sdk-cli.json
+++ b/bucket/geode-sdk-cli.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.5.0",
+    "version": "2.7.1",
     "description": "Command line application for Geode SDK, the Geometry Dash modding framework.",
     "homepage": "https://github.com/geode-sdk/cli",
     "license": "BSL-1.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/geode-sdk/cli/releases/download/v2.5.0/geode-cli-v2.5.0-win.zip",
-            "hash": "07706ccc327ae80b97ca7311ce898ecb69607a006c016c00a735188e214f4f25"
+            "url": "https://github.com/geode-sdk/cli/releases/download/v2.7.1/geode-cli-v2.7.1-win.zip",
+            "hash": "192a0539d56255afb100b70c85047d763e742ec7dc0b2288fe99b98fe397d545"
         }
     },
     "bin": "geode.exe",

--- a/bucket/geode-sdk-cli.json
+++ b/bucket/geode-sdk-cli.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.5.0",
+    "description": "Command line application for Geode SDK, the Geometry Dash modding framework.",
+    "homepage": "https://github.com/geode-sdk/cli",
+    "license": "BSL-1.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/geode-sdk/cli/releases/download/v2.5.0/geode-cli-v2.5.0-win.zip",
+            "hash": "07706ccc327ae80b97ca7311ce898ecb69607a006c016c00a735188e214f4f25"
+        }
+    },
+    "bin": "geode.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/geode-sdk/cli/releases/download/v$version/geode-cli-v$version-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #11955 

Command line application for Geode SDK, the Geometry Dash modding framework.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
