### PR TITLE
kasts: Add version 24.05-3241

### DIFF
--- a/bucket/kasts.json
+++ b/bucket/kasts.json
@@ -1,12 +1,12 @@
 {
-    "version": "24.05-3239",
+    "version": "24.05-3241",
     "description": "Convergent podcast application",
     "homepage": "https://apps.kde.org/kasts/",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-24.05/windows/kasts-release_24.05-3239-windows-gcc-x86_64.7z",
-            "hash": "5220a96b2632cfff3a1379325383a7eccb9719a7feb14a407319909b5e9cd0f7"
+            "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-24.05/windows/kasts-release_24.05-3241-windows-gcc-x86_64.7z",
+            "hash": "c5e4d83d4564af1880ccfd1556539817976c6fee7a09798f8c3b3838acc2181d"
         }
     },
     "bin": "bin\\kasts.exe",

--- a/bucket/kasts.json
+++ b/bucket/kasts.json
@@ -1,0 +1,33 @@
+{
+    "version": "24.05-3231",
+    "description": "Convergent podcast application",
+    "homepage": "https://apps.kde.org/kasts/",
+    "license": "LGPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-24.05/windows/kasts-release_24.05-3231-windows-gcc-x86_64.7z",
+            "hash": "5464fe868e1fd68f1118c7442dbbd1d0f5703f8b0eec3ce8e37668efdc9e743d"
+        }
+    },
+    "bin": "bin\\kasts.exe",
+    "shortcuts": [
+        [
+            "bin\\kasts.exe",
+            "Kasts"
+        ]
+    ],
+    "checkver": {
+        "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-24.05/windows/",
+        "regex": "kasts-release_([\\d.-]+)-windows-gcc-x86_64\\.7z"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-$matchHead/windows/kasts-release_$version-windows-gcc-x86_64.7z",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/kasts.json
+++ b/bucket/kasts.json
@@ -1,12 +1,12 @@
 {
-    "version": "24.05-3231",
+    "version": "24.05-3239",
     "description": "Convergent podcast application",
     "homepage": "https://apps.kde.org/kasts/",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-24.05/windows/kasts-release_24.05-3231-windows-gcc-x86_64.7z",
-            "hash": "5464fe868e1fd68f1118c7442dbbd1d0f5703f8b0eec3ce8e37668efdc9e743d"
+            "url": "https://cdn.kde.org/ci-builds/multimedia/kasts/release-24.05/windows/kasts-release_24.05-3239-windows-gcc-x86_64.7z",
+            "hash": "5220a96b2632cfff3a1379325383a7eccb9719a7feb14a407319909b5e9cd0f7"
         }
     },
     "bin": "bin\\kasts.exe",


### PR DESCRIPTION
Add manifest for [Kasts](https://apps.kde.org/kasts/), desktop & mobile podcast application from KDE.

Closes #11379

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
