### PR TITLE
mobaxterm: Work around persist issue

### DIFF
--- a/bucket/mobaxterm.json
+++ b/bucket/mobaxterm.json
@@ -19,6 +19,14 @@
         "}",
         "@('MobaXterm backup.zip', 'MobaXterm.ini') | ForEach-Object { PersistsFile $_ }"
     ],
+    "pre_uninstall": [
+        "function UpdatesFile([string] $file) {",
+        "    if ((Get-ChildItem \"$dir\\$file\").LastWriteTime -gt (Get-ChildItem \"$persist_dir\\$file\").LastWriteTime) {",
+        "        [System.IO.File]::WriteAllBytes(\"$persist_dir\\$file\", [System.IO.File]::ReadAllBytes(\"$dir\\$file\"))",
+        "    }",
+        "}",
+        "@('MobaXterm backup.zip', 'MobaXterm.ini') | ForEach-Object { UpdatesFile $_ }"
+    ],
     "bin": "MobaXterm.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Closes #12229

This is a partial fix for persist issue in `mobaxterm` package. The app deletes and re-creates the files to update them on app close. This fix can only handle the occasion when the app got updated.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
