### PR TITLE
ghidra: add GHIDRA_INSTALL_DIR environment variable

### DIFF
--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -28,6 +28,9 @@
             "ghidra"
         ]
     ],
+    "env_set": {
+        "GHIDRA_INSTALL_DIR": "$dir"
+    },
     "persist": "Ghidra/Configurations",
     "checkver": {
         "url": "https://api.github.com/repositories/173228436/releases/latest",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add `GHIDRA_INSTALL_DIR` environment variable used by many plugins.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
