### PR TITLE
nvcleanstall: new url scheme

### DIFF
--- a/bucket/nvcleanstall.json
+++ b/bucket/nvcleanstall.json
@@ -3,7 +3,7 @@
     "description": "Extends customization of NVIDIA GeForce Driver packages; can also decouple automatic updates from NVIDIA's servers.",
     "homepage": "https://www.techpowerup.com/nvcleanstall/",
     "license": "Freeware",
-    "url": "https://nl2-dl.techpowerup.com/files/NVCleanstall_1.16.0.exe#/NVCleanstall.exe",
+    "url": "https://nl1-dl.techpowerup.com/files/6sNxOc258nbDF0KZqi5bBQ/1706144967/NVCleanstall_1.16.0.exe#/NVCleanstall.exe",
     "hash": "md5:41421866b825dbdcc5f29a0bbd484362",
     "bin": "NVCleanstall.exe",
     "shortcuts": [


### PR DESCRIPTION
Upstreams uses a new URL scheme and server.

Changed subdomain: `nl2-dl.` -> `nl1-dl.`
New scheme: File in subdir `6sNxOc258nbDF0KZqi5bBQ/1706144967`.

It's not immediately obvious how the subdir name is generated. 

**This will break autoupdate most likely**, previous versions are in different (random?) subdirs.

Relates to #12651 #12650 #12517 #12549 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
