### PR TITLE
logseq@0.10.3: Fix autoupdate

### DIFF
--- a/bucket/logseq.json
+++ b/bucket/logseq.json
@@ -5,8 +5,8 @@
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/logseq/logseq/releases/download/0.10.2/Logseq-win-x64-0.10.2.zip",
-            "hash": "c85aea7f4923bdd6a9821a84361e415f6703af0bf838f65f85cd8de1a0f1a10a"
+            "url": "https://github.com/logseq/logseq/releases/download/0.10.3/Logseq-win-x64-0.10.3.zip",
+            "hash": "a81f2bbb920777a2150c84db9891f50b521a56dede45405107079c0ca2f84e0a"
         }
     },
     "shortcuts": [
@@ -21,7 +21,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/logseq/logseq/releases/download/0.10.2/Logseq-win-x64-0.10.2.zip",
+                "url": "https://github.com/logseq/logseq/releases/download/$version/Logseq-win-x64-$version.zip",
                 "hash": {
                     "url": "$baseurl/SHA256SUMS.txt"
                 }


### PR DESCRIPTION
- Fix autoupdate (looks like version hard-coded by accident in dfd8544).
 
Relates to #12514.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
