### PR TITLE
mcomix: Update to version 3.1.0

### DIFF
--- a/bucket/mcomix.json
+++ b/bucket/mcomix.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "User-friendly and customizable image viewer",
     "homepage": "https://sourceforge.net/projects/mcomix/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/mcomix/files/MComix-3.0.0/mcomix-win64-3.0.0.zip/download",
-            "hash": "sha1:FE8A930AA08F7CDCDAF3D4A114DD9A28A401E704"
+            "url": "https://downloads.sourceforge.net/project/mcomix/MComix-3.1.0/mcomix-win64-3.1.0.zip",
+            "hash": "sha1:3CE20463F0E37AAAB2EEAF6B442AA788472D27BC"
         }
     },
     "bin": "MComix.exe",


### PR DESCRIPTION
This pull request updates MComix to version 3.1.0: https://sourceforge.net/p/mcomix/news/2024/01/changelog---mcomix-310/

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
