### PR TITLE
chore (GitHub API): Use repo ID, instead of repo name

### DIFF
--- a/bucket/86box.json
+++ b/bucket/86box.json
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/86Box/86Box/releases/latest",
+        "url": "https://api.github.com/repositories/61964127/releases/latest",
         "jsonpath": "$.assets[*].browser_download_url",
         "regex": "v(?<version>[\\d.]+)/86Box-Windows-64-b(?<build>\\d+)\\.zip"
     },

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -15,7 +15,7 @@
         "age-keygen.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FiloSottile/age/releases",
+        "url": "https://api.github.com/repositories/187403699/releases",
         "regex": "/age-v([\\w.-]+)-windows"
     },
     "autoupdate": {

--- a/bucket/bitwarden.json
+++ b/bucket/bitwarden.json
@@ -22,7 +22,7 @@
     ],
     "persist": "bitwarden-appdata",
     "checkver": {
-        "url": "https://api.github.com/repos/bitwarden/clients/releases",
+        "url": "https://api.github.com/repositories/53538899/releases",
         "regex": "tag/desktop-v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/bloop.json
+++ b/bucket/bloop.json
@@ -14,7 +14,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/BloopAI/bloop/releases",
+        "url": "https://api.github.com/repositories/576642715/releases",
         "regex": "bloop_([\\d.]+)_x64_en-US.msi"
     },
     "autoupdate": {

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -33,7 +33,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://api.github.com/repos/Hibbiki/chromium-win64/tags",
+        "url": "https://api.github.com/repositories/220217660/tags",
         "jsonpath": "$..name",
         "regex": "v([\\d.\\-r]+)"
     },

--- a/bucket/clingo.json
+++ b/bucket/clingo.json
@@ -18,7 +18,7 @@
         "lpconvert.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/potassco/clingo/releases",
+        "url": "https://api.github.com/repositories/58459878/releases",
         "regex": "clingo-([\\d.]+)-win64\\.zip"
     },
     "autoupdate": {

--- a/bucket/debugviewpp.json
+++ b/bucket/debugviewpp.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.8.0.86",
+    "version": "1.8.0.103",
     "description": "Collect, view and filter application logs.",
     "homepage": "https://github.com/CobaltFusion/DebugViewPP",
     "license": "BSL-1.0",
     "notes": "The 'OutputForwarderVSIX.vsix' is located at '$dir'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.48-x64/DebugView%2B%2B.zip",
-            "hash": "7441cf9acce907b221ccc85be417a709f6938fbffdc251be108e46abcfe9959f"
+            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/1.8.0.103-x64/DebugView%2B%2B.zip",
+            "hash": "35fe7bf1713e5ffc0d89fb00e58deae414165fe4e8e0326a09a63cb040818c7e"
         },
         "32bit": {
-            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.86/DebugView%2B%2B.zip",
-            "hash": "b4e841575da785a1a13d974099c29d0425d9cb84ddc8ae62b82890f4842af67e"
+            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.95/DebugView%2B%2B.zip",
+            "hash": "98d2c858271b69f8577c6225905413b0c13139f6edc55d4ac92c7c92e6de22e6"
         }
     },
     "bin": [
@@ -23,16 +23,25 @@
         "DebugViewConsole.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repositories/14376430/releases",
-        "regex": "Debugview\\+\\+ v([\\d.]+) - 32 bit version"
+        "script": [
+            "try {",
+            "    foreach ($tag in (Invoke-RestMethod https://api.github.com/repositories/14376430/releases).tag_name) {",
+            "        if ($64 -and $32) { break }",
+            "        if ($_ -clike '*-x64') { $64 = $tag } else { $32 = $tag }",
+            "    }",
+            "    $64, $32 -join ' '",
+            "}",
+            "catch { '' }"
+        ],
+        "regex": "\\A(?<prefix64>v?)([\\d.]+)-x64 (?<prefix32>v?)(?<32>[\\d.]+)\\Z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$matchTag64-x64/DebugView%2B%2B.zip"
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix64$version-x64/DebugView%2B%2B.zip"
             },
             "32bit": {
-                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$matchTag32/DebugView%2B%2B.zip"
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix32$match32/DebugView%2B%2B.zip"
             }
         }
     }

--- a/bucket/debugviewpp.json
+++ b/bucket/debugviewpp.json
@@ -33,7 +33,7 @@
             "}",
             "catch { '' }"
         ],
-        "regex": "\\A(?<prefix64>v?)([\\d.]+)-x64 (?<prefix32>v?)(?<32>[\\d.]+)\\Z"
+        "regex": "\\A(?<prefix64>v?)([\\d.]+)-x64 (?<prefix32>v?)(?<ver32>[\\d.]+)\\Z"
     },
     "autoupdate": {
         "architecture": {
@@ -41,7 +41,7 @@
                 "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix64$version-x64/DebugView%2B%2B.zip"
             },
             "32bit": {
-                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix32$match32/DebugView%2B%2B.zip"
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix32$matchVer32/DebugView%2B%2B.zip"
             }
         }
     }

--- a/bucket/debugviewpp.json
+++ b/bucket/debugviewpp.json
@@ -23,7 +23,7 @@
         "DebugViewConsole.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/CobaltFusion/DebugViewPP/releases",
+        "url": "https://api.github.com/repositories/14376430/releases",
         "regex": "Debugview\\+\\+ v([\\d.]+) - 32 bit version"
     },
     "autoupdate": {

--- a/bucket/dismplusplus.json
+++ b/bucket/dismplusplus.json
@@ -45,9 +45,9 @@
     },
     "persist": "Config\\Config.ini",
     "checkver": {
-        "url": "https://api.github.com/repositories/74809720/releases",
-        "jsonpath": "$..browser_download_url",
-        "regex": "v(?<tag>[\\d.]+)/Dism%2B%2B(?<version>[\\w\\d.]+)\\.zip"
+        "url": "https://api.github.com/repositories/74809720/releases/latest",
+        "jsonpath": "$.assets[0].browser_download_url",
+        "regex": "v(?<tag>[\\d.]+)/Dism%2B%2B(?<version>[\\d.]+[a-z]?)\\.zip"
     },
     "autoupdate": {
         "url": "https://github.com/Chuyu-Team/Dism-Multi-language/releases/download/v$matchTag/Dism++$version.zip"

--- a/bucket/dismplusplus.json
+++ b/bucket/dismplusplus.json
@@ -45,7 +45,7 @@
     },
     "persist": "Config\\Config.ini",
     "checkver": {
-        "url": "https://api.github.com/repos/Chuyu-Team/Dism-Multi-language/releases",
+        "url": "https://api.github.com/repositories/74809720/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "v(?<tag>[\\d.]+)/Dism%2B%2B(?<version>[\\w\\d.]+)\\.zip"
     },

--- a/bucket/dosbox-x.json
+++ b/bucket/dosbox-x.json
@@ -30,7 +30,7 @@
     ],
     "persist": "dosbox.conf",
     "checkver": {
-        "url": "https://api.github.com/repos/joncampbell123/dosbox-x/releases/latest",
+        "url": "https://api.github.com/repositories/19881421/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "dosbox-x-v([\\d.]+).*vsbuild-arm64-(?<releasearm64>\\d+).*vsbuild-win32-(?<releasewin32>\\d+).*vsbuild-win64-(?<releasewin64>\\d+)"
     },

--- a/bucket/fancontrol.json
+++ b/bucket/fancontrol.json
@@ -23,7 +23,7 @@
         "Plugins"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Rem0o/FanControl.Releases/releases/latest",
+        "url": "https://api.github.com/repositories/268350681/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "/V([\\d.]+)/FanControl_net_(?<netver>(?!4_8)[\\d_]+).zip"
     },

--- a/bucket/fmedia.json
+++ b/bucket/fmedia.json
@@ -20,7 +20,7 @@
     ],
     "persist": "fmedia.conf",
     "checkver": {
-        "url": "https://api.github.com/repos/stsaz/fmedia/releases",
+        "url": "https://api.github.com/repositories/36122394/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "fmedia-([\\d.]+)-windows-x64.zip"
     },

--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
+        "url": "https://api.github.com/repositories/5736080/releases",
         "regex": "FreeCAD-([\\d.]+)-WIN-x64-portable((-\\d+)?)\\.zip",
         "replace": "${1}${2}"
     },

--- a/bucket/garbro.json
+++ b/bucket/garbro.json
@@ -12,7 +12,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/morkt/GARbro/releases/latest",
+        "url": "https://api.github.com/repositories/22076748/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "GARbro-v([\\d.]+).rar"
     },

--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -30,7 +30,7 @@
     ],
     "persist": "Ghidra/Configurations",
     "checkver": {
-        "url": "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest",
+        "url": "https://api.github.com/repositories/173228436/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "ghidra_([\\d.]+)_PUBLIC_(?<releasedate>\\d+)\\.zip",
         "replace": "${1}-${2}"

--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -21,7 +21,7 @@
     ],
     "persist": "GitExtensions.settings",
     "checkver": {
-        "url": "https://api.github.com/repos/gitextensions/gitextensions/releases",
+        "url": "https://api.github.com/repositories/85953/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/v(?<tag>[\\d.]+)/GitExtensions-Portable-([\\d.]+)-(?<commit>[\\w]+)\\.zip"
     },

--- a/bucket/github.json
+++ b/bucket/github.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/desktop/desktop/tags",
+        "url": "https://api.github.com/repositories/58559694/tags",
         "regex": "tags/release-([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/icecast.json
+++ b/bucket/icecast.json
@@ -58,7 +58,7 @@
         "icecast.xml"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/xiph/Icecast-Server/tags",
+        "url": "https://api.github.com/repositories/27493196/tags",
         "regex": "v([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/icsharpcode/ILSpy/releases/latest",
+        "url": "https://api.github.com/repositories/1327739/releases/latest",
         "jsonpath": "$.assets[*].browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+)/ILSpy_binaries_([\\d.]+).zip"
     },

--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.0.0.7345",
+    "version": "8.1.1.7464",
     "description": ".NET assembly browser and decompiler.",
     "homepage": "http://ilspy.net",
     "license": "MIT",
@@ -9,8 +9,16 @@
             "extras/windowsdesktop-runtime-lts"
         ]
     },
-    "url": "https://github.com/icsharpcode/ILSpy/releases/download/v8.0/ILSpy_binaries_8.0.0.7345.zip",
-    "hash": "2f3cb188eac706c08ea278201b4854030fd091697fb41f1b5654cb3a5835ae37",
+    "architecture": {
+        "arm64": {
+            "url": "https://github.com/icsharpcode/ILSpy/releases/download/v8.1.1/ILSpy_binaries_8.1.1.7464-arm64.zip",
+            "hash": "ed1d5689360580dd67b6480a62df75bb9cc4d0014f8e2d944016e83b8aa66cf8"
+        },
+        "64bit": {
+            "url": "https://github.com/icsharpcode/ILSpy/releases/download/v8.1.1/ILSpy_binaries_8.1.1.7464-x64.zip",
+            "hash": "c6ab2cb7f14b8e6aa667e4f0daa3023f603e8fe584952e58aa34a69a513a017a"
+        }
+    },
     "bin": "ILSpy.exe",
     "shortcuts": [
         [
@@ -20,10 +28,17 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/1327739/releases/latest",
-        "jsonpath": "$.assets[*].browser_download_url",
-        "regex": "download/v(?<tag>[\\d.]+)/ILSpy_binaries_([\\d.]+).zip"
+        "jsonpath": "$.assets..browser_download_url",
+        "regex": "download/v(?<tag>[\\d.]+)/ILSpy_binaries_([\\d.]+)-x64\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$matchTag/ILSpy_binaries_$version.zip"
+        "architecture": {
+            "arm64": {
+                "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$matchTag/ILSpy_binaries_$version-arm64.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$matchTag/ILSpy_binaries_$version-x64.zip"
+            }
+        }
     }
 }

--- a/bucket/inkscape-extension-sozi.json
+++ b/bucket/inkscape-extension-sozi.json
@@ -24,7 +24,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/sozi-projects/Sozi/releases/latest",
+        "url": "https://api.github.com/repositories/940219/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "/v(?<tag>[\\d.]+)/sozi-extras-media-([\\d.]+)-(?<build>[\\d]+)-inkscape-1.0.zip"
     },

--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Kong/insomnia/releases",
+        "url": "https://api.github.com/repositories/56899284/releases",
         "regex": "\"core@([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/jexiftoolgui.json
+++ b/bucket/jexiftoolgui.json
@@ -15,7 +15,7 @@
     ],
     "persist": "logs",
     "checkver": {
-        "url": "https://api.github.com/repos/hvdwolf/jExifToolGUI/releases/latest",
+        "url": "https://api.github.com/repositories/187222374/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "jExifToolGUI-([\\d.]+)-win-x86_64_with-jre\\.zip"
     },

--- a/bucket/lightbulb.json
+++ b/bucket/lightbulb.json
@@ -23,7 +23,7 @@
     ],
     "persist": "Settings.json",
     "checkver": {
-        "url": "https://api.github.com/repos/Tyrrrz/LightBulb/tags",
+        "url": "https://api.github.com/repositories/78772975/tags",
         "regex": "tags/([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/linkerd.json
+++ b/bucket/linkerd.json
@@ -11,7 +11,7 @@
     },
     "bin": "linkerd.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/linkerd/linkerd2/releases",
+        "url": "https://api.github.com/repositories/113106184/releases",
         "regex": "download/stable-([\\d.]+)/link"
     },
     "autoupdate": {

--- a/bucket/liteide.json
+++ b/bucket/liteide.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/visualfc/liteide/releases/latest",
+        "url": "https://api.github.com/repositories/6753728/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "liteidex([\\d.-]+).win64-qt(?<qt64bitver>[\\d.]+).zip"
     },

--- a/bucket/liteide.json
+++ b/bucket/liteide.json
@@ -1,12 +1,12 @@
 {
-    "version": "38.2",
+    "version": "38.3",
     "description": "Simple, open source, cross-platform Go IDE",
     "homepage": "http://liteide.org",
     "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/visualfc/liteide/releases/download/x38.2/liteidex38.2.win64-qt5.15.2.zip",
-            "hash": "9a19840d1d1295137d695a5d412d53327a997ed9db3c8183dfcf8e0bb7d05db5"
+            "url": "https://github.com/visualfc/liteide/releases/download/x38.3/liteidex38.3-win64-qt5.15.2.zip",
+            "hash": "83e610976f5503a9a9fffe32a4883eeae74685e339c69f388403ffec6cb409b3"
         }
     },
     "extract_dir": "liteide",
@@ -20,12 +20,12 @@
     "checkver": {
         "url": "https://api.github.com/repositories/6753728/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
-        "regex": "liteidex([\\d.-]+).win64-qt(?<qt64bitver>[\\d.]+).zip"
+        "regex": "liteidex([\\d.-]+)-win64-qt(?<qt>[\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/visualfc/liteide/releases/download/x$version/liteidex$version.win64-qt$matchQt64bitver.zip"
+                "url": "https://github.com/visualfc/liteide/releases/download/x$version/liteidex$version-win64-qt$matchQt.zip"
             }
         }
     }

--- a/bucket/magicavoxel.json
+++ b/bucket/magicavoxel.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ephtracy/ephtracy.github.io/releases",
+        "url": "https://api.github.com/repositories/32556501/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "MagicaVoxel-([\\d.]+)-win64\\.zip"
     },

--- a/bucket/mindforger.json
+++ b/bucket/mindforger.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/dvorka/mindforger/releases/latest",
+        "url": "https://api.github.com/repositories/115310754/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "mindforger-windows-installer-([\\d.]+)-([a-f0-9]{8}).exe"
     },

--- a/bucket/mpv.net.json
+++ b/bucket/mpv.net.json
@@ -18,7 +18,7 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://api.github.com/repos/mpvnet-player/mpv.net/releases/latest",
+        "url": "https://api.github.com/repositories/101537172/releases/latest",
         "jsonpath": "$.assets[*].browser_download_url",
         "regex": "download/v(?<tag>.*)/mpv.net-v([\\d.]+)(?<channel>-stable)?\\.zip"
     },

--- a/bucket/nekoray.json
+++ b/bucket/nekoray.json
@@ -23,7 +23,7 @@
     ],
     "persist": "config",
     "checkver": {
-        "url": "https://api.github.com/repos/MatsuriDayo/nekoray/releases/latest",
+        "url": "https://api.github.com/repositories/488177011/releases/latest",
         "regex": "nekoray-([\\d.]+)-(?<extra>[\\d-]+)-windows64"
     },
     "autoupdate": {

--- a/bucket/neovim-qt.json
+++ b/bucket/neovim-qt.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/equalsraf/neovim-qt/releases",
+        "url": "https://api.github.com/repositories/20190634/releases",
         "regex": "tag/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/notesnook.json
+++ b/bucket/notesnook.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/streetwriters/notesnook/releases",
+        "url": "https://api.github.com/repositories/353775942/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/v([\\d.]+)/notesnook_win_x64_portable.exe"
     },

--- a/bucket/nuclear.json
+++ b/bucket/nuclear.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/nukeop/nuclear/releases",
+        "url": "https://api.github.com/repositories/68968979/releases",
         "regex": "/nuclear\\.Setup\\.([\\d.]+)\\.exe"
     },
     "autoupdate": {

--- a/bucket/onlyoffice-desktopeditors.json
+++ b/bucket/onlyoffice-desktopeditors.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ONLYOFFICE/DesktopEditors/releases",
+        "url": "https://api.github.com/repositories/69867298/releases",
         "regex": "v([\\d.]+)/DesktopEditors_x64\\.exe"
     },
     "autoupdate": {

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/prusa3d/PrusaSlicer/releases",
+        "url": "https://api.github.com/repositories/52882701/releases",
         "regex": "PrusaSlicer-([\\d.]+)\\+win64-(?<timestamp64>\\d+)_signed\\.zip"
     },
     "autoupdate": {

--- a/bucket/puttie.json
+++ b/bucket/puttie.json
@@ -35,7 +35,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/lalbornoz/PuTTie/releases/latest",
+        "url": "https://api.github.com/repositories/138299134/releases/latest",
         "regex": "(?s)Release-(?<sha>[0-9a-f]{8}).*?updated_at.*?(\\d{4})-(\\d{2})-(\\d{2})",
         "replace": "${1}${2}${3}-${sha}"
     },

--- a/bucket/redasm.json
+++ b/bucket/redasm.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/REDasmOrg/REDasm/releases",
+        "url": "https://api.github.com/repositories/112006109/releases",
         "regex": "/REDasm_([\\d.]+)_Windows_x86_64\\.zip"
     },
     "autoupdate": {

--- a/bucket/regiontoshare.json
+++ b/bucket/regiontoshare.json
@@ -13,7 +13,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/tom-englert/RegionToShare/releases/latest",
+        "url": "https://api.github.com/repositories/435219615/releases/latest",
         "jsonpath": "$.name",
         "regex": "([\\d.]+)"
     },

--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -21,7 +21,7 @@
     ],
     "persist": "data4",
     "checkver": {
-        "url": "https://api.github.com/repos/martinrotter/rssguard/releases/latest",
+        "url": "https://api.github.com/repositories/23906078/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /^rssguard-([\\d.]+)-([\\w]+)-win10.7z$/)].name",
         "regex": "rssguard-(?<version>([\\d.]+))-(?<commit>[\\w]+)-win10.7z"
     },

--- a/bucket/saber.json
+++ b/bucket/saber.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/adil192/saber/releases/latest",
+        "url": "https://api.github.com/repositories/516598834/releases/latest",
         "regex": "(?sm)browser_download_url.*?releases/download/v([\\d.]+)/SaberInstaller_v([\\d.]+)(?<extra>_([\\d]+))?\\.exe"
     },
     "autoupdate": {

--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -37,7 +37,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Moeologist/scoop-completion/tags",
+        "url": "https://api.github.com/repositories/151275183/tags",
         "regex": "tags/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/scratch.json
+++ b/bucket/scratch.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/LLK/scratch-desktop/tags",
+        "url": "https://api.github.com/repositories/147715168/tags",
         "regex": "refs/tags/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/scratch.json
+++ b/bucket/scratch.json
@@ -19,8 +19,12 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repositories/147715168/tags",
-        "regex": "refs/tags/v([\\d.]+)"
+        "script": [
+            "$req = [System.Net.HttpWebRequest]::Create('https://downloads.scratch.mit.edu/desktop/Scratch%20Setup.exe')",
+            "$req.Method = 'head'",
+            "$req.GetResponse().ResponseUri.Segments[-1]"
+        ],
+        "regex": "\\AScratch%20([\\d.]+)%20Setup.exe\\Z"
     },
     "autoupdate": {
         "url": "https://downloads.scratch.mit.edu/desktop/Scratch%20$version%20Setup.exe#/dl.7z"

--- a/bucket/so.json
+++ b/bucket/so.json
@@ -15,7 +15,7 @@
     },
     "bin": "so.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/samtay/so/releases/latest",
+        "url": "https://api.github.com/repositories/268159767/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "v([\\d.]+)/so-x86_64-pc-windows-msvc\\.zip"
     },

--- a/bucket/soundswitch.json
+++ b/bucket/soundswitch.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Belphemur/SoundSwitch/releases/latest",
+        "url": "https://api.github.com/repositories/40604558/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "v([\\d.]+)/SoundSwitch_v([\\d.]+)_Release_Installer\\.exe"
     },

--- a/bucket/spicetify-themes.json
+++ b/bucket/spicetify-themes.json
@@ -25,7 +25,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/spicetify/spicetify-themes/commits",
+        "url": "https://api.github.com/repositories/204008310/commits",
         "regex": "([\\d-]+T)(\\d+):(\\d+):(\\d+)",
         "replace": "$1$2.$3.$4"
     },

--- a/bucket/standardnotes.json
+++ b/bucket/standardnotes.json
@@ -22,7 +22,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/standardnotes/app/releases/latest",
+        "url": "https://api.github.com/repositories/75675698/releases/latest",
         "regex": "@standardnotes/desktop@([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/status.json
+++ b/bucket/status.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/status-im/status-desktop/releases/latest",
+        "url": "https://api.github.com/repositories/261270348/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "StatusIm-Desktop-v(?<Ver>[\\d.]+)-(?<Build>[\\w]+)\\.",
         "replace": "${Ver}-${Build}"

--- a/bucket/streamlabs-obs.json
+++ b/bucket/streamlabs-obs.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/stream-labs/streamlabs-obs/tags?per_page=100",
+        "url": "https://api.github.com/repositories/108469351/tags?per_page=100",
         "regex": "\"v([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/stremio.json
+++ b/bucket/stremio.json
@@ -28,7 +28,7 @@
         "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/s/Stremio/Stremio",
+        "url": "https://api.github.com/repositories/197275551/contents/manifests/s/Stremio/Stremio",
         "jsonpath": "$..name",
         "regex": "([\\d.]+)",
         "reverse": true

--- a/bucket/subsync.json
+++ b/bucket/subsync.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/sc0ty/subsync/releases/latest",
+        "url": "https://api.github.com/repositories/154024711/releases/latest",
         "jsonpath": "$.name",
         "regex": "subsync\\sv([\\d.]+)"
     },

--- a/bucket/switchhosts.json
+++ b/bucket/switchhosts.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/oldj/SwitchHosts/releases/latest",
+        "url": "https://api.github.com/repositories/2312977/releases/latest",
         "regex": "SwitchHosts_windows_installer_x64_([\\d.]+)\\.exe"
     },
     "autoupdate": {

--- a/bucket/thonny.json
+++ b/bucket/thonny.json
@@ -16,7 +16,7 @@
     },
     "persist": "user_data",
     "checkver": {
-        "url": "https://api.github.com/repos/thonny/thonny/releases",
+        "url": "https://api.github.com/repositories/163728962/releases",
         "regex": "thonny-([\\d.]+)-windows-portable\\.zip"
     },
     "autoupdate": {

--- a/bucket/tlaplus-toolbox.json
+++ b/bucket/tlaplus-toolbox.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "extract_dir": "toolbox",
     "url": "https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/TLAToolbox-1.8.0-win32.win32.x86_64.zip",
-    "hash": "sha1:4cbf54cf923c385ac55725302b5fa4750118d497",
+    "hash": "sha1:e84f83f508897a9c844aa8888862bcb131da424b",
     "bin": [
         "toolbox.exe",
         [
@@ -27,8 +27,8 @@
     },
     "checkver": {
         "url": "https://api.github.com/repositories/50906927/releases",
-        "jsonpath": "$..browser_download_url",
-        "regex": "TLAToolbox-([\\d.]+)-win32\\.win32\\.x86_64\\.zip"
+        "jsonpath": "$.[0].tag_name",
+        "regex": "\\Av([\\d.]+)\\Z"
     },
     "autoupdate": {
         "url": "https://github.com/tlaplus/tlaplus/releases/download/v$version/TLAToolbox-$version-win32.win32.x86_64.zip",

--- a/bucket/tlaplus-toolbox.json
+++ b/bucket/tlaplus-toolbox.json
@@ -26,7 +26,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/tlaplus/tlaplus/releases",
+        "url": "https://api.github.com/repositories/50906927/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "TLAToolbox-([\\d.]+)-win32\\.win32\\.x86_64\\.zip"
     },

--- a/bucket/tlaplus-toolbox.json
+++ b/bucket/tlaplus-toolbox.json
@@ -27,7 +27,7 @@
     },
     "checkver": {
         "url": "https://api.github.com/repositories/50906927/releases",
-        "jsonpath": "$.[0].tag_name",
+        "jsonpath": "$[0].tag_name",
         "regex": "\\Av([\\d.]+)\\Z"
     },
     "autoupdate": {

--- a/bucket/todolist.json
+++ b/bucket/todolist.json
@@ -41,7 +41,7 @@
         "Resources\\TaskLists"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/abstractspoon/ToDoList_Downloads/commits",
+        "url": "https://api.github.com/repositories/39107460/commits",
         "jsonpath": "$..message",
         "regex": "Update to (\\d+[\\d.]+\\.\\d+)"
     },

--- a/bucket/total-registry.json
+++ b/bucket/total-registry.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/zodiacon/TotalRegistry/releases",
+        "url": "https://api.github.com/repositories/384228278/releases",
         "regex": "download/v([\\d.]+)/"
     },
     "autoupdate": {

--- a/bucket/ubports-installer.json
+++ b/bucket/ubports-installer.json
@@ -32,7 +32,7 @@
     ],
     "persist": "APPDATA",
     "checkver": {
-        "url": "https://api.github.com/repos/ubports/ubports-installer/releases",
+        "url": "https://api.github.com/repositories/81379180/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/download/(?<tag>[\\w.-]+)/ubports-installer_([\\w.-]+)_win_x64\\.exe"
     },

--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -29,7 +29,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Bioruebe/UniExtract2/releases",
+        "url": "https://api.github.com/repositories/29245432/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v([\\w.-]+)/(?<filename>\\w+\\.zip)"
     },

--- a/bucket/universal-android-debloater.json
+++ b/bucket/universal-android-debloater.json
@@ -15,7 +15,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/0x192/universal-android-debloater/releases",
+        "url": "https://api.github.com/repositories/414585797/releases",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/youtube-dl-gui.json
+++ b/bucket/youtube-dl-gui.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/oleksis/youtube-dl-gui/releases/latest",
+        "url": "https://api.github.com/repositories/280719816/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "v([\\d.]+)/yt-dlg-(?<Release>[\\d.]+).msi"
     },

--- a/bucket/zeronet.json
+++ b/bucket/zeronet.json
@@ -22,7 +22,7 @@
         "log"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/HelloZeroNet/ZeroNet-win/branches",
+        "url": "https://api.github.com/repositories/79958649/branches",
         "jsonpath": "$[?(@.name == 'dist-win64')].commit.sha"
     },
     "autoupdate": {


### PR DESCRIPTION
Repo names are subject to change, IDs aren't

Relates to https://github.com/ScoopInstaller/Main/pull/5215 https://github.com/ScoopInstaller/Versions/pull/1429

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).