### PR TITLE
Update bulk-crap-uninstaller to version 5.7

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,10 +1,10 @@
 {
-    "version": "5.6",
+    "version": "5.7",
     "description": "Bulk program uninstaller with advanced automation",
     "homepage": "https://www.bcuninstaller.com/",
     "license": "Apache-2.0",
-    "url": "https://dotsrc.dl.osdn.net/osdn/bulk-crap-uninstaller/78782/BCUninstaller_5.6_portable.zip",
-    "hash": "b1e190f85f0e1f5a680c94b54ed4a8ff8fb9afccc6b929f41503b8125438d1fb",
+    "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.7/BCUninstaller_5.7_portable.zip",
+    "hash": "sha1:bb7002d4e337dce9e989eb0ce31208f72a0ae7dc",
     "architecture": {
         "64bit": {
             "extract_dir": "win-x64"
@@ -35,14 +35,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://osdn.net/projects/bulk-crap-uninstaller/",
-        "regex": "releases/(?<Release>[\\d]+)\">Bulk-Crap-Uninstaller\\sBulk\\sCrap\\sUninstaller\\sv([\\d.]+)"
+        "github": "https://github.com/Klocman/Bulk-Crap-Uninstaller"
     },
     "autoupdate": {
-        "url": "https://dotsrc.dl.osdn.net/osdn/bulk-crap-uninstaller/$matchRelease/BCUninstaller_$version_portable.zip",
+        "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$version/BCUninstaller_$version_portable.zip",
         "hash": {
-            "url": "https://osdn.net/projects/bulk-crap-uninstaller/downloads/$matchRelease/$basename",
-            "regex": "SHA256</dt>\\n\\s+<dd>$sha256"
+            "url": "https://sourceforge.net/projects/bulk-crap-uninstaller/files/v$version/",
+            "regex": "$basename.*?\"sha1\":\"$sha1"
         }
     }
 }


### PR DESCRIPTION
Changed the download url from osdn to github due to the osdn website not functioning. 
Changed the hash extract url from osdn to sourceforge to make updating the package easier for the **github-actions** bot.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
