### PR TITLE
umi-ocr-paddle@2.1.2: Fix hash

### DIFF
--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/hiroi-sora/Umi-OCR/releases/download/v2.1.2/Umi-OCR_Paddle_v2.1.2.7z.exe",
-            "hash": "5dc35c798442dd357aed803d5a13c372a83f46f1be38655a7cbd8be26428bb95",
+            "hash": "6dce23ea7f95a2ffb9415f8f5bb588df75ddf90abdcbbb972cc38fe2dbbfc70d",
             "extract_dir": "Umi-OCR_Paddle_v2.1.2"
         }
     },


### PR DESCRIPTION
Relates to #13404, [commit/0858b881c40f1977fe57dd3531babc4bbf75827e](https://github.com/ScoopInstaller/Extras/commit/0858b881c40f1977fe57dd3531babc4bbf75827e)

The Hash in `bucket/umi-ocr.json` has been corrected. This PR is intended to fix the Hash in `bucket/umi-ocr-paddle.json`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).