### PR TITLE
sharex: Update to version 16.0.1

### DIFF
--- a/bucket/sharex.json
+++ b/bucket/sharex.json
@@ -1,10 +1,10 @@
 {
-    "version": "15.0.0",
+    "version": "16.0.1",
     "description": "Screen capture, file sharing and productivity tool.",
     "homepage": "https://getsharex.com/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/ShareX/ShareX/releases/download/v15.0.0/ShareX-15.0.0-portable.zip",
-    "hash": "c3bc97e9fb8d107e92cb494b50f842fccafbc9fd810588a1b635aee4dbe90bc1",
+    "url": "https://github.com/ShareX/ShareX/releases/download/v16.0.1/ShareX-16.0.1-portable.zip",
+    "hash": "5742B66E7504D083E9ABD2BC91A56242D347DFC76F356111177A40A6D00B1FB5",
     "pre_install": "if (!(Test-Path \"$persist_dir\\PersonalPath.cfg\")) { New-Item \"$dir\\PersonalPath.cfg\" | Out-Null }",
     "bin": "ShareX.exe",
     "shortcuts": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Updates the Scoop manifest to the latest version, from v15.0.0. I've tested this on my machine (updating from v15) and was successful. See linked issue for config details.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #12962.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
