### PR TITLE
Update foxit-pdf-reader.json

### DIFF
--- a/bucket/foxit-pdf-reader.json
+++ b/bucket/foxit-pdf-reader.json
@@ -1,18 +1,14 @@
 {
-    "##": "Using cdn06.foxitsoftware.com for better speed worldwide. (redirects to cdn06.foxitsoftware.com.cdn.cloudflare.net)",
-    "version": "12.1.3.15356",
+    "##": "Using cdn78.foxitsoftware.com for better speed worldwide. Please keep foxit-reader and foxit-pdf-reader in sync.",
+    "version": "2023.3.0",
     "description": "Fast and feature rich PDF reader that offers a delightful reading experience.",
     "homepage": "https://www.foxit.com/pdf-reader/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.foxit.com/pdf-editor/eula.html"
     },
-    "url": "https://cdn06.foxitsoftware.com/product/reader/desktop/win/12.1.3/FoxitPDFReader1213_L10N_Setup.msi",
-    "hash": "834e47c81fc4a2385fa75ac8b64f4819cc507b7470def7cb5a25f8e0103b7089",
-    "pre_install": [
-        "Copy-Item \"$dir\\Foxit Software\\Foxit PDF Reader\\*\" \"$dir\" -Force -Recurse | Out-Null",
-        "Remove-Item \"$dir\\Foxit Software\" -Force -Recurse | Out-Null"
-    ],
+    "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2023.3.0/FoxitPDFReader20233_enu_Setup_Prom.exe",
+    "hash": "9bf6b31d15784247b3fbd840e97a7a46987d04848bc04f84eed67e03b1607035",
     "bin": "FoxitPDFReader.exe",
     "shortcuts": [
         [
@@ -20,11 +16,25 @@
             "Foxit PDF Reader"
         ]
     ],
+    "installer": {
+        "args": [
+            "/DIR=$dir",
+            "/verysilent",
+            "/COMPONENTS=\"pdfviewer\""
+        ]
+    },
+    "uninstaller": {
+        "file": "$dir/unins000.exe",
+        "args": "/verysilent"
+    },
     "checkver": {
-        "url": "https://www.foxit.com/pdf-reader/version-history.html",
-        "regex": ">Version ([\\d.]+)</"
+        "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue).Headers.Location",
+        "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
     },
     "autoupdate": {
-        "url": "https://cdn06.foxitsoftware.com/product/reader/desktop/win/$matchHead/FoxitPDFReader$majorVersion$minorVersion$patchVersion_L10N_Setup.msi"
+        "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname",
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/foxit-pdf-reader.json
+++ b/bucket/foxit-pdf-reader.json
@@ -16,25 +16,12 @@
             "Foxit PDF Reader"
         ]
     ],
-    "installer": {
-        "args": [
-            "/DIR=$dir",
-            "/verysilent",
-            "/COMPONENTS=\"pdfviewer\""
-        ]
-    },
-    "uninstaller": {
-        "file": "$dir/unins000.exe",
-        "args": "/verysilent"
-    },
+    "innosetup": true,
     "checkver": {
         "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue).Headers.Location",
         "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
     },
     "autoupdate": {
-        "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname"
     }
 }

--- a/bucket/foxit-pdf-reader.json
+++ b/bucket/foxit-pdf-reader.json
@@ -18,7 +18,7 @@
     ],
     "innosetup": true,
     "checkver": {
-        "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue).Headers.Location",
+        "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue -SkipHttpErrorCheck).Headers.Location",
         "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
     },
     "autoupdate": {

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -1,18 +1,14 @@
 {
-    "##": "Using cdn06.foxitsoftware.com for better speed worldwide. (redirects to cdn06.foxitsoftware.com.cdn.cloudflare.net)",
-    "version": "12.1.3.15356",
+    "##": "Using cdn78.foxitsoftware.com for better speed worldwide. Please keep foxit-reader and foxit-pdf-reader in sync.",
+    "version": "2023.3.0",
     "description": "Fast and feature rich PDF reader that offers a delightful reading experience.",
     "homepage": "https://www.foxit.com/pdf-reader/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.foxit.com/pdf-editor/eula.html"
     },
-    "url": "https://cdn06.foxitsoftware.com/product/reader/desktop/win/12.1.3/FoxitPDFReader1213_L10N_Setup.msi",
-    "hash": "834e47c81fc4a2385fa75ac8b64f4819cc507b7470def7cb5a25f8e0103b7089",
-    "pre_install": [
-        "Copy-Item \"$dir\\Foxit Software\\Foxit PDF Reader\\*\" \"$dir\" -Force -Recurse | Out-Null",
-        "Remove-Item \"$dir\\Foxit Software\" -Force -Recurse | Out-Null"
-    ],
+    "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2023.3.0/FoxitPDFReader20233_enu_Setup_Prom.exe",
+    "hash": "9bf6b31d15784247b3fbd840e97a7a46987d04848bc04f84eed67e03b1607035",
     "bin": "FoxitPDFReader.exe",
     "shortcuts": [
         [
@@ -20,11 +16,25 @@
             "Foxit PDF Reader"
         ]
     ],
+    "installer": {
+        "args": [
+            "/DIR=$dir",
+            "/verysilent",
+            "/COMPONENTS=\"pdfviewer\""
+        ]
+    },
+    "uninstaller": {
+        "file": "$dir/unins000.exe",
+        "args": "/verysilent"
+    },
     "checkver": {
-        "url": "https://www.foxit.com/pdf-reader/version-history.html",
-        "regex": ">Version ([\\d.]+)</"
+        "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue).Headers.Location",
+        "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
     },
     "autoupdate": {
-        "url": "https://cdn06.foxitsoftware.com/product/reader/desktop/win/$matchHead/FoxitPDFReader$majorVersion$minorVersion$patchVersion_L10N_Setup.msi"
+        "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname",
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -16,25 +16,12 @@
             "Foxit PDF Reader"
         ]
     ],
-    "installer": {
-        "args": [
-            "/DIR=$dir",
-            "/verysilent",
-            "/COMPONENTS=\"pdfviewer\""
-        ]
-    },
-    "uninstaller": {
-        "file": "$dir/unins000.exe",
-        "args": "/verysilent"
-    },
+    "innosetup": true,
     "checkver": {
         "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue).Headers.Location",
         "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
     },
     "autoupdate": {
-        "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname"
     }
 }

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -18,7 +18,7 @@
     ],
     "innosetup": true,
     "checkver": {
-        "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue).Headers.Location",
+        "script": "(Invoke-WebRequest -Uri 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&version=&package_type=&language=English&distID=' -MaximumRedirection 0 -ErrorAction:SilentlyContinue -SkipHttpErrorCheck).Headers.Location",
         "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
     },
     "autoupdate": {


### PR DESCRIPTION
Update Foxit PDF reader:

Foxit changed:
* version numbering (incl omitting the patch version number when 0),
* installer (MSI -> exe) and
* URL (CDN)

This PR focuses on the Reader only. I would expect that similar changes are necessary for the foxit reader manifest.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
