### PR TITLE
vscode@1.86.0: fix hash when installing old versions

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -70,15 +70,15 @@
             "64bit": {
                 "url": "https://update.code.visualstudio.com/$version/win32-x64-archive/stable#/dl.7z",
                 "hash": {
-                    "url": "https://code.visualstudio.com/sha?build=stable",
-                    "jsonpath": "$.products[?(@.platform.os == 'win32-x64-archive')].sha256hash"
+                    "url": "https://update.code.visualstudio.com/api/versions/$version/win32-x64-archive/stable",
+                    "jsonpath": "$.sha256hash"
                 }
             },
             "arm64": {
                 "url": "https://update.code.visualstudio.com/$version/win32-arm64-archive/stable#/dl.7z",
                 "hash": {
-                    "url": "https://code.visualstudio.com/sha?build=stable",
-                    "jsonpath": "$.products[?(@.platform.os == 'win32-arm64-archive')].sha256hash"
+                    "url": "https://update.code.visualstudio.com/api/versions/$version/win32-arm64-archive/stable",
+                    "jsonpath": "$.sha256hash"
                 }
             }
         }


### PR DESCRIPTION
Refer to  #12742  

It is now (on x64)
```
$ scoop install scoop_bucket_extras/vscode@1.85.2
WARN  Given version (1.85.2) does not match manifest (1.86.0)
WARN  Attempting to generate manifest for 'vscode' (1.85.2)
Autoupdating vscode
Searching hash for dl.7z in https://update.code.visualstudio.com/api/versions/1.85.2/win32-x64-archive/stable
Found: a832fcc9b243d2fa0d21df6b19d6788da593c35ae8650c22dd0d8d8d8615b527 using Json Mode
Searching hash for dl.7z in https://update.code.visualstudio.com/api/versions/1.85.2/win32-arm64-archive/stable
Found: 4d3f3e2f08be33f61fdb95a123e02e69ca96567a7a7faec530451aae5c5119bc using Json Mode
Writing updated vscode manifest
WARN  Purging previous failed installation of vscode.
ERROR 'vscode' isn't installed correctly.
Removing older version (1.85.2).
'vscode' was uninstalled.
Installing 'vscode' (1.85.2) [64bit]
dl.7z (125.4 MB) [============================================================================================] 100%
Checking hash of dl.7z ... ok.
Extracting dl.7z ... done.
Linking D:\env\scoop\apps\vscode\current => D:\env\scoop\apps\vscode\1.85.2
Creating shortcut for Visual Studio Code (code.exe)
Persisting data
Running post_install script...
INFO  [Portable Mode] Copying extensions...
INFO  [Portable Mode] Copying user data...
INFO  Adjusting path in extensions file...
'vscode' (1.85.2) was installed successfully!
Notes
-----
Add Visual Studio Code as a context menu option by running:
'reg import "D:\env\scoop\apps\vscode\current\install-context.reg"'
For file associations, run:
'reg import "D:\env\scoop\apps\vscode\current\install-associations.reg"'
```