### PR TITLE
Update reaper.json

### DIFF
--- a/bucket/reaper.json
+++ b/bucket/reaper.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.001",
+    "version": "7.01",
     "description": "Digital Audio Workstation",
     "homepage": "https://www.reaper.fm",
     "license": {
@@ -9,12 +9,12 @@
     "notes": "The portable version of Reaper does not include ReWire.",
     "architecture": {
         "64bit": {
-            "url": "https://www.reaper.fm/files/7.x/reaper7001_x64-install.exe#/dl.7z",
-            "hash": "39d4e8306ebf819d40fbefc6dc8b49da5e7645f2139a5ab95aa4af9b3faf0178"
+            "url": "https://www.reaper.fm/files/7.x/reaper701_x64-install.exe#/dl.7z",
+            "hash": "fccc7e551fe831039d3aa27f3d554ba00b405c1f69c2c623f888c569d4ad4ef4"
         },
         "32bit": {
-            "url": "https://www.reaper.fm/files/7.x/reaper7001-install.exe#/dl.7z",
-            "hash": "d822a3951ef86c33a1486250e95c252049572db0101cab2f0991d9287888146b"
+            "url": "https://www.reaper.fm/files/7.x/reaper701-install.exe#/dl.7z",
+            "hash": "03c3888fcff93dd438662c2ec2b6d86168f8b0ce1fb20d3f8157804f5e370c0a"
         }
     },
     "bin": [

--- a/bucket/reaper.json
+++ b/bucket/reaper.json
@@ -18,17 +18,12 @@
         }
     },
     "bin": [
-        "reaper.exe",
-        "reamote.exe"
+        "reaper.exe"
     ],
     "shortcuts": [
         [
             "reaper.exe",
             "Reaper"
-        ],
-        [
-            "reamote.exe",
-            "ReaMote"
         ]
     ],
     "installer": {


### PR DESCRIPTION
reamote was removed from reaper on version 7.
would fix current installation error

`Can't shim 'reamote.exe': File doesn't exist.`

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
