### PR TITLE
fancontrol@177: switch to .NET 8.0 LTS build

### DIFF
--- a/bucket/fancontrol.json
+++ b/bucket/fancontrol.json
@@ -4,12 +4,12 @@
     "homepage": "https://getfancontrol.com/",
     "license": "Freeware",
     "suggest": {
-        ".NET Desktop Runtime": "extras/windowsdesktop-runtime"
+        ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Rem0o/FanControl.Releases/releases/download/V176/FanControl_net_7_0.zip",
-            "hash": "90b1a3bfa01d7dfec27eb94d1bff9978ec56100767d61b61a58f14c450165547"
+            "url": "https://github.com/Rem0o/FanControl.Releases/releases/download/V176/FanControl_net_8_0.zip",
+            "hash": "1aa411a54a3fb5eb723cbffb9e454f6a22189341d68850ea513a24372799e6af"
         }
     },
     "shortcuts": [
@@ -25,7 +25,7 @@
     "checkver": {
         "url": "https://api.github.com/repositories/268350681/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
-        "regex": "/V([\\d.]+)/FanControl_net_(?<netver>(?!4_8)[\\d_]+).zip"
+        "regex": "/V([\\d.]+)/FanControl_net_(?<netver>(?!4_8)(?!7_0)[\\d_]+).zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Currently, the upstream distributes builds for .NET 4.8, .NET 7.0, and .NET 8.0 LTS. This PR adds another negative lookahead in `checkver.regex` not to match the .NET 7.0 build. Consequently, the `autoupdate` process should select the .NET 8.0 LTS build, avoiding both the .NET 4.8 and .NET 7.0 builds from the release.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
