### PR TITLE
ida-free: Update manifest

### DIFF
--- a/bucket/ida-free.json
+++ b/bucket/ida-free.json
@@ -1,12 +1,12 @@
 {
-    "version": "8.3",
+    "version": "8.4",
     "description": "A multi-processor disassembler and debugger that offers so many features it is hard to describe them all",
     "homepage": "https://hex-rays.com/ida-free/",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://out7.hex-rays.com/files/idafree83_windows.exe",
-            "hash": "sha1:a63fe3107846ac60fd053c4312482f79d8ab179a"
+            "url": "https://out7.hex-rays.com/files/idafree84_windows.exe",
+            "hash": "065df6e50c4eadc8145e8748d7d58aa263c48c344c0f98f4fbdc65e7b4d990a0"
         }
     },
     "pre_install": "if (!(is_admin)) { throw 'Administrator privileges are required' }",
@@ -43,7 +43,7 @@
                 "url": "https://out7.hex-rays.com/files/idafree$majorVersion$minorVersion_windows.exe",
                 "hash": {
                     "url": "https://hex-rays.com/ida-free/#download",
-                    "regex": "$sha1\\s+$basename"
+                    "regex": "$sha256\\s+$basename"
                 }
             }
         }

--- a/bucket/ida-free.json
+++ b/bucket/ida-free.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.4",
+    "version": "8.4.240320",
     "description": "A multi-processor disassembler and debugger that offers so many features it is hard to describe them all",
     "homepage": "https://hex-rays.com/ida-free/",
     "license": "Freeware",
@@ -35,7 +35,7 @@
     },
     "checkver": {
         "url": "https://hex-rays.com/ida-free/#download",
-        "regex": "IDA\\sv([\\d.]+)\\s+"
+        "regex": ">v([\\d.]+)(?:sp\\d)?<"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This pull request updates the hash type in the manifest file for the ida-free package to align with the information provided on the official ida-free website, which is sha-256 now.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
