### PR TITLE
alacritty@0.13.2: Add Open with Alacritty context menu

### DIFF
--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -31,7 +31,7 @@
             "--working-directory \"%USERPROFILE%\""
         ]
     ],
-    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
+    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" *>nul }",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/alacritty/alacritty/releases/download/v$version/Alacritty-v$version-portable.exe#/alacritty.exe"

--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -3,11 +3,26 @@
     "description": "GPU-accelerated terminal emulator",
     "homepage": "https://github.com/alacritty/alacritty",
     "license": "Apache-2.0",
+    "notes": [
+        "Add Open with Alacritty as a context menu option by running:",
+        "reg import \"$dir\\install-context.reg\""
+    ],
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
     "url": "https://github.com/alacritty/alacritty/releases/download/v0.13.2/Alacritty-v0.13.2-portable.exe#/alacritty.exe",
     "hash": "909f51405aac3b6fd0e978d66abba9f888a4180f86799a266fb5bda3f3dfa923",
+    "post_install": [
+        "$alacrittyPath = \"$dir\\alacritty.exe\".Replace('\\', '\\\\')",
+        "'install-context', 'uninstall-context' | ForEach-Object {",
+        "    if (Test-Path \"$bucketsdir\\extras\\scripts\\$app\\$_.reg\") {",
+        "        $content = Get-Content \"$bucketsdir\\extras\\scripts\\$app\\$_.reg\"",
+        "        $content = $content.Replace('$alacrittyPath', $alacrittyPath)",
+        "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
+        "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
+        "    }",
+        "}"
+    ],
     "bin": "alacritty.exe",
     "shortcuts": [
         [
@@ -16,6 +31,7 @@
             "--working-directory \"%USERPROFILE%\""
         ]
     ],
+    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/alacritty/alacritty/releases/download/v$version/Alacritty-v$version-portable.exe#/alacritty.exe"

--- a/scripts/alacritty/install-context.reg
+++ b/scripts/alacritty/install-context.reg
@@ -1,0 +1,15 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shell\Open with &Alacritty]
+@="Open with &Alacritty"
+"Icon"="$alacrittyPath"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shell\Open with &Alacritty\command]
+@="\"$alacrittyPath\" --working-directory \"%v\""
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\Background\shell\Open with &Alacritty]
+@="Open with &Alacritty"
+"Icon"="$alacrittyPath"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\Background\shell\Open with &Alacritty\command]
+@="\"$alacrittyPath\" --working-directory \"%v\""

--- a/scripts/alacritty/uninstall-context.reg
+++ b/scripts/alacritty/uninstall-context.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shell\Open with &Alacritty]
+[-HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shell\Open with &Alacritty\command]
+[-HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\Background\shell\Open with &Alacritty]
+[-HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\Background\shell\Open with &Alacritty\command]


### PR DESCRIPTION
Adds a bundled registry file to optionally add an "Open Alacritty here" context menu entry just as Alacritty's own installer[^1] does.

Closes #12983

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

[^1]: https://github.com/alacritty/alacritty/blob/master/alacritty/windows/wix/alacritty.wxs#L41-L49
