### PR TITLE
emule-community@0.70a: fix extract_dir not set to the current version

### DIFF
--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -28,13 +28,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version_x64.zip",
-                "extract_dir": "eMule$version"
+                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version_x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version.zip",
-                "extract_dir": "eMule$version"
+                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version.zip"
             }
-        }
+        },
+        "extract_dir": "eMule$version"
     }
 }

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -13,7 +13,7 @@
             "hash": "968cd0cdd469c3d4c9412e490ca16c92da4e2632420c2303b4ab9509c5fa4fd6"
         }
     },
-    "extract_dir": "eMule0.60d",
+    "extract_dir": "eMule0.70a",
     "bin": "emule.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Closes #12007 

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
