### PR TITLE
materialgram: Add version 5.1.7.1

### DIFF
--- a/bucket/materialgram.json
+++ b/bucket/materialgram.json
@@ -1,13 +1,18 @@
 {
-    "version": "5.1.1.1",
+    "version": "5.1.7.1",
     "description": "Telegram Desktop fork with material icons and some improvements.",
     "homepage": "https://github.com/kukuruzka165/materialgram",
     "license": {
         "identifier": "GPL-3.0-only",
         "url": "https://github.com/kukuruzka165/materialgram/blob/main/LICENSE"
     },
-    "url": "https://github.com/kukuruzka165/materialgram/releases/download/v5.1.1.1/win64_materialgram_v5.1.1.1.zip",
-    "hash": "5806e432f4ed6269cd4472ed039be31d0c55a4ec5bd8eff9e3c13b1ac1f0df88",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kukuruzka165/materialgram/releases/download/v5.1.7.1/win64_materialgram_v5.1.7.1.zip",
+            "hash": "6dc41d400db41c48db49a222376ce5a327bd6443ccde008174d0dc9a81680224"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\Updater.exe\"",
     "shortcuts": [
         [
             "materialgram.exe",
@@ -15,11 +20,12 @@
         ]
     ],
     "persist": "tdata",
-    "checkver": {
-        "url": "https://github.com/kukuruzka165/materialgram",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/kukuruzka165/materialgram/releases/download/v$version/win64_materialgram_v$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kukuruzka165/materialgram/releases/download/v$version/win64_materialgram_v$version.zip"
+            }
+        }
     }
 }

--- a/bucket/materialgram.json
+++ b/bucket/materialgram.json
@@ -1,0 +1,25 @@
+{
+    "version": "5.1.1.1",
+    "description": "Telegram Desktop fork with material icons and some improvements.",
+    "homepage": "https://github.com/kukuruzka165/materialgram",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/kukuruzka165/materialgram/blob/main/LICENSE"
+    },
+    "url": "https://github.com/kukuruzka165/materialgram/releases/download/v5.1.1.1/win64_materialgram_v5.1.1.1.zip",
+    "hash": "5806e432f4ed6269cd4472ed039be31d0c55a4ec5bd8eff9e3c13b1ac1f0df88",
+    "shortcuts": [
+        [
+            "materialgram.exe",
+            "materialgram"
+        ]
+    ],
+    "persist": "tdata",
+    "checkver": {
+        "url": "https://github.com/kukuruzka165/materialgram",
+        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/kukuruzka165/materialgram/releases/download/v$version/win64_materialgram_v$version.zip"
+    }
+}


### PR DESCRIPTION
[materialgram](https://github.com/kukuruzka165/materialgram) is a [Telegram Desktop](https://github.com/telegramdesktop/tdesktop) fork with Material Design and other improvements.

Closes #13331

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
