### PR TITLE
Revert "qalculate: Fix `-gtk` rename (#11896)"

### DIFF
--- a/bucket/qalculate.json
+++ b/bucket/qalculate.json
@@ -16,12 +16,12 @@
     "extract_dir": "qalculate",
     "bin": [
         "qalc.exe",
-        "qalculate.exe",
+        "qalculate-gtk.exe",
         "qalculate-qt.exe"
     ],
     "shortcuts": [
         [
-            "qalculate.exe",
+            "qalculate-gtk.exe",
             "Qalculate! (GTK)"
         ],
         [


### PR DESCRIPTION
This reverts commit 39d6a97cb41665b0b446b21ae7ddc4d218ce7fde.

Relates to https://github.com/ScoopInstaller/Extras/pull/11896#issuecomment-1772331928

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).