### PR TITLE
delapp: extra comma in manifest

### DIFF
--- a/bucket/delapp.json
+++ b/bucket/delapp.json
@@ -1,8 +1,8 @@
 {
     "version": "1.0.2",
     "description": "A simple tool to delete files or folders in Windows",
-    "homepage":  "https://github.com/differentrain/Delapp",
-    "license":  "MIT",
+    "homepage": "https://github.com/differentrain/Delapp",
+    "license": "MIT",
     "suggest": {
         ".NET Desktop Runtime": "extras/windowsdesktop-runtime"
     },

--- a/bucket/delapp.json
+++ b/bucket/delapp.json
@@ -4,7 +4,7 @@
     "homepage":  "https://github.com/differentrain/Delapp",
     "license":  "MIT",
     "suggest": {
-        ".NET Desktop Runtime": "extras/windowsdesktop-runtime",
+        ".NET Desktop Runtime": "extras/windowsdesktop-runtime"
     },
     "url": "https://github.com/differentrain/Delapp/releases/download/1.0.2/Delapp.zip",
     "hash": "e1613df86a3a4928b36100de1412af694cf84476e655b12c8f50ef9560c17227",


### PR DESCRIPTION
I use some external json tools on buckets - they are not as forgiving as scoop's json parser.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
