### PR TITLE
exifglass: Add version 1.3.0.0

### DIFF
--- a/bucket/exifglass.json
+++ b/bucket/exifglass.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.3.0.0",
+    "description": "EXIF metadata viewing tool",
+    "homepage": "https://github.com/d2phap/ExifGlass",
+    "license": "GPL-3.0-or-later",
+    "depends": "main/exiftool",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/d2phap/ExifGlass/releases/download/1.3.0.0/ExifGlass_1.3.0.0_net8_x64.zip",
+            "hash": "491b7a7bbe761dd7ad6ae814e0d559636af376ebc6e6c95b441fa9a22cd6c62f",
+            "extract_dir": "ExifGlass_1.3.0.0_net8_x64"
+        }
+    },
+    "shortcuts": [
+        [
+            "ExifGlass.exe",
+            "ExifGlass"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repositories/610811824/releases/latest",
+        "jsonpath": "$.assets..browser_download_url",
+        "regex": "ExifGlass_([\\d.]+)_net(?<dotnetver>\\d+)_x64\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/d2phap/ExifGlass/releases/download/$version/ExifGlass_$version_net$matchDotnetver_x64.zip",
+                "extract_dir": "ExifGlass_$version_net8_x64"
+            }
+        }
+    }
+}

--- a/bucket/exifglass.json
+++ b/bucket/exifglass.json
@@ -26,7 +26,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/d2phap/ExifGlass/releases/download/$version/ExifGlass_$version_net$matchDotnetver_x64.zip",
-                "extract_dir": "ExifGlass_$version_net8_x64"
+                "extract_dir": "ExifGlass_$version_net$matchDotnetver_x64"
             }
         }
     }


### PR DESCRIPTION
[ExifGlass](https://github.com/d2phap/ExifGlass) is an EXIF metadata viewing tool, designed to work seamlessly with ImageGlass 9, but can also be used as a standalone software on your computer.

- persist: none

  ![](https://github.com/ScoopInstaller/Extras/assets/121542229/96ad44cf-d494-4b91-b09c-8cc6929fbcc4)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
