### PR TITLE
floorp@11.10.5: Fix uninstall error and rename

### DIFF
--- a/bucket/floorp-portable.json
+++ b/bucket/floorp-portable.json
@@ -36,10 +36,6 @@
             "-P"
         ]
     ],
-    "persist": [
-        "core",
-        "profile"
-    ],
     "checkver": {
         "github": "https://github.com/Floorp-Projects/Floorp-Portable"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix the below error when uninstalling Floorp and rename the manifest to make it clear that it is the portable version.

![image](https://github.com/ScoopInstaller/Extras/assets/87632612/32be2d7c-447b-4786-a126-2cf1f441df49)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
