### PR TITLE
ueli@8.27.0: update homepage URL

### DIFF
--- a/bucket/ueli.json
+++ b/bucket/ueli.json
@@ -1,7 +1,7 @@
 {
     "version": "8.27.0",
     "description": "A keystroke launcher",
-    "homepage": "https://ueli.oliverschwendener.ch",
+    "homepage": "https://ueli.app/",
     "license": "MIT",
     "url": "https://github.com/oliverschwendener/ueli/releases/download/v8.27.0/ueli-8.27.0-win.zip",
     "hash": "6b6221f837c0fa4e7546b6f5928d0379a242133c2296355c8fdc5d557dca5b45",


### PR DESCRIPTION
New home is now https://ueli.app/

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
