### PR TITLE
sfsu@1.8.6: Add arm64 arch, use direct exe download urls

### DIFF
--- a/bucket/sfsu.json
+++ b/bucket/sfsu.json
@@ -23,13 +23,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-x86_64.exe#/sfsu.exe",
+                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-x86_64.exe#/sfsu.exe"
             },
             "32bit": {
-                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-i686.exe#/sfsu.exe",
+                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-i686.exe#/sfsu.exe"
             },
             "arm64": {
-                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-aarch64.exe#/sfsu.exe",
+                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-aarch64.exe#/sfsu.exe"
             }
         },
         "hash": {

--- a/bucket/sfsu.json
+++ b/bucket/sfsu.json
@@ -5,12 +5,16 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jewlexx/sfsu/releases/download/v1.8.6/dl-x86_64.7z",
-            "hash": "dd600555c6b3d2da9a2933227d9a8c7df18f087e4ac3c2652dd2458de6a1f679"
+            "url": "https://github.com/jewlexx/sfsu/releases/download/v1.8.6/sfsu-x86_64.exe#/sfsu.exe",
+            "hash": "c871ebba8daf92073e1dd861d0e5894efa189208421f9ab75b79088e2817c969"
         },
         "32bit": {
-            "url": "https://github.com/jewlexx/sfsu/releases/download/v1.8.6/dl-i686.7z",
-            "hash": "1f561d297b1ebd883ef7ca84b484108ca605854023e835d9379c510e21767f13"
+            "url": "https://github.com/jewlexx/sfsu/releases/download/v1.8.6/sfsu-i686.exe#/sfsu.exe",
+            "hash": "afe3d7cce11a9fb0158e84a39c34334f9fe55f8dbca50afa24a1b4100aa26783"
+        },
+        "arm64": {
+            "url": "https://github.com/jewlexx/sfsu/releases/download/v1.8.6/sfsu-aarch64.exe#/sfsu.exe",
+            "hash": "055e158a1a3893b04c143d2186348271c09f6bcc1888f8731b18d2217959a196"
         }
     },
     "notes": "In order to replace scoop commands use `Invoke-Expression (&sfsu hook)` in your Powershell profile.",
@@ -19,14 +23,23 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/dl-x86_64.7z"
+                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-x86_64.exe#/sfsu.exe",
+                "hash": {
+                    "url": "$url.sha256"
+                }
             },
             "32bit": {
-                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/dl-i686.7z"
+                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-i686.exe#/sfsu.exe",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            },
+            "arm64": {
+                "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-aarch64.exe#/sfsu.exe",
+                "hash": {
+                    "url": "$url.sha256"
+                }
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/sfsu.json
+++ b/bucket/sfsu.json
@@ -24,22 +24,16 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-x86_64.exe#/sfsu.exe",
-                "hash": {
-                    "url": "$url.sha256"
-                }
             },
             "32bit": {
                 "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-i686.exe#/sfsu.exe",
-                "hash": {
-                    "url": "$url.sha256"
-                }
             },
             "arm64": {
                 "url": "https://github.com/jewlexx/sfsu/releases/download/v$version/sfsu-aarch64.exe#/sfsu.exe",
-                "hash": {
-                    "url": "$url.sha256"
-                }
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Added arm64 architecture support
- Use direct exe downloads rather than 7z archives

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
