### PR TITLE
vesktop@1.5.3: Add arm64 build, persist Data folder

### DIFF
--- a/bucket/vesktop.json
+++ b/bucket/vesktop.json
@@ -7,9 +7,14 @@
         "64bit": {
             "url": "https://github.com/Vencord/Vesktop/releases/download/v1.5.3/Vesktop-1.5.3-win.zip",
             "hash": "5cd18e7db8475a22a81a0a1e9a871648c36eb249f033b2d854d47ab02b68b1a4"
+        },
+        "arm64": {
+            "url": "https://github.com/Vencord/Vesktop/releases/download/v1.5.3/Vesktop-1.5.3-arm64-win.zip",
+            "hash": "4c74c7725c50552370864a350b37c171b87af154bfab26ea8cee1de266e327fb"
         }
     },
     "bin": "Vesktop.exe",
+    "persist": "Data",
     "shortcuts": [
         [
             "Vesktop.exe",
@@ -22,6 +27,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/Vencord/Vesktop/releases/download/v$version/Vesktop-$version-win.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Vencord/Vesktop/releases/download/v$version/Vesktop-$version-arm64-win.zip"
             }
         }
     }


### PR DESCRIPTION
Vesktop (portable) can now store configuration in the same folder as executables.
This should make scoop preserve the program data.
Bonus: arm64 architecture detection.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
