### PR TITLE
czkawka-gui: Update to 7.0.0

### DIFF
--- a/bucket/czkawka-gui.json
+++ b/bucket/czkawka-gui.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.1.0",
+    "version": "7.0.0",
     "description": "Find duplicates, empty folders, similar images, unnecessary files, etc.",
     "homepage": "https://github.com/qarmin/czkawka",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qarmin/czkawka/releases/download/6.1.0/windows_czkawka_gui.zip",
-            "hash": "ab2b6fff3059cee27116f13985a06a53ca46627fea2478e8949bf504ae50a144"
+            "url": "https://github.com/qarmin/czkawka/releases/download/7.0.0/windows_czkawka_gui_gtk_46.zip",
+            "hash": "63ce24d594659c48c540df3c8c0bab7b5a80d65cbda1e465cc9cdf157b22bd13"
         }
     },
     "shortcuts": [
@@ -22,8 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_czkawka_gui.zip"
+                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_czkawka_gui_gtk_46.zip"
             }
         }
     }
 }
+


### PR DESCRIPTION
Updates czkawka-gui to new version while still using the gtk gui as the slint ui is still experimental