### PR TITLE
windows-terminal: warn instead of fail in case of insufficient Windows OS version

### DIFF
--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -35,7 +35,7 @@
     "installer": {
         "script": [
             "$winVer = [Environment]::OSVersion.Version",
-            "if (($winver.Major -lt '10') -or ($winVer.Build -lt 19041)) { error 'At least Windows 10 20H1 (build 19041) is required.'; break }",
+            "if (($winver.Major -lt '10') -or ($winVer.Build -lt 19041)) { warn 'At least Windows 10 20H1 (build 19041) is required.' }",
             "if (!(Test-Path \"$persist_dir\\.portable\")) { Add-Content \"$dir\\.portable\" '' -Encoding Ascii }"
         ]
     },


### PR DESCRIPTION
Replace a hard install failure with a warning when the WIndows OS version requirementes are not met.

This allow to install using scoop on a computer not meeting runtime requirements (older or WSL), and use on a compliant one.
 
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
