### PR TITLE
avspmod: Fixed extract-dir, so it can support both 32-bit and 64-bit ZIPs.

### DIFF
--- a/bucket/avspmod.json
+++ b/bucket/avspmod.json
@@ -6,14 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/gispos/AvsPmod/releases/download/2.7.6.1/AvsPmod_v2.7.6.1_.Windows_x86-64.zip",
-            "hash": "8520c4c4003cc0d3129e81093f58d0018614c1473d01c09aacfe367dbef5a7df"
+            "hash": "8520c4c4003cc0d3129e81093f58d0018614c1473d01c09aacfe367dbef5a7df",
+            "extract_dir": "AvsPmod_64",
         },
         "32bit": {
             "url": "https://github.com/gispos/AvsPmod/releases/download/2.7.6.1/AvsPmod_v2.7.6.1_.Windows_x86-32.zip",
-            "hash": "b1b693f85e630bb9b4811fa9ce33afeb78068191dc20cce765a245d651439053"
+            "hash": "b1b693f85e630bb9b4811fa9ce33afeb78068191dc20cce765a245d651439053",
+            "extract_dir": "AvsPmod",
         }
     },
-    "extract_dir": "AvsPmod",
     "shortcuts": [
         [
             "AvsPmod.exe",


### PR DESCRIPTION
AvsPmod's newer builds use the `AvsPmod_64` folder for the 64-bit builds of their install ZIPs.

This bucket still uses the older `AvsPmod` folder, even for 64-bit, so i fixed it.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
