### PR TITLE
pipp@2.5.9: Fix urls, disable updates

### DIFF
--- a/bucket/pipp.json
+++ b/bucket/pipp.json
@@ -1,10 +1,10 @@
 {
     "version": "2.5.9",
-    "description": "An Application designed for pre-processing planetary images before stacking them with image stacking software such as Registax.",
-    "homepage": "https://sites.google.com/site/astropipp/home",
+    "description": "An application designed for pre-processing planetary images before stacking them with image stacking software such as Registax.",
+    "homepage": "https://web.archive.org/web/20230604160403/https://sites.google.com/site/astropipp/home",
     "license": {
         "identifier": "Freeware",
-        "url": "https://sites.google.com/site/astropipp/home#TOC-Acknowledgements"
+        "url": "https://web.archive.org/web/20230604160403/https://sites.google.com/site/astropipp/home#TOC-Acknowledgements"
     },
     "architecture": {
         "64bit": {

--- a/bucket/pipp.json
+++ b/bucket/pipp.json
@@ -28,19 +28,5 @@
             "PIPP.exe",
             "PIPP"
         ]
-    ],
-    "checkver": {
-        "url": "https://sites.google.com/site/astropipp/downloads",
-        "regex": "Windows Installer \\(v([\\d.]+)\\)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://sites.google.com/site/astropipp/downloads/pipp_install_x64_$version.zip"
-            },
-            "32bit": {
-                "url": "https://sites.google.com/site/astropipp/downloads/pipp_install_x86_$version.zip"
-            }
-        }
-    }
+    ]
 }

--- a/bucket/pipp.json
+++ b/bucket/pipp.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://sites.google.com/site/astropipp/downloads/pipp_install_x64_2.5.9.zip",
+            "url": "https://www.rsastro.com/download/pipp_install_x64_2.5.9.zip",
             "hash": "231f08bf36aa812946158d6239861bd9a3a328d33124afd357a35dc28d623efe"
         },
         "32bit": {
-            "url": "https://sites.google.com/site/astropipp/downloads/pipp_install_x86_2.5.9.zip",
+            "url": "https://www.rsastro.com/download/pipp_install_x86_2.5.9.zip",
             "hash": "87dfaa846e75e265a004961aa785b5544ec7cf8ae0cf4c7443a9c677172bba0d"
         }
     },

--- a/bucket/pipp.json
+++ b/bucket/pipp.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.rsastro.com/download/pipp_install_x64_2.5.9.zip",
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/pipp/pipp_install_x64_2.5.9.zip",
             "hash": "231f08bf36aa812946158d6239861bd9a3a328d33124afd357a35dc28d623efe"
         },
         "32bit": {
-            "url": "https://www.rsastro.com/download/pipp_install_x86_2.5.9.zip",
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/pipp/pipp_install_x86_2.5.9.zip",
             "hash": "87dfaa846e75e265a004961aa785b5544ec7cf8ae0cf4c7443a9c677172bba0d"
         }
     },


### PR DESCRIPTION
Attempt to fix unavailable `pipp` installations download:

- broken update from Excavator log:
> pipp: couldn't match 'Windows Installer \(v([\d.]+)\)' in https://sites.google.com/site/astropipp/downloads
- site and download locations unavailability reported by users: cgarry/ser-player#15, [link](https://www.cloudynights.com/topic/880084-pipp-download-location-seems-unavailable/), [link](https://www.reddit.com/r/AskAstrophotography/comments/14hg05c/the_link_to_download_pipp_isnt_working_anymore/).

Binaries are still available via [Wayback Machine archive](https://web.archive.org/web/20230604160403/https://sites.google.com/site/astropipp/downloads) ([x86](https://web.archive.org/web/20230604160535if_/https://3670d42b-a-62cb3a1a-s-sites.googlegroups.com/site/astropipp/downloads/pipp_install_x86_2.5.9.zip?attachauth=ANoY7crLNAqqt8W8_VKOuFNKAwb-dZnFKIibRiYMzgnIQrJfnuGy0lZdjsSLdjTOkXPpP2zNhoRHG-2fTCFbiIxFFHmORPM2gvVVE8ii4HQuWCEg8hFSsC4pCvOVNxXtxz0NyNkp97KVoETuLSECpTL8nCBkypcWvE93qXEdpYBoxbX-JVhkejbcswOy5hGI5DyEIvjWTEtszzMsUlb6nR2dBeNQ8xV43UFwt6NC52l3pcqFMwfkQqo%3D&attredirects=0&d=1), [x64](https://web.archive.org/web/20230604160513if_/https://3670d42b-a-62cb3a1a-s-sites.googlegroups.com/site/astropipp/downloads/pipp_install_x64_2.5.9.zip?attachauth=ANoY7cqdYBVS5zJC7cDe3vfRpo1UMuG8uqwsEO3H3XSOQs9lsTvdMkjXyFDtFmjblJQVQIDiodyD-n1hBMzwLp3J6YqrQ6NVQcpIi2kjYw03KcUfRMhRY6pXH8Wv0oSbX9ulSYm686MqNwRHvw6E7P9HOe_taIkV7VYAdWLJl7SutLtgDbhRchbozZxTh0GgrAIQc8INM8T4dSLaa5O9vbyxSaZT7DiRYHOrBIjgo2ALCjnfG3gigmY%3D&attredirects=0&d=1)) but
1. links seem to long to be used via scoop;
2. using links from WBM will trigger `hash check failed` each time, same as ScoopInstaller/Extras#12574.

So 
- adding links to mirrored files [on another resource](https://www.rsastro.com/downloads/) instead: same hashes as originals,  virustotal check passed;
_(will be replaced if/after ScoopInstaller/Binary#25 will be merged)_
- disabling updates check ([last release in 2017](https://web.archive.org/web/20230604160403/https://sites.google.com/site/astropipp/downloads)).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

---

Waiting on https://github.com/ScoopInstaller/Binary/pull/25 to be merged first.