### PR TITLE
imageglass: Update to version 9.1.6.14, remove arm64 version

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -1,19 +1,14 @@
 {
-    "version": "9.0.10.201",
+    "version": "9.0.11.502",
     "description": "A lightweight, versatile image viewer",
     "homepage": "https://imageglass.org",
     "license": "GPL-3.0-only",
     "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.json' and reinstall '$dir\\Themes'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.10.201/ImageGlass_9.0.10.201_x64.zip",
-            "hash": "222b97a8746b337b06dc7f072fedaf4b22884ecc4152657e80da1461a432759c",
-            "extract_dir": "ImageGlass_9.0.10.201_x64"
-        },
-        "arm64": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.10.201/ImageGlass_9.0.10.201_arm64.zip",
-            "hash": "f9706df1e975772e94295b648ad3a3b572e4954ee74d3c2ee6a3dabd5b10f7dd",
-            "extract_dir": "ImageGlass_9.0.10.201_arm64"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.11.502/ImageGlass_9.0.11.502_x64.zip",
+            "hash": "ed9c0a3616d262dd1c094ae7205c6833bdfbc962d99d4c8ddb8f4a792a7ab882",
+            "extract_dir": "ImageGlass_9.0.11.502_x64"
         }
     },
     "pre_install": [
@@ -43,10 +38,6 @@
             "64bit": {
                 "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x64.zip",
                 "extract_dir": "ImageGlass_$version_x64"
-            },
-            "arm64": {
-                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_arm64.zip",
-                "extract_dir": "ImageGlass_$version_arm64"
             }
         }
     }

--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -1,14 +1,14 @@
 {
-    "version": "9.0.11.502",
+    "version": "9.1.6.14",
     "description": "A lightweight, versatile image viewer",
     "homepage": "https://imageglass.org",
     "license": "GPL-3.0-only",
     "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.json' and reinstall '$dir\\Themes'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.0.11.502/ImageGlass_9.0.11.502_x64.zip",
-            "hash": "ed9c0a3616d262dd1c094ae7205c6833bdfbc962d99d4c8ddb8f4a792a7ab882",
-            "extract_dir": "ImageGlass_9.0.11.502_x64"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/9.1.6.14/ImageGlass_9.1.6.14_x64.zip",
+            "hash": "b03ca6c19d481525c6d23fa4b029bd9c667d149d2d849a11a4bd421cd93c547a",
+            "extract_dir": "ImageGlass_9.1.6.14_x64"
         }
     },
     "pre_install": [


### PR DESCRIPTION
imageglass no longer releases package files for arm64

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
