### PR TITLE
Ngspice: fixed ngspice-41_64.7z hash

### DIFF
--- a/bucket/ngspice.json
+++ b/bucket/ngspice.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/41/ngspice-41_64.7z",
-            "hash": "sha1:e6677bb4932ea4e7ceb9f44af5e60df05fec320b",
+            "hash": "sha1:5600b3a129d220e58921324bfc27a598c86b88f4",
             "extract_dir": "Spice64"
         }
     },


### PR DESCRIPTION
current hash value is wrong this pr fixed hash check