### PR TITLE
mpc-hc-fork: Update to version 2.3.2.1

### DIFF
--- a/bucket/mpc-hc-fork.json
+++ b/bucket/mpc-hc-fork.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.3.2",
+    "version": "2.3.2.1",
     "description": "An extremely light-weight, open source media player for Windows.",
     "homepage": "https://github.com/clsid2/mpc-hc",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.2/MPC-HC.2.3.2.x64.zip",
-            "hash": "527528b3ea852e241f2bbe8206dbc1f324f4339d15074a6492f0d6f0ae926df5",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.2/MPC-HC.2.3.2.1.x64.zip",
+            "hash": "97dd77eb4f43fdd8b301fccc17ebaa707f6ce8bf417ffd0b60745bfb01cca3db",
             "bin": [
                 [
                     "mpc-hc64.exe",
@@ -22,7 +22,7 @@
         },
         "32bit": {
             "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.2/MPC-HC.2.3.2.x86.zip",
-            "hash": "0a6197c276670b1d9c42bb738e45bd9f03407c97604743fdf874ec248285a82a",
+            "hash": "8838d5fa805ef3f17fa8f46ee285c8c2701bfb62a6bb51681f6b24f998211b13",
             "bin": "mpc-hc.exe",
             "shortcuts": [
                 [
@@ -43,8 +43,9 @@
         "default.mpcpl"
     ],
     "checkver": {
-        "github": "https://github.com/clsid2/mpc-hc",
-        "regex": "(?<tag>[\\d.]+)\\/MPC-HC.([\\d.]+).x64.exe"
+        "url": "https://api.github.com/repositories/91570348/releases/latest",
+        "jsonpath": "$..browser_download_url",
+        "regex": "download/(?<tag>[\\d.]+)\\/MPC-HC.([\\d.]+).x64.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/mpc-hc-fork.json
+++ b/bucket/mpc-hc-fork.json
@@ -1,11 +1,11 @@
 {
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "An extremely light-weight, open source media player for Windows.",
     "homepage": "https://github.com/clsid2/mpc-hc",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.1/MPC-HC.2.3.1.x64.zip",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.2/MPC-HC.2.3.2.x64.zip",
             "hash": "527528b3ea852e241f2bbe8206dbc1f324f4339d15074a6492f0d6f0ae926df5",
             "bin": [
                 [
@@ -21,7 +21,7 @@
             ]
         },
         "32bit": {
-            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.1/MPC-HC.2.3.1.x86.zip",
+            "url": "https://github.com/clsid2/mpc-hc/releases/download/2.3.2/MPC-HC.2.3.2.x86.zip",
             "hash": "0a6197c276670b1d9c42bb738e45bd9f03407c97604743fdf874ec248285a82a",
             "bin": "mpc-hc.exe",
             "shortcuts": [


### PR DESCRIPTION
Updates the MPC-HC to latest version (v2.3.2)

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
