### PR TITLE
logseq: fix hash regex

### DIFF
--- a/bucket/logseq.json
+++ b/bucket/logseq.json
@@ -5,14 +5,10 @@
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/logseq/logseq/releases/download/0.10.2/logseq-win-x64-0.10.2.exe#/dl.7z",
-            "hash": "f9dd8efcc5b234b0c7275a354f6e729ac5635addd4e2999080ccdfcb0a91db14"
+            "url": "https://github.com/logseq/logseq/releases/download/0.10.2/Logseq-win-x64-0.10.2.zip",
+            "hash": "c85aea7f4923bdd6a9821a84361e415f6703af0bf838f65f85cd8de1a0f1a10a"
         }
     },
-    "pre_install": [
-        "Expand-7ZipArchive \"$dir\\logseq-*-full.nupkg\" -ExtractDir 'lib\\net45' -Removal",
-        "Remove-Item \"$dir\\lib\", \"$dir\\Update*\" -Recurse"
-    ],
     "shortcuts": [
         [
             "Logseq.exe",
@@ -25,10 +21,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/logseq/logseq/releases/download/$version/logseq-win-x64-$version.exe#/dl.7z",
+                "url": "https://github.com/logseq/logseq/releases/download/0.10.2/Logseq-win-x64-0.10.2.zip",
                 "hash": {
-                    "url": "$baseurl/SHA256SUMS.txt",
-                    "regex": "$sha256\\s+Logseq-win-x64-$version.exe"
+                    "url": "$baseurl/SHA256SUMS.txt"
                 }
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix logseq hash regex to adapt for `.exe` dist
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12513

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
