### PR TITLE
#12147 update vscode.json to 1.84.0, remove 32 bit architectures

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.83.1",
+    "version": "1.84.0",
     "description": "Lightweight but powerful source code editor",
     "homepage": "https://code.visualstudio.com/",
     "license": {
@@ -14,16 +14,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://update.code.visualstudio.com/1.83.1/win32-x64-archive/stable#/dl.7z",
-            "hash": "bf53268e45d12cd43d4f7c61cd782d11d13646eb21e7d57532739a952f4d7ff5"
-        },
-        "32bit": {
-            "url": "https://update.code.visualstudio.com/1.83.1/win32-archive/stable#/dl.7z",
-            "hash": "91f1e91dfc17caaa23d7c0bdf889581b79621362eb10bda00ed0a9bb0c13ff77"
+            "url": "https://update.code.visualstudio.com/1.84.0/win32-x64-archive/stable#/dl.7z",
+            "hash": "455f9467ae70369e6c265b7ea2fbe8b53c1f8e53298712ae5bd75f963d1a5652"
         },
         "arm64": {
-            "url": "https://update.code.visualstudio.com/1.83.1/win32-arm64-archive/stable#/dl.7z",
-            "hash": "91d66a14408ea12bf63905f56b7673242ea3e4f797f75df3b4c0e702c9e3a1b7"
+            "url": "https://update.code.visualstudio.com/1.84.0/win32-arm64-archive/stable#/dl.7z",
+            "hash": "9f845496aa3cf2557c6929fdc0a7d1748fd094d2f7b74f1f12c91061110bc039"
         }
     },
     "env_add_path": "bin",
@@ -76,13 +72,6 @@
                 "hash": {
                     "url": "https://code.visualstudio.com/sha?build=stable",
                     "jsonpath": "$.products[?(@.platform.os == 'win32-x64-archive')].sha256hash"
-                }
-            },
-            "32bit": {
-                "url": "https://update.code.visualstudio.com/$version/win32-archive/stable#/dl.7z",
-                "hash": {
-                    "url": "https://code.visualstudio.com/sha?build=stable",
-                    "jsonpath": "$.products[?(@.platform.os == 'win32-archive')].sha256hash"
                 }
             },
             "arm64": {


### PR DESCRIPTION
Removes the remaining 32 bit architecture sections from the manifest.

Supersedes #12154
Closes #12147 


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
