### PR TITLE
Update bulk-crap-uninstaller.json bulk-crap-uninstaller@5.7: update version

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,10 +1,10 @@
 {
-    "version": "5.6",
+    "version": "5.7",
     "description": "Bulk program uninstaller with advanced automation",
     "homepage": "https://www.bcuninstaller.com/",
     "license": "Apache-2.0",
-    "url": "https://dotsrc.dl.osdn.net/osdn/bulk-crap-uninstaller/78782/BCUninstaller_5.6_portable.zip",
-    "hash": "b1e190f85f0e1f5a680c94b54ed4a8ff8fb9afccc6b929f41503b8125438d1fb",
+    "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.7/BCUninstaller_5.7_portable.zip",
+    "hash": "ce593513568ef69483a14cfbdf3c75377764da4eb2de1789ea773bb50728bc2c",
     "architecture": {
         "64bit": {
             "extract_dir": "win-x64"
@@ -35,14 +35,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://osdn.net/projects/bulk-crap-uninstaller/",
-        "regex": "releases/(?<Release>[\\d]+)\">Bulk-Crap-Uninstaller\\sBulk\\sCrap\\sUninstaller\\sv([\\d.]+)"
+        "github": "https://github.com/Klocman/Bulk-Crap-Uninstaller"
     },
     "autoupdate": {
-        "url": "https://dotsrc.dl.osdn.net/osdn/bulk-crap-uninstaller/$matchRelease/BCUninstaller_$version_portable.zip",
-        "hash": {
-            "url": "https://osdn.net/projects/bulk-crap-uninstaller/downloads/$matchRelease/$basename",
-            "regex": "SHA256</dt>\\n\\s+<dd>$sha256"
-        }
+        "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$version/BCUninstaller_$version_portable.zip"
     }
 }


### PR DESCRIPTION
updated version and hash
Closes #11968 

- [ X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
