### PR TITLE
keepassxc@2.7.7: Add vcredist suggest

### DIFF
--- a/bucket/keepassxc.json
+++ b/bucket/keepassxc.json
@@ -3,6 +3,9 @@
     "description": "Community fork of KeePass",
     "homepage": "https://keepassxc.org",
     "license": "GPL-2.0-only",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.7.7/KeePassXC-2.7.7-Win64.zip",


### PR DESCRIPTION
Fixes missing runtime error
https://keepassxc.org/docs/#faq-msvc-runtime-missing