### PR TITLE
TreeComp: Add version 4.0-b62

### DIFF
--- a/bucket/treecomp.json
+++ b/bucket/treecomp.json
@@ -1,0 +1,41 @@
+{
+    "version": "4.0-b62",
+    "description": "Utility to keep 2 directory trees and the files within the directions in sync",
+    "homepage": "https://lploeger.home.xs4all.nl/TreeComp.htm",
+    "license": "Freeware",
+    "architecture": {
+        "32bit": {
+            "url": "https://lploeger.home.xs4all.nl/TreeCompLatest_noinstall.zip",
+            "hash": "92f337be70dd833fd709927c0ec36a643cb8f7ba1f4bf1c3e6c86ad41e8dc88b"
+        },
+        "64bit": {
+            "url": "https://lploeger.home.xs4all.nl/TreeCompx64Latest_noinstall.zip",
+            "hash": "5319f3a541cd3af31053949fa79282d5e01dddf0e55d27df35131cc94adad5fa"
+        }
+    },
+    "pre_install": "if (!(test-path \"$persist_dir\\TreeComp.ini\")) { Add-Content \"$dir\\TreeComp.ini\" $null }",
+    "shortcuts": [
+        [
+            "TreeComp.exe",
+            "TreeComp"
+        ]
+    ],
+    "persist": [
+        "TreeComp.ini"
+    ],
+    "checkver": {
+        "url": "https://lploeger.home.xs4all.nl/TreeComp3.htm#download",
+        "regex": "Latest Version \\(([\\d.]+) ?(b[\\d]+)?\\)",
+        "replace": "$1-$2"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://lploeger.home.xs4all.nl/TreeCompLatest_noinstall.zip"
+            },
+            "64bit": {
+                "url": "https://lploeger.home.xs4all.nl/TreeCompx64Latest_noinstall.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introductory manifest for TreeComp utility.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
