### PR TITLE
Calibre: Fix path too long problem

### DIFF
--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -11,9 +11,9 @@
     },
     "installer": {
         "script": [
-            "Start-Process \"$dir\\calibre-portable-installer-$version.exe\" @(\"$dir\") -Wait",
-            "Move-Item \"$dir\\Calibre Portable\\**\" \"$dir\"",
-            "Remove-Item \"$dir\\Calibre Portable\""
+            "Start-Process \"$dir\\calibre-portable-installer-$version.exe\" @(\"$env:TEMP\") -Wait",
+            "Move-Item \"$env:TEMP\\Calibre Portable\\**\" \"$dir\"",
+            "Remove-Item \"$env:TEMP\\Calibre Portable\""
         ]
     },
     "bin": [

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -1,12 +1,12 @@
 {
-    "version": "6.28.1",
+    "version": "7.3.0",
     "description": "Powerful and easy to use e-book manager",
     "homepage": "https://calibre-ebook.com",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.calibre-ebook.com/6.28.1/calibre-portable-installer-6.28.1.exe",
-            "hash": "sha512:d3016a3fa6746b8c8bfd48502a49dc162f40f6ceb1406e15972293f7a1182732b1fe848fd8cf6667d26e35ff38b7b6c44306943bc517519521b339e2a89cd109"
+            "url": "https://download.calibre-ebook.com/7.3.0/calibre-portable-installer-7.3.0.exe",
+            "hash": "sha512:70088489ec8fe8c9af0aa932b9986b5616b4038f95e1cc26ede4273f9dfff18b1cb2f35f1e26ca96f6fec060e07327dc99711dce680cc7ad24ff407223c18ef1"
         }
     },
     "installer": {


### PR DESCRIPTION
Use the temporally directory from environment variables.

Closes #11367 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
