### PR TITLE
fiddler: Update to version 5.0.20243.10853

### DIFF
--- a/bucket/fiddler.json
+++ b/bucket/fiddler.json
@@ -1,10 +1,10 @@
 {
-    "version": "5.0.20242.10753",
+    "version": "5.0.20243.10853",
     "description": "The free web debugging proxy for any browser, system or platform.",
     "homepage": "https://www.telerik.com/fiddler",
     "license": "Unknown",
-    "url": "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe#/dl.7z",
-    "hash": "06812518a722af6f98fbd8c3a5ace0cad1c6d53477972618728e64bafcbc948c",
+    "url": "https://downloads.getfiddler.com/fiddler-classic/FiddlerSetup.5.0.20243.10853-latest.exe#/dl.7z",
+    "hash": "174c811a5c0da930f53f29d68fcce985e88994e4bef869a04b57f399bef25bbc",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\FiddlerSetup.exe\" \"$dir\" -Removal",
         "Remove-Item \"$dir\\`$*\" -Recurse",


### PR DESCRIPTION
Updates the manifest to version 5.0.20243.10853, which is the latest version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
