### PR TITLE
theia-ide: Add version 1.49.100

### DIFF
--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://raw.github.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "1.49.1",
+    "description": "A modern and open IDE for cloud and desktop. Theia platform based. Formerly “Theia Blueprint”.",
+    "homepage": "https://theia-ide.org/#theiaide",
+    "license": "EPL-2.0, GPL-2.0, MIT",
+    "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop. Also, the download URL will work only with latest version.",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.eclipse.org/theia/ide/latest/windows/TheiaIDESetup-1.49.100.exe#/dl.7z",
+            "hash": "e25463e2ce8f60a321ddaa5e76d20ce569c0ebfff6489ac1aca641980639897f"
+        }
+    },
+    "extract_dir": "$PLUGINSDIR",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal"
+        ]
+    },
+    "bin": "TheiaIDE.exe",
+    "shortcuts": [
+        [
+            "TheiaIDE.exe",
+            "TheiaIDE"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/eclipse-theia/theia"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.eclipse.org/theia/ide/latest/windows/TheiaIDESetup-$version00.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -4,11 +4,11 @@
     "description": "A modern and open IDE for cloud and desktop. Theia platform based. Formerly “Theia Blueprint”.",
     "homepage": "https://theia-ide.org/#theiaide",
     "license": "EPL-2.0, GPL-2.0, MIT",
-    "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop. Also, the download URL will work only with latest version.",
+    "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop. For using explicit versions: neither hash, nor all old versions are available.",
     "architecture": {
         "64bit": {
-            "url": "https://download.eclipse.org/theia/ide/latest/windows/TheiaIDESetup-1.49.100.exe#/dl.7z",
-            "hash": "e25463e2ce8f60a321ddaa5e76d20ce569c0ebfff6489ac1aca641980639897f"
+            "url": "https://download.eclipse.org/theia/ide/1.49.100/windows/TheiaIDESetup-1.49.100.exe#/dl.7z",
+            "hash": "sha512:a88a979fb1446cf463517377331ed67c78cdb9e2dec70e5d139b1b751883e2cecb20d45f060d9a1a8b30d7fb374d98ddd089e60c071cb5d8fd35819ba06a9156"
         }
     },
     "extract_dir": "$PLUGINSDIR",
@@ -30,7 +30,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.eclipse.org/theia/ide/latest/windows/TheiaIDESetup-$version00.exe#/dl.7z"
+                "url": "https://download.eclipse.org/theia/ide/$version00/windows/TheiaIDESetup-$version00.exe#/dl.7z",
+                "hash": {
+                    "url": "https://download.eclipse.org/theia/ide/latest/windows/latest.yml",
+                    "regex": "sha512: $base64"
+                }
             }
         }
     }

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -1,10 +1,9 @@
 {
-    "$schema": "https://raw.github.com/ScoopInstaller/Scoop/master/schema.json",
-    "version": "1.49.1",
+    "version": "1.49.100",
     "description": "A modern and open IDE for cloud and desktop. Theia platform based. Formerly “Theia Blueprint”.",
     "homepage": "https://theia-ide.org/#theiaide",
     "license": "EPL-2.0, GPL-2.0, MIT",
-    "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop. For using explicit versions: neither hash, nor all old versions are available.",
+    "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop.",
     "architecture": {
         "64bit": {
             "url": "https://download.eclipse.org/theia/ide/1.49.100/windows/TheiaIDESetup-1.49.100.exe#/dl.7z",
@@ -13,9 +12,7 @@
     },
     "extract_dir": "$PLUGINSDIR",
     "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal"
-        ]
+        "script": "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal"
     },
     "bin": "TheiaIDE.exe",
     "shortcuts": [
@@ -25,12 +22,13 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/eclipse-theia/theia"
+        "github": "https://github.com/eclipse-theia/theia",
+        "replace": "${1}00"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.eclipse.org/theia/ide/$version00/windows/TheiaIDESetup-$version00.exe#/dl.7z",
+                "url": "https://download.eclipse.org/theia/ide/$version/windows/TheiaIDESetup-$version.exe#/dl.7z",
                 "hash": {
                     "url": "https://download.eclipse.org/theia/ide/latest/windows/latest.yml",
                     "regex": "sha512: $base64"

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -22,8 +22,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/eclipse-theia/theia",
-        "replace": "${1}00"
+        "url": "https://download.eclipse.org/theia/ide/latest/windows/latest.yml",
+        "regex": "version: ([\\d\\.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -6,7 +6,7 @@
     "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop.",
     "architecture": {
         "64bit": {
-            "url": "https://download.eclipse.org/theia/ide/1.49.100/windows/TheiaIDESetup-1.49.100.exe#/dl.7z",
+            "url": "https://www.eclipse.org/downloads/download.php?mirror_id=1&file=/theia/ide/1.49.100/windows/TheiaIDESetup-1.49.100.exe#/dl.7z",
             "hash": "sha512:a88a979fb1446cf463517377331ed67c78cdb9e2dec70e5d139b1b751883e2cecb20d45f060d9a1a8b30d7fb374d98ddd089e60c071cb5d8fd35819ba06a9156"
         }
     },
@@ -28,7 +28,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.eclipse.org/theia/ide/$version/windows/TheiaIDESetup-$version.exe#/dl.7z",
+                "url": "https://www.eclipse.org/downloads/download.php?mirror_id=1&file=/theia/ide/$version/windows/TheiaIDESetup-$version.exe#/dl.7z",
                 "hash": {
                     "url": "https://download.eclipse.org/theia/ide/latest/windows/latest.yml",
                     "regex": "sha512: $base64"

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -23,7 +23,7 @@
     ],
     "checkver": {
         "url": "https://download.eclipse.org/theia/ide/latest/windows/latest.yml",
-        "regex": "version: ([\\d\\.]+)"
+        "regex": "version: ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
  * Note: checkver returns `1.49.1`, download-url is at `1.49.100` so, used in manifest is `$version00` in hopes that future versions will follow the same pattern.

  * Version specific download link for theia (for use in `"autoupdate"`) https://projects.eclipse.org/projects/ecd.theia/downloads -> https://download.eclipse.org/theia / ide / latest / windows

  * Dealing with NSIS pkgs: examples at https://github.com/search via: `user:scoopinstaller path:bucket/*.json "\"extract_dir\": \"$P"` https://github.com/ScoopInstaller/Extras/blob/d48d63f0bf/bucket/android-messages.json#L10-L18

  * `checkver: github` from https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate#special-cases

Close: https://github.com/ScoopInstaller/Extras/issues/13272

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
Relates to #XXXX
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
