### PR TITLE
clumsy: Update to version 0.3, fix checkver

### DIFF
--- a/bucket/clumsy.json
+++ b/bucket/clumsy.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.2",
+    "version": "0.3",
     "description": "Broken network simulator",
     "homepage": "https://jagt.github.io/clumsy/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win64.zip",
-            "hash": "md5:c5117edad320930d14d18c1cac2a4ccd"
+            "url": "https://github.com/jagt/clumsy/releases/download/0.3/clumsy-0.3-win64-a.zip",
+            "hash": "f50dc734148815831c67d9fc2c246c22d421c53dcea51e26eee905b0b2806c27"
         },
         "32bit": {
-            "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win32.zip",
-            "hash": "md5:9aab0d257661a4f75831a7186254725b"
+            "url": "https://github.com/jagt/clumsy/releases/download/0.3/clumsy-0.3-win32-a.zip",
+            "hash": "57b880f65e8a628a84749df09358235676e361f576fc263f00f4f275c1a4ea51"
         }
     },
     "bin": "clumsy.exe",
@@ -23,20 +23,16 @@
     "persist": "config.txt",
     "checkver": {
         "url": "https://jagt.github.io/clumsy/download.html",
-        "regex": "clumsy-([\\d.]+)-win64\\.zip"
+        "regex": "clumsy-([\\d.]+)-win64(?:-a)?\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win64.zip"
+                "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win64-a.zip"
             },
             "32bit": {
-                "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win32.zip"
+                "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win32-a.zip"
             }
-        },
-        "hash": {
-            "url": "https://jagt.github.io/clumsy/download.html",
-            "regex": "$basename</a>\\s*\\(MD5:$md5\\)"
         }
     }
 }


### PR DESCRIPTION
- Fix checkver.
- Remove hash section from autoupdate (since hashes not provided more).
- Update to version 0.3.

Closes #12389.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
