### PR TITLE
KakaoTalkAdBlock: Add version 2.1.4

### DIFF
--- a/bucket/kakaotalkadblock.json
+++ b/bucket/kakaotalkadblock.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.0.0",
+    "description": "AdBlocker for KakaoTalk Windows Client",
+    "homepage": "https://kakao.xo.dev/",
+    "license": "Unknown",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.0.0/KakaoTalkAdBlock_amd64.exe",
+            "hash": "2A7315C448CA6577D7F5B334649066527CDECDA6E43D3D8931312644A5B78DB2"
+        }
+    },
+    "shortcuts": [
+        [
+            "KakaoTalkAdBlock_amd64.exe",
+            "KakaoTalkAdBlock"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/blurfx/KakaoTalkAdBlock"
+    }
+}

--- a/bucket/kakaotalkadblock.json
+++ b/bucket/kakaotalkadblock.json
@@ -5,36 +5,30 @@
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.1.4/KakaoTalkAdBlock_amd64.exe",
-            "hash": "951e277d65ac26c15437c24f0cd40983690321c104c491791035a420d62f8623",
-            "shortcuts": [
-                [
-                    "KakaoTalkAdBlock_amd64.exe",
-                    "KakaoTalkAdBlock"
-                ]
-            ]
+            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.1.4/KakaoTalkAdBlock_amd64.exe#/KakaoTalkAdBlock.exe",
+            "hash": "951e277d65ac26c15437c24f0cd40983690321c104c491791035a420d62f8623"
         },
         "32bit": {
-            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.1.4/KakaoTalkAdBlock_i386.exe",
-            "hash": "4d13af451e31c5b41bbc8d31073c01e0dff4fe62e7b4d19bf9b85e0feb5142ab",
-            "shortcuts": [
-                [
-                    "KakaoTalkAdBlock_i386.exe",
-                    "KakaoTalkAdBlock"
-                ]
-            ]
+            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.1.4/KakaoTalkAdBlock_i386.exe#/KakaoTalkAdBlock.exe",
+            "hash": "4d13af451e31c5b41bbc8d31073c01e0dff4fe62e7b4d19bf9b85e0feb5142ab"
         }
     },
+    "shortcuts": [
+        [
+            "KakaoTalkAdBlock.exe",
+            "KakaoTalkAdBlock"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/blurfx/KakaoTalkAdBlock"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/$version/KakaoTalkAdBlock_amd64.exe"
+                "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/$version/KakaoTalkAdBlock_amd64.exe#/KakaoTalkAdBlock.exe"
             },
             "32bit": {
-                "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/$version/KakaoTalkAdBlock_i386.exe"
+                "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/$version/KakaoTalkAdBlock_i386.exe#/KakaoTalkAdBlock.exe"
             }
         }
     }

--- a/bucket/kakaotalkadblock.json
+++ b/bucket/kakaotalkadblock.json
@@ -1,21 +1,41 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.4",
     "description": "AdBlocker for KakaoTalk Windows Client",
     "homepage": "https://kakao.xo.dev/",
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.0.0/KakaoTalkAdBlock_amd64.exe",
-            "hash": "2A7315C448CA6577D7F5B334649066527CDECDA6E43D3D8931312644A5B78DB2"
+            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.1.4/KakaoTalkAdBlock_amd64.exe",
+            "hash": "951e277d65ac26c15437c24f0cd40983690321c104c491791035a420d62f8623",
+            "shortcuts": [
+                [
+                    "KakaoTalkAdBlock_amd64.exe",
+                    "KakaoTalkAdBlock"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/2.1.4/KakaoTalkAdBlock_i386.exe",
+            "hash": "4d13af451e31c5b41bbc8d31073c01e0dff4fe62e7b4d19bf9b85e0feb5142ab",
+            "shortcuts": [
+                [
+                    "KakaoTalkAdBlock_i386.exe",
+                    "KakaoTalkAdBlock"
+                ]
+            ]
         }
     },
-    "shortcuts": [
-        [
-            "KakaoTalkAdBlock_amd64.exe",
-            "KakaoTalkAdBlock"
-        ]
-    ],
     "checkver": {
         "github": "https://github.com/blurfx/KakaoTalkAdBlock"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/$version/KakaoTalkAdBlock_amd64.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/blurfx/KakaoTalkAdBlock/releases/download/$version/KakaoTalkAdBlock_i386.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds `KakaoTalkAdBlock` (2.0.0) to the bucket. 

Closes #12883

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
