### PR TITLE
gnucash: Fix version 5.6

### DIFF
--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -3,8 +3,8 @@
     "description": "Personal and small-business financial-accounting software",
     "homepage": "https://www.gnucash.org/",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/Gnucash/gnucash/releases/download/5.6/gnucash-5.6.setup.exe",
-    "hash": "dc6139469696168ddd13ad617a8fbd31c2389b0960a82bc2da1c0c5606b37f46",
+    "url": "https://github.com/Gnucash/gnucash/releases/download/5.6/gnucash-5.6-1.setup.exe",
+    "hash": "4596d431e5785ef3d80bcbea6e1c5e1df98c3b9b27314e6d8d2eae679424f56c",
     "innosetup": true,
     "architecture": {
         "64bit": {

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -31,7 +31,8 @@
     ],
     "persist": "etc\\gnucash\\environment.local",
     "checkver": {
-        "github": "https://github.com/Gnucash/gnucash",
+        "url": "https://api.github.com/repositories/7966650/releases/latest",
+        "jsonpath": "$..browser_download_url",
         "regex": "/download/([\\d.]+)/gnucash-([\\w.-]+)\\.setup\\.exe"
     },
     "autoupdate": {


### PR DESCRIPTION
Fixes wrong GnuCash link of version 5.6 which was replaced.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
