### PR TITLE
change homepage URL for live777, whepfrom, whipinto

### DIFF
--- a/bucket/live777.json
+++ b/bucket/live777.json
@@ -1,7 +1,7 @@
 {
     "version": "0.3.3",
     "description": "A very simple, high performance, edge WebRTC SFU",
-    "homepage": "https://live777.binbat.com/",
+    "homepage": "https://github.com/binbat/live777/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {

--- a/bucket/whepfrom.json
+++ b/bucket/whepfrom.json
@@ -1,7 +1,7 @@
 {
     "version": "0.3.3",
     "description": "From shep to rtp",
-    "homepage": "https://live777.binbat.com/",
+    "homepage": "https://github.com/binbat/live777/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {

--- a/bucket/whipinto.json
+++ b/bucket/whipinto.json
@@ -1,7 +1,7 @@
 {
     "version": "0.3.3",
     "description": "From rtp to whip",
-    "homepage": "https://live777.binbat.com/",
+    "homepage": "https://github.com/binbat/live777/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
The packages `live777` (PR #12602), `whepfrom` (PR #12607) and `whipinto` (PR #12614) all currently refer to https://live777.binbat.com/ as their package homepage. However, this website does not provide any information about what these packages are or how they are used (https://binbat.com also doesn't have any helpful info on that). The download links however mention a [GitHub Repository](https://github.com/binbat/live777/) which (supposedly) hosts the source code for all three packages. It also contains a README which provides a rather detailed description of what live777 is. That is why I think this github repo should instead be referred to as the packages' homepage.

Additional note: The packages `live777` and `whepfrom` both declare `live777.exe` as their binary name. I do not know what the intention behind this is, but this should probably be looked into as well.

Relates to #12602, #12607, #12614

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
