### PR TITLE
hwinfo: Fix HWiNFO64_KEY.txt persistence

### DIFF
--- a/bucket/hwinfo.json
+++ b/bucket/hwinfo.json
@@ -1,10 +1,10 @@
 {
-    "version": "8.02-5440",
+    "version": "8.04-5470",
     "description": "Comprehensive Hardware Analysis, Monitoring and Reporting for Windows and DOS",
     "homepage": "https://www.hwinfo.com",
     "license": "Freeware",
-    "url": "https://www.fosshub.com/HWiNFO.html/hwi_802.zip",
-    "hash": "d03502ba1216fa202aed1a0a5d031bf0a881f16a658a8aa6a3ad21c5f5f7999e",
+    "url": "https://www.fosshub.com/HWiNFO.html/hwi_804.zip",
+    "hash": "f3d10e879b660e4d929c3401d66e03a9d246fbca18c938ddd7a25a0b561e0658",
     "pre_install": [
         "foreach ($conf in 'HWiNFO64.INI', 'HWiNFO32.INI') {",
         "    if (!(Test-Path \"$persist_dir\\$conf\")) { Set-Content \"$dir\\$conf\" '[Settings]', 'AutoUpdate=0' -Encoding ASCII }",

--- a/bucket/hwinfo.json
+++ b/bucket/hwinfo.json
@@ -8,6 +8,17 @@
     "pre_install": [
         "foreach ($conf in 'HWiNFO64.INI', 'HWiNFO32.INI') {",
         "    if (!(Test-Path \"$persist_dir\\$conf\")) { Set-Content \"$dir\\$conf\" '[Settings]', 'AutoUpdate=0' -Encoding ASCII }",
+        "}",
+        "if (Test-PATH \"$persist_dir\\HWiNFO64_KEY.txt\" -PathType Leaf) {",
+        "    Copy-Item \"$persist_dir\\HWiNFO64_KEY.txt\" \"$dir\"",
+        "}"
+    ],
+    "pre_uninstall": [
+        "if (Test-PATH \"$dir\\HWiNFO64_KEY.txt\" -PathType Leaf) {",
+        "    if (Test-PATH \"$persist_dir\\HWiNFO64_KEY.txt\" -PathType Container) {",
+        "        Remove-Item \"$persist_dir\\HWiNFO64_KEY.txt\" -Recurse",
+        "    }",
+        "    Copy-Item \"$dir\\HWiNFO64_KEY.txt\" \"$persist_dir\"",
         "}"
     ],
     "architecture": {
@@ -42,8 +53,7 @@
     },
     "persist": [
         "HWiNFO64.INI",
-        "HWiNFO32.INI",
-        "HWiNFO64_KEY.txt"
+        "HWiNFO32.INI"
     ],
     "checkver": {
         "url": "https://www.hwinfo.com/ver.txt",


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #11759
HWiNFO64_KEY.txt is a file, not a folder.
If this file exists but does not have a valid license, hwinfo reports an error.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
