### PR TITLE
twinkle-tray: Update pre_install scripts

### DIFF
--- a/bucket/twinkle-tray.json
+++ b/bucket/twinkle-tray.json
@@ -6,13 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/xanderfrangos/twinkle-tray/releases/download/v1.15.4/Twinkle.Tray.v1.15.4.exe#/dl.7z",
-            "hash": "e90db0513a6d31fb92ba12b3ecb284f2950f35a3b4f46a910933201fc36a96af"
+            "hash": "e90db0513a6d31fb92ba12b3ecb284f2950f35a3b4f46a910933201fc36a96af",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
+            ]
         }
     },
-    "pre_install": [
-        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninst*\" -Force -Recurse"
-    ],
     "bin": [
         [
             "Twinkle Tray.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Update `pre_install` scripts to adapt for new file path in package installer
- Move 64bit exclusive content to `architecture` field

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
