### PR TITLE
dxwnd: Update to version 2.06.02f and fix autoupdate

### DIFF
--- a/bucket/dxwnd.json
+++ b/bucket/dxwnd.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.06.01",
+    "version": "2.06.02f",
     "description": "Window hooker to run fullscreen programs in window and much more.",
     "homepage": "https://sourceforge.net/projects/dxwnd/",
     "license": "GPL-3.0-or-later",
-    "url": "https://downloads.sourceforge.net/project/dxwnd/Latest%20build/V2_06_01_build.rar",
-    "hash": "sha1:38e9300f516726f10ddfcfc1592d3f64b7162e87",
+    "url": "https://downloads.sourceforge.net/project/dxwnd/Latest%20build/v2_06_02f_build.rar",
+    "hash": "sha1:f0b562ed67bd38e7c5c8fa852565919a48081d76",
     "pre_install": "if (!(Test-Path \"$persist_dir\\dxwnd.ini\")) { New-Item \"$dir\\dxwnd.ini\" | Out-Null }",
     "shortcuts": [
         [
@@ -22,7 +22,7 @@
         "script": [
             "$url = 'https://sourceforge.net/projects/dxwnd/files/Latest%20build/'",
             "$cont = $(Invoke-WebRequest($url)).Content",
-            "if(!($cont -match 'V(\\d+)_(\\d+)_(\\d+)(_(fx\\d+))?_build\\.rar')) { continue }",
+            "if(!($cont -match 'v(\\d+)_(\\d+)_([\\d\\w]+)(_(fx\\d+))?_build\\.rar')) { continue }",
             "if ($matches[4] -eq $null) { $script_ver = \"{0}.{1}.{2}\" -f $matches[1], $matches[2], $matches[3] }",
             "else { $script_ver = \"{0}.{1}.{2}-{3}\" -f $matches[1], $matches[2], $matches[3], $matches[5] }",
             "Write-Output $script_ver"
@@ -30,6 +30,6 @@
         "regex": "(.*)"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/dxwnd/Latest%20build/V$underscoreVersion_build.rar"
+        "url": "https://downloads.sourceforge.net/project/dxwnd/Latest%20build/v$underscoreVersion_build.rar"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The version of dxwnd V2_06_00_build starts with V, but the past and latest versions are v, which invalidates the url obtained by autoupdate. 

![image](https://github.com/ScoopInstaller/Extras/assets/61418658/ea2c65d0-ca94-44a6-a9a5-c66084c66f74)

This PR fixes this v issue, updates the checkver rules for the latest version v2_06_02f_build, and updates to the latest version v2_06_02f_build. 

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
