### PR TITLE
Initial manifest for restic-browser

### DIFF
--- a/bucket/restic-browser.json
+++ b/bucket/restic-browser.json
@@ -1,0 +1,30 @@
+{
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/emuell/restic-browser/releases/download/v0.3.0/Restic-Browser-v0.3.0-windows.zip",
+            "hash": "3cf25b9bb513252f1e1c70fd6b2863c6fde4ef5fc1aa8eeb210e4872b81f32dc"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/emuell/restic-browser/releases/download/v$version/Restic-Browser-v$version-windows.zip"
+            }
+        }
+    },
+    "bin": "Restic-Browser.exe",
+    "checkver": {
+        "github": "https://github.com/emuell/restic-browser"
+    },
+    "depends": "restic",
+    "description": "A GUI to browse and restore restic backup repositories",
+    "homepage": "https://github.com/emuell/restic-browser",
+    "license": "MIT",
+    "shortcuts": [
+        [
+            "restic-browser.exe",
+            "Restic-Browser"
+        ]
+    ],
+    "version": "0.3.0"
+}


### PR DESCRIPTION
This adds a manifest for restic-browser, a tool for browsing restic repositories and restoring files from them.

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
