### PR TITLE
archi: fixed URL

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/archi.php?/5.2.0/Archi-Win64-5.2.0.zip",
+            "url": "https://www.archimatetool.com/downloads/archi-5.php?/5.2.0/Archi-Win64-5.2.0.zip",
             "hash": "sha1:3bac2f7e1f97035cba907fe917a09374c79f2153"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.archimatetool.com/downloads/archi.php?/$version/Archi-Win64-$version.zip"
+                "url": "https://www.archimatetool.com/downloads/archi-5.php?/$version/Archi-Win64-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The download URL was wrong.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
