### PR TITLE
geogebra: Update version to 6.0.814.0 and fix checkver

### DIFF
--- a/bucket/geogebra.json
+++ b/bucket/geogebra.json
@@ -37,17 +37,8 @@
         ]
     ],
     "checkver": {
-        "script": [
-            "try {",
-            "    $res = Invoke-WebRequest -Uri https://download.geogebra.org/package/win-port6 -Method Head -MaximumRedirection 0 -ErrorAction Ignore",
-            "} catch [Microsoft.PowerShell.Commands.HttpResponseException] {",
-            "    $releaseUrl = $_.Exception.Response.Headers.Location.ToString()",
-            "}",
-            "$releaseUrl = if ($null -eq $releaseUrl) { $res.Headers['Location'] } else { $releaseUrl }",
-            "$releaseUrl"
-        ],
-        "regex": "\\d-(\\d+)-(\\d+)-(\\d+)",
-        "replace": "6.${1}.${2}.${3}"
+        "url": "https://wiki.geogebra.org/en/Reference:Changelog_6.0",
+        "regex": "([\\d.]+)_\\(\\w+_build\\)"
     },
     "autoupdate": {
         "url": "https://download.geogebra.org/installers/$majorVersion.$minorVersion/GeoGebra-Windows-Portable-$dashVersion.zip",


### PR DESCRIPTION
The old `checkver` is not working:

```console
PS> curl "https://download.geogebra.org/installers/6.0/version.txt"
5-2-813-0
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
