### PR TITLE
gitkraken: Update to version 9.11.0, drop 32bit support

### DIFF
--- a/bucket/gitkraken.json
+++ b/bucket/gitkraken.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.10.0",
+    "version": "9.11.0",
     "description": "A Git client which helps you track and manage changes to your code.",
     "homepage": "https://www.gitkraken.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://release.gitkraken.com/win64/gitkraken-9.10.0-full.nupkg",
-            "hash": "sha1:865e3a77e47a9631510480146303a156affe65fe"
+            "url": "https://release.gitkraken.com/win64/gitkraken-9.11.0-full.nupkg",
+            "hash": "sha1:e4fb5b5fcb5bcb3c779f119d5f0ff283e39ecec5"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/gitkraken.json
+++ b/bucket/gitkraken.json
@@ -10,10 +10,6 @@
         "64bit": {
             "url": "https://release.gitkraken.com/win64/gitkraken-9.10.0-full.nupkg",
             "hash": "sha1:865e3a77e47a9631510480146303a156affe65fe"
-        },
-        "32bit": {
-            "url": "https://release.gitkraken.com/win32/gitkraken-9.10.0-full.nupkg",
-            "hash": "sha1:bc6f2ddf6bab3429f862f259b11c9beaf4ac94e5"
         }
     },
     "extract_dir": "lib\\net45",
@@ -33,9 +29,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://release.gitkraken.com/win64/gitkraken-$version-full.nupkg"
-            },
-            "32bit": {
-                "url": "https://release.gitkraken.com/win32/gitkraken-$version-full.nupkg"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

On [GitKraken's download page](https://www.gitkraken.com/download), 32 bit binaries are no longer available.

They were however, available previously.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12708

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
