### PR TITLE
USBImager@1.0.10: Fix hash

### DIFF
--- a/bucket/usbimager.json
+++ b/bucket/usbimager.json
@@ -4,7 +4,7 @@
     "homepage": "https://bztsrc.gitlab.io/usbimager/",
     "license": "MIT",
     "url": "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_1.0.10-i686-win-gdi.zip",
-    "hash": "ad83b75c186994f732d913b27394e86214296f708a26021b70e561004e4499f7",
+    "hash": "7c57380c050f186e420aa60a15a0f16b047539160d98bc2b7cae97882ff992ca",
     "extract_dir": "USBImager",
     "shortcuts": [
         [


### PR DESCRIPTION
Updated the hash value to match the correct one based on the information from the original repository at https://gitlab.com/bztsrc/usbimager/-/blob/binaries/sha256checksums.txt. The corrected hash is now "7C57380C050F186E420AA60A15A0F16B047539160D98BC2B7CAE97882FF992CA"

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
