### PR TITLE
restfox: Add version 0.3.2

### DIFF
--- a/bucket/restfox.json
+++ b/bucket/restfox.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "An offline-first minimalistic HTTP client for API development and testing",
     "homepage": "https://restfox.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.3.0/Restfox-0.3.0-full.nupkg",
-            "hash": "sha1:ac4da0283fd7340a4cae55f2313704d7820afc5f"
+            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.3.1/Restfox-0.3.1-full.nupkg",
+            "hash": "sha1:c2d972216fbe9f7b8cdcd2e951ca616033acffcb"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/restfox.json
+++ b/bucket/restfox.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.1",
+    "version": "0.3.0",
     "description": "An offline-first minimalistic HTTP client for API development and testing",
     "homepage": "https://restfox.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.2.1/Restfox-0.2.1-full.nupkg",
-            "hash": "sha1:94dd871b3eed75540c74360fe04fae200be02a64"
+            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.3.0/Restfox-0.3.0-full.nupkg",
+            "hash": "sha1:ac4da0283fd7340a4cae55f2313704d7820afc5f"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/restfox.json
+++ b/bucket/restfox.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "An offline-first minimalistic HTTP client for API development and testing",
     "homepage": "https://restfox.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.1.0/Restfox-0.1.0-full.nupkg",
-            "hash": "sha1:4e30d9641b01ce79256420ca4442a283fa2b270b"
+            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.2.0/Restfox-0.2.0-full.nupkg",
+            "hash": "sha1:df99524e5b40da4ee7dc4e0a743aab92ccbd6afc"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/restfox.json
+++ b/bucket/restfox.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "An offline-first minimalistic HTTP client for API development and testing",
     "homepage": "https://restfox.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.2.0/Restfox-0.2.0-full.nupkg",
-            "hash": "sha1:df99524e5b40da4ee7dc4e0a743aab92ccbd6afc"
+            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.2.1/Restfox-0.2.1-full.nupkg",
+            "hash": "sha1:94dd871b3eed75540c74360fe04fae200be02a64"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/restfox.json
+++ b/bucket/restfox.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.1.0",
+    "description": "An offline-first minimalistic HTTP client for API development and testing",
+    "homepage": "https://restfox.dev/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.1.0/Restfox-0.1.0-full.nupkg",
+            "hash": "sha1:4e30d9641b01ce79256420ca4442a283fa2b270b"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "shortcuts": [
+        [
+            "Restfox.exe",
+            "Restfox"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/flawiddsouza/Restfox"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/flawiddsouza/Restfox/releases/download/v$version/Restfox-$version-full.nupkg"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/RELEASES"
+        }
+    }
+}

--- a/bucket/restfox.json
+++ b/bucket/restfox.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "An offline-first minimalistic HTTP client for API development and testing",
     "homepage": "https://restfox.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.3.1/Restfox-0.3.1-full.nupkg",
-            "hash": "sha1:c2d972216fbe9f7b8cdcd2e951ca616033acffcb"
+            "url": "https://github.com/flawiddsouza/Restfox/releases/download/v0.3.2/Restfox-0.3.2-full.nupkg",
+            "hash": "sha1:c0f11c20cfb3f1bc92fa55bd84014b611c77accd"
         }
     },
     "extract_dir": "lib\\net45",


### PR DESCRIPTION
Add [Restfox](https://github.com/flawiddsouza/Restfox) - an offline-first, minimalistic alternative to `postman`/`insomnia`/`hoppscotch`.

Closes #12065.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
