### PR TITLE
vscodium: Update to version 1.84.1.23311, remove 32bit

### DIFF
--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.83.1.23285",
+    "version": "1.84.1.23311",
     "description": "A community-driven, freely-licensed binary distribution of Microsoft’s editor VS Code.",
     "homepage": "https://vscodium.com/",
     "license": "MIT",
@@ -9,16 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.83.1.23285/VSCodium-win32-x64-1.83.1.23285.zip",
-            "hash": "c2fe9978ca162f89925c57f69b283656603d79e657f46445653ca9dd4004191f"
-        },
-        "32bit": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.83.1.23285/VSCodium-win32-ia32-1.83.1.23285.zip",
-            "hash": "124633de279acbb18b0dbb826feab124b239ba774e2ea003ab1ddd41dfbebb9d"
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.84.1.23311/VSCodium-win32-x64-1.84.1.23311.zip",
+            "hash": "5c0374f81346a008050135fc86a6a424f4c28a17a31add6f91698f23b6ca0fba"
         },
         "arm64": {
-            "url": "https://github.com/VSCodium/vscodium/releases/download/1.83.1.23285/VSCodium-win32-arm64-1.83.1.23285.zip",
-            "hash": "714ad131d8988bce6234aee642810ed184fd7eda22d9491fe916c7b80b55812e"
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.84.1.23311/VSCodium-win32-arm64-1.84.1.23311.zip",
+            "hash": "6f032a4464e45f9b4f98cddf09d97fb93c3ee2dfb1a3400aac7f80c8030fcec9"
         }
     },
     "pre_install": [
@@ -81,9 +77,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-x64-$version.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-ia32-$version.zip"
             },
             "arm64": {
                 "url": "https://github.com/VSCodium/vscodium/releases/download/$version/VSCodium-win32-arm64-$version.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Windows x86 (32bits) version has been removed.
https://github.com/VSCodium/vscodium/pull/1706

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
