### PR TITLE
shadowexplorer: Add version 0.9

### DIFF
--- a/bucket/shadowexplorer.json
+++ b/bucket/shadowexplorer.json
@@ -1,12 +1,12 @@
 {
-    "version":  "0.9",
-    "description": "ShadowExplorer allows you to browse the Shadow Copies created by the Windows Vista / 7 / 8 / 10 / 11 Volume Shadow Copy Service",
-    "license":  "unknown",
-    "extract_dir":  "ShadowExplorerPortable-0.9",
-    "url":  "https://www.shadowexplorer.com/uploads/ShadowExplorer-0.9-portable.zip",
-    "homepage":  "https://www.shadowexplorer.com",
-    "hash":  "92590121920b130a7787c25036d17cf4bd188f1de7cfac6d98c254eef531bb92",
-    "bin":  "ShadowExplorerPortable.exe",
+    "version": "0.9",
+    "description": "Browse the Shadow Copies created by the Windows Vista / 7 / 8 / 10 / 11 Volume Shadow Copy Service",
+    "homepage": "https://www.shadowexplorer.com",
+    "license": "Freeware",
+    "url": "https://www.shadowexplorer.com/uploads/ShadowExplorer-0.9-portable.zip",
+    "hash": "92590121920b130a7787c25036d17cf4bd188f1de7cfac6d98c254eef531bb92",
+    "extract_dir": "ShadowExplorerPortable-0.9",
+    "bin": "ShadowExplorerPortable.exe",
     "shortcuts": [
         [
             "ShadowExplorerPortable.exe",

--- a/bucket/shadowexplorer.json
+++ b/bucket/shadowexplorer.json
@@ -1,0 +1,17 @@
+{
+    "version":  "0.9",
+    "description": "ShadowExplorer allows you to browse the Shadow Copies created by the Windows Vista / 7 / 8 / 10 / 11 Volume Shadow Copy Service",
+    "license":  "unknown",
+    "extract_dir":  "ShadowExplorerPortable-0.9",
+    "url":  "https://www.shadowexplorer.com/uploads/ShadowExplorer-0.9-portable.zip",
+    "homepage":  "https://www.shadowexplorer.com",
+    "hash":  "92590121920b130a7787c25036d17cf4bd188f1de7cfac6d98c254eef531bb92",
+    "bin":  "ShadowExplorerPortable.exe",
+    "shortcuts": [
+        [
+            "ShadowExplorerPortable.exe",
+            "ShadowExplorerPortable"
+        ]
+    ],
+    "persist": "ShadowExplorerPortable.exe.config"
+}


### PR DESCRIPTION
ShadowExplorer allows you to browse the Shadow Copies created by the Windows Vista / 7 / 8 / 10 / 11 Volume Shadow Copy Service

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
