### PR TITLE
thorium: Update to version 121.0.6167.204, fix autoupdate & checkver

### DIFF
--- a/bucket/thorium.json
+++ b/bucket/thorium.json
@@ -6,8 +6,12 @@
         "identifier": "BSD 3-Clause",
         "url": "https://github.com/Alex313031/Thorium-Win/blob/main/LICENSE"
     },
-    "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M119.0.6045.214/Thorium_119.0.6045.214.zip",
-    "hash": "0af9e4391dd67948732ffc1d8b8e194003163b757d7c84ae7191d814548dddac",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M120.0.6099.235/Thorium_SSE3_120.0.6099.235.zip",
+            "hash": "3765aa7af355a8526409db8ed2cf8b3cb8dc68ebf4d8b4ec79fa3280f2e24750"
+        }
+    },
     "bin": [
         [
             "bin\\thorium.exe",
@@ -34,9 +38,14 @@
     "persist": "USER_DATA",
     "checkver": {
         "github": "https://github.com/Alex313031/Thorium-Win",
-        "regex": "/releases/tag/M(?:v|V)?([\\d.]+)"
+        "regex": "/releases/tag/M(?<version>(?:\\d+\\.){3}\\d+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M$version/Thorium_$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M$version/Thorium_SSE3_$version.zip"
+            }
+        }
+
     }
 }

--- a/bucket/thorium.json
+++ b/bucket/thorium.json
@@ -1,5 +1,5 @@
 {
-    "version": "119.0.6045.214",
+    "version": "120.0.6099.235",
     "description": "Chromium fork for Linux, Windows, MacOS, Android, and Raspberry Pi named after radioactive element No. 90.",
     "homepage": "https://thorium.rocks/",
     "license": {
@@ -46,6 +46,5 @@
                 "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M$version/Thorium_SSE3_$version.zip"
             }
         }
-
     }
 }

--- a/bucket/thorium.json
+++ b/bucket/thorium.json
@@ -1,5 +1,5 @@
 {
-    "version": "120.0.6099.235",
+    "version": "121.0.6167.204",
     "description": "Chromium fork for Linux, Windows, MacOS, Android, and Raspberry Pi named after radioactive element No. 90.",
     "homepage": "https://thorium.rocks/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M120.0.6099.235/Thorium_SSE3_120.0.6099.235.zip",
-            "hash": "3765aa7af355a8526409db8ed2cf8b3cb8dc68ebf4d8b4ec79fa3280f2e24750"
+            "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M121.0.6167.204/Thorium_SSE3_121.0.6167.204.zip",
+            "hash": "f1f56f9c83401fc6937124bbec0a3665c06fb77c617ca7aa33e8fea95c75356e"
         }
     },
     "bin": [


### PR DESCRIPTION
Updates the manifest to support the new versioning in the thorium repo. Now looks for SSE3 version in the release to maintain support for older cpus as before, also adds architecture properties.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
