### PR TITLE
Wireshark@4.0.10: Update wireshark.json for scoop autoupdate to 4.2.0 url.

### DIFF
--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.10",
+    "version": "4.2.0",
     "description": "A network protocol analyzer that lets you see what’s happening on your network at a microscopic level.",
     "homepage": "https://www.wireshark.org/",
     "license": "GPL-2.0-or-later",
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://www.wireshark.org/download/win64/Wireshark-win64-4.0.10.exe#/dl.7z",
-            "hash": "085d9aa4f6614730f132fb5c28ec5fa445dea79687e4c648d586de569ffcc5e2"
+            "url": "https://www.wireshark.org/download/win64/Wireshark-4.2.0-x64.exe#/dl.7z",
+            "hash": "a68a8298662af5cc4bb4a454c66f49d0bcc0bacfd16e00e818b4c77ae8281c26"
         }
     },
     "installer": {

--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -53,7 +53,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.wireshark.org/download/win64/Wireshark-win64-$version.exe#/dl.7z",
+                "url": "https://www.wireshark.org/download/win64/Wireshark-$version-x64.exe#/dl.7z",
                 "hash": {
                     "url": "https://www.wireshark.org/download/SIGNATURES-$version.txt",
                     "regex": "SHA256\\($basename\\)=$sha256"


### PR DESCRIPTION
The WireShark download URL format has changed.
Replaced the old URL with the new WireShark download URL for scoop autoupdate.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
