### PR TITLE
sumatrapdf: Fix URLs / Add ARM64 / Update to 3.5.2

### DIFF
--- a/bucket/sumatrapdf.json
+++ b/bucket/sumatrapdf.json
@@ -1,16 +1,20 @@
 {
-    "version": "3.4.6",
+    "version": "3.5.2",
     "description": "PDF and eBook reader",
     "homepage": "https://www.sumatrapdfreader.org/free-pdf-reader",
     "license": "GPL-3.0-only,BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/3.4.6/SumatraPDF-3.4.6-64.zip",
-            "hash": "2bb05aa8b74bc748bc1f6a2b6f6ec4ba22bd5b1eaeec767d0a7f97cfd436d40d"
+            "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/3.5.2/SumatraPDF-3.5.2-64.zip",
+            "hash": "66ccb395c9184dce6822dfbb9970c877383b3ead6d9417b5106a844aac512989"
         },
         "32bit": {
-            "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/3.4.6/SumatraPDF-3.4.6.zip",
-            "hash": "4eadd78dc8ae95a585474a9bff8fb25d84c239a9c7ca2bdc00a6a497283ef841"
+            "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/3.5.2/SumatraPDF-3.5.2.zip",
+            "hash": "5f1f460ff72ddd48979dbcfc2d427d53a473d43e18425470c78e94b19fee70b6"
+        },
+        "arm64": {
+            "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/3.5.2/SumatraPDF-3.5.2-arm64.zip",
+            "hash": "d6fa6678f3dd3017515faa74735ecbf860cb6825bd61f109f9157f0b171e882f"
         }
     },
     "pre_install": [
@@ -39,10 +43,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/$version/SumatraPDF-$version-64.zip"
+                "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/$version/SumatraPDF-$version-64.zip"
             },
             "32bit": {
-                "url": "https://files.sumatrapdfreader.org/file/kjk-files/software/sumatrapdf/rel/$version/SumatraPDF-$version.zip"
+                "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/$version/SumatraPDF-$version.zip"
+            },
+            "arm64": {
+                "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/rel/$version/SumatraPDF-$version-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Use target URLs as mentioned in #8679 
- Add ARM64 version
- Update to 3.5.2

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
