### PR TITLE
grafana@11.1.0: Add `grafana-cli` to `bin`

### DIFF
--- a/bucket/grafana.json
+++ b/bucket/grafana.json
@@ -11,6 +11,7 @@
     },
     "extract_dir": "grafana-v11.1.0",
     "bin": [
+        "bin\\grafana-cli.exe",
         [
             "bin\\grafana-server.exe",
             "grafana-server",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add `grafana-cli.exe` to `bin` so Scoop adds it to PATH.

Tested by installing edited manifest file locally.

```pwsh
PS > & $(Try{$psEditor.GetEditorContext().CurrentFile.Path}Catch{$psISE.CurrentFile.FullPath}) -App 'grafana'
# Doing scoop checkver
grafana: 11.1.0
# Install
Installed apps matching 'grafana':
Installing 'grafana' (11.1.0) [64bit] from 'C:\Users\olav.birkeland\OneDrive\IT\Code\PowerShell\CLI\Scoop\Scoop-ManifestAuthoring\grafana.json'
Loading grafana-11.1.0.windows-amd64.zip from cache
Checking hash of grafana-11.1.0.windows-amd64.zip ... ok.
Extracting grafana-11.1.0.windows-amd64.zip ... done.
Linking ~\scoop\apps\grafana\current => ~\scoop\apps\grafana\11.1.0
Creating shim for 'grafana-cli'.
Creating shim for 'grafana-server'.
Persisting conf
Persisting data
'grafana' (11.1.0) was installed successfully!
PS > grafana-cli --version
grafana version 11.1.0
PS >
```

Closes #13542

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
