### PR TITLE
beyondcompare@4.4.7.28397: Shim `BCompare.exe`

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -18,7 +18,10 @@
         }
     },
     "extract_dir": "Beyond Compare 4",
-    "bin": "Bcomp.exe",
+    "bin": [
+        "Bcomp.exe",
+        "BCompare.exe"
+    ],
     "shortcuts": [
         [
             "BCompare.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

According to the [official documentation](https://documentation.help/BeyondCompare4/command_line_reference.html), `BCompare.exe` should be added to `PATH`.

<!-- or -->
Relates to ScooterSoftware/bcompare-vscode#2

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
