### PR TITLE
tts-voice-wizard: update suggested runtime package

### DIFF
--- a/bucket/tts-voice-wizard.json
+++ b/bucket/tts-voice-wizard.json
@@ -5,12 +5,10 @@
     "license": "MIT",
     "notes": [
         "Some features require a virtual audio cable like VB-CABLE <https://vb-audio.com/Cable/>",
-        "Requires .NET Desktop Runtime 6.0. To install with scoop:",
-        "  scoop install sudo",
-        "  sudo scoop install windowsdesktop-runtime-lts"
+        "Requires .NET Desktop Runtime 6.0 (see suggested packages)."
     ],
     "suggest": {
-        ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts"
+        ".NET Desktop Runtime": "versions/windowsdesktop-runtime-6.0"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Updates the suggested runtime package from `extras/windowsdesktop-runtime-lts` (now 8.0) to `versions/windowsdesktop-runtime-6.0`.