### PR TITLE
hexchat: Update to version 2.16.2, switch to github releases

### DIFF
--- a/bucket/hexchat.json
+++ b/bucket/hexchat.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.16.1",
+    "version": "2.16.2",
     "description": "An IRC client based on XChat",
     "homepage": "https://hexchat.github.io",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://dl.hexchat.net/hexchat/HexChat%202.16.1%20x64.exe",
-            "hash": "4b47930951ebc46e9cb8e8201856b8bddcd7499f5510fe1059f67d65cc80bf07"
+            "url": "https://github.com/hexchat/hexchat/releases/download/v2.16.2/HexChat.2.16.2.x64.exe",
+            "hash": "39da96a323ba98583e716a7ee5af1a02a34935dbe3b0865b54c65ce7784e0828"
         },
         "32bit": {
-            "url": "https://dl.hexchat.net/hexchat/HexChat%202.16.1%20x86.exe",
-            "hash": "ab6db5c0cdd0a1ddd80dd7124430a6b56d75905859e4bab68c973837171c6161"
+            "url": "https://github.com/hexchat/hexchat/releases/download/v2.16.2/HexChat.2.16.2.x86.exe",
+            "hash": "830f32073130faaeaba22b7e4f7f8b21ecd476a1236fabb675b7de5a8bf8c026"
         }
     },
     "innosetup": true,
@@ -31,14 +31,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.hexchat.net/hexchat/HexChat%20$version%20x64.exe"
+                "url": "https://github.com/hexchat/hexchat/releases/download/v$version/HexChat.$version.x64.exe"
             },
             "32bit": {
-                "url": "https://dl.hexchat.net/hexchat/HexChat%20$version%20x86.exe"
+                "url": "https://github.com/hexchat/hexchat/releases/download/v$version/HexChat.$version.x86.exe"
             }
-        },
-        "hash": {
-            "url": "https://hexchat.github.io/downloads.html"
         }
     }
 }


### PR DESCRIPTION
As per [The Final Release](https://hexchat.github.io/news/2.16.2.html) notification from the author:

> This will be the last release I make of HexChat. The project has largely been unmaintained for years now and nobody else stepped up to do that work.
> ...
> I am going to move all data that I can to be hosted on Github, so all documentation, installers, and dependencies will be there until the end of Microsoft.

Thereby

- update to version 2.16.2;
- switch to using artifacts from GitHub releases.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
