### PR TITLE
wslinternals: Add wsl-perf.exe and update version

### DIFF
--- a/bucket/wslinternals.json
+++ b/bucket/wslinternals.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "A collection of some nifty WSL-related utilities.",
     "homepage": "https://github.com/sirredbeard/wslinternals",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sirredbeard/wslinternals/releases/download/0.0.13/0.0.13.zip",
-            "hash": "e2e25f50b8ec06f2517b4988e9e43b4acd3cb55a751700b6ef353e7410c82f9b"
+            "url": "https://github.com/sirredbeard/wslinternals/releases/download/0.0.14/0.0.14.zip",
+            "hash": "6E667966954FBF670A340F213970D2CBDFFC58061B85A66833F9540DABCE8069"
         }
     },
     "bin": [
@@ -15,7 +15,8 @@
         "wslctl.exe",
         "wsl-dist-update.exe",
         "wsl-latest-kernel.exe",
-        "wsl-reset.exe"
+        "wsl-reset.exe",
+        "wsl-perf.exe"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
Add wsl-perf.exe to wslinternals and updates to version 0.0.14

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
