### PR TITLE
freecad@0.21.2: adapt manifest to new release artifact structure

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -1,30 +1,31 @@
 {
-    "version": "0.20.2-2",
+    "version": "0.21.2",
     "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.20.2/FreeCAD-0.20.2-WIN-x64-portable-2.zip",
-            "hash": "d8af7454f43f1753fd6141fd2172aa9bc7513b4b9cbbac4cd7cee0567a1bca7f"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.21.2/FreeCAD-0.21.2-Windows-x86_64.7z",
+            "hash": "06a8f162e3fa9bd8cc98c0cf117d1b3507b9a6564d3da0d16bc5e5c11d7e7880"
         }
     },
-    "bin": "FreeCAD-portable\\bin\\FreeCADCmd.exe",
+    "pre_install": "pushd $dir ; mv */* . ; rm FreeCAD_* ; popd",
+    "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
-            "FreeCAD-portable\\bin\\FreeCAD.exe",
+            "bin\\FreeCAD.exe",
             "FreeCAD"
         ]
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/5736080/releases",
-        "regex": "FreeCAD-([\\d.]+)-WIN-x64-portable((-\\d+)?)\\.zip",
+        "regex": "FreeCAD-([\\d.]+)-Windows-x86_64((-\\d+)?)\\.7z",
         "replace": "${1}${2}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD-$matchHead-WIN-x64-portable$matchTail.zip"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD-$matchHead-Windows-x86_64$matchTail.7z"
             }
         },
         "hash": {

--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -27,10 +27,6 @@
             "64bit": {
                 "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD-$matchHead-Windows-x86_64$matchTail.7z"
             }
-        },
-        "hash": {
-            "url": "$url-SHA256.txt",
-            "regex": "SHA256: $sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

update version form 0.20.2-2 to 0.21.2
adapt manifest to install according to new release artifact structure
- archive name changed
- archive contains subdirectory with additional release infos which is truncated by pre_install script

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
