### PR TITLE
 blender-benchmark-cli: Add version 3.1.0

### DIFF
--- a/bucket/benchmark-launcher-cli.json
+++ b/bucket/benchmark-launcher-cli.json
@@ -1,0 +1,16 @@
+{
+    "version": "3.1.0",
+    "license": "GPL-3.0-or-later",
+    "homepage": "https://opendata.blender.org",
+    "description": "The Blender Open Data Benchmark launcher command line interface",
+    "url": "https://download.blender.org/release/BlenderBenchmark2.0/launcher/benchmark-launcher-cli-3.1.0-windows.zip",
+    "hash": "d8009db3b053df4a6eb18c1dcb9c10b8972daf75b1a526b8a331fda66b557e62",
+    "bin": "benchmark-launcher-cli.exe",
+    "checkver": {
+        "url": "https://opendata.blender.org/",
+        "regex": "benchmark-launcher-cli-([\\w.]+)-windows.zip"
+    },
+    "autoupdate": {
+        "url": "https://download.blender.org/release/BlenderBenchmark2.0/launcher/benchmark-launcher-cli-$version-windows.zip"
+    }
+}

--- a/bucket/benchmark-launcher-cli.json
+++ b/bucket/benchmark-launcher-cli.json
@@ -1,8 +1,8 @@
 {
     "version": "3.1.0",
-    "license": "GPL-3.0-or-later",
-    "homepage": "https://opendata.blender.org",
     "description": "The Blender Open Data Benchmark launcher command line interface",
+    "homepage": "https://opendata.blender.org",
+    "license": "GPL-3.0-or-later",
     "url": "https://download.blender.org/release/BlenderBenchmark2.0/launcher/benchmark-launcher-cli-3.1.0-windows.zip",
     "hash": "d8009db3b053df4a6eb18c1dcb9c10b8972daf75b1a526b8a331fda66b557e62",
     "bin": "benchmark-launcher-cli.exe",

--- a/bucket/blender-benchmark-cli.json
+++ b/bucket/blender-benchmark-cli.json
@@ -5,7 +5,12 @@
     "license": "GPL-3.0-or-later",
     "url": "https://download.blender.org/release/BlenderBenchmark2.0/launcher/benchmark-launcher-cli-3.1.0-windows.zip",
     "hash": "d8009db3b053df4a6eb18c1dcb9c10b8972daf75b1a526b8a331fda66b557e62",
-    "bin": "benchmark-launcher-cli.exe",
+    "bin": [
+        [
+            "benchmark-launcher-cli.exe",
+            "blender-benchmark-cli"
+        ]
+    ],
     "checkver": {
         "url": "https://opendata.blender.org/",
         "regex": "benchmark-launcher-cli-([\\w.]+)-windows.zip"


### PR DESCRIPTION

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
