### PR TITLE
everything@1.4.1.1024: fix license to Freeware

### DIFF
--- a/bucket/everything.json
+++ b/bucket/everything.json
@@ -2,7 +2,7 @@
     "version": "1.4.1.1024",
     "description": "Locate files and folders by name instantly.",
     "homepage": "https://www.voidtools.com",
-    "license": "MIT",
+    "license": "Freeware",
     "notes": [
         "To add Everything to right-click context menu, run:",
         "reg import \"$dir\\install-context.reg\""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

According to the [official website](https://www.voidtools.com/License.txt), this is not an MIT license.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
