### PR TITLE
emule-community(fix): extract_dir param error

### DIFF
--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -6,14 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/irwir/eMule/releases/download/eMule_v0.70a-community/eMule0.70a_x64.zip",
-            "hash": "7641973bc4f92295ca498e4315bb7452a50ebfb6ee829874962be73c521d73ee"
+            "hash": "7641973bc4f92295ca498e4315bb7452a50ebfb6ee829874962be73c521d73ee",
+            "extract_dir": "eMule0.70a"
         },
         "32bit": {
             "url": "https://github.com/irwir/eMule/releases/download/eMule_v0.70a-community/eMule0.70a.zip",
-            "hash": "968cd0cdd469c3d4c9412e490ca16c92da4e2632420c2303b4ab9509c5fa4fd6"
+            "hash": "968cd0cdd469c3d4c9412e490ca16c92da4e2632420c2303b4ab9509c5fa4fd6",
+            "extract_dir": "eMule0.70a"
         }
     },
-    "extract_dir": "eMule0.60d",
     "bin": "emule.exe",
     "shortcuts": [
         [

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -6,12 +6,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/irwir/eMule/releases/download/eMule_v0.70a-community/eMule0.70a_x64.zip",
-            "hash": "7641973bc4f92295ca498e4315bb7452a50ebfb6ee829874962be73c521d73ee",
+            "hash": "9d372bf6a4ef35bc621360ba00925043118c9a98b81373d8827355bcc1e75b0a",
             "extract_dir": "eMule0.70a"
         },
         "32bit": {
             "url": "https://github.com/irwir/eMule/releases/download/eMule_v0.70a-community/eMule0.70a.zip",
-            "hash": "968cd0cdd469c3d4c9412e490ca16c92da4e2632420c2303b4ab9509c5fa4fd6",
+            "hash": "2f8b55e1becd3a62a110c0b10535ca0938a2059a39ab46dd09dc141dcae40c78",
             "extract_dir": "eMule0.70a"
         }
     },


### PR DESCRIPTION
`extract_dir` should be placed at `architecture.64bit.extract_dir` and `architecture.32bit.extract_dir`, so that `checkver.ps1` can automatically update it.

Closes #12007
Relates to #12008

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).