### PR TITLE
media-downloader: Add version 4.7.0

### DIFF
--- a/bucket/media-downloader.json
+++ b/bucket/media-downloader.json
@@ -1,0 +1,15 @@
+{
+    "version": "4.7.0",
+    "description": "A Qt/C++ front end to yt-dlp, youtube-dl, gallery-dl, lux, you-get, svtplay-dl, aria2c, wget and safari books..",
+    "homepage": "https://github.com/mhogomchungu/media-downloader",
+    "license": "GPL-2.0",
+    "url": "https://github.com/mhogomchungu/media-downloader/releases/download/4.7.0/MediaDownloader-4.7.0.zip",
+    "hash": "181527e400b672a36e5b652ae9fd03f5df7c9a8d5b0933c48b003b7856410387",
+    "extract_dir": "MediaDownloader-4.7.0",
+    "bin": "media-downloader.exe",
+    "shortcuts": [["media-downloader.exe", "media-downloader"]],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/mhogomchungu/media-downloader/releases/download/$version/MediaDownloader-$version.zip"
+    }
+}

--- a/bucket/media-downloader.json
+++ b/bucket/media-downloader.json
@@ -1,6 +1,6 @@
 {
     "version": "4.7.0",
-    "description": "A Qt/C++ front end to yt-dlp, youtube-dl, gallery-dl, lux, you-get, svtplay-dl, aria2c, wget and safari books..",
+    "description": "A Qt/C++ front-end to yt-dlp, youtube-dl, gallery-dl, lux, you-get, svtplay-dl, aria2c, wget and safari books.",
     "homepage": "https://github.com/mhogomchungu/media-downloader",
     "license": "GPL-2.0",
     "url": "https://github.com/mhogomchungu/media-downloader/releases/download/4.7.0/MediaDownloader-4.7.0.zip",

--- a/bucket/media-downloader.json
+++ b/bucket/media-downloader.json
@@ -15,6 +15,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mhogomchungu/media-downloader/releases/download/$version/MediaDownloader-$version.zip"
+        "url": "https://github.com/mhogomchungu/media-downloader/releases/download/$version/MediaDownloader-$version.zip",
+        "extract_dir": "MediaDownloader-$version"
     }
 }

--- a/bucket/media-downloader.json
+++ b/bucket/media-downloader.json
@@ -7,7 +7,12 @@
     "hash": "181527e400b672a36e5b652ae9fd03f5df7c9a8d5b0933c48b003b7856410387",
     "extract_dir": "MediaDownloader-4.7.0",
     "bin": "media-downloader.exe",
-    "shortcuts": [["media-downloader.exe", "media-downloader"]],
+    "shortcuts": [
+        [
+            "media-downloader.exe",
+            "Media Downloader"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/mhogomchungu/media-downloader/releases/download/$version/MediaDownloader-$version.zip"


### PR DESCRIPTION
Add [media-downloader](https://github.com/mhogomchungu/media-downloader), a Qt/C++ front end to yt-dlp, youtube-dl, gallery-dl, lux, you-get, svtplay-dl, aria2c, wget and safari books..

Closes https://github.com/ScoopInstaller/Extras/issues/11167

* [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).