### PR TITLE
heynote: Add version 1.7.0

### DIFF
--- a/bucket/heynote.json
+++ b/bucket/heynote.json
@@ -1,7 +1,7 @@
 {
     "version": "1.7.0",
-    "homepage": "https://github.com/heyman/heynote",
     "description": "A dedicated scratchpad for developers",
+    "homepage": "https://heynote.com/",
     "license": "MIT",
     "architecture": {
         "64bit": {
@@ -9,15 +9,19 @@
             "hash": "sha512:d884e43cf996a5aee4bfcc9b18b7ea258f4b7af3094d636389ce05bfee7bfb28630db2061678ec1d99477afd86c5fd665ab222c42114ac9ce61d50152b018af0"
         }
     },
-    "extract_dir": "$PLUGINSDIR",
-    "pre_install": "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal",
+    "pre_install": [
+        "Expand-7ZipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+        "Remove-Item \"$dir\\`$*\" -Recurse"
+    ],
     "shortcuts": [
         [
             "Heynote.exe",
             "Heynote"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/heyman/heynote"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/heynote.json
+++ b/bucket/heynote.json
@@ -1,7 +1,7 @@
 {
     "version": "1.7.0",
     "homepage": "https://github.com/heyman/heynote",
-    "description": " A dedicated scratchpad for developers",
+    "description": "A dedicated scratchpad for developers",
     "license": "MIT",
     "architecture": {
         "64bit": {

--- a/bucket/heynote.json
+++ b/bucket/heynote.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.7.0",
+    "homepage": "https://github.com/heyman/heynote",
+    "description": " A dedicated scratchpad for developers",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/heyman/heynote/releases/download/v1.7.0/Heynote_1.7.0.exe#/dl.7z",
+            "hash": "sha512:d884e43cf996a5aee4bfcc9b18b7ea258f4b7af3094d636389ce05bfee7bfb28630db2061678ec1d99477afd86c5fd665ab222c42114ac9ce61d50152b018af0"
+        }
+    },
+    "extract_dir": "$PLUGINSDIR",
+    "pre_install": "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal",
+    "shortcuts": [
+        [
+            "Heynote.exe",
+            "Heynote"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/heyman/heynote/releases/download/v$version/Heynote_$version.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "regex": "sha512:\\s$base64"
+        }
+    }
+}


### PR DESCRIPTION
Add heynote 1.7.0 -  A dedicated scratchpad for developers 

https://github.com/heyman/heynote


Closes #12986 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

(copied from the `upscayl` manifest: https://github.com/ScoopInstaller/Extras/blob/master/bucket/upscayl.json)