### PR TITLE
qefi-entry-manager: Add version 0.3.0

### DIFF
--- a/bucket/qefi-entry-manager.json
+++ b/bucket/qefi-entry-manager.json
@@ -12,10 +12,11 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/Inokinoki/QEFIEntryManager",
-        "regex": "\/releases\/tag\/(?:v\\.|V\\.)?([\\d.]+)"
+        "url": "https://api.github.com/repositories/380314737/releases/latest",
+        "jsonpath": "$..browser_download_url",
+        "regex": "download/(?<prefix>[v|V][\\.]?)?([\\d.]+)/QEFI.Entry.Manager.for.Windows.Qt(?<qt>[\\d.]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v.$version/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip"
+        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/$matchPrefix$version/QEFI.Entry.Manager.for.Windows.Qt$matchQt.zip"
     }
 }

--- a/bucket/qefi-entry-manager.json
+++ b/bucket/qefi-entry-manager.json
@@ -12,9 +12,10 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/Inokinoki/QEFIEntryManager"
+        "github": "https://github.com/Inokinoki/QEFIEntryManager",
+        "regex": "\/releases\/tag\/(?:v\\.|V\\.)?([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v.$version/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip"
+        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v$version/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip"
     }
 }

--- a/bucket/qefi-entry-manager.json
+++ b/bucket/qefi-entry-manager.json
@@ -16,6 +16,6 @@
         "regex": "\/releases\/tag\/(?:v\\.|V\\.)?([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v$version/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip"
+        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v.$version/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip"
     }
 }

--- a/bucket/qefi-entry-manager.json
+++ b/bucket/qefi-entry-manager.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.3.0",
+    "description": "A userspace cross-platform EFI boot entry management GUI App based on Qt.",
+    "homepage": "https://github.com/Inokinoki/QEFIEntryManager",
+    "license": "GPL-3.0",
+    "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v.0.3.0/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip",
+    "hash": "6ea1dd431c9b8c2d4813e1503670ff0624f6a77d8e7c881ed9e507b602417c10",
+    "shortcuts": [
+        [
+            "QEFIEntryManager.exe",
+            "QEFI Entry Manager"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Inokinoki/QEFIEntryManager"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Inokinoki/QEFIEntryManager/releases/download/v.$version/QEFI.Entry.Manager.for.Windows.Qt5.15.2.zip"
+    }
+}


### PR DESCRIPTION
Closes #12990

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
