### PR TITLE
Update synology-surveillance-station.json

### DIFF
--- a/bucket/synology-surveillance-station.json
+++ b/bucket/synology-surveillance-station.json
@@ -18,7 +18,7 @@
     },
     "shortcuts": [
         [
-            "bin\\SynologySurveillanceStationClient.exe",
+            "bin\\Synology Surveillance Station Client.exe",
             "Synology Surveillance Station Client"
         ]
     ],


### PR DESCRIPTION
incorrect exe file fixed

<!-- Provide a general summary of your changes in the title above -->

After updating with scoop, the shim will try to execute an exe file that does not exist, my proposed pull request updates to the correct exe file.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
