### PR TITLE
VencordInstallerCli: Add version `1.4.0`

### DIFF
--- a/bucket/vencord-installer-cli.json
+++ b/bucket/vencord-installer-cli.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.4.0",
+    "description": "A cross platform cli app for installing Vencord",
+    "homepage": "https://github.com/Vencord/Installer",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Vencord/Installer/releases/download/v1.4.0/VencordInstallerCli.exe",
+            "hash": "466d2a0be1f380ddffed052df3cc132125fa34dc1af29312e14f13f358c8d2a2"
+        }
+    },
+    "bin": "VencordInstallerCli.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Vencord/Installer/releases/download/v$version/VencordInstallerCli.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add https://github.com/Vencord/Installer (only the CLI variant, there's also a GUI one).
I'm not certain if the GUI version should be it's own manifest or part of this one.

Hope I've not messed up anything but do lemme know if something's wrong, thanks!

Relates to #13200

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
