### PR TITLE
screentogif@2.40: Add arm64 version

### DIFF
--- a/bucket/screentogif.json
+++ b/bucket/screentogif.json
@@ -14,6 +14,10 @@
         "32bit": {
             "url": "https://github.com/NickeManarin/ScreenToGif/releases/download/2.40/ScreenToGif.2.40.Portable.x86.zip",
             "hash": "09fa973121114cd2d5dfee0c1e2ab15a81f7056e86430f64ea26b644364cc10c"
+        },
+        "arm64": {
+            "url": "https://github.com/NickeManarin/ScreenToGif/releases/download/2.40/ScreenToGif.2.40.Portable.Arm64.zip",
+            "hash": "ff6d96000368d10e988fbafdc99a7ea41859db29065fd6e0b7409a15da0feb32"
         }
     },
     "pre_install": [
@@ -44,6 +48,9 @@
             },
             "32bit": {
                 "url": "https://github.com/NickeManarin/ScreenToGif/releases/download/$version/ScreenToGif.$version.Portable.x86.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/NickeManarin/ScreenToGif/releases/download/$version/ScreenToGif.$version.Portable.Arm64.zip"
             }
         }
     }


### PR DESCRIPTION
- Add arm64 version.

Closes #12435.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
