### PR TITLE
zaproxy: Update shortcut

### DIFF
--- a/bucket/zaproxy.json
+++ b/bucket/zaproxy.json
@@ -14,7 +14,7 @@
     "shortcuts": [
         [
             "zap.bat",
-            "OWASP Zed Attack Proxy",
+            "Zed Attack Proxy",
             "",
             "zap.ico"
         ]


### PR DESCRIPTION
ZAP is no longer part of OWASP: https://www.zaproxy.org/blog/2023-08-01-zap-is-joining-the-software-security-project/

Closes #12028

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
