### PR TITLE
BoilR: Add version 1.9.4

### DIFF
--- a/bucket/boilr.json
+++ b/bucket/boilr.json
@@ -1,8 +1,8 @@
 {
-    "version": ".1.9.4",
-    "description": "Synchronize games from other platforms into your Steam library.",
+    "version": "1.9.4",
+    "description": "Synchronize games from other platforms into your Steam library",
     "homepage": "https://github.com/PhilipK/BoilR",
-    "license": "MIT,Apache-2.0",
+    "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/PhilipK/BoilR/releases/download/v.1.9.4/windows_BoilR.exe",
@@ -12,7 +12,8 @@
     "bin": [
         [
             "windows_BoilR.exe",
-            "boilr"
+            "boilr",
+            "--no-ui"
         ]
     ],
     "shortcuts": [
@@ -21,11 +22,15 @@
             "BoilR"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://api.github.com/repositories/403282138/releases/latest",
+        "jsonpath": "$.assets..browser_download_url",
+        "regex": "/v\\.([\\d.]+)/windows_BoilR\\.exe"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/PhilipK/BoilR/releases/download/v$version/windows_BoilR.exe"
+                "url": "https://github.com/PhilipK/BoilR/releases/download/v.$version/windows_BoilR.exe"
             }
         }
     }

--- a/bucket/boilr.json
+++ b/bucket/boilr.json
@@ -1,0 +1,32 @@
+{
+    "version": ".1.9.4",
+    "description": "Synchronize games from other platforms into your Steam library.",
+    "homepage": "https://github.com/PhilipK/BoilR",
+    "license": "MIT,Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PhilipK/BoilR/releases/download/v.1.9.4/windows_BoilR.exe",
+            "hash": "9ce90494ad5fe94bbc2c88a11e58685933c335176cca2462c1ebdc4e22d901b3"
+        }
+    },
+    "bin": [
+        [
+            "windows_BoilR.exe",
+            "boilr"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "windows_BoilR.exe",
+            "BoilR"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PhilipK/BoilR/releases/download/v$version/windows_BoilR.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added [BoilR](https://github.com/PhilipK/BoilR).

This manifest does not handle the persistence: (BoilR writes its settings to %APPDATA%/BoilR. I didn't know how to remap.)
It also used just uses the skewed version scheme of BoilR (having `v.x.x.x` Tags instead of `vx.x.x`). Since scoop will just work fine with it, I didn't bother writing a complex regex. This is also why the version number currently starts with a dot.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12171 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
