### PR TITLE
emeditor: Fix checkver & Update to 23.0.4

### DIFF
--- a/bucket/emeditor.json
+++ b/bucket/emeditor.json
@@ -35,7 +35,7 @@
     ],
     "checkver": {
         "url": "https://support.emeditor.com/en/downloads",
-        "regex": "v([\\d.]+)"
+        "regex": "<td>v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/emeditor.json
+++ b/bucket/emeditor.json
@@ -1,16 +1,16 @@
 {
-    "version": "22.9.906",
+    "version": "23.0.4",
     "description": "A fast, lightweight and extensible text editor for Windows. Useful for opening very large files.",
     "homepage": "https://www.emeditor.com/",
     "license": "Shareware",
     "architecture": {
         "64bit": {
-            "url": "https://emeditor.blob.core.windows.net/emed64_22.9.906_portable.zip",
-            "hash": "d003cc67d9830e50ec00b95c3e8b850c0847f283c76b1ff63f2328f166721c12"
+            "url": "https://emeditor.blob.core.windows.net/emed64_23.0.4_portable.zip",
+            "hash": "4db8b359a101054500a11a02e2a69ec2ca54cd88609f2e8d2d5ad4ac8ac37da0"
         },
         "32bit": {
-            "url": "https://emeditor.blob.core.windows.net/emed32_22.9.906_portable.zip",
-            "hash": "a48742761cd016302068c90da5028bb30d4c19f5781d4ff05d02e8b983f89f70"
+            "url": "https://emeditor.blob.core.windows.net/emed32_23.0.4_portable.zip",
+            "hash": "123e6b86b828ccae797ad0d63189bd08a458ef2420ced7fe292eb1e2deffdd39"
         }
     },
     "pre_install": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

They add a font link containing `v36` in their [download page](https://support.emeditor.com/en/downloads)'s header, which breaks checkver.

Using `<td>v([\\d.]+)` instead of `v([\\d.]+)` should fix it.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
