### PR TITLE
qownnotes@23.11.3: Make a shortcut for the exe directly

### DIFF
--- a/bucket/qownnotes.json
+++ b/bucket/qownnotes.json
@@ -9,16 +9,11 @@
             "hash": "c7f72d56a7cf752bee228873694fda6f7d298c90c9e1af074415b38cef9c76b8"
         }
     },
-    "bin": [
-        [
-            "QOwnNotesPortable.bat",
-            "QOwnNotes"
-        ]
-    ],
     "shortcuts": [
         [
-            "QOwnNotesPortable.bat",
-            "QOwnNotes"
+            "QOwnNotes.exe",
+            "QOwnNotes",
+            "--portable"
         ]
     ],
     "persist": "Data",


### PR DESCRIPTION
Also removes the "bin" shortcut, as it's not a CLI utility and never runs from $PWD (the .bat script causes it to change directories), making it fairly useless.

Closes #12346

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
