### PR TITLE
v2rayn: Remove uninstaller script

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -42,13 +42,6 @@
         ]
     ],
     "persist": "guiConfigs",
-    "uninstaller": {
-        "script": [
-            "if (Test-Path \"$dir\\guiConfigs\\config.json\") {",
-            "    Copy-Item \"$dir\\guiConfigs\\config.json\" \"$persist_dir\\guiConfigs\\config.json\" | Out-Null",
-            "}"
-        ]
-    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
```
Running uninstaller script...
Copy-Item:
Line |
   2 |      Copy-Item "$dir\guiConfigs\config.json" "$persist_dir\guiConfigs\ …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot overwrite the item D:\scoop\apps\v2rayn\6.23\guiConfigs\config.json with itself.
```

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
