### PR TITLE
love@11.5: Fix hash

### DIFF
--- a/bucket/love.json
+++ b/bucket/love.json
@@ -7,12 +7,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/love2d/love/releases/download/11.5/love-11.5-win64.zip",
-            "hash": "cc71dbc24a9eb65aa988d3f0dc77d090f340e14ed32bbbc9e7bfaf1988cd0455",
+            "hash": "BA6E56BE2685E53C817749C4A5007F51137136FE5A3AB64920508BABC2E74369",
             "extract_dir": "love-11.5-win64"
         },
         "32bit": {
             "url": "https://github.com/love2d/love/releases/download/11.5/love-11.5-win32.zip",
-            "hash": "15ddf5b06c293722275cf32e167c418120dd80380e5565739a29b7d5e5d6d44a",
+            "hash": "910C88CEBC6A3B91F9104BE505F5FFFAC0C91C95B072394AA67EB3CC63AA0A3B",
             "extract_dir": "love-11.5-win32"
         }
     },


### PR DESCRIPTION
Installing 'love' (11.5) [64bit] from extras bucket love-11.5-win64.zip (4.3 MB) [================================================================================] 100% Checking hash of love-11.5-win64.zip ... ERROR Hash check failed!
App:         extras/love
URL:         https://github.com/love2d/love/releases/download/11.5/love-11.5-win64.zip
First bytes: 50 4B 03 04 14 00 08 00
Expected:    cc71dbc24a9eb65aa988d3f0dc77d090f340e14ed32bbbc9e7bfaf1988cd0455
Actual:      ba6e56be2685e53c817749c4a5007f51137136fe5a3ab64920508babc2e74369

Please try again or create a new issue by using the following link and paste your console output: https://github.com/ScoopInstaller/Extras/issues/new?title=love%4011.5%3a+hash+check+failed

<!-- Provide a general summary of your changes in the title above -->
Updated Hash to the correct values 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
