### PR TITLE
komac: Update to version 2.0.1

### DIFF
--- a/bucket/komac.json
+++ b/bucket/komac.json
@@ -1,16 +1,38 @@
 {
-    "version": "1.11.0",
-    "description": "The Kotlin manifest creator for WinGet",
+    "version": "2.0.1",
+    "description": "The Community Manifest Creator for WinGet",
     "homepage": "https://github.com/russellbanks/Komac",
     "license": "GPL-3.0-only",
     "suggest": {
-        "JDK": "java/openjdk"
+        "vcredist": "extras/vcredist2022"
     },
-    "url": "https://github.com/russellbanks/Komac/releases/download/v1.11.0/Komac-1.11.0-all.jar#/Komac.jar",
-    "hash": "1c26bb7bee6228ad095fe67d10ed254363099b3395f809bd6d95a3f72b2740fc",
-    "bin": "Komac.jar",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/russellbanks/Komac/releases/download/v2.0.1/KomacPortable-v2.0.1-x64.exe#/Komac.exe",
+            "hash": "3e3dfdba109e361952d891d5d0fcebcc7ee0a2eeb27e4a7b6c56fd9c1341d8a9"
+        },
+        "32bit": {
+            "url": "https://github.com/russellbanks/Komac/releases/download/v2.0.1/KomacPortable-v2.0.1-x86.exe#/Komac.exe",
+            "hash": "2b097e893cb529e13f17e3aa0f23e863579848a6d47b49fcd14a20f6f283b76e"
+        },
+        "arm64": {
+            "url": "https://github.com/russellbanks/Komac/releases/download/v2.0.1/KomacPortable-v2.0.1-arm64.exe#/Komac.exe",
+            "hash": "40faa948aa827254a8353151a30d1567e82aa2c992523f6a5e5f2f8ba815dc2a"
+        }
+    },
+    "bin": "Komac.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/russellbanks/Komac/releases/download/v$version/Komac-$version-all.jar#/Komac.jar"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/russellbanks/Komac/releases/download/v$version/KomacPortable-v$version-x64.exe#/Komac.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/russellbanks/Komac/releases/download/v$version/KomacPortable-v$version-x86.exe#/Komac.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/russellbanks/Komac/releases/download/v$version/KomacPortable-v$version-arm64.exe#/Komac.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

> Komac has been fully rewritten in [Rust](https://www.rust-lang.org/)! Because of this, Komac v2 is incompatible with Komac v1. If you have Komac v1 installed, please uninstall it before installing Komac v2.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
