### PR TITLE
gcc-aarch64-none-elf/gcc-aarch64-none-linux-gnu/gcc-arm-none-linux-gnueabihf: Add version 13.2.rel1

### DIFF
--- a/bucket/gcc-aarch64-none-elf.json
+++ b/bucket/gcc-aarch64-none-elf.json
@@ -1,0 +1,24 @@
+{
+    "version": "13.2.rel1",
+    "description": "Pre-built GNU Toolchain for the Arm Architecture",
+    "homepage": "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain",
+    "license": "GPL-3.0-only",
+    "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf.zip",
+    "hash": "7d35492cc0255e54b5b58259ccde1b1ab9efc494a70bc6f9ed3e601a2c607605",
+    "extract_dir": "arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf",
+    "env_add_path": "bin",
+    "env_set": {
+        "TL_PATH": "$dir\\bin"
+    },
+    "checkver": {
+        "url": "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads",
+        "regex": "arm-gnu-toolchain-([\\d.]+(rel\\d+)?)-mingw-w64-i686-aarch64-none-elf.zip"
+    },
+    "autoupdate": {
+        "url": "https://developer.arm.com/-/media/Files/downloads/gnu/$version/binrel/arm-gnu-toolchain-$version-mingw-w64-i686-aarch64-none-elf.zip",
+        "hash": {
+            "url": "$url.sha256asc"
+        },
+        "extract_dir": "arm-gnu-toolchain-$version-mingw-w64-i686-aarch64-none-elf"
+    }
+}

--- a/bucket/gcc-aarch64-none-linux-gnu.json
+++ b/bucket/gcc-aarch64-none-linux-gnu.json
@@ -1,0 +1,24 @@
+{
+    "version": "13.2.rel1",
+    "description": "Pre-built GNU Toolchain for the Arm Architecture",
+    "homepage": "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain",
+    "license": "GPL-3.0-only",
+    "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-linux-gnu.zip",
+    "hash": "ccca7e520adbc5deb36d53a2b373e28a0c7e21107c487d4f5fd9cc8e0dbf6a11",
+    "extract_dir": "arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-linux-gnu",
+    "env_add_path": "bin",
+    "env_set": {
+        "TL_PATH": "$dir\\bin"
+    },
+    "checkver": {
+        "url": "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads",
+        "regex": "arm-gnu-toolchain-([\\d.]+(rel\\d+)?)-mingw-w64-i686-aarch64-none-linux-gnu.zip"
+    },
+    "autoupdate": {
+        "url": "https://developer.arm.com/-/media/Files/downloads/gnu/$version/binrel/arm-gnu-toolchain-$version-mingw-w64-i686-aarch64-none-linux-gnu.zip",
+        "hash": {
+            "url": "$url.sha256asc"
+        },
+        "extract_dir": "arm-gnu-toolchain-$version-mingw-w64-i686-aarch64-none-linux-gnu"
+    }
+}

--- a/bucket/gcc-arm-none-linux-gnueabihf.json
+++ b/bucket/gcc-arm-none-linux-gnueabihf.json
@@ -1,0 +1,24 @@
+{
+    "version": "13.2.rel1",
+    "description": "Pre-built GNU Toolchain for the Arm Architecture",
+    "homepage": "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain",
+    "license": "GPL-3.0-only",
+    "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-linux-gnueabihf.zip",
+    "hash": "047e72bcef8f7767691f36929a8c74ef66f717cf6264a31f48dd31bfb067f4c8",
+    "extract_dir": "arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-linux-gnueabihf",
+    "env_add_path": "bin",
+    "env_set": {
+        "TL_PATH": "$dir\\bin"
+    },
+    "checkver": {
+        "url": "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads",
+        "regex": "arm-gnu-toolchain-([\\d.]+(rel\\d+)?)-mingw-w64-i686-arm-none-linux-gnueabihf.zip"
+    },
+    "autoupdate": {
+        "url": "https://developer.arm.com/-/media/Files/downloads/gnu/$version/binrel/arm-gnu-toolchain-$version-mingw-w64-i686-arm-none-linux-gnueabihf.zip",
+        "hash": {
+            "url": "$url.sha256asc"
+        },
+        "extract_dir": "arm-gnu-toolchain-$version-mingw-w64-i686-arm-none-linux-gnueabihf"
+    }
+}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
