### PR TITLE
scribus: update to version 1.6.0 (new stable branch)

### DIFF
--- a/bucket/scribus.json
+++ b/bucket/scribus.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.8",
+    "version": "1.6.0",
     "description": "Open Source Desktop Publishing",
     "homepage": "https://www.scribus.net",
     "license": "GPL-2.0-or-later",
@@ -10,12 +10,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/scribus/scribus/1.4.8/scribus-1.4.8-windows-x64.exe#/dl.7z",
-            "hash": "sha1:2e56d27c6e13b1170e8c80996129494dedacc250"
+            "url": "https://downloads.sourceforge.net/project/scribus/scribus/1.6.0/scribus-1.6.0-windows-x64.exe#/dl.7z",
+            "hash": "sha1:c0330c73697a4c07f0e7972fbe15da15bed2ae19"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/scribus/scribus/1.4.8/scribus-1.4.8-windows.exe#/dl.7z",
-            "hash": "sha1:bb772ddf3b491401992a0e2f541107996762e7fb"
+            "url": "https://downloads.sourceforge.net/project/scribus/scribus/1.6.0/scribus-1.6.0-windows.exe#/dl.7z",
+            "hash": "sha1:8bbeda928733fc89983967a8d0c03cc34e087077"
         }
     },
     "bin": "Scribus.exe",

--- a/bucket/scribus.json
+++ b/bucket/scribus.json
@@ -26,16 +26,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.scribus.net/downloads/stable-branch/",
-        "regex": "Current stable release: Scribus ([\\d.]+)"
+        "url": "https://www.scribus.net/downloads/",
+        "regex": "http://sourceforge.net/projects/scribus/files/scribus/([\\d.]+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/scribus/scribus/$version/scribus-$version-windows-x64.exe#/dl.7z"
+                "url": "https://downloads.sourceforge.net/project/scribus/files/scribus/$version/scribus-$version-windows-x64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/scribus/scribus/$version/scribus-$version-windows.exe#/dl.7z"
+                "url": "https://downloads.sourceforge.net/project/scribus/files/scribus/$version/scribus-$version-windows.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Old unstable finally graduated to stable. 1.6 branch is new stable, 1.7 branch new devel will start soon. (Scribus uses an even/odd system for stable/unstable).

- [x] Checked that the manifest works correctly by invoking `scoop install https://github.com/LaPingvino/Extras/raw/patch-1/bucket/scribus.json`
- [x] Fixed the checkver and autoupdate links
- [x] Tried to create the PR title properly

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
