### PR TITLE
fancontrol@v183: fix zip name

### DIFF
--- a/bucket/fancontrol.json
+++ b/bucket/fancontrol.json
@@ -1,5 +1,5 @@
 {
-    "version": "181",
+    "version": "183",
     "description": "A highly customizable fan controlling software for Windows",
     "homepage": "https://getfancontrol.com/",
     "license": "Freeware",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Rem0o/FanControl.Releases/releases/download/V181/FanControl_net_8_0.zip",
-            "hash": "f8507b69d83969d1951c66c5a962592e9c3782426d3095bbd07a1aff39da2bd9"
+            "url": "https://github.com/Rem0o/FanControl.Releases/releases/download/V183/FanControl_183_net_8_0.zip",
+            "hash": "80c6a0273bd07ca6ea09ef99732e10379dc1a32f02ca27400dd592c6e77194f6"
         }
     },
     "shortcuts": [
@@ -25,12 +25,12 @@
     "checkver": {
         "url": "https://api.github.com/repositories/268350681/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
-        "regex": "/V([\\d.]+)/FanControl_net_(?<netver>(?!4_8)(?!7_0)[\\d_]+).zip"
+        "regex": "/V([\\d.]+)/FanControl_([\\d.]+)_net_(?<netver>(?!4_8)(?!7_0)[\\d_]+).zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Rem0o/FanControl.Releases/releases/download/V$version/FanControl_net_$matchNetver.zip"
+                "url": "https://github.com/Rem0o/FanControl.Releases/releases/download/V$version/FanControl_$version_net_$matchNetver.zip"
             }
         }
     }


### PR DESCRIPTION
Fancontrol changed assets naming scheme as of V183
FanControl_net_8_0.zip changed to FanControl_$version_net_8_0.zip

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
