### PR TITLE
appflowy@0.4.2: uprgade  to 0.4.3

### DIFF
--- a/bucket/appflowy.json
+++ b/bucket/appflowy.json
@@ -1,15 +1,15 @@
 {
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "An open-source alternative to Notion. You are in charge of your data and customizations.",
     "homepage": "https://www.appflowy.io/",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.4.2/AppFlowy-0.4.2-windows-x86_64.zip",
-            "hash": "151315b4d85a8ee6619516ac48b329a206e90b0524e17167dc31604f4edc7c45"
+            "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.4.3/AppFlowy-0.4.3-windows-x86_64.exe",
+            "hash": "f443455e79a1173b96c32bf90175b100f65769c6006bf86243b4c0551c409e72"
         }
     },
-    "extract_dir": "AppFlowy",
+    "innosetup": true,
     "shortcuts": [
         [
             "AppFlowy.exe",
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/$version/AppFlowy-$version-windows-x86_64.zip"
+                "url": "https://github.com/AppFlowy-IO/AppFlowy/releases/download/$version/AppFlowy-$version-windows-x86_64.exe"
             }
         }
     }


### PR DESCRIPTION
Appflowy has been updated to v4.3, and not packaged as a zip any more. [change](https://github.com/AppFlowy-IO/AppFlowy/pull/4404#issue-2083001140)

change manifest to use innosetup

Closes #12647

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
