### PR TITLE
bruno: add version 1.2.0

### DIFF
--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/usebruno/bruno/releases/download/v1.2.0/bruno_1.2.0_x64_win.zip",
-            "hash": "98941b455b71d7c8c8bfff5c448c0587960962d947a2e37665e411bffb95d4d0",
-            "extract_dir": "win-unpacked"
+            "hash": "98941b455b71d7c8c8bfff5c448c0587960962d947a2e37665e411bffb95d4d0"
         }
     },
+    "extract_dir": "win-unpacked",
     "shortcuts": [
         [
             "Bruno.exe",

--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.16.5",
+    "homepage": "https://www.usebruno.com/",
+    "license": "MIT",
+    "description": "Opensource IDE For Exploring and Testing Api's (lightweight alternative to postman/insomnia)",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/usebruno/bruno/releases/download/v0.16.5/bruno_0.16.5_x64_win.exe#dl.7z",
+            "hash": "26fcdc54e4993c3e2d89a1b6ea2e56714eeda3ef6d24e89e28e26abb3f5d094e",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
+            ]
+        }
+    },
+    "shortcuts": [
+        [
+            "Bruno.exe",
+            "Bruno"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/usebruno/bruno/releases/download/v$version/bruno_$version_x64_win.exe#dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -2,7 +2,7 @@
     "version": "0.25.0",
     "homepage": "https://www.usebruno.com/",
     "license": "MIT",
-    "description": "Opensource IDE For Exploring and Testing Api's (lightweight alternative to postman/insomnia)",
+    "description": "Open source IDE for exploring and testing APIs (lightweight alternative to Postman/Insomnia)",
     "architecture": {
         "64bit": {
             "url": "https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_win.zip",

--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.25.0",
+    "version": "1.2.0",
     "homepage": "https://www.usebruno.com/",
     "license": "MIT",
     "description": "Open source IDE for exploring and testing APIs (lightweight alternative to Postman/Insomnia)",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_win.zip",
-            "hash": "0afe50d2dac68b778f11b456feb2924e365e55fa31f6ebe44be039d84326f85b",
+            "url": "https://github.com/usebruno/bruno/releases/download/v1.2.0/bruno_1.2.0_x64_win.zip",
+            "hash": "98941b455b71d7c8c8bfff5c448c0587960962d947a2e37665e411bffb95d4d0",
 			"extract_dir": "win-unpacked"
         }
     },

--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -19,7 +19,9 @@
             "Bruno"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/usebruno/bruno"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/usebruno/bruno/releases/download/v1.2.0/bruno_1.2.0_x64_win.zip",
             "hash": "98941b455b71d7c8c8bfff5c448c0587960962d947a2e37665e411bffb95d4d0",
-			"extract_dir": "win-unpacked"
+            "extract_dir": "win-unpacked"
         }
     },
     "shortcuts": [

--- a/bucket/bruno.json
+++ b/bucket/bruno.json
@@ -1,16 +1,13 @@
 {
-    "version": "0.16.5",
+    "version": "0.25.0",
     "homepage": "https://www.usebruno.com/",
     "license": "MIT",
     "description": "Opensource IDE For Exploring and Testing Api's (lightweight alternative to postman/insomnia)",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/usebruno/bruno/releases/download/v0.16.5/bruno_0.16.5_x64_win.exe#dl.7z",
-            "hash": "26fcdc54e4993c3e2d89a1b6ea2e56714eeda3ef6d24e89e28e26abb3f5d094e",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
-            ]
+            "url": "https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_win.zip",
+            "hash": "0afe50d2dac68b778f11b456feb2924e365e55fa31f6ebe44be039d84326f85b",
+			"extract_dir": "win-unpacked"
         }
     },
     "shortcuts": [
@@ -25,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/usebruno/bruno/releases/download/v$version/bruno_$version_x64_win.exe#dl.7z"
+                "url": "https://github.com/usebruno/bruno/releases/download/v$version/bruno_$version_x64_win.zip"
             }
         }
     }


### PR DESCRIPTION
This PR adds the bruno manifest.

Closes #11969

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
