### PR TITLE
kicad@7.0.11: Fix shortcuts

### DIFF
--- a/bucket/kicad.json
+++ b/bucket/kicad.json
@@ -41,7 +41,7 @@
             "Image Converter"
         ],
         [
-            "\bin\\kicad-cmd.bat",
+            "bin\\kicad-cmd.bat",
             "KiCad Command Prompt"
         ]
     ],


### PR DESCRIPTION
Fixing a typo in the shortcuts that would cause the shim linking to fail.


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
