### PR TITLE
electrum: Update to version 4.4.6 and fix autoupdate

### DIFF
--- a/bucket/electrum.json
+++ b/bucket/electrum.json
@@ -1,10 +1,10 @@
 {
-    "version": "4.4.3",
+    "version": "4.4.6",
     "description": "A Bitcoin SPV Wallet",
     "homepage": "https://electrum.org",
     "license": "MIT",
-    "url": "https://download.electrum.org/4.4.3/electrum-4.4.3-portable.exe#/electrum.exe",
-    "hash": "9d3716a2d68f39c8522d2ec8f59723cc3543d9efbd038e30d5f06a3fdb2d5ee6",
+    "url": "https://download.electrum.org/4.4.6/electrum-4.4.6-portable.exe#/electrum.exe",
+    "hash": "5235debde1ca611c6d21c26b6a059b4b627d122fb761bf37b6ea0a7b3efe9216",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\electrum_data\\config\")) {",
         "   ensure \"$dir\\electrum_data\" | Out-Null",
@@ -20,7 +20,7 @@
     ],
     "persist": "electrum_data",
     "checkver": {
-        "url": "https://raw.githubusercontent.com/spesmilo/electrum-web/master/panel-download.html",
+        "url": "https://raw.githubusercontent.com/spesmilo/electrum-web/master/index.html",
         "regex": "Latest release: Electrum-([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
Auto-update was broken in the 4.4.3 release cycle, this PR fixes both that and updates the current release to the most recent version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
