### PR TITLE
go-chromecast: Add version 0.3.1

### DIFF
--- a/bucket/go-chromecast.json
+++ b/bucket/go-chromecast.json
@@ -23,6 +23,9 @@
             "32bit": {
                 "url": "https://github.com/vishen/go-chromecast/releases/download/v$version/go-chromecast_$version_windows_386.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/go-chromecast.json
+++ b/bucket/go-chromecast.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.3.1",
+    "description": "CLI for controlling Google Chromecast devices.",
+    "homepage": "https://github.com/vishen/go-chromecast",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/vishen/go-chromecast/releases/download/v0.3.1/go-chromecast_0.3.1_windows_amd64.zip",
+            "hash": "27787c49fc6db1158c174b48d6551344019780a06d5fe1f5d7763b7f13c29b7b"
+        },
+        "32bit": {
+            "url": "https://github.com/vishen/go-chromecast/releases/download/v0.3.1/go-chromecast_0.3.1_windows_386.zip",
+            "hash": "7a63c82172d854ae3d17c3fc743b478c89aac5c949b9382b3d940d821a6b0fb1"
+        }
+    },
+    "bin": "go-chromecast.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/vishen/go-chromecast/releases/download/v$version/go-chromecast_$version_windows_amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/vishen/go-chromecast/releases/download/v$version/go-chromecast_$version_windows_386.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
go-chromecast is a nice CLI tool written in Golang to manage chromecast eligible devices (e.g. Smart-TVs, STBs, etc.)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
