### PR TITLE
tux-guitar: Fix install on x64, fix malicious homepage url

### DIFF
--- a/bucket/tuxguitar.json
+++ b/bucket/tuxguitar.json
@@ -1,18 +1,15 @@
 {
     "version": "1.5.6",
     "description": "Multitrack guitar tablature editor and player",
-    "homepage": "http://www.tuxguitar.com.ar/",
+    "homepage": "https://sourceforge.net/projects/tuxguitar/",
     "license": "GPL-2.0-or-later",
     "suggest": {
-        "JRE": "java/oraclejre8"
+        "JRE": "java/temurin8-jre"
     },
-    "architecture": {
-        "32bit": {
-            "url": "https://downloads.sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-1.5.6/tuxguitar-1.5.6-windows-x86.zip",
-            "hash": "sha1:15f74237a9178ae45206bcb9bd2ec7514804cdc8",
-            "extract_dir": "tuxguitar-1.5.6-windows-x86"
-        }
-    },
+
+    "url": "https://downloads.sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-1.5.6/tuxguitar-1.5.6-windows-x86.zip",
+    "hash": "sha1:15f74237a9178ae45206bcb9bd2ec7514804cdc8",
+    "extract_dir": "tuxguitar-1.5.6-windows-x86",
     "pre_install": "Add-Content \"$dir\\tuxguitar.ini\" \"vm.location=%JAVA_HOME%/bin/client/jvm.dll\"",
     "bin": "tuxguitar.exe",
     "shortcuts": [
@@ -26,11 +23,7 @@
         "regex": "tuxguitar-([\\d.]+)-windows-x86\\.zip"
     },
     "autoupdate": {
-        "architecture": {
-            "32bit": {
-                "url": "https://downloads.sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-$version/tuxguitar-$version-windows-x86.zip",
-                "extract_dir": "tuxguitar-$version-windows-x86"
-            }
-        }
+        "url": "https://downloads.sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-$version/tuxguitar-$version-windows-x86.zip",
+        "extract_dir": "tuxguitar-$version-windows-x86"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
TuxGuitar was setup only to install on 32bit versions of windows, fixed the json to allow for installation on x86_64 and fixed the malicious homepage URL.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12082


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
