### PR TITLE
keepass-plugin-keeautoexec: Add version 2.6

### DIFF
--- a/bucket/keepass-plugin-keeautoexec.json
+++ b/bucket/keepass-plugin-keeautoexec.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.6",
+    "description": "Plugin for KeePass 2.x that allows automatic opening of additional databases.",
+    "homepage": "https://keepass.info/plugins.html#keeautoexec",
+    "license": "GPL-2.0-only",
+    "depends": "extras/keepass",
+    "url": "https://keepass.info/extensions/v2/keeautoexec/KeeAutoExec-2.6.zip",
+    "hash": "65b998deadeb954233f9a4f195906840bd7620a02e559a6dfb7ffb6732c5d87b",
+    "installer": {
+        "script": [
+            "'KeeAutoExec.dll', 'KeeAutoExec.plgx', 'KeeAutoExec_ReadMe.html' | ForEach-Object {",
+            "   Copy-Item \"$dir\\$_\" \"$(appdir keepass $global)\\current\\Plugins\" -Force",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "'KeeAutoExec.dll', 'KeeAutoExec.plgx', 'KeeAutoExec_ReadMe.html' | ForEach-Object {",
+            "   Remove-Item \"$(appdir keepass $global)\\current\\Plugins\\$_\" -Force",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://keepass.info/update/version2x.txt",
+        "regex": "KeeAutoExec:([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://keepass.info/extensions/v2/keeautoexec/KeeAutoExec-$version.zip"
+    }
+}


### PR DESCRIPTION
New manifest for the official KeePass plugin KeeAutoExec

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

---

I've tested locally the install, update, forced update and uninstall.