### PR TITLE
gitify@5.0.0: Fix bundle name

### DIFF
--- a/bucket/gitify.json
+++ b/bucket/gitify.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/manosim/gitify/releases/download/v5.0.0/Gitify.Setup.5.0.0.exe#/dl.7z",
+            "url": "https://github.com/gitify-app/gitify/releases/download/v5.0.0/Gitify.Setup.5.0.0.exe#/dl.7z",
             "hash": "sha512:c70fc6707ff6efd17d02549bd16a1dc9b38d153f753501fcab7a7d5ac055e58bb44feb91d31ad4303a62639cb7f9c344db6d89bc23e91edbb43eb5755a0088a0",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
@@ -20,12 +20,12 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/manosim/gitify"
+        "github": "https://github.com/gitify-app/gitify"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/manosim/gitify/releases/download/v$version/Gitify.Setup.$version.exe#/dl.7z"
+                "url": "https://github.com/gitify-app/gitify/releases/download/v$version/Gitify.Setup.$version.exe#/dl.7z"
             }
         },
         "hash": {

--- a/bucket/gitify.json
+++ b/bucket/gitify.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/manosim/gitify/releases/download/v5.0.0/Gitify-Setup-5.0.0.exe#/dl.7z",
+            "url": "https://github.com/manosim/gitify/releases/download/v5.0.0/Gitify.Setup.5.0.0.exe#/dl.7z",
             "hash": "sha512:c70fc6707ff6efd17d02549bd16a1dc9b38d153f753501fcab7a7d5ac055e58bb44feb91d31ad4303a62639cb7f9c344db6d89bc23e91edbb43eb5755a0088a0",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/manosim/gitify/releases/download/v$version/Gitify-Setup-$version.exe#/dl.7z"
+                "url": "https://github.com/manosim/gitify/releases/download/v$version/Gitify.Setup.$version.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

gitify now uses dots instead of dash in the exe released bundle

Closes #12980

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
