### PR TITLE
clash-verge-rev: Add Version 1.4.4 and `description`; clash-verge: Fallback original repo and update `note`

### DIFF
--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.4.4",
+    "description": "Continuation of Clash Verge - A Clash Meta GUI based on Tauri.",
+    "homepage": "https://github.com/clash-verge-rev/clash-verge-rev",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v1.4.4/Clash.Verge_1.4.4_x64_portable.zip",
+            "hash": "d4fc14937bd47b3735b0159426045df9f3308853828f8456d584675673657019"
+        }
+    },
+    "shortcuts": [
+        [
+            "Clash Verge.exe",
+            "Clash Verge"
+        ]
+    ],
+    "persist": ".config",
+    "post_install": [
+        "if (!(Test-Path \"$persist_dir\\.config\\PORTABLE\")) {",
+        "    New-Item -Path \"$persist_dir\\.config\\PORTABLE\" -ItemType file | Out-Null",
+        "}"
+    ],
+    "pre_uninstall": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "Start-Process \"$dir\\resources\\uninstall-service.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden'; Start-Sleep -Seconds 3"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64_portable.zip"
+            }
+        }
+    }
+}

--- a/bucket/clash-verge.json
+++ b/bucket/clash-verge.json
@@ -1,12 +1,13 @@
 {
-    "version": "1.4.4",
+    "version": "1.3.8",
     "description": "A Clash GUI based on Tauri.",
-    "homepage": "https://github.com/clash-verge-rev/clash-verge-rev",
+    "homepage": "https://github.com/zzzgydi/clash-verge",
     "license": "GPL-3.0-only",
+    "notes": "zzzgydi/clash-verge has been archived, continue to use 'scoop install extras/clash-verge-rev' instead",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v1.4.4/Clash.Verge_1.4.4_x64_portable.zip",
-            "hash": "d4fc14937bd47b3735b0159426045df9f3308853828f8456d584675673657019"
+            "url": "https://github.com/zzzgydi/clash-verge/releases/download/v1.3.8/Clash.Verge_1.3.8_x64_portable.zip",
+            "hash": "a7c296228e054930fabdbfd836279d0d3c413b1a08dcaa4604c540bf8905d529"
         }
     },
     "shortcuts": [
@@ -29,7 +30,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64_portable.zip"
+                "url": "https://github.com/zzzgydi/clash-verge/releases/download/v$version/Clash.Verge_$version_x64_portable.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

After using `clash-verge-rev`, I believe that clash-verge-rev is a continuation of clash-verge, BUT the repositories and software are different.
`clash-verge-rev` still has some bugs, I divided the two manifests for people to choose from and added `notes`.


Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
