### PR TITLE
owncloud: Add version 5.2.1.13040

### DIFF
--- a/bucket/owncloud.json
+++ b/bucket/owncloud.json
@@ -33,7 +33,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.owncloud.com/desktop/ownCloud/stable/5.2.1.13040/win/ownCloud-$version.x64.msi"
+                "url": "https://download.owncloud.com/desktop/ownCloud/stable/$version/win/ownCloud-$version.x64.msi"
             }
         }
     }

--- a/bucket/owncloud.json
+++ b/bucket/owncloud.json
@@ -1,0 +1,40 @@
+{
+    "version": "5.2.1.13040",
+    "description": "The ownCloud Desktop Client is a tool to synchronize files from ownCloud Server with your computer.",
+    "homepage": "https://owncloud.com/",
+    "license": "GPL-2.0",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://download.owncloud.com/desktop/ownCloud/stable/5.2.1.13040/win/ownCloud-5.2.1.13040.x64.msi",
+            "hash": "e30eb458dd6e724c69700b881e94e47d0aae7fdbe7292e0e86bb870fb062bc0f"
+        }
+    },
+    "extract_dir": "PFiles\\ownCloud",
+    "bin": [
+        "owncloudcmd.exe",
+        [
+            "owncloudcmd.exe",
+            "owncloud"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "owncloud.exe",
+            "ownCloud"
+        ]
+    ],
+    "checkver": {
+        "url": "https://owncloud.com/de/desktop-app/",
+        "regex": "ownCloud-([\\d.]+).x64.msi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.owncloud.com/desktop/ownCloud/stable/5.2.1.13040/win/ownCloud-$version.x64.msi"
+            }
+        }
+    }
+}

--- a/bucket/owncloud.json
+++ b/bucket/owncloud.json
@@ -27,7 +27,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://owncloud.com/de/desktop-app/",
+        "url": "https://owncloud.com/desktop-app/",
         "regex": "ownCloud-([\\d.]+).x64.msi"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Created an app manifest for the ownCloud desktop client. Since the clients are still very similar, I used the manifest of Nextcloud as blueprint.

Closes #13229 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
