### PR TITLE
clash-verge: change homepage to new official repo

### DIFF
--- a/bucket/clash-verge.json
+++ b/bucket/clash-verge.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.3.8",
+    "version": "1.4.2",
     "description": "A Clash GUI based on Tauri.",
-    "homepage": "https://github.com/zzzgydi/clash-verge",
+    "homepage": "https://github.com/clash-verge-rev/clash-verge-rev",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zzzgydi/clash-verge/releases/download/v1.3.8/Clash.Verge_1.3.8_x64_portable.zip",
-            "hash": "a7c296228e054930fabdbfd836279d0d3c413b1a08dcaa4604c540bf8905d529"
+            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v1.4.2/Clash.Verge_1.4.2_x64_portable.zip",
+            "hash": "c1964c6ea4fb7b4c6c336f81f2aa99c7102d0c882e37681604fe378572425c7a"
         }
     },
     "shortcuts": [
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zzzgydi/clash-verge/releases/download/v$version/Clash.Verge_$version_x64_portable.zip"
+                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64_portable.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
[the old repo](https://github.com/zzzgydi/clash-verge) of clash-verge has been archived,
and the new one with same contributors is https://github.com/clash-verge-rev/clash-verge-rev
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes  #12417
<!-- or -->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
