### PR TITLE
apifox: Update to version 2.4.8, fix checkver

### DIFF
--- a/bucket/apifox.json
+++ b/bucket/apifox.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.3.24",
+    "version": "2.4.8",
     "description": "All-in-one collaboration platform for API documentation, API debugging, API Mock and API test automation.",
     "homepage": "https://apifox.com",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.apifox.cn/download/2.3.24/Apifox-2.3.24.exe#/dl.7z",
-            "hash": "sha512:ca10b5277e6fe8048df4be3e544f66043de44b66ce5ef8d3b51d2d4fb655176bf175799d62c669d73ca03e499a7f49895d376eab3b2a82bea65b3e07d106e73c"
+            "url": "https://cdn.apifox.cn/download/2.4.8/Apifox-2.4.8.exe#/dl.7z",
+            "hash": "sha512:be34daa10f594cbf3bd7bd567f9b8a41dcd1e18d910971e45394f8abb8da43b1cf798112299e7ed5f23d8389bec7626cebe8cd56a7892f39b08ee97b640d5e1a"
         }
     },
     "pre_install": [
@@ -26,8 +26,8 @@
         "Wait-Process -Name 'ApifoxAppAgent' -ErrorAction SilentlyContinue -Timeout 30"
     ],
     "checkver": {
-        "url": "https://cdn.apifox.cn/download/latest.yml",
-        "regex": "version: ([\\d.]+)"
+        "url": "https://apifox.com/help/app/changelog",
+        "regex": ">([\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Fix `checkver` to prevent repetitive upgrade-downgrade updates, possibly caused by CDN or whatever (see screen below):

![apifox_upgrade-downgrade-repetitions](https://github.com/ScoopInstaller/Extras/assets/1752374/9fa19a69-8754-4f6f-a87b-9b43d8d652b5)

- Update to version 2.4.8.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
