### PR TITLE
pacaptr: Update to version 0.20.1

### DIFF
--- a/bucket/pacaptr.json
+++ b/bucket/pacaptr.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.19.1",
+    "version": "0.20.1",
     "description": "A wrapper for many package managers with pacman-style command syntax",
     "homepage": "https://github.com/rami3l/pacaptr",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rami3l/pacaptr/releases/download/v0.19.1/pacaptr-windows-amd64.tar.gz",
-            "hash": "d29a6b0b7857a64608ba1b64e4d7f11377ddbad6b3c070d93c797be4fe7c25a9"
+            "url": "https://github.com/rami3l/pacaptr/releases/download/v0.20.1/pacaptr-windows-amd64.zip",
+            "hash": "92cbc5303698638b8a09ce78defb396614d9398be409c8b7c9f39ab972decfbb"
         }
     },
     "bin": "pacaptr.exe",
@@ -14,9 +14,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/rami3l/pacaptr/releases/download/v$version/pacaptr-windows-amd64.tar.gz",
+                "url": "https://github.com/rami3l/pacaptr/releases/download/v$version/pacaptr-windows-amd64.zip",
                 "hash": {
-                    "url": "$url.sha256"
+                    "url": "$baseurl/checksums.txt"
                 }
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

`pacaptr.json` was added to this repo by @ptanmay143 in https://github.com/ScoopInstaller/Extras/pull/9521.

However, as a consequence of `pacaptr`'s migration to GoReleaser in https://github.com/rami3l/pacaptr/pull/627, the release layout has been changed since [`v0.19.2`](https://github.com/rami3l/pacaptr/releases/tag/v0.19.2), so a manual change of the manifest is required.

~~`v0.19.2` is not the latest version so that we can test autoupdate as well.~~ The manifest has been updated to `v0.20.1`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
