### PR TITLE
sumatrapdf@3.5.2: Add arm64 version

### DIFF
--- a/bucket/sumatrapdf.json
+++ b/bucket/sumatrapdf.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://www.sumatrapdfreader.org/dl/rel/3.5.2/SumatraPDF-3.5.2.zip",
             "hash": "5f1f460ff72ddd48979dbcfc2d427d53a473d43e18425470c78e94b19fee70b6"
+        },
+        "arm64": {
+            "url": "https://www.sumatrapdfreader.org/dl/rel/3.5.2/SumatraPDF-3.5.2-arm64.zip",
+            "hash": "d6fa6678f3dd3017515faa74735ecbf860cb6825bd61f109f9157f0b171e882f"
         }
     },
     "pre_install": [
@@ -43,6 +47,9 @@
             },
             "32bit": {
                 "url": "https://www.sumatrapdfreader.org/dl/rel/$version/SumatraPDF-$version.zip"
+            },
+            "arm64": {
+                "url": "https://www.sumatrapdfreader.org/dl/rel/$version/SumatraPDF-$version-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
- Add arm64 version.

Closes #12384.
Relates to #12104, #12153.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
