### PR TITLE
teraterm: url and format fixes (#12387)

### DIFF
--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -1,11 +1,11 @@
 {
     "version": "5.0",
     "description": "Terminal emulator for ssh/telnet/serial connection.",
-    "homepage": "https://osdn.net/projects/ttssh2/",
+    "homepage": "https://teratermproject.github.io/index-en.html",
     "license": "BSD-3-Clause",
     "notes": "OSDN is currently unstable. See: https://github.com/TeraTermProject/osdn-download",
     "url": "https://github.com/TeraTermProject/teraterm/releases/download/v5.0/teraterm-5.0.zip",
-    "hash": "sha1:20120e05e09bba7be159631513d237ac67c15433",
+    "hash": "a6f7724930c1d21c7bfa777aa8f2486ba0ce00ea26f42d947efe2e5bcf5ef7ac",
     "extract_dir": "teraterm-5.0",
     "bin": "ttermpro.exe",
     "shortcuts": [
@@ -22,7 +22,7 @@
         "TERATERM.INI"
     ],
     "checkver": {
-        "github": "https://github.com/TeraTermProject/teraterm",
+        "github": "https://github.com/TeraTermProject/teraterm"
     },
     "autoupdate": {
         "url": "https://github.com/TeraTermProject/teraterm/releases/download/v$version/teraterm-$version.zip",


### PR DESCRIPTION
Closes #12387

1. Remove trailing comma

and additionally,

2. Replace old OSDN homepage url
3. Replace sha1 hash value

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
