### PR TITLE
vscode@1.83.1: 32-bit version disable autoupdate

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -79,7 +79,8 @@
                 }
             },
             "32bit": {
-                "url": "https://update.code.visualstudio.com/1.83.1/win32-archive/stable#/dl.7z"
+                "url": "https://update.code.visualstudio.com/1.83.1/win32-archive/stable#/dl.7z",
+                "hash": "91f1e91dfc17caaa23d7c0bdf889581b79621362eb10bda00ed0a9bb0c13ff77"
             },
             "arm64": {
                 "url": "https://update.code.visualstudio.com/$version/win32-arm64-archive/stable#/dl.7z",

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -79,11 +79,7 @@
                 }
             },
             "32bit": {
-                "url": "https://update.code.visualstudio.com/$version/win32-archive/stable#/dl.7z",
-                "hash": {
-                    "url": "https://code.visualstudio.com/sha?build=stable",
-                    "jsonpath": "$.products[?(@.platform.os == 'win32-archive')].sha256hash"
-                }
+                "url": "https://update.code.visualstudio.com/1.83.1/win32-archive/stable#/dl.7z"
             },
             "arm64": {
                 "url": "https://update.code.visualstudio.com/$version/win32-arm64-archive/stable#/dl.7z",

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -17,10 +17,6 @@
             "url": "https://update.code.visualstudio.com/1.83.1/win32-x64-archive/stable#/dl.7z",
             "hash": "bf53268e45d12cd43d4f7c61cd782d11d13646eb21e7d57532739a952f4d7ff5"
         },
-        "32bit": {
-            "url": "https://update.code.visualstudio.com/1.83.1/win32-archive/stable#/dl.7z",
-            "hash": "91f1e91dfc17caaa23d7c0bdf889581b79621362eb10bda00ed0a9bb0c13ff77"
-        },
         "arm64": {
             "url": "https://update.code.visualstudio.com/1.83.1/win32-arm64-archive/stable#/dl.7z",
             "hash": "91d66a14408ea12bf63905f56b7673242ea3e4f797f75df3b4c0e702c9e3a1b7"
@@ -77,10 +73,6 @@
                     "url": "https://code.visualstudio.com/sha?build=stable",
                     "jsonpath": "$.products[?(@.platform.os == 'win32-x64-archive')].sha256hash"
                 }
-            },
-            "32bit": {
-                "url": "https://update.code.visualstudio.com/1.83.1/win32-archive/stable#/dl.7z",
-                "hash": "91f1e91dfc17caaa23d7c0bdf889581b79621362eb10bda00ed0a9bb0c13ff77"
             },
             "arm64": {
                 "url": "https://update.code.visualstudio.com/$version/win32-arm64-archive/stable#/dl.7z",


### PR DESCRIPTION
Disable vscode autoupdate for 32-bit version because of end of support
https://code.visualstudio.com/updates/v1_84#_windows-32bit-support-ends

Closes #12147

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
