### PR TITLE
bambu-studio: Add version 01.09.02.57

### DIFF
--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -1,12 +1,12 @@
 {
-    "version": "01.09.03.50",
+    "version": "01.09.05.51",
     "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
     "homepage": "https://github.com/bambulab/BambuStudio",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.03.50/Bambu_Studio_win-v01.09.03.50-20240621095059.zip",
-            "hash": "11ca8b3e9027164b121c9d4758a7c6c8fb679b071ebe171c9bf0d05da0131384"
+            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.05.51/Bambu_Studio_win-v01.09.05.51-20240828205639.zip",
+            "hash": "9d92da20d5086c68ead9cae4f05d941fa9918bd410f1f56bcd0c793b17741b38"
         }
     },
     "shortcuts": [

--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -1,0 +1,30 @@
+{
+    "version": "01.09.02.57",
+    "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
+    "homepage": "https://github.com/bambulab/BambuStudio",
+    "license": "AGPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_win-v01.09.02.57-20240607194639.zip",
+            "hash": "135d9573dc13cbbbc98273f119c8d57b5a04499f65726680e701ff3ca231f02a"
+        }
+    },
+    "shortcuts": [
+        [
+            "bambu-studio.exe",
+            "Bambu Studio"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/bambulab/BambuStudio/releases/latest",
+        "jsonpath": "$..assets[?(@.browser_download_url =~ /Bambu_Studio_win-.*\\.zip/i)].browser_download_url",
+        "regex": ".*Bambu_Studio_win-v([\\d.]+)-(?<date>[0-9]+)\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bambulab/BambuStudio/releases/download/v$version/Bambu_Studio_win-v$version-$matchDate.zip"
+            }
+        }
+    }
+}

--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -1,12 +1,12 @@
 {
-    "version": "01.09.02.57",
+    "version": "01.09.03.50",
     "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
     "homepage": "https://github.com/bambulab/BambuStudio",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.02.57/Bambu_Studio_win-v01.09.02.57-20240607194639.zip",
-            "hash": "135d9573dc13cbbbc98273f119c8d57b5a04499f65726680e701ff3ca231f02a"
+            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.03.50/Bambu_Studio_win-v01.09.03.50-20240621095059.zip",
+            "hash": "11ca8b3e9027164b121c9d4758a7c6c8fb679b071ebe171c9bf0d05da0131384"
         }
     },
     "shortcuts": [

--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -1,6 +1,6 @@
 {
     "version": "01.09.07.52",
-    "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
+    "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software for BambuLab and other 3D printers",
     "homepage": "https://github.com/bambulab/BambuStudio",
     "license": "AGPL-3.0-or-later",
     "architecture": {
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/bambulab/BambuStudio/releases/latest",
+        "url": "https://api.github.com/repositories/511797274/releases/latest",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /Bambu_Studio_win-.*\\.zip/i)].browser_download_url",
         "regex": ".*Bambu_Studio_win-v([\\d.]+)-(?<date>[0-9]+)\\.zip"
     },

--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -1,12 +1,12 @@
 {
-    "version": "01.09.05.51",
+    "version": "01.09.07.52",
     "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software. It contains project-based workflows, systematically optimized slicing algorithms, and an easy-to-use graphical interface, bringing users an incredibly smooth printing experience.",
     "homepage": "https://github.com/bambulab/BambuStudio",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.05.51/Bambu_Studio_win-v01.09.05.51-20240828205639.zip",
-            "hash": "9d92da20d5086c68ead9cae4f05d941fa9918bd410f1f56bcd0c793b17741b38"
+            "url": "https://github.com/bambulab/BambuStudio/releases/download/v01.09.07.52/Bambu_Studio_win-v01.09.07.52-20240920143753.zip",
+            "hash": "f2d3d0b4b19497e4c8b60be8f79fa3f2a4ec679e05967762c05877bb8eea8d6b"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Added an initial manifest to install Bambu Studio (https://github.com/bambulab/BambuStudio).

The versioning is quite strange but it seems the settled (tickets regarding versioning got closed).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
