### PR TITLE
rtss@7.3.5: Fix url, hash

### DIFF
--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -4,14 +4,14 @@
     "homepage": "https://www.guru3d.com/files-details/rtss-rivatuner-statistics-server-download.html",
     "license": "Freeware",
     "suggest": {
-        "vcredist": "extras/vcredist2008",
+        "vcredist": "extras/vcredist2022",
         "MSI Afterburner": "extras/msiafterburner"
     },
-    "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D.com%5D-RTSS.zip",
-    "hash": "c38a21238536270078bb3f425192375f001e721ffd26346a6db5e6365aca47c5",
+    "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/rtss/%5BGuru3D.com%5D-RTSS.zip",
+    "hash": "20a0d1849cee429b8dda5b6d8be77f2286da9b219cd343a888fd75daf3da1441",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\*RTSSSetup*.exe\" -Removal",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Guru3D.com\", \"$dir\\Uninstall*\" -Recurse",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\*Guru3D.com*\", \"$dir\\Uninstall*\", \"$dir\\Redist\" -Recurse",
         "Move-Item \"$dir\\RTSSHooks.dll.copy\" \"$dir\\RTSSHooks.dll\"",
         "Move-Item \"$dir\\RTSSHooks64.dll.copy\" \"$dir\\RTSSHooks64.dll\"",
         "# configs",
@@ -45,6 +45,6 @@
         "regex": "ProductVersion\\s+=\\s*([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D.com%5D-RTSS.zip"
+        "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/rtss/%5BGuru3D.com%5D-RTSS.zip"
     }
 }


### PR DESCRIPTION
The previous update was not correct. Instead of version 7.3.5, version 7.3.4 was installed.
Also removed more installer files.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
