### PR TITLE
restish: Update to version 0.20.0

### DIFF
--- a/bucket/restish.json
+++ b/bucket/restish.json
@@ -1,20 +1,20 @@
 {
-    "version": "0.17.0",
+    "version": "0.20.0",
     "description": "Restish is a CLI for interacting with REST-ish HTTP APIs with some nice features built-in",
     "homepage": "https://rest.sh/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.17.0/restish-0.17.0-windows-x86_64.zip",
-            "hash": "4d48968fa300be3f30da1d88781425b579d6a0e5974f9d3d0d4224c1b67964b7"
+            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.20.0/restish-0.20.0-windows-amd64.zip",
+            "hash": "22cbefc96fdf36d3b1a9ca9c9bed24c2a9abefb62c5318c9d8ad977ad6d42add"
         },
         "32bit": {
-            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.17.0/restish-0.17.0-windows-i386.zip",
-            "hash": "e8cab8cad21dbd4b379f5c2a730278bf44345e19cbbcaac887d1ed8e3db76b8e"
+            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.20.0/restish-0.20.0-windows-386.zip",
+            "hash": "e7360a95dd3519a04e0db0c2ccb9d43bec2c866fb21a30ec05c30e5ec45f0fc0"
         },
         "arm64": {
-            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.17.0/restish-0.17.0-windows-arm64.zip",
-            "hash": "24938e88a846e78d7fe5fc1ebee2ef2c7a1f0e342f6a36e69ff4f5dca032035e"
+            "url": "https://github.com/danielgtaylor/restish/releases/download/v0.20.0/restish-0.20.0-windows-arm64.zip",
+            "hash": "19c805fd546ac7720b95bd467286de3b0a885b30266f6c639ae21250aa7e9e98"
         }
     },
     "bin": "restish.exe",
@@ -24,10 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-x86_64.zip"
+                "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-i386.zip"
+                "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-386.zip"
             },
             "arm64": {
                 "url": "https://github.com/danielgtaylor/restish/releases/download/v$version/restish-$version-windows-arm64.zip"


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 0.20.0.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
