### PR TITLE
fluidsynth@2.3.4: Add notes about DLLs

### DIFF
--- a/bucket/fluidsynth.json
+++ b/bucket/fluidsynth.json
@@ -14,6 +14,11 @@
         }
     },
     "bin": "bin/fluidsynth.exe",
+    "notes": [
+        "This manifest contains the barebones FluidSynth installation.",
+        "For appropriate programming DLLs, add `~/scoop/apps/fluidsynth/current/bin` to PATH.",
+        "For example, executing `$env:Path += \";$(Resolve-Path '~/scoop/apps/fluidsynth/current/bin')\"` will add it to PATH for the current shell."
+    ],
     "checkver": {
         "github": "https://github.com/FluidSynth/fluidsynth"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Add some notes on how to use DLLs.

Closes #12055

```powershell
> scoop install ./fluidsynth.json
Installing 'fluidsynth' (2.3.4) [64bit]
Loading fluidsynth-2.3.4-win10-x64.zip from cache.
Checking hash of fluidsynth-2.3.4-win10-x64.zip ... ok.
Extracting fluidsynth-2.3.4-win10-x64.zip ... done.
Linking ~\scoop\apps\fluidsynth\current => ~\scoop\apps\fluidsynth\2.3.4
Creating shim for 'fluidsynth'.
'fluidsynth' (2.3.4) was installed successfully!
Notes
-----
This manifest contains the barebones FluidSynth installation.
For appropriate programming DLLs, add `~/scoop/apps/fluidsynth/current/bin` to PATH.
For example, executing `$env:Path += ";$(Resolve-Path '~/scoop/apps/fluidsynth/current/bin')"` will add it to PATH for the
current shell.
```

Relates to #11280

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
