### PR TITLE
cpu-z-arm64: add v1.01

### DIFF
--- a/bucket/cpu-z-arm64.json
+++ b/bucket/cpu-z-arm64.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.01",
+    "description": "ARM64 native version of CPU-Z.",
+    "homepage": "https://www.cpuid.com/softwares/cpu-z-arm64.html",
+    "license": "Freeware",
+    "url": "https://download.cpuid.com/cpu-z/arm64/cpuz-arm64_1.01.zip",
+    "hash": "3fe10247711bc4714948ed4b4bee7b2dd2c7d72721073c42772a0f58c6182608",
+    "architecture": {
+        "arm64": {
+            "bin": [
+                [
+                    "cpuz_arm64.exe",
+                    "cpuz"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "cpuz_arm64.exe",
+                    "CPU-Z"
+                ]
+            ]
+        }
+    },
+    "pre_install": [
+        "if ((!(Test-Path \"$persist_dir\\cpuz.ini\")) -and (!(Test-Path \"$dir\\cpuz.ini\"))) {",
+        "    New-Item \"$dir\\cpuz.ini\" -ItemType File | Out-Null",
+        "}"
+    ],
+    "persist": "cpuz.ini",
+    "checkver": "Version ([\\d.]+) for windows&reg; ARM64",
+    "autoupdate": {
+        "url": "https://download.cpuid.com/cpu-z/arm64/cpuz-arm64_$version.zip"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
### Help needed 

The package of arm64 version does not include config file, therefore a `pre_install` script was added to ensure the file before persist.
However, I have no WoA device to test the manifest, I'll appreciate if someone can come with help ^^
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12698

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
