### PR TITLE
cnping: Add version 1.0.0

### DIFF
--- a/bucket/cnping.json
+++ b/bucket/cnping.json
@@ -14,8 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cntools/cnping/releases/download/$version/cnping.exe",
-                "hash": "ed61944a9d720fd0ad429fa7ec97c2357fa805301532dd43049ffc5666bfdc8e"
+                "url": "https://github.com/cntools/cnping/releases/download/$version/cnping.exe"
             }
         }
     }

--- a/bucket/cnping.json
+++ b/bucket/cnping.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.0.0",
+    "description": "Minimal Graphical IPV4 Ping/HTTP Ping Tool.",
+    "homepage": "https://github.com/cntools/cnping",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cntools/cnping/releases/download/1.0.0/cnping.exe",
+            "hash": "ed61944a9d720fd0ad429fa7ec97c2357fa805301532dd43049ffc5666bfdc8e"
+        }
+    },
+    "bin": "cnping.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cntools/cnping/releases/download/$version/cnping.exe",
+                "hash": "ed61944a9d720fd0ad429fa7ec97c2357fa805301532dd43049ffc5666bfdc8e"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Minimal Graphical IPV4 Ping/HTTP Ping Tool.

https://github.com/cntools/cnping

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
