### PR TITLE
hekasoft-backup-restore: Update to version 0.96

### DIFF
--- a/bucket/hekasoft-backup-restore.json
+++ b/bucket/hekasoft-backup-restore.json
@@ -13,7 +13,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.majorgeeks.com/mg/getmirror/hekasoft_backup_restore,2.htmll",
+        "url": "https://www.majorgeeks.com/mg/getmirror/hekasoft_backup_restore,2.html",
         "regex": "Hekasoft\\sBackup\\s&amp;\\sRestore\\s+([\\d.]+)[\\s\\S]+https\\:[\\w.-/]+com/(?<Hash>[\\w]+)/backup/backup-restore-[\\d.]+\\.exe"
     },
     "autoupdate": {

--- a/bucket/hekasoft-backup-restore.json
+++ b/bucket/hekasoft-backup-restore.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.95",
+    "version": "0.96",
     "description": "Hekasoft Backup and Restore is a free tool to backup and restores your browser settings. It allows you to migrate your profile from one browser to another and even custom your profile by removing unwanted files",
     "homepage": "http://www.hekasoft.com/hekasoft-backup-restore/",
     "license": "Freeware",
-    "url": "https://www.fosshub.com/Hekasoft-Backup-Restore.html/backup-restore-0.95-portable.zip",
-    "hash": "cd85023db4fdc0c16d4edd2722418978ca3ace855edf52bb2f8660d9a330d561",
-    "extract_dir": "hbr095",
+    "url": "https://files2.majorgeeks.com/90a90fc8da88d39ea0b2bd526769f8b1c2f8cb85/backup/backup-restore-0.96.exe",
+    "hash": "3b4200c463c7c0d3cc3a27ddb50e09f887c841e2eff39a6173a7fa9518fa1b25",
+    "innosetup": true,
     "shortcuts": [
         [
             "hbr.exe",
@@ -13,11 +13,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.fosshub.com/Hekasoft-Backup-Restore.html",
-        "regex": "backup-restore-([\\d.]+)-portable\\.zip"
+        "url": "https://www.majorgeeks.com/mg/getmirror/hekasoft_backup_restore,2.htmll",
+        "regex": "Hekasoft\\sBackup\\s&amp;\\sRestore\\s+([\\d.]+)[\\s\\S]+https\\:[\\w.-/]+com/(?<Hash>[\\w]+)/backup/backup-restore-[\\d.]+\\.exe"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/Hekasoft-Backup-Restore.html/backup-restore-$version-portable.zip",
-        "extract_dir": "hbr$cleanVersion"
+        "url": "https://files2.majorgeeks.com/$matchHash/backup/backup-restore-$version.exe"
     }
 }


### PR DESCRIPTION
Updates the manifest to version 0.96, which is the latest version.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
