### PR TITLE
prusaslicer: Update to version 2.7.2, fix checkver and autoupdate

### DIFF
--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/52882701/releases",
-        "regex": "PrusaSlicer-([\\d.]+)\\+win64-(?<timestamp64>\\d+).zip"
+        "regex": "PrusaSlicer-([\\d.]+)\\+win64-(?<timestamp64>\\d+)\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.7.1",
+    "version": "2.7.2",
     "description": "G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.)",
     "homepage": "https://www.prusa3d.com/prusaslicer/",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.7.1/PrusaSlicer-2.7.1+win64-202312121425_signed.zip",
-            "hash": "6cf5540c56f7eb072328b04fe991b25042bb91bfebd0bf3391191fdfd9607f42",
-            "extract_dir": "PrusaSlicer-2.7.1+win64-202312121425_signed"
+            "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.7.2/PrusaSlicer-2.7.2+win64-202402291307.zip",
+            "hash": "a155f1179a987dfc8c5fa34aeed2384d1470f5390848c1fb489448e1e336b5d6",
+            "extract_dir": "PrusaSlicer-2.7.2+win64-202402291307"
         }
     },
     "bin": "prusa-slicer-console.exe",
@@ -19,13 +19,13 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/52882701/releases",
-        "regex": "PrusaSlicer-([\\d.]+)\\+win64-(?<timestamp64>\\d+)_signed\\.zip"
+        "regex": "PrusaSlicer-([\\d.]+)\\+win64-(?<timestamp64>\\d+).zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_$version/PrusaSlicer-$version+win64-$matchTimestamp64_signed.zip",
-                "extract_dir": "PrusaSlicer-$version+win64-$matchTimestamp64_signed"
+                "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_$version/PrusaSlicer-$version+win64-$matchTimestamp64.zip",
+                "extract_dir": "PrusaSlicer-$version+win64-$matchTimestamp64"
             }
         }
     }


### PR DESCRIPTION
prusaslicer: updated to version 2.7.2 and updated filename and hash to match

<!-- Provide a general summary of your changes in the title above -->
prusaslicer changed their filename and took out -signed

I have updated this file bucket/prusaslicer.json to fix this

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12889
<!-- or -->
Relates to #12889

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
