### PR TITLE
josm@19096: Add missing JVM arguments to fix startup error

### DIFF
--- a/bucket/josm.json
+++ b/bucket/josm.json
@@ -14,7 +14,7 @@
         "a17f41f7cca3f569932c65670cef21389feb6053132e24dacf5756b9f0f5c2a8",
         "0e78546d0a884a22a6badeb3cfadbae4b85ab2091240ed2d50ee7f78f0da5e03"
     ],
-    "pre_install": "Set-Content \"$dir\\JOSM.bat\" \"@start javaw.exe -Djosm.cache=$dir\\data\\cache -Djosm.userdata=$dir\\data -Djosm.pref=$dir\\data -jar \"\"%~dp0josm.jar\"\"\" -Encoding Ascii",
+    "pre_install": "Set-Content \"$dir\\JOSM.bat\" \"@start javaw.exe --add-exports=java.base/sun.security.action=ALL-UNNAMED --add-exports=java.desktop/com.sun.imageio.plugins.jpeg=ALL-UNNAMED --add-exports=java.desktop/com.sun.imageio.spi=ALL-UNNAMED -Djosm.cache=$dir\\data\\cache -Djosm.userdata=$dir\\data -Djosm.pref=$dir\\data -jar \"\"%~dp0josm.jar\"\"\" -Encoding Ascii",
     "shortcuts": [
         [
             "JOSM.bat",


### PR DESCRIPTION
> This is mostly so we stop getting tickets where any of the following are true:
> * User is missing a required JVM argument

Related info:
* https://josm.openstreetmap.de/ticket/23355
* https://josm.openstreetmap.de/ticket/23489

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
