### PR TITLE
autohotkey@2.0.13: Fix pre_uninstall script

### DIFF
--- a/bucket/autohotkey.json
+++ b/bucket/autohotkey.json
@@ -66,7 +66,7 @@
         "            if (!($dirs.Contains($current)) -and ($_.'Path' -notlike '*.lnk')) { $dirs += $current }",
         "        }",
         "        $export | Out-File \"$persist_dir\\installed-files.csv\" -Encoding ASCII",
-        "        $dirs | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\installed-files\" -Recurse }",
+        "        $dirs | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\installed-files\" -Recurse -ErrorAction SilentlyContinue }",
         "    }",
         "}"
     ],


### PR DESCRIPTION
Fixes reported errors during autohotkey updates.

Closes #13075 .
