### PR TITLE
streamlink: Update to version 6.5.1-1, fix autoupdate

### DIFF
--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.5.0-2",
+    "version": "6.5.1-1",
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",
     "license": "BSD-2-Clause",
@@ -10,14 +10,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/streamlink/windows-builds/releases/download/6.5.0-2/streamlink-6.5.0-2-py311-x86_64.zip",
-            "hash": "60184d9b30ade51273b9a10ee73ce23962d60902a63ec977a1a201cd4a6da904",
-            "extract_dir": "streamlink-6.5.0-2-py311-x86_64"
+            "url": "https://github.com/streamlink/windows-builds/releases/download/6.5.1-1/streamlink-6.5.1-1-py312-x86_64.zip",
+            "hash": "b1e494af8f843b2a5e7b607440d494348a2ede46725318e5ea72a0da56dbc176",
+            "extract_dir": "streamlink-6.5.1-1-py312-x86_64"
         },
         "32bit": {
-            "url": "https://github.com/streamlink/windows-builds/releases/download/6.5.0-2/streamlink-6.5.0-2-py311-x86.zip",
-            "hash": "86c186654e9368810dcc565ee570ee221f8db7ab451ed80d5ffc5da9c30e3b9d",
-            "extract_dir": "streamlink-6.5.0-2-py311-x86"
+            "url": "https://github.com/streamlink/windows-builds/releases/download/6.5.1-1/streamlink-6.5.1-1-py312-x86.zip",
+            "hash": "5fc67e1c66748e9cc7518efc711f495bfdd023a1dc7170c05389963036c3c716",
+            "extract_dir": "streamlink-6.5.1-1-py312-x86"
         }
     },
     "pre_install": [
@@ -46,12 +46,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py311-x86_64.zip",
-                "extract_dir": "streamlink-$version-py311-x86_64"
+                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py312-x86_64.zip",
+                "extract_dir": "streamlink-$version-py312-x86_64"
             },
             "32bit": {
-                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py311-x86.zip",
-                "extract_dir": "streamlink-$version-py311-x86"
+                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py312-x86.zip",
+                "extract_dir": "streamlink-$version-py312-x86"
             }
         }
     }


### PR DESCRIPTION
`streamlink>=6.5.1-1` is now based on py312

----

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

----

I'm the dev of the Streamlink project and its Windows builds.

All py311 builds were bumped to py312, which broke your autoupdate config here:

- https://github.com/streamlink/windows-builds/blob/6.5.1-1/CHANGELOG.md
- https://github.com/streamlink/windows-builds/releases/tag/6.5.1-1
