### PR TITLE
kodi: Update to version 21.0

### DIFF
--- a/bucket/kodi.json
+++ b/bucket/kodi.json
@@ -1,5 +1,5 @@
 {
-    "version": "20.5",
+    "version": "21.0",
     "description": "Open source home theater/media center software and entertainment hub for digital media",
     "homepage": "https://kodi.tv/",
     "license": "GPL-2.0-or-later",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://mirrors.kodi.tv/releases/windows/win64/kodi-20.5-Nexus-x64.exe#/dl.7z",
-            "hash": "f5585bb12f5027eb86dcfac60a790faffd6ac7aa06cdc0d5c47b87ef0ee7a9ea"
+            "url": "https://mirrors.kodi.tv/releases/windows/win64/kodi-21.0-Omega-x64.exe#/dl.7z",
+            "hash": "62768c33e149969d20bcc9e4df235e9896611d4fa1e96c5912ccc5f1d3cc34f5"
         },
         "32bit": {
-            "url": "https://mirrors.kodi.tv/releases/windows/win32/kodi-20.5-Nexus-x86.exe#/dl.7z",
-            "hash": "a1d8e6922c90b5756863c6c5362425110ae313f1d6b9cce5bf2e7c8dffd8f351"
+            "url": "https://mirrors.kodi.tv/releases/windows/win32/kodi-21.0-Omega-x86.exe#/dl.7z",
+            "hash": "3a50d0d112c36920693c082d7a7f8c6965c1e10f4e2a0f40ef5771d28629c8dc"
         }
     },
     "post_install": "'$PLUGINSDIR', '$TEMP', 'AppxManifest.xml', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
@@ -27,7 +27,7 @@
     "persist": "portable_data",
     "checkver": {
         "url": "https://kodi.tv/download/windows",
-        "regex": "Kodi v(?<version>[\\d.]+) \\((?<name>\\w+)\\)"
+        "regex": "kodi-(?<version>[\\d.]+)-(?<name>\\w+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Update kodi to v21.0

checkver now uses actual filenames instead of title (which omitted `.0` from `21.0`)

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
