### PR TITLE
horizon-eda@2.6.0: fix shortcut path, remove bin

### DIFF
--- a/bucket/horizon-eda.json
+++ b/bucket/horizon-eda.json
@@ -10,10 +10,9 @@
         }
     },
     "extract_dir": "PFiles/Horizon EDA",
-    "bin": "horizon-eda.exe",
     "shortcuts": [
         [
-            "horizon-eda.exe",
+            "bin/horizon-eda.exe",
             "Horizon EDA"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The executable is now in a `bin` subdirectory. I was not able to update to 2.6.0 before. This now works.

This PR also removes the `"bin"` section, as it is a GUI program, which does not really take CLI arguments. At least that I'm aware of.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
