### PR TITLE
mesonlsp@4.1.3: Rename from swift-mesonlsp to mesonlsp

### DIFF
--- a/bucket/mesonlsp.json
+++ b/bucket/mesonlsp.json
@@ -1,6 +1,6 @@
 {
     "version": "4.1.3",
-    "description": "An unofficial, unendorsed language server for meson written in Swift.",
+    "description": "An unofficial, unendorsed language server for meson written in C++.",
     "homepage": "https://github.com/JCWasmx86/mesonlsp",
     "license": "GPL-3.0-only",
     "architecture": {


### PR DESCRIPTION
Rename manifest since project rewritten in C++ instead of Swift.
Manifest was already updated accordingly in 2de79bc.

Relates to JCWasmx86/mesonlsp#49.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
