### PR TITLE
gitify@5.1.0: Fix bundle name

### DIFF
--- a/bucket/gitify.json
+++ b/bucket/gitify.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/gitify-app/gitify/releases/download/v5.1.0/Gitify.Setup.5.1.0.exe#/dl.7z",
+            "url": "https://github.com/gitify-app/gitify/releases/download/v5.1.0/Gitify-Setup-5.1.0.exe#/dl.7z",
             "hash": "sha512:6734b904ab86d7bbb52046f1005dbac0951107e2166be7dbc56c83c37fbbf13baf61b8bb6bae49a1235b57aa9116925b6f3920346bd80900560c42b51836e136",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/gitify-app/gitify/releases/download/v$version/Gitify.Setup.$version.exe#/dl.7z"
+                "url": "https://github.com/gitify-app/gitify/releases/download/v$version/Gitify-Setup-$version.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
It seems they  switch back (fix) so previous fix at #12981 needs to be reverted

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
