### PR TITLE
alacritty: Update to version 0.13.1

### DIFF
--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "GPU-accelerated terminal emulator",
     "homepage": "https://github.com/alacritty/alacritty",
     "license": "Apache-2.0",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
-    "url": "https://github.com/alacritty/alacritty/releases/download/v0.13.0/Alacritty-v0.13.0-portable.exe#/alacritty.exe",
-    "hash": "4cd15d155e2a6d03aaad186f024678ece1957924b9e168b7792d3a6b4d56d5b2",
+    "url": "https://github.com/alacritty/alacritty/releases/download/v0.13.1/Alacritty-v0.13.1-portable.exe#/alacritty.exe",
+    "hash": "af199fdb16447f5ee4c88cf7b646b10a1a9f930032fea3a69aaed945adda75c6",
     "bin": "alacritty.exe",
     "shortcuts": [
         [

--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -1,51 +1,23 @@
 {
-    "version": "0.12.3",
+    "version": "0.13.0",
     "description": "GPU-accelerated terminal emulator",
     "homepage": "https://github.com/alacritty/alacritty",
     "license": "Apache-2.0",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
-    "url": [
-        "https://github.com/alacritty/alacritty/releases/download/v0.12.3/Alacritty-v0.12.3-portable.exe#/alacritty.exe",
-        "https://github.com/alacritty/alacritty/releases/download/v0.12.3/alacritty.yml"
-    ],
-    "hash": [
-        "e9c8800565f85f31f6da2723256c8a2a1dae2ad41493b16bc2fd9226684e2cb4",
-        "3110fbf1d8cbeaaa388670dc6a86493a052903610bbdaa4d17150da833029e2b"
-    ],
-    "bin": [
-        "alacritty.exe",
-        [
-            "alacritty.exe",
-            "alacritty-config",
-            "--config-file \"$persist_dir\\alacritty.yml\""
-        ]
-    ],
+    "url": "https://github.com/alacritty/alacritty/releases/download/v0.13.0/Alacritty-v0.13.0-portable.exe#/alacritty.exe",
+    "hash": "4cd15d155e2a6d03aaad186f024678ece1957924b9e168b7792d3a6b4d56d5b2",
+    "bin": "alacritty.exe",
     "shortcuts": [
         [
             "alacritty.exe",
             "Alacritty",
             "--working-directory \"%USERPROFILE%\""
-        ],
-        [
-            "alacritty.exe",
-            "Alacritty with Configuration",
-            "--config-file \"$persist_dir\\alacritty.yml\""
-        ]
-    ],
-    "persist": [
-        [
-            "alacritty.yml",
-            "alacritty.yml.example"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": [
-            "https://github.com/alacritty/alacritty/releases/download/v$version/Alacritty-v$version-portable.exe#/alacritty.exe",
-            "https://github.com/alacritty/alacritty/releases/download/v$version/alacritty.yml"
-        ]
-    },
-    "notes": "An example config has been placed in $persist_dir as alacritty.yml.example. Change this to alacritty.yml to use it with alacritty-config and the appropriate shortcut."
+        "url": "https://github.com/alacritty/alacritty/releases/download/v$version/Alacritty-v$version-portable.exe#/alacritty.exe"
+    }
 }


### PR DESCRIPTION
Alacritty moved from yml config file to toml and the config file is no longer included in the github releases so I had to remove the persistent config 
