### PR TITLE
git-stack: Add version 0.10.17

### DIFF
--- a/bucket/git-stack.json
+++ b/bucket/git-stack.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.10.17",
+    "homepage": "https://github.com/gitext-rs/git-stack",
+    "description": "Stacked branch management for Git.",
+    "license": "Apache-2.0 OR MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gitext-rs/git-stack/releases/download/v0.10.17/git-stack-v0.10.17-x86_64-pc-windows-msvc.zip",
+            "hash": "b2ade870029f38861295f84558f8dd97fd448c9f8d5e9b1f1923a87c707cb6d7"
+        }
+    },
+    "bin": "git-stack.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gitext-rs/git-stack/releases/download/v$version/git-stack-v$version-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds git-stack: "Stacked branch management for Git".

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
