### PR TITLE
emule-community: Fix `hash`

### DIFF
--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -6,14 +6,14 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/irwir/eMule/releases/download/eMule_v0.70a-community/eMule0.70a_x64.zip",
-            "hash": "7641973bc4f92295ca498e4315bb7452a50ebfb6ee829874962be73c521d73ee"
+            "hash": "9d372bf6a4ef35bc621360ba00925043118c9a98b81373d8827355bcc1e75b0a"
         },
         "32bit": {
             "url": "https://github.com/irwir/eMule/releases/download/eMule_v0.70a-community/eMule0.70a.zip",
-            "hash": "968cd0cdd469c3d4c9412e490ca16c92da4e2632420c2303b4ab9509c5fa4fd6"
+            "hash": "2f8b55e1becd3a62a110c0b10535ca0938a2059a39ab46dd09dc141dcae40c78"
         }
     },
-    "extract_dir": "eMule0.60d",
+    "extract_dir": "eMule0.70a",
     "bin": "emule.exe",
     "shortcuts": [
         [
@@ -28,13 +28,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version_x64.zip",
-                "extract_dir": "eMule$version"
+                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version_x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version.zip",
-                "extract_dir": "eMule$version"
+                "url": "https://github.com/irwir/eMule/releases/download/eMule_v$version-community/eMule$version.zip"
             }
-        }
+        },
+        "extract_dir": "eMule$version"
     }
 }


### PR DESCRIPTION
Closes #12368
Relates to #12264

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
