### PR TITLE
Fix hashes for qtemu@2.1

### DIFF
--- a/bucket/qtemu.json
+++ b/bucket/qtemu.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://web.archive.org/web/20210417194244/https://carlavilla.es/qtemu/qtemu_portable_x86_64.zip",
-            "hash": "6d5624c37a5a6e6fa05d4379574d69fe6316bb2818a08b5f7777dfe0ca39160e",
+            "hash": "7999d54cc3b433de5299a5644e4d3f9d073636b243d2a3335af478c7fadd2e0e",
             "extract_dir": "qtemu_portable_x86_64"
         }
     },


### PR DESCRIPTION
It seems reporting hash error using the issues tab only make a lot generate [a](https://github.com/ScoopInstaller/Extras/issues/12552) [new](https://github.com/ScoopInstaller/Extras/issues/12571) [random](https://github.com/ScoopInstaller/Extras/issues/12572) [hash](https://github.com/ScoopInstaller/Extras/issues/12552) instead of actually fixing the error...
I fixed hash for the `qtemu@2.1` package here.