### PR TITLE
protege: Add version 5.6.3

### DIFF
--- a/bucket/protege.json
+++ b/bucket/protege.json
@@ -1,0 +1,29 @@
+{
+    "url": "https://github.com/protegeproject/protege-distribution/releases/download/protege-5.6.3/Protege-5.6.3-win.zip",
+    "version": "5.6.3",
+    "description": "Protege is a free, open-source ontology editor that supports the latest OWL 2.0 standard. Protege has a pluggable architecture, and many plugins for different functionalities are available.",
+    "license": "BSD-2-Clause-Views",
+    "homepage": "https://protege.stanford.edu/",
+    "checkver": {
+        "url": "https://github.com/protegeproject/protege-distribution/releases/latest",
+        "regex": "releases/tag/(?<prefix>(v|protege-)?)(?<version>[\\d\\w.]+)\"",
+        "replace": "${version}"
+    },
+    "bin": "Protege.exe",
+    "hash": "1f432d3c10d5a8a80214ff33502b4ab2b30e04324d831c77694b6094ac9dc981",
+    "extract_dir": "Protege-5.6.3",
+    "persist": [
+        "conf",
+        "plugins"
+    ],
+    "shortcuts": [
+        [
+            "Protege.exe",
+            "Protege"
+        ]
+    ],
+    "autoupdate": {
+        "url": "https://github.com/protegeproject/protege-distribution/releases/download/$matchPrefix$version/Protege-$version-win.zip",
+        "extract_dir": "Protege-$version"
+    }
+}


### PR DESCRIPTION
This PR adds a manifest file for Protégé.

Closes #12294

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
