### PR TITLE
tidal: Fix preinstall

### DIFF
--- a/bucket/tidal.json
+++ b/bucket/tidal.json
@@ -8,10 +8,7 @@
     },
     "url": "https://download.tidal.com/desktop/TIDALSetup.exe#/dl.7z",
     "hash": "c254585d8b2ba1711a645c1c4f4141a700620d4b806aa3c50d2e5317f5c26946",
-    "pre_install": [
-        "Expand-7zipArchive \"$dir\\TIDAL-$version-full.nupkg\" -ExtractDir 'lib\\net45' -Removal",
-        "Remove-Item \"$dir\\lib\""
-    ],
+    "pre_install": "Expand-7zipArchive \"$dir\\TIDAL-$version-full.nupkg\" -ExtractDir 'lib\\net45' -Removal",
     "shortcuts": [
         [
             "TIDAL.exe",


### PR DESCRIPTION
```
Running pre_install script...Remove-Item:
Line |
   2 |  Remove-Item "$dir\lib"
     |  ~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path '~\scoop\apps\tidal\2.37.8\lib' because it does not exist.
```
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).