### PR TITLE
krita@5.2.2: Fix install errors on removing a non-existent file

### DIFF
--- a/bucket/krita.json
+++ b/bucket/krita.json
@@ -9,7 +9,7 @@
             "hash": "f4fe0a3edf163d7154a6f6b7e9634494be84a666a465dd59751e27659dfe3c50"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe.nsis\" -Recurse -Force",
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe.nsis*\" -Recurse -Force",
     "bin": [
         "bin\\krita.exe",
         "bin\\kritarunner.exe"


### PR DESCRIPTION
Added a "*" to the Remove-Item expression, so it won't error if the file does not exist.

Closes #13220

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
