### PR TITLE
Add gobrew app

### DIFF
--- a/bucket/gobrew.json
+++ b/bucket/gobrew.json
@@ -3,6 +3,11 @@
     "description": "Go version manager, written in Go. Super simple tool to install and manage Go versions. Install go without root. Gobrew doesn't require shell rehash. ",
     "homepage": "https://github.com/kevincobain2000/gobrew",
     "license": "MIT",
+    "notes": [
+        "gobrew uses symlinks to switch between go versions.",
+        "To be able to create symlinks without elevated privileges, Developer Mode needs to be enabled.",
+        "You can do this either in the settings app, or by setting the HKLM\\Software\\Policies\\Microsoft\\Windows\\Appx\\AllowDevelopmentWithoutDevLicense RKey accordingly."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/kevincobain2000/gobrew/releases/download/v1.9.7/gobrew-windows-amd64.exe",

--- a/bucket/gobrew.json
+++ b/bucket/gobrew.json
@@ -1,0 +1,55 @@
+{
+    "version": "v1.9.7",
+    "description": "Go version manager, written in Go. Super simple tool to install and manage Go versions. Install go without root. Gobrew doesn't require shell rehash. ",
+    "homepage": "https://github.com/kevincobain2000/gobrew",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kevincobain2000/gobrew/releases/download/v1.9.7/gobrew-windows-amd64.exe",
+            "hash": "bb097b4cf10308ec89f41f5cb602d2a8acd349da8e08e0522d5b807c7ad9fa1a"
+        }
+    },
+    "bin": [
+        [
+            "gobrew-windows-amd64.exe",
+            "gobrew"
+        ]
+    ],
+    "env_add_path": [
+        ".gobrew\\current\\bin",
+        ".gobrew\\bin"
+    ],
+    "env_set": {
+        "GOBREW_ROOT": "$dir",
+        "GOROOT": "$dir\\.gobrew\\current\\go"
+    },
+    "persist": [
+        ".gobrew"
+    ],
+    "installer": {
+        "script": [
+            "$envgopath = \"$env:USERPROFILE\\go\"",
+            "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
+            "info \"Adding '$envgopath\\bin' to PATH...\"",
+            "add_first_in_path \"$envgopath\\bin\" $global"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$envgopath = \"$env:USERPROFILE\\go\"",
+            "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
+            "info \"Removing '$envgopath\\bin' from PATH...\"",
+            "remove_from_path \"$envgopath\\bin\" $global"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/kevincobain2000/gobrew"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kevincobain2000/gobrew/releases/download/$version/gobrew-windows-amd64.exe"
+            }
+        }
+    }
+}

--- a/bucket/gobrew.json
+++ b/bucket/gobrew.json
@@ -14,23 +14,6 @@
             "hash": "bb097b4cf10308ec89f41f5cb602d2a8acd349da8e08e0522d5b807c7ad9fa1a"
         }
     },
-    "bin": [
-        [
-            "gobrew-windows-amd64.exe",
-            "gobrew"
-        ]
-    ],
-    "env_add_path": [
-        ".gobrew\\current\\bin",
-        ".gobrew\\bin"
-    ],
-    "env_set": {
-        "GOBREW_ROOT": "$dir",
-        "GOROOT": "$dir\\.gobrew\\current\\go"
-    },
-    "persist": [
-        ".gobrew"
-    ],
     "installer": {
         "script": [
             "$envgopath = \"$env:USERPROFILE\\go\"",
@@ -39,6 +22,23 @@
             "add_first_in_path \"$envgopath\\bin\" $global"
         ]
     },
+    "env_add_path": [
+        ".gobrew\\current\\bin",
+        ".gobrew\\bin"
+    ],
+    "env_set": {
+        "GOBREW_ROOT": "$dir",
+        "GOROOT": "$dir\\.gobrew\\current\\go"
+    },
+    "bin": [
+        [
+            "gobrew-windows-amd64.exe",
+            "gobrew"
+        ]
+    ],
+    "persist": [
+        ".gobrew"
+    ],
     "uninstaller": {
         "script": [
             "$envgopath = \"$env:USERPROFILE\\go\"",


### PR DESCRIPTION
I have added the app `gobrew` to the extras bucket. Gobrew is a go version manager, just like nvm for example.

I hope everything is sound for the bucket. If not, please add a comment and I am happy to fix it up. 🙂 


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
