### PR TITLE
video-compare@20240107: Add send to shortcut

### DIFF
--- a/bucket/video-compare.json
+++ b/bucket/video-compare.json
@@ -9,6 +9,20 @@
             "hash": "7c2b7c719b3d80cc99f2fb62a7f5d2133636ba01e805e414e413cab1b86193e3"
         }
     },
+    "post_install": [
+        "$LnkPath = Join-Path ([System.Environment]::GetFolderPath('SendTo')) video-compare.lnk",
+        "if (Test-Path $LnkPath){Remove-Item $LnkPath}",
+        "$WScriptShell = New-Object -ComObject WScript.Shell",
+        "$Shortcut = $WScriptShell.CreateShortcut($LnkPath)",
+        "$Shortcut.TargetPath = (Join-Path $DIR video-compare.exe)",
+        "$Shortcut.Save()"
+    ],
+    "uninstaller": {
+        "script": [
+            "$LnkPath = Join-Path ([System.Environment]::GetFolderPath('SendTo')) video-compare.lnk",
+            "if (Test-Path $LnkPath){Remove-Item $LnkPath}"
+        ]
+    },
     "bin": "video-compare.exe",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
it is suggested in the README: https://github.com/pixop/video-compare#practical-tips, costs nothing to add it 👍



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
