### PR TITLE
audacity: Fixes download URLs and updates to version 3.4.1

### DIFF
--- a/bucket/audacity.json
+++ b/bucket/audacity.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "An easy-to-use, multi-track audio editor and recorder",
     "homepage": "https://www.audacityteam.org",
     "license": {
@@ -8,14 +8,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.4.0/audacity-win-3.4.0-64bit.zip",
-            "hash": "85f5bba21fb466434ca732aa8ee28ce8d16b221578d933de455aa986de1239aa",
-            "extract_dir": "audacity-win-3.4.0-64bit"
+            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.4.1/audacity-win-3.4.1-64bit.zip",
+            "hash": "980d2ba7fa50c69e9b85a4a80918dd5bf645e55a6cf898b56a6c11604953669d",
+            "extract_dir": "audacity-win-3.4.1-64bit"
         },
         "32bit": {
-            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.4.0/audacity-win-3.4.0-32bit.zip",
-            "hash": "d2c4dacaa0ac4dbbf680e8bdbca0e23a485201d85133c0fe5eb3079e3e27c389",
-            "extract_dir": "audacity-win-3.4.0-32bit"
+            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.4.1/audacity-win-3.4.1-32bit.zip",
+            "hash": "b4222108a8e0c5f06c8251ccd85de720d77ca8f7c43d020eb261096e771f6cb4",
+            "extract_dir": "audacity-win-3.4.1-32bit"
         }
     },
     "pre_install": [

--- a/bucket/audacity.json
+++ b/bucket/audacity.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.3.3",
+    "version": "3.4.0",
     "description": "An easy-to-use, multi-track audio editor and recorder",
     "homepage": "https://www.audacityteam.org",
     "license": {
@@ -8,14 +8,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.3.3/audacity-win-3.3.3-x64.zip",
-            "hash": "3060f6a46b4eaf23816826037fb05934812199f19944162e9d9ba03ba5d8cc4a",
-            "extract_dir": "audacity-win-3.3.3-x64"
+            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.4.0/audacity-win-3.4.0-64bit.zip",
+            "hash": "85f5bba21fb466434ca732aa8ee28ce8d16b221578d933de455aa986de1239aa",
+            "extract_dir": "audacity-win-3.4.0-64bit"
         },
         "32bit": {
-            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.3.3/audacity-win-3.3.3-x32.zip",
-            "hash": "b593f2496a8c945234ebac7da354b110faf404785f90dbda9be29c6426860d74",
-            "extract_dir": "audacity-win-3.3.3-x32"
+            "url": "https://github.com/audacity/audacity/releases/download/Audacity-3.4.0/audacity-win-3.4.0-32bit.zip",
+            "hash": "d2c4dacaa0ac4dbbf680e8bdbca0e23a485201d85133c0fe5eb3079e3e27c389",
+            "extract_dir": "audacity-win-3.4.0-32bit"
         }
     },
     "pre_install": [
@@ -39,12 +39,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/audacity/audacity/releases/download/Audacity-$version/audacity-win-$version-x64.zip",
-                "extract_dir": "audacity-win-$version-x64"
+                "url": "https://github.com/audacity/audacity/releases/download/Audacity-$version/audacity-win-$version-64bit.zip",
+                "extract_dir": "audacity-win-$version-64bit"
             },
             "32bit": {
-                "url": "https://github.com/audacity/audacity/releases/download/Audacity-$version/audacity-win-$version-x32.zip",
-                "extract_dir": "audacity-win-$version-x32"
+                "url": "https://github.com/audacity/audacity/releases/download/Audacity-$version/audacity-win-$version-32bit.zip",
+                "extract_dir": "audacity-win-$version-32bit"
             }
         },
         "hash": {


### PR DESCRIPTION
Since Audacity 3.4.0, new releases use different suffixes for bit, which break compatibility with the current manifest and makes auto-update non-functional. This should fix "404 Not Found" error and update the manifest to the latest program version as well.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
