### PR TITLE
komf: make run behaviour same as komga

### DIFF
--- a/bucket/komf.json
+++ b/bucket/komf.json
@@ -17,6 +17,7 @@
             "--config-dir=\"$dir\\config\""
         ]
     ],
+    "persist": "config",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Snd-R/komf/releases/download/$version/komf-$version.jar#/komf.jar"

--- a/bucket/komf.json
+++ b/bucket/komf.json
@@ -10,7 +10,13 @@
     },
     "url": "https://github.com/Snd-R/komf/releases/download/0.33.2/komf-0.33.2.jar#/komf.jar",
     "hash": "ba9d11f16c87c7809a7c51bb602ae4d04a6525b61533458e010e5ca538bf0016",
-    "bin": "komf.jar",
+    "bin": [
+        [
+            "komf.jar",
+            "komf",
+            "--config-dir=\"$dir\\config\""
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Snd-R/komf/releases/download/$version/komf-$version.jar#/komf.jar"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Currently komf run behaviour is not consistent with komga, this PR will make it consistent by configuring config folder on installation directory as config directory and persist it like komga (https://github.com/ScoopInstaller/Extras/blob/master/bucket/komga.json#L15)

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
