### PR TITLE
redshift-tray: get releases from Codeberg

### DIFF
--- a/bucket/redshift-tray.json
+++ b/bucket/redshift-tray.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.2.3",
+    "version": "2.3.0",
     "description": "A no-frills GUI for Redshift.",
-    "homepage": "https://github.com/ltGuillaume/Redshift-Tray",
+    "homepage": "https://codeberg.org/ltguillaume/redshift-tray",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/ltGuillaume/Redshift-Tray/releases/download/2.2.3/redshift-tray_2.2.3.zip",
-    "hash": "53947e64befd93aad09a3c694f5d8dd1f36d08c78c5def8e916bc0f861f40f9c",
+    "url": "https://codeberg.org/ltguillaume/redshift-tray/releases/download/2.3.0/redshift-tray_2.3.0.zip",
+    "hash": "01f111c56bebe25f06ffa7c20c4e37aa193ddf77e9886e83fe081aad8a30e2f0",
     "pre_install": "if (!(Test-Path \"$persist_dir\\rstray.ini\")) { New-Item \"$dir\\rstray.ini\" | Out-Null }",
     "bin": [
         "redshift.exe",
@@ -17,8 +17,11 @@
         ]
     ],
     "persist": "rstray.ini",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://codeberg.org/api/v1/repos/ltguillaume/redshift-tray/releases/latest",
+        "jsonpath": "$.tag_name"
+    },
     "autoupdate": {
-        "url": "https://github.com/ltGuillaume/Redshift-Tray/releases/download/$version/redshift-tray_$version.zip"
+        "url": "https://codeberg.org/ltguillaume/redshift-tray/releases/download/$version/redshift-tray_$version.zip"
     }
 }

--- a/bucket/redshift-tray.json
+++ b/bucket/redshift-tray.json
@@ -3,8 +3,12 @@
     "description": "A no-frills GUI for Redshift.",
     "homepage": "https://codeberg.org/ltguillaume/redshift-tray",
     "license": "GPL-3.0-only",
-    "url": "https://codeberg.org/ltguillaume/redshift-tray/releases/download/2.3.0/redshift-tray_2.3.0.zip",
-    "hash": "01f111c56bebe25f06ffa7c20c4e37aa193ddf77e9886e83fe081aad8a30e2f0",
+    "architecture": {
+        "64bit": {
+            "url": "https://codeberg.org/ltguillaume/redshift-tray/releases/download/2.3.0/redshift-tray_2.3.0.zip",
+            "hash": "01f111c56bebe25f06ffa7c20c4e37aa193ddf77e9886e83fe081aad8a30e2f0"
+        }
+    },
     "pre_install": "if (!(Test-Path \"$persist_dir\\rstray.ini\")) { New-Item \"$dir\\rstray.ini\" | Out-Null }",
     "bin": [
         "redshift.exe",
@@ -22,6 +26,13 @@
         "jsonpath": "$.tag_name"
     },
     "autoupdate": {
-        "url": "https://codeberg.org/ltguillaume/redshift-tray/releases/download/$version/redshift-tray_$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://codeberg.org/ltguillaume/redshift-tray/releases/download/$version/redshift-tray_$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/redshift-tray_$version.sha256"
+        }
     }
 }


### PR DESCRIPTION
...because I will no longer upload releases to GitHub.

<!-- Provide a general summary of your changes in the title above -->
Check versions and download from Codeberg, instead of GitHub.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
