### PR TITLE
cura: Update to version 5.6.0 and fix autoupdate

### DIFF
--- a/bucket/cura.json
+++ b/bucket/cura.json
@@ -1,12 +1,12 @@
 {
-    "version": "5.4.0",
+    "version": "5.6.0",
     "description": "Model editing tools for 3D printing",
     "homepage": "https://ultimaker.com/software/ultimaker-cura",
     "license": "LGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ultimaker/Cura/releases/download/5.4.0/Ultimaker-Cura-5.4.0-win64.exe#/dl.7z",
-            "hash": "7c77add8f11f8a62475df07502d6b03737d31d0bef3ffc0b1f74dbe60198caf7"
+            "url": "https://github.com/Ultimaker/Cura/releases/download/5.6.0/Ultimaker-Cura-5.6.0-win64-X64.exe#/dl.7z",
+            "hash": "5e8307725cd27f6214b86a60c6bf97c91ddb388f01c2871916405d5dbf85d170"
         }
     },
     "pre_install": "Remove-Item \"$dir\\Uninstall*\", \"$dir\\`$*\", \"$dir\\vcredist_*.exe\" -Recurse",
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker-Cura-$version-win64.exe#/dl.7z"
+                "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker-Cura-$version-win64-X64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Update Cura to version 5.6.0, and update the autoupdate url to the new format introduced with 5.5.0.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
