### PR TITLE
easy-context-menu@1.6: Fix hash

### DIFF
--- a/bucket/easy-context-menu.json
+++ b/bucket/easy-context-menu.json
@@ -7,7 +7,7 @@
         "url": "https://www.sordum.org/eula/"
     },
     "url": "https://www.sordum.org/files/easy-context-menu/ec_menu.zip",
-    "hash": "e28b9c0f52ce7ecd28a83ed18ab9132e446aa8c0199f5a0156b1252a867c7ac5",
+    "hash": "8768e32f7ff059f758bac2a66624d1a38fd87edaa9985506e35e86ea286ae21a",
     "extract_dir": "EcMenu_v1.6",
     "pre_install": "New-Item \"$dir\\Files\\EcMenu.ini\" -ItemType 'File' | Out-Null",
     "architecture": {


### PR DESCRIPTION
Update the hash

````
 scoop install extras/easy-context-menu
Installing 'easy-context-menu' (1.6) [64bit] from extras bucket
ec_menu.zip (1.6 MB) [========================================================================================] 100%
Checking hash of ec_menu.zip ... ERROR Hash check failed!
App:         extras/easy-context-menu
URL:         https://www.sordum.org/files/easy-context-menu/ec_menu.zip
First bytes: 50 4B 03 04 14 00 00 00
Expected:    e28b9c0f52ce7ecd28a83ed18ab9132e446aa8c0199f5a0156b1252a867c7ac5
Actual:      8768e32f7ff059f758bac2a66624d1a38fd87edaa9985506e35e86ea286ae21a

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/ScoopInstaller/Extras/issues/new?title=easy-context-menu%401.6%3a+hash+check+failed
```