### PR TITLE
LunarVim@1.3.0: Update install.ps1 hash

### DIFF
--- a/bucket/lunarvim.json
+++ b/bucket/lunarvim.json
@@ -9,7 +9,7 @@
         "https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/bin/lvim.ps1"
     ],
     "hash": [
-        "d4c8fc99b9e92ee5c92d267341040075618d7c096161bafa4f385d7b64c474f2",
+        "fc6f0ebc6104cd085c58e35ce737a367afcda2e10080a506212762eae5294d52",
         "90799fcdc9dd2ca8959281fabeed2683562a9df59943fbec63405266ebde8f0e",
         "1a04e5c7981598105d26f6340d9c6f80c2486515842a797e3918151861e713a1"
     ],

--- a/bucket/lunarvim.json
+++ b/bucket/lunarvim.json
@@ -3,19 +3,28 @@
     "description": "Lunarvim is a community-driven framework for neovim, written in lua. It is a full-featured IDE, with a focus on simplicity and ease of use.",
     "homepage": "https://www.lunarvim.org/",
     "license": "GPL-3.0-only",
+    "suggest": {
+        "Neovim": "main/neovim"
+    },
     "url": [
-        "https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/installer/install.ps1",
-        "https://raw.githubusercontent.com/lunarvim/lunarvim/master/utils/installer/uninstall.ps1",
-        "https://raw.githubusercontent.com/LunarVim/LunarVim/master/utils/bin/lvim.ps1"
+        "https://raw.githubusercontent.com/LunarVim/LunarVim/1.3.0/utils/installer/install.ps1",
+        "https://raw.githubusercontent.com/LunarVim/LunarVim/1.3.0/utils/installer/uninstall.ps1",
+        "https://raw.githubusercontent.com/LunarVim/LunarVim/1.3.0/utils/bin/lvim.ps1"
     ],
     "hash": [
-        "fc6f0ebc6104cd085c58e35ce737a367afcda2e10080a506212762eae5294d52",
+        "d4c8fc99b9e92ee5c92d267341040075618d7c096161bafa4f385d7b64c474f2",
         "90799fcdc9dd2ca8959281fabeed2683562a9df59943fbec63405266ebde8f0e",
         "1a04e5c7981598105d26f6340d9c6f80c2486515842a797e3918151861e713a1"
     ],
     "bin": [
-        ["install.ps1", "lvim_install"],
-        ["bin\\lvim.ps1", "lvim"]
+        [
+            "install.ps1",
+            "lvim_install"
+        ],
+        [
+            "bin\\lvim.ps1",
+            "lvim"
+        ]
     ],
     "env_set": {
         "LUNARVIM_RUNTIME_DIR": "$dir\\lunarvim",
@@ -32,6 +41,16 @@
     },
     "notes": "To finish installing it, run `lvim_install`. To run it, `lvim`.",
     "uninstaller": {
-        "script": ["Invoke-Expression -Command \"& '$dir\\uninstall.ps1'\""]
+        "script": "Invoke-Expression -Command \"& '$dir\\uninstall.ps1'\""
+    },
+    "checkver": {
+        "github": "https://github.com/LunarVim/LunarVim"
+    },
+    "autoupdate": {
+        "url": [
+            "https://raw.githubusercontent.com/LunarVim/LunarVim/$version/utils/installer/install.ps1",
+            "https://raw.githubusercontent.com/LunarVim/LunarVim/$version/utils/installer/uninstall.ps1",
+            "https://raw.githubusercontent.com/LunarVim/LunarVim/$version/utils/bin/lvim.ps1"
+        ]
     }
 }


### PR DESCRIPTION
LunarVim install.ps1 hash is not correct so I downloaded the `install.ps1` script and hash it manually to get a correct hash  

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
