### PR TITLE
mqtt-cli: Add version 4.22.0

### DIFF
--- a/bucket/mqtt-cli.json
+++ b/bucket/mqtt-cli.json
@@ -1,0 +1,23 @@
+{
+    "version": "4.22.0",
+    "description": "MQTT CLI is a useful command line interface for connecting various MQTT clients supporting MQTT 5.0 and 3.1.1 ",
+    "homepage": "https://hivemq.github.io/mqtt-cli/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hivemq/mqtt-cli/releases/download/v4.22.0/mqtt-cli-4.22.0-win.zip",
+            "hash": "b00c7b300b24bc3e95703d7dd3b637505650caa76c9922ec0df6ebcc24c623b1"
+        }
+    },
+    "bin": "mqtt-cli.exe",
+    "checkver": {
+        "github": "https://github.com/hivemq/mqtt-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/hivemq/mqtt-cli/releases/download/v$version/mqtt-cli-$version-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

[mqtt.cli](https://hivemq.github.io/mqtt-cli/) is a full MQTT 5.0 and MQTT 3.1.1 compatible command line interface for MQTT clients which uses the [HiveMQ MQTT Client API](https://github.com/hivemq/hivemq-mqtt-client).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
