### PR TITLE
wait4x: Add version 2.14.1

### DIFF
--- a/bucket/wait4x.json
+++ b/bucket/wait4x.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "Wait4X allows you to wait for a port or a service to enter the requested state",
     "homepage": "https://wait4x.dev/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/atkrad/wait4x/releases/download/v2.14.0/wait4x-windows-amd64.tar.gz",
-            "hash": "db0c6e3944655b8dd56187b3ed21f2176a7d8376d6804cfbc00b377baeed2f02"
+            "url": "https://github.com/atkrad/wait4x/releases/download/v2.14.1/wait4x-windows-amd64.tar.gz",
+            "hash": "3c7acab48fcd58693b686383e81104d9366fe56999abb5cbe09992b2ac48ed2b"
         },
         "arm64": {
-            "url": "https://github.com/atkrad/wait4x/releases/download/v2.14.0/wait4x-windows-arm64.tar.gz",
-            "hash": "573e1dfa2fd858b713273bc23a414fe00de925e7974dc77b88c5558e98358e10"
+            "url": "https://github.com/atkrad/wait4x/releases/download/v2.14.1/wait4x-windows-arm64.tar.gz",
+            "hash": "804225d6ddc09f229178f3becb62572f3c70bdc179610500c2dda448e94ef9f0"
         }
     },
     "bin": "wait4x.exe",

--- a/bucket/wait4x.json
+++ b/bucket/wait4x.json
@@ -1,0 +1,33 @@
+{
+    "version": "2.14.0",
+    "description": "Wait4X allows you to wait for a port or a service to enter the requested state",
+    "homepage": "https://wait4x.dev/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/atkrad/wait4x/releases/download/v2.14.0/wait4x-windows-amd64.tar.gz",
+            "hash": "db0c6e3944655b8dd56187b3ed21f2176a7d8376d6804cfbc00b377baeed2f02"
+        },
+        "arm64": {
+            "url": "https://github.com/atkrad/wait4x/releases/download/v2.14.0/wait4x-windows-arm64.tar.gz",
+            "hash": "573e1dfa2fd858b713273bc23a414fe00de925e7974dc77b88c5558e98358e10"
+        }
+    },
+    "bin": "wait4x.exe",
+    "checkver": {
+        "github": "https://github.com/atkrad/wait4x"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/atkrad/wait4x/releases/download/v$version/wait4x-windows-amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/atkrad/wait4x/releases/download/v$version/wait4x-windows-arm64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256sum"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Add Wait4X v2.14.1, Wait4X allows you to wait for a port or a service to enter the requested state, with a customizable timeout and interval time.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13463 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
