### PR TITLE
adwcleaner: Fix `autoupdate`

### DIFF
--- a/bucket/adwcleaner.json
+++ b/bucket/adwcleaner.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.fosshub.com/Malwarebytes-AdwCleaner.html/adwcleaner_8.4.2.exe",
+            "url": "https://adwcleaner.malwarebytes.com/adwcleaner?channel=release",
             "hash": "91068efbef44f8ceedbbbdfeea8959633c4ecc9100c3ba08b2603d7c5d59ac22"
         }
     },
@@ -21,19 +21,13 @@
         ]
     ],
     "checkver": {
-        "script": [
-            "$content = (Invoke-WebRequest 'https://toolslib.net/downloads/viewdownload/1-adwcleaner/files/?t=release').Content",
-            "$content -match '1-adwcleaner/files/(?<release>\\d+)/'; $release = $Matches['release']",
-            "$content = (Invoke-WebRequest \"https://toolslib.net/downloads/finish/1-adwcleaner/$release/\").Content",
-            "$content -match 'AdwCleaner \\((?<version>[\\d.]+)\\)'; $version = $Matches['version']",
-            "Write-Output $version $release"
-        ],
-        "regex": "([\\d.]+) (?<release>\\d+)"
+        "url": "https://toolslib.net/downloads/viewdownload/1-adwcleaner/files/?t=release",
+        "regex": "/(?<release>\\d+)/\">AdwCleaner</a>\\s*</td>\\s*<td class=\"text-center\">([\\d.]+)</td>"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.fosshub.com/Malwarebytes-AdwCleaner.html/adwcleaner_$version.exe"
+                "url": "https://adwcleaner.malwarebytes.com/adwcleaner?channel=release"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Uses official bins from Malwarebytes instead of the mirror, previously a mirror (which's currently out of date, and causing an error) was used because prior to the Malwarebytes acquisition, the official bin was only acquirable via the toolslib site, which required a js generated query param.

Closes #12908

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).