### PR TITLE
hub-tool: Add version 0.4.5

### DIFF
--- a/bucket/hub-tool.json
+++ b/bucket/hub-tool.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.4.5",
+    "description": "The Docker Hub Tool is a CLI tool for interacting with the Docker Hub.",
+    "homepage": "https://github.com/docker/hub-tool",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/docker/hub-tool/releases/download/v0.4.5/hub-tool-windows-amd64.zip",
+            "hash": "2d078e10a757629f0682db9772f565c46b2a841c3f76f28318e70918f4ec56b3"
+        }
+    },
+    "bin": "hub-tool.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/docker/hub-tool/releases/download/v$version/hub-tool-windows-amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR adds a manifest for hub-tool, a CLI tool for interacting with the Docker Hub. Does not seems to fit Main bucket criteria since it has lower than 500 stars.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
