### PR TITLE
syncthingctl: Add version 1.4.12

### DIFF
--- a/bucket/syncthingctl.json
+++ b/bucket/syncthingctl.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.4.12",
+    "description": "Command line app to control Syncthing",
+    "homepage": "https://github.com/Martchus/syncthingtray",
+    "license": {
+        "identifier": "GPL-2.0-only,...",
+        "url": "https://github.com/Martchus/syncthingtray/blob/master/LICENSES-windows-distribution.md"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Martchus/syncthingtray/releases/download/v1.4.12/syncthingctl-1.4.12-x86_64-w64-mingw32.exe.zip",
+            "hash": "8d2e3c4a70ee7662c5ec0087c1b2232aae617faefe5ec614dc54c12a65322dfe"
+        },
+        "32bit": {
+            "url": "https://github.com/Martchus/syncthingtray/releases/download/v1.4.12/syncthingctl-1.4.12-i686-w64-mingw32.exe.zip",
+            "hash": "530301075fcfdef3dd01ff5be4418aa73d4ed87a87617eed8b1bf2a6db0a29ff"
+        }
+    },
+    "pre_install": "Move-Item \"$dir\\syncthingctl-*.exe\" \"$dir\\syncthingctl.exe\"",
+    "bin": "syncthingctl.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingctl-$version-x86_64-w64-mingw32.exe.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingctl-$version-i686-w64-mingw32.exe.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add [syncthingctl](https://github.com/Martchus/syncthingtray#using-the-command-line-interface) - command line utility to control Syncthing.

Closes #11662.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
