### PR TITLE
calibre-normal@7.0.0:  Path error, unable to install

### DIFF
--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -8,7 +8,7 @@
         "64bit": {
             "url": "https://download.calibre-ebook.com/7.0.0/calibre-64bit-7.0.0.msi",
             "hash": "sha512:862e76a93e4b6d1ab810375374c9d7cd4828c326134816acde6568153a413c444367b16bebb9f9aabb10f93698f4e476611f54d8db77a2c11456d91a9a5759cb",
-            "extract_dir": "PFiles\\Calibre2"
+            "extract_dir": "PFiles64\\Calibre2"
         }
     },
     "bin": [


### PR DESCRIPTION

Closes #12262 

- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
