### PR TITLE
sleek@2.0.12: Update download URL

### DIFF
--- a/bucket/sleek.json
+++ b/bucket/sleek.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ransome1/sleek/releases/download/v2.0.12/sleek-2.0.12-win-Setup.exe#/dl.7z",
+            "url": "https://github.com/ransome1/sleek/releases/download/v2.0.12/sleek-2.0.12-win-x64-Setup.exe#/dl.7z",
             "hash": "sha512:bffb2a546f1d1c3bd5838bae5b27e28fd1cac982c23733ff2ecbc1422dd4c687b383baf872ff286a52ba02db6007bebae434d8aff2b36c83fc5215c83a3d8450"
         }
     },
@@ -28,7 +28,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ransome1/sleek/releases/download/v$version/sleek-$version-win-Setup.exe#/dl.7z"
+                "url": "https://github.com/ransome1/sleek/releases/download/v$version/sleek-$version-win-x64-Setup.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
The download URL of sleek changed slightly. This PR changes the download URL & the update URL.

Closes #12994


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
