### PR TITLE
bt@3.7.2: Update persist

### DIFF
--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -31,7 +31,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/aloneguid/bt/releases/download/$version/bt-$version.zip"
+                "url": "https://github.com/aloneguid/bt/releases/download/$version/bt-$version.zip",
+                "hash": {
+                    "url": "$url.sha256.txt"
+                }
             }
         }
     }

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -21,7 +21,10 @@
             "Browser Tamer"
         ]
     ],
-    "persist": "bt.ini",
+    "persist": [
+        "config.ini",
+        "hit_log.csv"
+    ],,
     "checkver": {
         "github": "https://github.com/aloneguid/bt"
     },

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -24,7 +24,7 @@
     "persist": [
         "config.ini",
         "hit_log.csv"
-    ],,
+    ],
     "checkver": {
         "github": "https://github.com/aloneguid/bt"
     },

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -12,7 +12,8 @@
     "pre_install": [
         "# Portable",
         "New-Item \"$dir\\.portable\" -ItemType File | Out-Null",
-        "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item \"$dir\\config.ini\" -ItemType File | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item \"$dir\\config.ini\" -ItemType File | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\hit_log.csv\")) { New-Item \"$dir\\hit_log.csv\" -ItemType File | Out-Null }"
     ],
     "bin": "bt.exe",
     "shortcuts": [

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.7.1",
+    "version": "3.7.2",
     "description": "Opens required browser based on configuration",
     "homepage": "https://www.aloneguid.uk/projects/bt/",
     "license": "Freeware",

--- a/bucket/bt.json
+++ b/bucket/bt.json
@@ -5,8 +5,8 @@
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aloneguid/bt/releases/download/3.7.1/bt-3.7.1.zip",
-            "hash": "8b0cf7840ffe10d6e3c3ba353e7234d04f92f200f6f91b5d338f714c032b7546"
+            "url": "https://github.com/aloneguid/bt/releases/download/3.7.2/bt-3.7.2.zip",
+            "hash": "3196a584c89dfcd2194dc489ae43f1fe3b0249c5f457eb59e52fb97fd2e0b6f4"
         }
     },
     "pre_install": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
New version of bt changed the configuration file name, current `persists` setting no longer works as expected.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- or -->
Relates to #11925

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

![image](https://github.com/ScoopInstaller/Extras/assets/38985073/319b3615-5b8b-4ba0-b7e5-e1fca2eaa416)
