### PR TITLE
Insomnia@8.3.0: Update license to Apache 2.0

### DIFF
--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -2,7 +2,7 @@
     "version": "8.3.0",
     "description": "HTTP and GraphQL client",
     "homepage": "https://insomnia.rest",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Kong/insomnia/releases/download/core%408.3.0/insomnia-8.3.0-full.nupkg",


### PR DESCRIPTION
Used to be MIT, is Apache 2.0 since https://github.com/Kong/insomnia/commit/11b354ce7c728498b71cb0ce10087177c6d5dca3

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
