### PR TITLE
add context menu for alacritty and fix sublime bug

### DIFF
--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -3,6 +3,24 @@
     "description": "GPU-accelerated terminal emulator",
     "homepage": "https://github.com/alacritty/alacritty",
     "license": "Apache-2.0",
+    "notes": [
+        "Add Open with Alacritty as a context menu option by running:",
+        "reg import \"$dir\\install-context.reg\""
+    ],
+    "post_install": [
+        "$alacrittypath = \"$dir\\alacritty.exe\".Replace('\\', '\\\\')",
+        "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
+        "    if (Test-Path \"$bucketsdir\\extras\\scripts\\$app\\$_\") {",
+        "        $content = Get-Content \"$bucketsdir\\extras\\scripts\\$app\\$_\"",
+        "        $content = $content.Replace('$alacritty', $alacrittypath)",
+        "        if ($global) {",
+        "            $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "        }",
+        "    }",
+        "    $content | Set-Content -Path \"$dir\\$_\" -Encoding ascii",
+        "}"
+    ],
+    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },

--- a/scripts/alacritty/install-context.reg
+++ b/scripts/alacritty/install-context.reg
@@ -1,0 +1,13 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Alacritty]
+@="Open with &Alacritty"
+"Icon"="$alacritty"
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Alacritty\command]
+@="\"$alacritty\" --working-directory %v"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Alacritty]
+@="Open with &Alacritty"
+"Icon"="$alacritty"
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Alacritty\command]
+@="\"$alacritty\" --working-directory %v"

--- a/scripts/alacritty/uninstall-context.reg
+++ b/scripts/alacritty/uninstall-context.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Alacritty]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Alacritty\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Alacritty]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Alacritty\command]

--- a/scripts/sublime-text/install-context.reg
+++ b/scripts/sublime-text/install-context.reg
@@ -16,4 +16,4 @@ Windows Registry Editor Version 5.00
 @="Open with &Sublime"
 "Icon"="$sublime"
 [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Sublime\command]
-@="\"$sublime\" \"%V\""
+@="\"$sublime\" %V"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Inspired on the #12997, add more registry entries to work with right click on folder directly. Alter the pop-up text to be `Open with Alacritty` instead of `Open Alacritty here` to be cohesive with `sublime-text`  and `vscode` examples.

Closes #12997
<!-- or -->

Sublime:
Fix wrong path in background directory. If i open in the root of any drive, it opens a file.
Correct behavior: open the folder instead.

Wrong:
![image](https://github.com/ScoopInstaller/Extras/assets/51183852/37dbd3b8-1b17-460f-acb5-2486e67664b5)

Correct:
![image](https://github.com/ScoopInstaller/Extras/assets/51183852/728efe29-f2ce-40b2-9279-af32dd3c1a46)

Accordingly to my tests, surrounding the %v sequence with escaped `"` in alacritty causes it to reproduce the same behavior of sublime's bug being corrected. But this behavior is unpredictable, it internaly transforms the path and `cd` in, despite of accusing the error.

![image](https://github.com/ScoopInstaller/Extras/assets/51183852/ce0f001a-1745-4646-801e-cf2e438bf1c9)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
