### PR TITLE
losslesscut: use v3.59.1 instead of v3.59.0

### DIFF
--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.59.0",
+    "version": "3.59.1",
     "description": "Lossless trimming tool for video and audio files",
     "homepage": "https://github.com/mifi/lossless-cut",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mifi/lossless-cut/releases/download/v3.59.0/LosslessCut-win-x64.7z",
-            "hash": "bee0e6be6923062634068fc5605cd24c2f03a8536eada76f0f91177a95441ade"
+            "url": "https://github.com/mifi/lossless-cut/releases/download/v3.59.1/LosslessCut-win-x64.7z",
+            "hash": "54663de6f81bda72ac3fcd8c01bce3da751ad91d9e1eab75500335adbb6723f0"
         }
     },
     "bin": "LosslessCut.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
v3.59.0 has removed, the latest version is v3.59.1.

Relates to #12518

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
