### PR TITLE
Wireshark: Added notes & script to enable USBPcap.

### DIFF
--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -8,7 +8,9 @@
         "$dir\\npcap-installer.exe",
         "",
         "You can also install USBPcap from the 'wireshark' directory if you need the USB packets capture funcionality.",
-        "$dir\\USBPcapSetup-installer.exe"
+        "$dir\\USBPcapSetup-installer.exe",
+        "",
+        "If this is the first time you opted to install USBPcap, please restart and run: $dir\\enable-usbpcap.ps1"
     ],
     "architecture": {
         "64bit": {
@@ -23,6 +25,10 @@
             "Get-ChildItem \"$dir\\USBPcapSetup-*.exe\" | Rename-Item -NewName 'USBPcapSetup-installer.exe'"
         ]
     },
+    "post_install": [
+        "Get-ChildItem \"$bucketsdir\\extras\\scripts\\wireshark\" | Copy-Item -Force -Destination \"$dir\"",
+        "& \"$dir\\enable-usbpcap.ps1\" 2>$null   # Attempt try to enable USBPcap if already installed"
+    ],
     "bin": [
         "capinfos.exe",
         "dumpcap.exe",

--- a/scripts/wireshark/enable-usbpcap.ps1
+++ b/scripts/wireshark/enable-usbpcap.ps1
@@ -1,0 +1,32 @@
+<#
+    To enable USBPcap, Wireshark requires `USBPcapCMD.exe` to be copied to `wireshark/Data/extcap/`.
+    This script will try its best to find the file, then create a symlink in the required dir.
+#>
+$dst_dir = "$PSScriptRoot\Data\extcap"
+$exe_name = "USBPcapCMD.exe"
+
+# The USBPCap dir should've been added to the user's PATH by its installer.
+$src_exe = (Get-Command $exe_name -ErrorAction Ignore).Source
+
+# If for any reason it wasn't (e.g. installed by a different user), try looking in some common locations.
+if (-not $src_exe) {
+    try {
+        $src_dir = ((Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\USBPcap' -Name 'UninstallString').Replace('"', '') | Get-Item).DirectoryName 2>$null
+        $src_exe = "$src_dir\$exe_name"
+    } catch {}
+}
+if (-not $src_exe) {
+    $src_exe = "$env:ProgramFiles\USBPcap\$exe_name"
+}
+
+if (Test-Path $src_exe) {
+    $dst_exe = "$dst_dir\$exe_name"
+    if ( -not (Test-Path $dst_exe) -or ((Get-Item $dst_exe).Target -ne $src_exe)) {
+        New-Item -Force -ItemType Directory -Path $dst_dir | Out-Null
+        New-Item -Force -ItemType SymbolicLink -Path $dst_exe -Value $src_exe | Out-Null
+        Write-Output "Linking $(Resolve-Path $dst_exe -Relative -RelativeBasePath $PSScriptRoot) => $src_exe"
+    }
+} else {
+    Write-Error "'$exe_name' not found. Please ensure USBPcap is installed, and the computer has been restarted after installation.
+If it still fails, you need to manually copy USBPCapCMD.exe from the USBPcap install location to '$dst_dir'"
+}


### PR DESCRIPTION
Closes #11545

Script is also triggered on `post_install`, in the event that USBPcap has previously been installed in the system.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
