### PR TITLE
elucidisk: Add version 1.2

### DIFF
--- a/bucket/elucidisk.json
+++ b/bucket/elucidisk.json
@@ -10,6 +10,12 @@
         }
     },
     "bin": "elucidisk.exe",
+    "shortcuts": [
+        [
+            "elucidisk.exe",
+            "Elucidisk"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/elucidisk.json
+++ b/bucket/elucidisk.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.2",
+    "description": "Disk space usage visualizer",
+    "homepage": "https://github.com/chrisant996/elucidisk",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/chrisant996/elucidisk/releases/download/v1.2/elucidisk-v1.2.zip",
+            "hash": "3c8e25d7385d807ec765dbf8375fbee4210e2f85c65b13e478d0ac690da73b2c"
+        }
+    },
+    "bin": "elucidisk.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/chrisant996/elucidisk/releases/download/v$version/elucidisk-v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add `elucidisk` to Extras.

> https://github.com/chrisant996/elucidisk
> 
> This uses a sunburst chart to visualize disk space usage on Windows.
> 
> It is modelled after [Scanner](http://www.steffengerlach.de/freeware/), [Diskitude](https://madebyevan.com/diskitude/), and other similar disk space viewers.
> 


![](https://raw.githubusercontent.com/chrisant996/elucidisk/master/demo.png)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13277


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
