### PR TITLE
buildcache: Update to version 0.30.1, switch to gitlab releases

### DIFF
--- a/bucket/buildcache.json
+++ b/bucket/buildcache.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.28.4",
-    "description": "An advanced compiler accelerator that caches and reuses build results to avoid unnecessary re-compilations, and thereby speeding up the build process",
-    "homepage": "https://github.com/mbitsnbites/buildcache",
+    "version": "0.30.1",
+    "description": "An advanced compiler accelerator that caches and reuses build results to avoid unnecessary re-compilations, and thereby speeding up the build process.",
+    "homepage": "https://gitlab.com/bits-n-bites/buildcache",
     "license": "Zlib",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mbitsnbites/buildcache/releases/download/v0.28.4/buildcache-windows.zip",
-            "hash": "8003f9c79152092ec37397873d668d68f6e4cb78ca1ef04389c3f5ad6bac7fc4"
+            "url": "https://gitlab.com/bits-n-bites/buildcache/-/releases/v0.30.1/downloads/buildcache-windows.zip",
+            "hash": "45de197318c1c81aa5ad33ddaf08d0b805b148f60bcb11508807c582295bdc25"
         }
     },
     "extract_dir": "buildcache",
@@ -17,11 +17,14 @@
             "buildcache"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://gitlab.com/api/v4/projects/49153623/releases/permalink/latest",
+        "jsonpath": "$.tag_name"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mbitsnbites/buildcache/releases/download/v$version/buildcache-windows.zip"
+                "url": "https://gitlab.com/bits-n-bites/buildcache/-/releases/v$version/downloads/buildcache-windows.zip"
             }
         }
     }

--- a/bucket/buildcache.json
+++ b/bucket/buildcache.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.30.1",
+    "version": "v0.30.1",
     "description": "An advanced compiler accelerator that caches and reuses build results to avoid unnecessary re-compilations, and thereby speeding up the build process.",
     "homepage": "https://gitlab.com/bits-n-bites/buildcache",
     "license": "Zlib",
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/bits-n-bites/buildcache/-/releases/v$version/downloads/buildcache-windows.zip"
+                "url": "https://gitlab.com/bits-n-bites/buildcache/-/releases/$version/downloads/buildcache-windows.zip"
             }
         }
     }

--- a/bucket/buildcache.json
+++ b/bucket/buildcache.json
@@ -1,5 +1,5 @@
 {
-    "version": "v0.30.1",
+    "version": "0.30.1",
     "description": "An advanced compiler accelerator that caches and reuses build results to avoid unnecessary re-compilations, and thereby speeding up the build process.",
     "homepage": "https://gitlab.com/bits-n-bites/buildcache",
     "license": "Zlib",
@@ -19,12 +19,13 @@
     ],
     "checkver": {
         "url": "https://gitlab.com/api/v4/projects/49153623/releases/permalink/latest",
-        "jsonpath": "$.tag_name"
+        "jsonpath": "$.tag_name",
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/bits-n-bites/buildcache/-/releases/$version/downloads/buildcache-windows.zip"
+                "url": "https://gitlab.com/bits-n-bites/buildcache/-/releases/v$version/downloads/buildcache-windows.zip"
             }
         }
     }


### PR DESCRIPTION
This PR updates the buildcache package to point at GitLab. The GitHub link is outdated as the project moved to GitLab.
Also bumps the version to 0.30.1

The current GitLab version has only 12 stars which no longer qualifies to appear in the Extras bucket. However it did qualify before when it was hosted on GitHub. Unsure if we want to move it elsewhere; it is a dev tool.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
