### PR TITLE
crystaldiskinfo(fix): switch to sourceforge source

### DIFF
--- a/bucket/crystaldiskinfo.json
+++ b/bucket/crystaldiskinfo.json
@@ -1,10 +1,10 @@
 {
     "version": "9.1.1",
-    "description": "A HDD/SSD utility software which supports a part of USB, Intel RAID and NVMe",
-    "homepage": "https://crystalmark.info/en/software/crystaldiskinfo/",
+    "description": "A HDD/SSD utility software which supports a part of USB, RAID and NVMe.",
+    "homepage": "https://sourceforge.net/projects/crystaldiskinfo/",
     "license": "MIT",
-    "url": "https://crystalmark.info/download/zz/CrystalDiskInfo9_1_1.zip",
-    "hash": "b5ee4c97cdb7cae31ba1d6636646d02471457852b6855ecc81587d0a05460d62",
+    "url": "https://sourceforge.net/projects/crystaldiskinfo/files/9.1.1/CrystalDiskInfo9_1_1.zip",
+    "hash": "sha1:a434f1ac36aafe7daf63cb46f8bb7da5e32859b2",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\DiskInfo.ini\")) { New-Item \"$dir\\DiskInfo.ini\" | Out-Null }",
         "# Manually persist AMD RAID plugins (AMD_RC2t7x64.dll, AMD_RC2t7x86.dll)",
@@ -46,10 +46,10 @@
     ],
     "pre_uninstall": "if (Test-Path \"$dir\\AMD_RC2t7*.dll\") { Copy-Item \"$dir\\AMD_RC2t7*.dll\" \"$persist_dir\\\" }",
     "checkver": {
-        "url": "https://crystalmark.info/en/download/",
-        "regex": "CrystalDiskInfo\\s+([\\w.]+)\\s"
+        "sourceforge": "crystaldiskinfo",
+        "regex": "([\\d.]+)/CrystalDiskInfo([\\d_]+).zip"
     },
     "autoupdate": {
-        "url": "https://crystalmark.info/download/zz/CrystalDiskInfo$underscoreVersion.zip"
+        "url": "https://sourceforge.net/projects/crystaldiskinfo/files/$version/CrystalDiskInfo$underscoreVersion.zip"
     }
 }


### PR DESCRIPTION
https://crystalmark.info is offline, so we should instead download it from sourceforge.

Relates to #11604

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
