### PR TITLE
imageglass@9.0.7.1125: Fix manifest for v9

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -3,29 +3,27 @@
     "description": "A lightweight, versatile image viewer",
     "homepage": "https://imageglass.org",
     "license": "GPL-3.0-only",
-    "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.xml'.",
+    "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.json'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.7.1125/ImageGlass_Kobe_9.0.7.1125_x64.zip",
-            "hash": "sha1:0af64d67e4095e914a97b6056ac34843098fa5fb",
-            "extract_dir": "ImageGlass_Kobe_9.0.7.1125_x64"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.7.1125/ImageGlass_9.0.7.1125_x64.zip",
+            "hash": "e5a40d616d1f37d4a4bdbc5d8d09aa5c88f84ade36b64c7c2a219f19f6d44030",
+            "extract_dir": "ImageGlass_9.0.7.1125_x64"
         },
-        "32bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.7.1125/ImageGlass_Kobe_9.0.7.1125_x86.zip",
-            "hash": "sha1:5dcecc9cc746dfb2b3793f4a1b0bb02f5454c4e4",
-            "extract_dir": "ImageGlass_Kobe_9.0.7.1125_x86"
+        "arm64": {
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.7.1125/ImageGlass_9.0.7.1125_arm64.zip",
+            "hash": "f2706c50d08fc5c916ed7834231b995f2ecc482e9a7dd880031f67308e75aabe",
+            "extract_dir": "ImageGlass_9.0.7.1125_arm64"
         }
     },
     "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\igconfig.xml\")) {",
-        "    Add-Content \"$dir\\igconfig.xml\" '<ImageGlass><Configuration><Info description=\"ImageGlass Configuration file\" version=\"7.5\" /><Info/><Content><Item key=\"AutoUpdate\" value=\"0\" /></Content></Configuration></ImageGlass>' -Encoding Ascii",
+        "if (!(Test-Path \"$persist_dir\\igconfig.json\")) {",
+        "    Add-Content \"$dir\\igconfig.json\" '{}' -Encoding utf8",
         "}"
     ],
     "bin": [
         "ImageGlass.exe",
-        "igcmd.exe",
-        "igcmdWin10.exe",
-        "igtasks.exe"
+        "igcmd.exe"
     ],
     "shortcuts": [
         [
@@ -35,7 +33,7 @@
     ],
     "persist": [
         "Themes",
-        "igconfig.xml"
+        "igconfig.json"
     ],
     "checkver": {
         "github": "https://github.com/d2phap/ImageGlass"
@@ -43,20 +41,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_Kobe_$version_x64.zip",
-                "hash": {
-                    "url": "https://github.com/d2phap/ImageGlass/releases",
-                    "regex": "ImageGlass_Kobe_[\\d.]+_x64.zip</td>\\n<td><code>$sha1"
-                },
-                "extract_dir": "ImageGlass_Kobe_$version_x64"
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x64.zip",
+                "extract_dir": "ImageGlass_$version_x64"
             },
-            "32bit": {
-                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_Kobe_$version_x86.zip",
-                "hash": {
-                    "url": "https://github.com/d2phap/ImageGlass/releases",
-                    "regex": "ImageGlass_Kobe_[\\d.]+_x86.zip</td>\\n<td><code>$sha1"
-                },
-                "extract_dir": "ImageGlass_Kobe_$version_x86"
+            "arm64": {
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_arm64.zip",
+                "extract_dir": "ImageGlass_$version_arm64"
             }
         }
     }

--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -18,7 +18,7 @@
     },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\igconfig.json\")) {",
-        "    Add-Content \"$dir\\igconfig.json\" '{}' -Encoding utf8",
+        "    Add-Content \"$dir\\igconfig.json\" '{\"AutoUpdate\": \"0\"}' -Encoding utf8",
         "}"
     ],
     "bin": [

--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -3,7 +3,7 @@
     "description": "A lightweight, versatile image viewer",
     "homepage": "https://imageglass.org",
     "license": "GPL-3.0-only",
-    "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.json'.",
+    "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.json' and reinstall '$dir\\Themes'.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.7.1125/ImageGlass_9.0.7.1125_x64.zip",


### PR DESCRIPTION
https://imageglass.org/news/introducing-the-new-imageglass-version-9-88

Breaking changes

- User config files are now in the JSON format: igconfig.json. ImageGlass 9 cannot import settings from version 8.
- Similarly, theme and language pack also updated to use JSON format. You can download theme packs for version 9 at Download / Theme packs.
- For power users:
  - Version 9 uses Per-user setting model which is different from Per-machine setting of version 8:
    - The app settings are now saved in the %LocalAppData% folder. Refer to Docs / App configuration for more information.
    - The app registry uses HKEY_CURRENT_USER for file type associations and app protocol.
  - igtasks.exe has been removed.
  - All commands in igcmd.exe have been reworked. Visit Docs / Command line utilities for the updated information.
  - To skip the "ImageGlass Quick Setup" dialog, set QuickSetupVersion value to any number greater than 9 in the igconfig.json file.

---

Closes #12313

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
