### PR TITLE
wabt: Fixed shim creation error in 1.0.34

### DIFF
--- a/bucket/wabt.json
+++ b/bucket/wabt.json
@@ -17,7 +17,7 @@
         "wasm-decompile.exe",
         "wasm-interp.exe",
         "wasm-objdump.exe",
-        "wasm-opcodecnt.exe",
+        "wasm-stats.exe",
         "wasm-strip.exe",
         "wasm-validate.exe",
         "wast2json.exe",


### PR DESCRIPTION
wabt 1.0.34 renamed wasm-opcodecnt.exe to wasm-stats.exe. Manifest updated to reflect this change.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
