### PR TITLE
teraterm@5.0: Switch to github release

### DIFF
--- a/bucket/musicbee.json
+++ b/bucket/musicbee.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.5.8447",
+    "version": "3.5.8698",
     "description": "The ultimate music player to easily manage, find, and play music, podcasts, web radio stations, etc",
     "homepage": "https://getmusicbee.com",
     "license": {
@@ -7,7 +7,7 @@
         "url": "https://musicbee.fandom.com/wiki/FAQ#Are_there_any_limitations_on_using_MusicBee.3F"
     },
     "url": "https://files1.majorgeeks.com/10afebdbffcd4742c81a3cb0f6ce4092156b4375/multimedia/MusicBeePortable_3_5.zip",
-    "hash": "706a8bb4c1b453af0619a28705bc461011f77828aaaecbb67e1f48552addbed9",
+    "hash": "a1da2ff921922fe4323f062a0032b6182b5dd000d6b5df34998614377aa3977a",
     "pre_install": [
         "(Get-ChildItem \"$dir\" 'MusicBee*.exe').FullName | Expand-7zipArchive -DestinationPath \"$dir\" -Removal",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse",

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -21,13 +21,11 @@
         "ssh_known_hosts",
         "TERATERM.INI"
     ],
-    "checkver": "releases/(?<tag>\\d+)\">Tera Term ([\\d.]+)</a>",
+    "checkver": {
+        "github": "https://github.com/TeraTermProject/osdn-download"
+    },
     "autoupdate": {
-        "url": "https://dotsrc.dl.osdn.net/osdn/ttssh2/$matchTag/teraterm-$version.zip",
-        "hash": {
-            "url": "https://osdn.net/projects/ttssh2/downloads/$matchTag/$basename/",
-            "regex": "(?sm)SHA1</dt>\\s+<dd>$sha1</dd>"
-        },
+        "url": "https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-$version/teraterm-$version.zip",
         "extract_dir": "teraterm-$version"
     }
 }

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -22,7 +22,8 @@
         "TERATERM.INI"
     ],
     "checkver": {
-        "github": "https://github.com/TeraTermProject/osdn-download"
+        "url": "https://github.com/TeraTermProject/osdn-download/releases";
+        "regex": "teraterm-([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "url": "https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-$version/teraterm-$version.zip",

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -23,7 +23,7 @@
     ],
     "checkver": {
         "url": "https://github.com/TeraTermProject/osdn-download/releases",
-        "regex": "teraterm-([\\d.]+)\\.zip"
+        "regex": "teraterm-([\\d\\.]+)\\.zip"
     },
     "autoupdate": {
         "url": "https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-$version/teraterm-$version.zip",

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -22,7 +22,7 @@
         "TERATERM.INI"
     ],
     "checkver": {
-        "url": "https://github.com/TeraTermProject/osdn-download/releases";
+        "url": "https://github.com/TeraTermProject/osdn-download/releases",
         "regex": "teraterm-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -4,7 +4,7 @@
     "homepage": "https://osdn.net/projects/ttssh2/",
     "license": "BSD-3-Clause",
     "notes": "OSDN is currently unstable. See: https://github.com/TeraTermProject/osdn-download",
-    "url": "https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-5.0/teraterm-5.0.zip",
+    "url": "https://github.com/TeraTermProject/teraterm/releases/download/v5.0/teraterm-5.0.zip",
     "hash": "sha1:20120e05e09bba7be159631513d237ac67c15433",
     "extract_dir": "teraterm-5.0",
     "bin": "ttermpro.exe",
@@ -22,11 +22,10 @@
         "TERATERM.INI"
     ],
     "checkver": {
-        "url": "https://github.com/TeraTermProject/osdn-download/releases",
-        "regex": "teraterm-([\\d\\.]+)\\.zip"
+        "github": "https://github.com/TeraTermProject/teraterm",
     },
     "autoupdate": {
-        "url": "https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-$version/teraterm-$version.zip",
+        "url": "https://github.com/TeraTermProject/teraterm/releases/download/v$version/teraterm-$version.zip",
         "extract_dir": "teraterm-$version"
     }
 }

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -1,11 +1,12 @@
 {
-    "version": "4.106",
+    "version": "5.0",
     "description": "Terminal emulator for ssh/telnet/serial connection.",
     "homepage": "https://osdn.net/projects/ttssh2/",
     "license": "BSD-3-Clause",
-    "url": "https://dotsrc.dl.osdn.net/osdn/ttssh2/74780/teraterm-4.106.zip",
-    "hash": "sha1:b3734bbcc38b7d389243fd93af7b85460bd435ae",
-    "extract_dir": "teraterm-4.106",
+    "notes": "OSDN is currently unstable. See: https://github.com/TeraTermProject/osdn-download",
+    "url": "https://github.com/TeraTermProject/osdn-download/releases/download/teraterm-5.0/teraterm-5.0.zip",
+    "hash": "sha1:20120e05e09bba7be159631513d237ac67c15433",
+    "extract_dir": "teraterm-5.0",
     "bin": "ttermpro.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
OSDN is currently unstable, so [current redistribution is via GitHub](https://github.com/TeraTermProject/osdn-download/releases).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
