### PR TITLE
komorebi: Add komorebi-gui.exe

### DIFF
--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.1.25",
+    "version": "0.1.26",
     "description": "A tiling window manager for Windows",
     "homepage": "https://github.com/LGUG2Z/komorebi",
-    "license": "MIT",
+    "license": "PolyForm Strict",
     "notes": "Check out the quickstart guide on https://lgug2z.github.io/komorebi",
     "suggest": {
         "whkd": "extras/whkd",
@@ -10,8 +10,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LGUG2Z/komorebi/releases/download/v0.1.25/komorebi-0.1.25-x86_64-pc-windows-msvc.zip",
-            "hash": "8da0d8f4f5316ef2be2c6217296d3b57391ef5349761ec56e540697602435d91"
+            "url": "https://github.com/LGUG2Z/komorebi/releases/download/v0.1.26/komorebi-0.1.26-x86_64-pc-windows-msvc.zip",
+            "hash": "320b4f6724b97ed4579cba27baf91abc4a963d9b8c79f7f3356962a60a11541a "
         }
     },
     "bin": [

--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -17,7 +17,8 @@
     "bin": [
         "komorebi.exe",
         "komorebic.exe",
-        "komorebic-no-console.exe"
+        "komorebic-no-console.exe",
+        "komorebi-gui.exe"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -11,7 +11,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/LGUG2Z/komorebi/releases/download/v0.1.26/komorebi-0.1.26-x86_64-pc-windows-msvc.zip",
-            "hash": "320b4f6724b97ed4579cba27baf91abc4a963d9b8c79f7f3356962a60a11541a "
+            "hash": "320b4f6724b97ed4579cba27baf91abc4a963d9b8c79f7f3356962a60a11541a"
         }
     },
     "bin": [


### PR DESCRIPTION
Add `komorebi-gui.exe` which will be part of `v0.1.26`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
