### PR TITLE
Determined AI CLI

### DIFF
--- a/bucket/determined.json
+++ b/bucket/determined.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.27.0",
+    "description": "The Determined CLI is a command line tool that lets you launch new experiments and interact with a Determined cluster.",
+    "homepage": "https://github.com/sirredbeard/determined-windows-cli",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sirredbeard/determined-windows-cli/releases/download/0.27.0/determined-cli.zip",
+            "hash": "EF8B24D00AAE8C2019B7C80E1626CB69AAD03070E88E0F5055BA5CEDC16BE2EC"
+        }
+    },
+    "bin": "det.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/sirredbeard/determined-windows-cli/releases/download/$version/determined-cli.zip"
+        }
+}


### PR DESCRIPTION
This PR adds the Determined AI CLI tool to Scoop.

It was previously excluded from Extras due to a dependency on Python and Pip.

However, it has since been re-built as a standalone binary.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
