### PR TITLE
argyllcms@3.2.0: Remove non-existent bin (spec2cie.exe)

### DIFF
--- a/bucket/argyllcms.json
+++ b/bucket/argyllcms.json
@@ -51,7 +51,6 @@
         "bin\\refine.exe",
         "bin\\revfix.exe",
         "bin\\scanin.exe",
-        "bin\\spec2cie.exe",
         "bin\\specplot.exe",
         "bin\\splitti3.exe",
         "bin\\spotread.exe",


### PR DESCRIPTION
Whether intentional or not by the author of the software, spec2cie.exe is no longer a part of the bin dir, making the installation through Scoop fail.

This simple change to the manifest should fix that.

Closes #13147

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
