### PR TITLE
Fix download url for dbeaver

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -12,7 +12,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.dbeaver.com/community/24.0.2/dbeaver-ce-24.0.2-win32.win32.x86_64.zip",
+            "url": "https://dbeaver.io/files/24.0.2/dbeaver-ce-24.0.2-win32.win32.x86_64.zip",
             "hash": "e16a319fbad0564b1a557285b76411b0857a6c400bca2a245f0e4394468b4c1a"
         }
     },
@@ -33,7 +33,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.dbeaver.com/community/$version/dbeaver-ce-$version-win32.win32.x86_64.zip"
+                "url": "https://dbeaver.io/files/$version/dbeaver-ce-$version-win32.win32.x86_64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Fix download urls for dbeaver, the old domain (`download.dbeaver.com`) is not available anymore.

No issue or open PR for this exists yet.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
