### PR TITLE
GoofCord: Add version 1.7.1

### DIFF
--- a/bucket/goofcord.json
+++ b/bucket/goofcord.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.4.2",
+    "description": "A privacy minded and highly configurable Discord client",
+    "homepage": "https://github.com/Milkshiift/GoofCord",
+    "license": "OSL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.4.2/GoofCord-1.4.2-win-x64.zip",
+            "hash": "654d80c4a92a0b5ed7f0791cae7d6f7b7b99ce8da35fc38613613f03dad2b1cf"
+        },
+        "32bit": {
+            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.4.2/GoofCord-1.4.2-win-ia32.zip",
+            "hash": "5ed65185030ebfaf0c3bd5968c0f59931ae73b18665f16819badc47ae2ab83f9"
+        },
+        "arm64": {
+            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.4.2/GoofCord-1.4.2-win-arm64.zip",
+            "hash": "c695a8986d7205483efb80471f7333eea2afd224da918bf16a2f748579321632"
+        }
+    },
+    "shortcuts": [
+        [
+            "GoofCord.exe",
+            "GoofCord"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Milkshiift/GoofCord/releases/download/v$version/GoofCord-$version-win-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Milkshiift/GoofCord/releases/download/v$version/GoofCord-$version-win-ia32.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Milkshiift/GoofCord/releases/download/v$version/GoofCord-$version-win-arm64.zip"
+            }
+        }
+    }
+}

--- a/bucket/goofcord.json
+++ b/bucket/goofcord.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.4.2",
+    "version": "1.7.1",
     "description": "A privacy minded and highly configurable Discord client",
     "homepage": "https://github.com/Milkshiift/GoofCord",
     "license": "OSL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.4.2/GoofCord-1.4.2-win-x64.zip",
-            "hash": "654d80c4a92a0b5ed7f0791cae7d6f7b7b99ce8da35fc38613613f03dad2b1cf"
+            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.7.1/GoofCord-1.7.1-win-x64.zip",
+            "hash": "f5635b128a03e6178f2b376239c35400adde3caa788d9753521b3011c467536a"
         },
         "32bit": {
-            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.4.2/GoofCord-1.4.2-win-ia32.zip",
-            "hash": "5ed65185030ebfaf0c3bd5968c0f59931ae73b18665f16819badc47ae2ab83f9"
+            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.7.1/GoofCord-1.7.1-win-ia32.zip",
+            "hash": "9da1cb32d9c95c8660cce036accba8fdfa9d66ddae748dea7fe6cc93b2a30fb9"
         },
         "arm64": {
-            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.4.2/GoofCord-1.4.2-win-arm64.zip",
-            "hash": "c695a8986d7205483efb80471f7333eea2afd224da918bf16a2f748579321632"
+            "url": "https://github.com/Milkshiift/GoofCord/releases/download/v1.7.1/GoofCord-1.7.1-win-arm64.zip",
+            "hash": "193b45d965adc4aa3a869c0e47e04bb4842d42e70ce9df77724276882f647e07"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Add [GoofCord](https://github.com/Milkshiift/GoofCord), a standalone Discord client

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
