### PR TITLE
keymouse: Add version 1.5.2

### DIFF
--- a/bucket/keymouse.json
+++ b/bucket/keymouse.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.5.2",
+    "description": "KeyMouse is a program which works like the chrome plugin vimium, but is designed for other programs (like windows file browser).",
+    "homepage": "https://github.com/iscooool/KeyMouse",
+    "license": "MIT",
+    "notes": [
+        "May need to be excluded from antivirus as it reads cache which cause false positive.",
+        "Select mode: Press Alt + ; to enter select mode, then press tag to select item. If you hit rightClickPrefix before hitting tag, KeyMouse will simulate right click instead.",
+        "Fast Select mode: Alt + I to enter fast select mode. This mode may fail in some situations.",
+        "Esc Select mode: Press Esc to esc.",
+        "Disable: Press Alt + [ to enable/disable the program.",
+        "Scroll down: Press Alt + J.",
+        "Scroll up: Press Alt + K.",
+        "singleClickPrefix : Press Shift + S.",
+        "rightClickPrefix : Press Shift + A.",
+        "Force not use cache: When enableCache is true and you're in select mode. Press space to force not use cache.",
+        "if KeyMouse doesn't work, try to run as Administrator.",
+        "You may edit the 'config.json' file in program folder to modify the above shortcut-keys."
+    ],
+    "url": "https://github.com/iscooool/KeyMouse/releases/download/V1.5.2/KeyMouse-1.5.2.zip",
+    "shortcuts": [
+        [
+            "KeyMouse.exe",
+            "KeyMouse"
+        ]
+    ],
+    "hash": "2541c4dd4d99a2c89ab994768efb83b32b992c85c795d7191836c13412f56da1",
+    "extract_dir": "",
+    "checkver": {
+        "url": "https://github.com/iscooool/KeyMouse/releases/latest",
+        "regex": "Release\\(V([\\d.]+)\\)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/iscooool/KeyMouse/releases/download/V$version/KeyMouse-1.5.2.zip"
+    }
+}


### PR DESCRIPTION
KeyMouse is a program which works like the chrome plugin vimium, but is designed for other programs (like windows file browser). The github checkver doesn't work, so regex checkver is used.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
