### PR TITLE
hysteria: Update to version 2.1.1

### DIFF
--- a/bucket/hysteria.json
+++ b/bucket/hysteria.json
@@ -1,27 +1,37 @@
 {
-    "version": "1.3.5",
+    "version": "2.1.1",
     "description": "Network utility optimized for networks of poor quality (e.g. satellite connections, congested public Wi-Fi, connecting from China to servers abroad)",
-    "homepage": "https://github.com/HyNetwork/hysteria",
+    "homepage": "https://github.com/apernet/hysteria",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/HyNetwork/hysteria/releases/download/v1.3.5/hysteria-windows-amd64.exe#/hysteria.exe",
-            "hash": "1001bd4a83f6addac166bfdfc3e777f3b751bb397e11b5d8f1d6ec1c2dd44023"
+            "url": "https://github.com/apernet/hysteria/releases/download/app/v2.1.1/hysteria-windows-amd64.exe#/hysteria.exe",
+            "hash": "e85cecdc6339f2df8717ba4024598a53bbd54693b6e5638a7567555283318b87"
         },
         "32bit": {
-            "url": "https://github.com/HyNetwork/hysteria/releases/download/v1.3.5/hysteria-windows-386.exe#/hysteria.exe",
-            "hash": "d6b1edb35721bb7b52034e1ae2d89da3ce16469966d8cfb587da38a43aab9277"
+            "url": "https://github.com/apernet/hysteria/releases/download/app/v2.1.1/hysteria-windows-386.exe#/hysteria.exe",
+            "hash": "643f0bad544d0d1818617a257a18acb55345d8302fedb34e0e817f4337f760fc"
+        },
+        "arm64": {
+            "url": "https://github.com/apernet/hysteria/releases/download/app/v2.1.1/hysteria-windows-arm64.exe#/hysteria.exe",
+            "hash": "c548c6e24de5e6585d00566dc0f2f3ea27afd247e1402f668d172a1c0d7237b3"
         }
     },
     "bin": "hysteria.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/apernet/hysteria/releases/latest",
+        "regex": "app/v([\\d\\.]*)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/HyNetwork/hysteria/releases/download/v$version/hysteria-windows-amd64.exe#/hysteria.exe"
+                "url": "https://github.com/apernet/hysteria/releases/download/app/v$version/hysteria-windows-amd64.exe#/hysteria.exe"
             },
             "32bit": {
-                "url": "https://github.com/HyNetwork/hysteria/releases/download/v$version/hysteria-windows-386.exe#/hysteria.exe"
+                "url": "https://github.com/apernet/hysteria/releases/download/app/v$version/hysteria-windows-386.exe#/hysteria.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/apernet/hysteria/releases/download/app/v$version/hysteria-windows-arm64.exe#/hysteria.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
hysteria: Update to version 2.1.1
- fix checkver
- and add arm64


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
