### PR TITLE
insomnium: Add version 0.2.3-a

### DIFF
--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.3",
+    "version": "0.2.3-a",
     "description": "The Insomnia HTTP and GraphQL client with online functionality removed",
     "homepage": "https://github.com/ArchGPT/insomnium",
     "license": "MIT",
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ArchGPT/insomnium/releases/download/core%40$version/insomnia-$version-full.nupkg"
+                "url": "https://github.com/ArchGPT/insomnium/releases/download/core%40$version/insomnium-$version-full.nupkg"
             }
         },
         "hash": {

--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/ArchGPT/insomnium/releases",
-        "regex": "\"core@([\\d.]+)\""
+        "regex": "\"core@([^\"]+)\""
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Kong/insomnia/releases/download/core%40$version/insomnia-$version-full.nupkg"
+                "url": "https://github.com/ArchGPT/insomnium/releases/download/core%40$version/insomnia-$version-full.nupkg"
             }
         },
         "hash": {

--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ArchGPT/insomnium/releases/download/core%400.1.3/insomnia-0.1.3-full.nupkg",
-            "hash": "sha1:32A31C4DF841145334404DA98C8758E9464ADDCE"
+            "url": "https://github.com/ArchGPT/insomnium/releases/download/core%400.2.3-a/insomnium-0.2.3-a-full.nupkg",
+            "hash": "sha1:8EF4D8DD233612AFE8D5699EF0CCB1C3E130A062"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.1.3",
+    "description": "The Insomnia HTTP and GraphQL client with online functionality removed",
+    "homepage": "https://github.com/ArchGPT/insomnium",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Kong/insomnia/releases/download/core%400.1.3/insomnia-0.1.3-full.nupkg",
+            "hash": "sha1:32A31C4DF841145334404DA98C8758E9464ADDCE"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "shortcuts": [
+        [
+            "Insomnium.exe",
+            "Insomnium"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/Kong/insomnia/releases",
+        "regex": "\"core@([\\d.]+)\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Kong/insomnia/releases/download/core%40$version/insomnia-$version-full.nupkg"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/RELEASES"
+        }
+    }
+}

--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Kong/insomnia/releases/download/core%400.1.3/insomnia-0.1.3-full.nupkg",
+            "url": "https://github.com/ArchGPT/insomnium/releases/download/core%400.1.3/insomnia-0.1.3-full.nupkg",
             "hash": "sha1:32A31C4DF841145334404DA98C8758E9464ADDCE"
         }
     },
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Kong/insomnia/releases",
+        "url": "https://api.github.com/repos/ArchGPT/insomnium/releases",
         "regex": "\"core@([\\d.]+)\""
     },
     "autoupdate": {


### PR DESCRIPTION
This pr adds the fork of Insomnia, Insomnium. After Insomnia begun to require account logins, Insomnium was created which converted the REST client to an offline only software.

Closes #11980

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
