### PR TITLE
focus@1.4.1: Add arm64 version

### DIFF
--- a/bucket/focus.json
+++ b/bucket/focus.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.4.1",
+    "version": "1.4.2",
     "homepage": "https://github.com/ayoisaiah/focus",
     "description": "A fully featured productivity timer for the command line, based on the Pomodoro Technique.",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ayoisaiah/focus/releases/download/v1.4.1/focus_1.4.1_windows_amd64.tar.gz",
-            "hash": "385551a944fda2bfcc4657fdd11d89df93874f704725f59ebb0c27bf0a307539"
+            "url": "https://github.com/ayoisaiah/focus/releases/download/v1.4.2/focus_1.4.2_windows_amd64.tar.gz",
+            "hash": "6c5fc8c39cc1f8938535989f9ac4113e2c9a7a2008563dd1c429a16966f3e40a"
         },
         "arm64": {
-            "url": "https://github.com/ayoisaiah/focus/releases/download/v1.4.1/focus_1.4.1_windows_arm64.tar.gz",
-            "hash": "fbe30db2f2326238d1588182460b5815431bf097d7d328c434dec2dda88639c7"
+            "url": "https://github.com/ayoisaiah/focus/releases/download/v1.4.2/focus_1.4.2_windows_arm64.tar.gz",
+            "hash": "a1f3faa7c9d2e79488e3e2fc686dedff78176d2660e79c3aaa3ba0c5c0e1dfe7"
         }
     },
     "bin": "focus.exe",

--- a/bucket/focus.json
+++ b/bucket/focus.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/ayoisaiah/focus/releases/download/v1.4.1/focus_1.4.1_windows_amd64.tar.gz",
             "hash": "385551a944fda2bfcc4657fdd11d89df93874f704725f59ebb0c27bf0a307539"
+        },
+        "arm64": {
+            "url": "https://github.com/ayoisaiah/focus/releases/download/v1.4.1/focus_1.4.1_windows_arm64.tar.gz",
+            "hash": "fbe30db2f2326238d1588182460b5815431bf097d7d328c434dec2dda88639c7"
         }
     },
     "bin": "focus.exe",
@@ -15,7 +19,13 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ayoisaiah/focus/releases/download/v$version/focus_$version_windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/ayoisaiah/focus/releases/download/v$version/focus_$version_windows_arm64.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
- Add arm64 version.
- Add `hash` section.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
