### PR TITLE
halloy@2024.8: fix installer script

### DIFF
--- a/bucket/halloy.json
+++ b/bucket/halloy.json
@@ -13,14 +13,13 @@
     "installer": {
         "script": [
             "if (!(Test-Path \"$persist_dir\\config.toml\")) {",
-            "    $configContent = '# Halloy config.
-# For a complete list of available options,
-# please visit https://halloy.squidowl.org/configuration/index.html
-
-[servers.liberachat]
-    nickname = \"halloy8765\"
-    server = \"irc.libera.chat\"
-    channels = [\"#halloy\"]'",
+            "    $configContent = '# Halloy config.",
+            "# For a complete list of available options,",
+            "# please visit https://halloy.squidowl.org/configuration/index.html",
+            "[servers.liberachat]",
+            "    nickname = \"halloy8765\"",
+            "    server = \"irc.libera.chat\"",
+            "    channels = [\"#halloy\"]'",
             "    Set-Content \"$dir\\config.toml\" $configContent -Encoding ASCII -Force",
             "    if (Test-Path \"$env:AppData\\halloy\") {",
             "        Copy-Item \"$env:AppData\\halloy\\*\" \"$dir\" -Recurse -Exclude '*config.toml' -ErrorAction SilentlyContinue",


### PR DESCRIPTION
Fixes the error:

	DEBUG[1720354523] "Failed to parse manifest file: $filepath (error: $_)" = Failed to parse manifest file: <redacted>\scoop\buckets\extras\bucket\halloy.json (error: Exception calling "Parse" with "1" argument(s): "'0x0D' is invalid within a JSON string. The string should be correctly escaped. LineNumber: 15 | BytePositionInLine: 51.") -> <redacted>\scoop\apps\scoop\current\libexec\scoop-search.ps1:69:13

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

The script was broken in https://github.com/ScoopInstaller/Extras/commit/451f8728dab7c9d2b34372caf5525570a6c6efac, because I guess the auto-update script doesn't escape newlines in JSON properly.
