### PR TITLE
dosbox-staging: Update to version 0.81.0

### DIFF
--- a/bucket/dosbox-staging.json
+++ b/bucket/dosbox-staging.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.80.1",
+    "version": "0.81.0",
     "description": "A DOS/x86 emulator based on DOSBox which focuses on ease of use.",
     "homepage": "https://dosbox-staging.github.io/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.1/dosbox-staging-windows-x86_64-v0.80.1.zip",
-            "hash": "e7ab98013b55f6fd6db1f529574b8f2905d374225f532ce0905666281cbe32af",
-            "extract_dir": "dosbox-staging-windows-x86_64-v0.80.1"
+            "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.81.0/dosbox-staging-windows-v0.81.0.zip",
+            "hash": "ce772a963716d63610e6cb0e817b16f1b5a3cbfd3d5ad802726ddd583f32b79d",
+            "extract_dir": "dosbox-staging-v0.81.0"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\dosbox-staging.conf\")) { New-Item -ItemType File \"$dir\\dosbox-staging.conf\" | Out-Null }",
@@ -33,8 +33,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-x86_64-v$version.zip",
-                "extract_dir": "dosbox-staging-windows-x86_64-v$version"
+                "url": "https://github.com/dosbox-staging/dosbox-staging/releases/download/v$version/dosbox-staging-windows-v$version.zip",
+                "extract_dir": "dosbox-staging-v$version"
             }
         }
     },


### PR DESCRIPTION
`autoupdate` failed since the URL omits “x86_64”; the project focuses on 64 bit only going forward.

As can be seen in the `extract_dir` portion, for some reason they omit “windows”; unclear if it stays that way or not — time will tell.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
