### PR TITLE
notepadplusplus: fixes issue where plugins that were shipped with package when updating notepadplusplus are not updated

### DIFF
--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -33,6 +33,7 @@
         "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
         "    }",
         "}",
+        "# Update shipped plugins",
         "if (Test-Path \"$dir\\plugins.original\") {",
         "    Copy-Item -Recurse \"$dir\\plugins.original\\*\" \"$dir\\plugins\\\" -Force",
         "}"

--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -32,6 +32,9 @@
         "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
         "    }",
+        "}",
+        "if (Test-Path \"$dir\\plugins.original\") {",
+        "    Copy-Item -Recurse \"$dir\\plugins.original\\*\" \"$dir\\plugins\\\" -Force",
         "}"
     ],
     "uninstaller": {


### PR DESCRIPTION
Closes #12589

When there is a `plugins.original` folder after updating the notepadplusplus package, than the content of that folder is copied over to the persistent `plugins` folder.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
