### PR TITLE
Add Insomnium

### DIFF
--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.3-a",
+  "description": "HTTP and GraphQL client",
+  "homepage": "https://archgpt.dev/insomnium",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/ArchGPT/insomnium/releases/download/core%400.2.3-a/insomnium-0.2.3-a-full.nupkg",
+      "hash": "sha1:8ef4d8dd233612afe8d5699ef0ccb1c3e130a062"
+    }
+  },
+  "extract_dir": "lib\\net45",
+  "shortcuts": [["Insomnium.exe", "Insomnium"]],
+  "checkver": {
+    "url": "https://api.github.com/repositories/698242651/releases",
+    "regex": "\"core@([\\d.]+)\""
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/ArchGPT/insomnium/releases/download/core%40$version/insomnium-$version-full.nupkg"
+      }
+    },
+    "hash": {
+      "url": "$baseurl/RELEASES"
+    }
+  }
+}


### PR DESCRIPTION
Insomium is a fork of Insomnia (a REST/GraphQL testing tool) that does not require a mandatory account.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
