### PR TITLE
Update archisteamfarm.json: persist "plugins" folder

### DIFF
--- a/bucket/archisteamfarm.json
+++ b/bucket/archisteamfarm.json
@@ -26,7 +26,10 @@
             "ArchiSteamFarm"
         ]
     ],
-    "persist": ["config","plugins"],
+    "persist": [
+        "config",
+        "plugins"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
If custom plugins have been added to the subfolder, they won't be kept properly when updating to a new version. This PR should fix this issue.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
