### PR TITLE
opera-gx: update to v106.0.4998.49

### DIFF
--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -30,7 +30,7 @@
     "shortcuts": [
         [
             "launcher.exe",
-            "OperaGX"
+            "Opera GX"
         ]
     ],
     "persist": "profile",

--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -1,5 +1,5 @@
 {
-    "version": "99.0.4788.86",
+    "version": "106.0.4998.49",
     "description": "Gaming counterpart of Opera web browser",
     "homepage": "https://www.opera.com/gx",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download3.operacdn.com/pub/opera_gx/99.0.4788.86/win/Opera_GX_99.0.4788.86_Setup_x64.exe#/dl.7z",
-            "hash": "a41a838357ce3e8d1c3b606847927da45fb1405dfed232a81e31806a5460f459"
+            "url": "https://download3.operacdn.com/pub/opera_gx/106.0.4998.49/win/Opera_GX_106.0.4998.49_Setup_x64.exe#/dl.7z",
+            "hash": "654bd3800ad0d083b3f4b8113a3a1934b7c2f11e95991e08879c31dc4bfb6a6e"
         },
         "32bit": {
-            "url": "https://download3.operacdn.com/pub/opera_gx/99.0.4788.86/win/Opera_GX_99.0.4788.86_Setup.exe#/dl.7z",
-            "hash": "c4f1fb8db14081457594c10731a5a9173e7181e735d4c2af02ff7a34e86e20e5"
+            "url": "https://download3.operacdn.com/pub/opera_gx/106.0.4998.49/win/Opera_GX_106.0.4998.49_Setup.exe#/dl.7z",
+            "hash": "cd8d61c393e503de99738e660c289f89566045cfed16cd7c4f46d65125652624"
         }
     },
     "installer": {

--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -1,6 +1,6 @@
 {
     "version": "106.0.4998.49",
-    "description": "Gaming counterpart of Opera web browser",
+    "description": "Opera GX is a special version of the Opera browser built specifically for gamers.",
     "homepage": "https://www.opera.com/gx",
     "license": {
         "identifier": "Freeware",
@@ -8,44 +8,50 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download3.operacdn.com/pub/opera_gx/106.0.4998.49/win/Opera_GX_106.0.4998.49_Setup_x64.exe#/dl.7z",
+            "url": "https://get.opera.com/pub/opera_gx/106.0.4998.49/win/Opera_GX_106.0.4998.49_Setup_x64.exe#/dl.7z",
             "hash": "654bd3800ad0d083b3f4b8113a3a1934b7c2f11e95991e08879c31dc4bfb6a6e"
         },
         "32bit": {
-            "url": "https://download3.operacdn.com/pub/opera_gx/106.0.4998.49/win/Opera_GX_106.0.4998.49_Setup.exe#/dl.7z",
+            "url": "https://get.opera.com/pub/opera_gx/106.0.4998.49/win/Opera_GX_106.0.4998.49_Setup.exe#/dl.7z",
             "hash": "cd8d61c393e503de99738e660c289f89566045cfed16cd7c4f46d65125652624"
         }
     },
     "installer": {
         "script": [
-            "Remove-Item \"$dir\\*_list\" -Force",
-            "Move-Item \"$dir\\*\" \"$dir\\$version\" -Exclude 'Assets', 'launcher*', 'Resources.pri' -ErrorAction Ignore",
-            "if (-not (Test-Path \"$dir\\$version\\localization\")) {",
+            "Remove-Item -Path \"$dir\\*_list\" -Force",
+            "Move-Item -Path \"$dir\\*\" -Destination \"$dir\\$version\" -Exclude 'Assets', 'launcher*', 'Resources.pri' -ErrorAction Ignore",
+            "if (!(Test-Path \"$dir\\$version\\localization\")) {",
             "   New-Item -Path \"$dir\\$version\\localization\" -ItemType Directory | Out-Null",
             "   Move-Item -Path \"$dir\\$version\\*.pak\" -Destination \"$dir\\$version\\localization\" -Exclude 'opera*' -ErrorAction Ignore",
             "}",
-            "@{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 20 | Out-File \"$dir\\installer_prefs.json\" -Encoding ASCII"
+            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value (@{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json) -Encoding ASCII"
         ]
     },
     "shortcuts": [
         [
             "launcher.exe",
-            "Opera GX"
+            "OperaGX"
         ]
     ],
     "persist": "profile",
     "checkver": {
-        "url": "https://get.opera.com/ftp/pub/opera_gx/",
-        "regex": ">(\\d{3}\\.\\d+\\.\\d+\\.\\d+)/",
-        "reverse": true
+        "script": [
+            "$releases = 'https://get.opera.com/pub/opera_gx/'",
+            "$download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing",
+            "$versionSort   = { [version]$_.href.TrimEnd('/') }",
+            "$last_ver = $download_page.links | Where-Object href -match '^[\\d]+[\\d\\.]+/$' | Sort-Object $versionSort -Descending | Select-Object -first 1 -expand href",
+            "$version = $last_ver -replace '/', ''",
+            "Write-Output $version"
+        ],
+        "regex": "(\\S+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download3.operacdn.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup_x64.exe#/dl.7z"
+                "url": "https://get.opera.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup_x64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://download3.operacdn.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup.exe#/dl.7z"
+                "url": "https://get.opera.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup.exe#/dl.7z"
             }
         },
         "hash": {

--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -36,7 +36,7 @@
     "persist": "profile",
     "checkver": {
         "url": "https://get.opera.com/ftp/pub/opera_gx/",
-        "regex": "([\\d.]+)/",
+        "regex": ">(\\d{3}\\.\\d+\\.\\d+\\.\\d+)/",
         "reverse": true
     },
     "autoupdate": {


### PR DESCRIPTION
* updated checkver regex to only match versions starting with 3-digits.
* update manifest to latest version

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12628

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
