### PR TITLE
Otvdm: extract_dir

### DIFF
--- a/bucket/otvdm.json
+++ b/bucket/otvdm.json
@@ -2,7 +2,7 @@
     "version": "0.9.0",
     "description": "16-bit Windows (Windows 1.x, 2.x, 3.0, 3.1, etc.) emulator for 64-bit Windows.",
     "homepage": "https://github.com/otya128/winevdm/",
-    "license": "GPL-2.0-1",
+    "license": "GPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/otya128/winevdm/releases/download/v0.9.0/otvdm-v0.9.0.zip",

--- a/bucket/otvdm.json
+++ b/bucket/otvdm.json
@@ -2,7 +2,7 @@
     "version": "0.9.0",
     "description": "16-bit Windows (Windows 1.x, 2.x, 3.0, 3.1, etc.) emulator for 64-bit Windows.",
     "homepage": "https://github.com/otya128/winevdm/",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-1",
     "architecture": {
         "64bit": {
             "url": "https://github.com/otya128/winevdm/releases/download/v0.9.0/otvdm-v0.9.0.zip",
@@ -10,10 +10,7 @@
         }
     },
     "extract_dir": "otvdm-v0.9.0",
-    "bin": [
-        "otvdm.exe",
-        "otvdmw.exe"
-    ],
+    "bin": "otvdm.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This is improvement of otvdm manifest to use extract_dir instead of bin: "directory/executable".

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
