### PR TITLE
pkg-config-lite: Add version 0.28-1

### DIFF
--- a/bucket/pkg-config-lite.json
+++ b/bucket/pkg-config-lite.json
@@ -1,0 +1,10 @@
+{
+    "version": "0.28-1",
+    "description": "pkg-config-lite is based on pkg-config, but is built with a glib code snippet which eliminates the glib dependency, so it is possible once again to build and run pkg-config without dependencies.",
+    "homepage": "https://sourceforge.net/projects/pkgconfiglite/",
+    "license": "GPL-2.0-only",
+    "url": "https://sourceforge.net/projects/pkgconfiglite/files/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip",
+    "hash": "2038c49d23b5ca19e2218ca89f06df18fe6d870b4c6b54c0498548ef88771f6f",
+    "extract_dir": "pkg-config-lite-0.28-1",
+    "bin": "bin/pkg-config.exe"
+}


### PR DESCRIPTION
Adds pkg-config-lite (pkg-config for windows without glib dependency). Version is newer than pkg-config version included in main bucket.

Adding to extras as I didn't feel this met the "a reasonably well-known and widely used developer tool" criteria of the main bucket since this is a "fork" of pkg-config


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
