### PR TITLE
Gisto: Add version 1.13.4

### DIFF
--- a/bucket/gisto.json
+++ b/bucket/gisto.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.13.4",
+    "description": "Gisto is a code snippet manager that runs on GitHub Gists and adds additional features such as searching, tagging and sharing gists while including a rich code editor. All your data is stored on GitHub and you can access it from GitHub Gists at any time with changes carrying over to Gisto.",
+    "homepage": "http://www.gistoapp.com/",
+    "license": "MIT",
+    "url": "https://github.com/Gisto/Gisto/releases/download/v1.13.4/Gisto-1.13.4-Portable.exe#/gisto.exe",
+    "hash": "2ad00f8a7672e3e97b64f9eda628383967b116e5c8716de4c0a840cf7fdb9b3d",
+    "shortcuts": [
+        [
+            "gisto.exe",
+            "Gisto"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Gisto/Gisto"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Gisto/Gisto/releases/download/v$version/Gisto-$version-Portable.exe#/gisto.exe"
+    }
+}


### PR DESCRIPTION
Add [Gisto](https://github.com/Gisto/Gisto) - cross-platform gist snippets management desktop application.

Closes #10293.
Supersedes #10294, closed since the author [accidentally removed branch](https://github.com/ScoopInstaller/Extras/pull/10294#issuecomment-1458752555).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
