### PR TITLE
ytmdesktop: Update to version 2.0.0, switch to nupkg

### DIFF
--- a/bucket/ytmdesktop.json
+++ b/bucket/ytmdesktop.json
@@ -1,21 +1,18 @@
 {
-    "version": "1.13.0",
+    "version": "2.0.0",
     "description": "An unofficial desktop app for YouTube Music",
     "homepage": "https://ytmdesktop.app",
-    "license": "CC0-1.0",
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v1.13.0/YouTube-Music-Desktop-App-Setup-1.13.0.exe#/dl.7z",
-            "hash": "sha512:6bcff62101fcf59babf584e6da82987d44bbc5bfb7408d83e48a7b83f7a4daa7a6a7fdd31add02eeacf734696242c39a7e0810f25ad75f9cf56cd90e026e034e",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse"
-            ]
+            "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v2.0.0/youtube_music_desktop_app-2.0.0-full.nupkg",
+            "hash": "sha1:9159b708a363c1990d75eeca0af153abf1c8c424"
         }
     },
+    "extract_dir": "lib\\net45",
     "shortcuts": [
         [
-            "YouTube Music Desktop App.exe",
+            "youtube-music-desktop-app.exe",
             "YouTube Music Desktop"
         ]
     ],
@@ -25,12 +22,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v$version/YouTube-Music-Desktop-App-Setup-$version.exe#/dl.7z"
+                "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v$version/youtube_music_desktop_app-$version-full.nupkg"
             }
         },
         "hash": {
-            "url": "$baseurl/latest.yml",
-            "regex": "sha512: $base64"
+            "url": "$baseurl/RELEASES"
         }
     }
 }


### PR DESCRIPTION
Since ytmdesktop got a [major update from 1.x to 2.x](https://github.com/ytmdesktop/ytmdesktop/issues/1139) with many changes would like to submit PR for review instead of simply update the version:

- switch to nupkg;
- update to version 2.0.0;
- update license.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
