### PR TITLE
firefoxpwa: Specify repository for checkver

### DIFF
--- a/bucket/firefoxpwa.json
+++ b/bucket/firefoxpwa.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.7.3",
+    "version": "2.8.0",
     "description": "A tool to install, manage and use Progressive Web Apps (PWAs) in Mozilla Firefox (native component)",
     "homepage": "https://pwasforfirefox.filips.si/",
     "license": "MPL-2.0",
@@ -14,12 +14,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.7.3/firefoxpwa-2.7.3-x86_64.msi",
-            "hash": "2222ab932229af3b15b20be11b4509edaa16f2071d563676b03c02342bc16885"
+            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.8.0/firefoxpwa-2.8.0-x86_64.msi",
+            "hash": "1c219620c99cfc5d75f23393b6a74c893387c4d6151ef51c0e8bcddfb3c7a632"
         },
         "32bit": {
-            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.7.3/firefoxpwa-2.7.3-x86.msi",
-            "hash": "91142c369ec4d6dbab52284f4f58ed1851fe17b2367aabc5693df444393b8f1d"
+            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.8.0/firefoxpwa-2.8.0-x86.msi",
+            "hash": "4e0534b34bcab1cc69dcf609be92222b212b2aa16479deefc8e2cd1f95be7aee"
         }
     },
     "post_install": [

--- a/bucket/firefoxpwa.json
+++ b/bucket/firefoxpwa.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "A tool to install, manage and use Progressive Web Apps (PWAs) in Mozilla Firefox (native component)",
     "homepage": "https://pwasforfirefox.filips.si/",
     "license": "MPL-2.0",
@@ -14,12 +14,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.8.0/firefoxpwa-2.8.0-x86_64.msi",
-            "hash": "1c219620c99cfc5d75f23393b6a74c893387c4d6151ef51c0e8bcddfb3c7a632"
+            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.9.0/firefoxpwa-2.9.0-x86_64.msi",
+            "hash": "185ae052b9e3e4ce0c40af936c45da1035f4b63570793845eb9ab776f42cdc3b"
         },
         "32bit": {
-            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.8.0/firefoxpwa-2.8.0-x86.msi",
-            "hash": "4e0534b34bcab1cc69dcf609be92222b212b2aa16479deefc8e2cd1f95be7aee"
+            "url": "https://github.com/filips123/PWAsForFirefox/releases/download/v2.9.0/firefoxpwa-2.9.0-x86.msi",
+            "hash": "4e625c8f0a7daa920408a8f473beba54cacea83e7099a6f95e0b9a9104277cf8"
         }
     },
     "post_install": [

--- a/bucket/firefoxpwa.json
+++ b/bucket/firefoxpwa.json
@@ -37,7 +37,9 @@
     ],
     "extract_dir": "PFiles\\FirefoxPWA",
     "bin": "firefoxpwa.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/filips123/PWAsForFirefox"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
This specifies repository URL for checkver, so that the package can be autoupdated properly.

Because it's quite a simple change, I haven't created a new issue about this. 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
