### PR TITLE
space: Add version 0.1.2

### DIFF
--- a/bucket/space.json
+++ b/bucket/space.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.1.2",
+    "version": "1.0.1",
     "description": "A fast disk space analyzer and cleaner powered by Rust!",
     "homepage": "https://github.com/emilevr/space",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/emilevr/space/releases/download/0.1.2/space-x86_64-pc-windows-msvc.zip",
-            "hash": "8687b4ef3918af8f0c2d8b29db02773bbb228a377e1a2669739ac1deb330a6c9"
+            "url": "https://github.com/emilevr/space/releases/download/1.0.1/space-x86_64-pc-windows-msvc.zip",
+            "hash": "c47f817ba6049e96932e2ce106da87e9305e3437fce7511dbcc1951d090004a4"
         }
     },
     "bin": "space.exe",
@@ -16,9 +16,6 @@
             "64bit": {
                 "url": "https://github.com/emilevr/space/releases/download/$version/space-x86_64-pc-windows-msvc.zip"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/space.json
+++ b/bucket/space.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.1.2",
+    "description": "A fast disk space analyzer and cleaner powered by Rust!",
+    "homepage": "https://github.com/emilevr/space",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/emilevr/space/releases/download/0.1.2/space-x86_64-pc-windows-msvc.zip",
+            "hash": "8687b4ef3918af8f0c2d8b29db02773bbb228a377e1a2669739ac1deb330a6c9"
+        }
+    },
+    "bin": "space.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/emilevr/space/releases/download/$version/space-x86_64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/emilevr/space/releases/download/$version/space-x86_64-pc-windows-msvc.zip.sha256"
+        }
+    }
+}

--- a/bucket/space.json
+++ b/bucket/space.json
@@ -18,7 +18,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/emilevr/space/releases/download/$version/space-x86_64-pc-windows-msvc.zip.sha256"
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
Adds a new manifest for the space CLI, which is yet another disk space usage tool, written in Rust (for fun and learning).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
