### PR TITLE
drawpile: Add version 2.2.1

### DIFF
--- a/bucket/drawpile.json
+++ b/bucket/drawpile.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.2.1",
+    "description": "Drawpile is a drawing program that lets you draw, paint and animate together with others on the same canvas. It runs on Windows, Linux, macOS and Android.",
+    "homepage": "https://drawpile.net/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/drawpile/Drawpile/releases/download/2.2.1/Drawpile-2.2.1-64bit.zip",
+            "hash": "26fe00dcf4bc358b1c23e509747c420df4e146eaf79c87d83e16c09166ff187e",
+            "extract_dir": "Drawpile-2.2.1-64bit"
+        },
+        "32bit": {
+            "url": "https://github.com/drawpile/Drawpile/releases/download/2.2.1/Drawpile-2.2.1-32bit.zip",
+            "hash": "DEEB4E043F9286F7800698896FADB054925E2AA349E60E44BDEA7EE8F785E628",
+            "extract_dir": "Drawpile-2.2.1-32bit"
+        }
+    },
+    "bin": "drawpile.exe",
+    "checkver": {
+        "url": "https://github.com/drawpile/Drawpile/releases/latest",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/drawpile/Drawpile/releases/$version/Drawpile-$version-64bit.zip",
+                "extract_dir": "Drawpile-$version-64bit"
+            },
+            "32bit": {
+                "url": "https://github.com/drawpile/Drawpile/releases/$version/Drawpile-$version-32bit.zip",
+                "extract_dir": "Drawpile-$version-32bit"
+            }
+        },
+        "hash": {
+            "mode": "extract",
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Add manifest for [Drawpile](https://drawpile.net/), a collaborative drawing program that lets multiple people draw, sketch, paint and animate on the same canvas simultaneously.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13510

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
