### PR TITLE
naps2: Update to version 7.1.2

### DIFF
--- a/bucket/naps2.json
+++ b/bucket/naps2.json
@@ -1,10 +1,10 @@
 {
-    "version": "6.1.2",
+    "version": "7.1.2",
     "description": "A document scanning application with a focus on simplicity and ease of use",
     "homepage": "https://www.naps2.com/",
-    "license": "GPL-2.0-only",
-    "url": "https://github.com/cyanfish/naps2/releases/download/v6.1.2/naps2-6.1.2-portable.7z",
-    "hash": "2b2ebb144716774505c8abf6b121cbb2684be9ea273299681178f1bc7c75e166",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/cyanfish/naps2/releases/download/v7.1.2/naps2-7.1.2-win.zip",
+    "hash": "79b12dd2fa86fc66d7aaecdc943e551d6e6aaa7d58794905142c2195fbc58e51",
     "bin": [
         [
             "App\\NAPS2.Console.exe",
@@ -22,6 +22,6 @@
         "github": "https://github.com/cyanfish/naps2"
     },
     "autoupdate": {
-        "url": "https://github.com/cyanfish/naps2/releases/download/v$version/naps2-$version-portable.7z"
+        "url": "https://github.com/cyanfish/naps2/releases/download/v$version/naps2-$version-win.zip"
     }
 }


### PR DESCRIPTION
- Update to 7.1.2
- Fix autoupdate
- Fix license

Closes #12106

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
