### PR TITLE
cyberchef@10.18.9: fix pre_install script

### DIFF
--- a/bucket/cyberchef.json
+++ b/bucket/cyberchef.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "url": "https://github.com/gchq/CyberChef/releases/download/v10.18.9/CyberChef_v10.18.9.zip",
     "hash": "e285233b36dc7c36fdeafbab271db23ca9ab82d73d8398b35a5736fc00729a2e",
-    "pre_install": "Rename-Item \"$dir\\*.html\" \"$dir\\CyberChef.html\"",
+    "pre_install": "Rename-Item \"$dir\\CyberChef_v$version.html\" \"$dir\\CyberChef.html\"",
     "shortcuts": [
         [
             "CyberChef.html",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

PowerShell doesn't like the wildcard in the input path.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
