### PR TITLE
umi-ocr: Update to version 2.1.1, fix checkver and autoupdate

### DIFF
--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://github.com/hiroi-sora/Umi-OCR/releases/",
-        "regex": "v([\\d\\w.]+)"
+        "regex": "tag\\/v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -5,7 +5,7 @@
     "license": "MIT License",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/release/2.1.1/Umi-OCR_Paddle_v2.1.1.7z.exe",
+            "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v2.1.1/Umi-OCR_Paddle_v2.1.1.7z.exe",
             "hash": "53e144b07c3ddfc1038e16926912de75c8212840c84cd56713f9e93ecc22e753",
             "extract_dir": "Umi-OCR_Paddle_v2.1.1"
         }
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/release/$version/Umi-OCR_Paddle_v$version.7z.exe",
+                "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v$version/Umi-OCR_Paddle_v$version.7z.exe",
                 "extract_dir": "Umi-OCR_Paddle_v$version"
             }
         }

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://github.com/hiroi-sora/Umi-OCR/releases/",
-        "regex": "release/([\\d\\w.]+)"
+        "regex": "v([\\d\\w.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -16,16 +16,17 @@
             "Umi-OCR"
         ]
     ],
-    "checkver": {
-        "url": "https://github.com/hiroi-sora/Umi-OCR/releases/",
-        "regex": "tag\\/v([\\d.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v$version/Umi-OCR_Paddle_v$version.7z.exe",
                 "extract_dir": "Umi-OCR_Paddle_v$version"
             }
+        },
+        "hash": {
+            "url": "https://github.com/hiroi-sora/Umi-OCR/releases/tag/v$version",
+            "find": "(?sm)Umi-OCR_Paddle.*?SHA256:.*?$sha256"
         }
     }
 }

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -5,7 +5,7 @@
     "license": "MIT License",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/release/2.1.1/Umi-OCR_Rapid_v2.1.1.7z.exe",
+            "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v2.1.1/Umi-OCR_Rapid_v2.1.1.7z.exe",
             "hash": "09f10d04bd1915ad67a76e57e54adad781a295e8bbf64c7a3e7207f056cafee6",
             "extract_dir": "Umi-OCR_Rapid_v2.1.1"
         }

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/release/$version/Umi-OCR_Rapid_v$version.7z.exe",
+                "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v$version/Umi-OCR_Rapid_v$version.7z.exe",
                 "extract_dir": "Umi-OCR_Rapid_v$version"
             }
         }

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://github.com/hiroi-sora/Umi-OCR/releases/",
-        "regex": "v([\\d\\w.]+)"
+        "regex": "tag\\/v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -16,16 +16,17 @@
             "Umi-OCR"
         ]
     ],
-    "checkver": {
-        "url": "https://github.com/hiroi-sora/Umi-OCR/releases/",
-        "regex": "tag\\/v([\\d.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v$version/Umi-OCR_Rapid_v$version.7z.exe",
                 "extract_dir": "Umi-OCR_Rapid_v$version"
             }
+        },
+        "hash": {
+            "url": "https://github.com/hiroi-sora/Umi-OCR/releases/tag/v$version",
+            "find": "(?sm)Umi-OCR_Rapid.*?SHA256:.*?$sha256"
         }
     }
 }

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "https://github.com/hiroi-sora/Umi-OCR/releases/",
-        "regex": "release/([\\d\\w.]+)"
+        "regex": "v([\\d\\w.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Update the format of version tag

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
