### PR TITLE
vscode: Add GitHub integration

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -10,7 +10,9 @@
         "Add Visual Studio Code as a context menu option by running:",
         "'reg import \"$dir\\install-context.reg\"'",
         "For file associations, run:",
-        "'reg import \"$dir\\install-associations.reg\"'"
+        "'reg import \"$dir\\install-associations.reg\"'",
+        "For github integration, run:",
+        "'reg import \"$dir\\install-github-integration.reg\"'"
     ],
     "architecture": {
         "64bit": {
@@ -32,7 +34,7 @@
     "post_install": [
         "$dirpath = \"$dir\".Replace('\\', '\\\\')",
         "$exepath = \"$dir\\Code.exe\".Replace('\\', '\\\\')",
-        "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context' | ForEach-Object {",
+        "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context', 'install-github-integration', 'uninstall-github-integration' | ForEach-Object {",
         "  if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",
         "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\"",
         "    $content = $content.Replace('$codedir', $dirpath)",
@@ -58,7 +60,13 @@
         "}"
     ],
     "uninstaller": {
-        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }"
+        "script": [
+            "if ($cmd -eq 'uninstall')",
+            "{",
+            "   reg import \"$dir\\uninstall-context.reg\" ",
+            "   reg import \"$dir\\uninstall-github-integration.reg\" ",
+            "}"
+        ]
     },
     "persist": "data",
     "checkver": {

--- a/scripts/vscode/install-github-integration.reg
+++ b/scripts/vscode/install-github-integration.reg
@@ -1,0 +1,7 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1]
+"DisplayIcon"="\"$code\""
+"DisplayName"="Microsoft Visual Studio Code"
+"Publisher"="Microsoft Corporation"
+"InstallLocation"="$codedir"

--- a/scripts/vscode/uninstall-github-integration.reg
+++ b/scripts/vscode/uninstall-github-integration.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This pull request addresses an annoying issue where Visual Studio Code (vscode) installed via the 'Extra' bucket is not recognized by GitHub Desktop. Consequently, users are unable to open files in vscodedirectly from the GitHub Desktop interface using the right-click context menu.

Inspired by https://github.com/desktop/desktop/issues/13798#issuecomment-1687374045, this pull request adds two reg files for installing/uninstalling github-vscode integration, and updates vscode.json to replace variables in reg files in each installation.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12555 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
