### PR TITLE
Update Beyond Compare 4 to 4.4.7.28397

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.4.6.27483",
+    "version": "4.4.7.28397",
     "description": "Directory and file compare functions in one package",
     "homepage": "https://www.scootersoftware.com",
     "license": {
@@ -9,12 +9,12 @@
     "notes": "Add Beyond Compare as a context menu option by running: '$dir\\install-context.reg'",
     "architecture": {
         "64bit": {
-            "url": "https://www.scootersoftware.com/BCompare-4.4.6.27483_x64.msi",
-            "hash": "afb9a40136da34c8851e34ff422ff6bda269f0d0de52dd23c41363fb99353379"
+            "url": "https://www.scootersoftware.com/files/BCompare-4.4.7.28397_x64.msi",
+            "hash": "089b8acbe228e876f4847132ec71fe256b134703e2e6205619b28905cb69f881"
         },
         "32bit": {
-            "url": "https://www.scootersoftware.com/BCompare-4.4.6.27483_x86.msi",
-            "hash": "31a1b42ad817f4b951e0f5ece0517605d3353c4ee5b5f2a03120e75350bcc689"
+            "url": "https://www.scootersoftware.com/files/BCompare-4.4.7.28397_x86.msi",
+            "hash": "7d722749e18309212f7d483b80e992b1c0f35dc437b93be6133cfe6b03574307"
         }
     },
     "extract_dir": "Beyond Compare 4",
@@ -44,16 +44,16 @@
         "}"
     ],
     "checkver": {
-        "url": "https://www.scootersoftware.com/download.php?zz=kb_dl4_winalternate",
+        "url": "https://www.scootersoftware.com/kb/dl4_winalternate",
         "regex": "BCompare-([\\d.]+)_x64\\.msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.scootersoftware.com/BCompare-$version_x64.msi"
+                "url": "https://www.scootersoftware.com/files/BCompare-$version_x64.msi"
             },
             "32bit": {
-                "url": "https://www.scootersoftware.com/BCompare-$version_x86.msi"
+                "url": "https://www.scootersoftware.com/files/BCompare-$version_x86.msi"
             }
         }
     }


### PR DESCRIPTION
Update Beyond Compare to 4.4.7.28397 and fix checkver and autoupdate rules

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
