### PR TITLE
vnote: Update to version 3.18.1

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.17.0",
+    "version": "3.18.0",
     "description": "A Vim-inspired note-taking platform",
     "homepage": "https://app.vnote.fun",
     "license": "LGPL-3.0-only",
@@ -8,14 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.17.0/vnote-win-x64-qt5.15.2_v3.17.0.zip",
-            "hash": "a19ee888d4302f21f593ff3f043ff9966448996e5ae92e4142a7b435d5de3c98"
-        },
-        "32bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.17.0/vnote-win-x86-qt5.15.2_v3.17.0.zip",
-            "hash": "089449a95a448d07b879c0b74ff49687978d7da204d242714c8a69afc8a08cf1"
+            "url": "https://github.com/vnotex/vnote/releases/download/v3.18.0/VNote-3.18.0-win64.zip",
+            "hash": "f20f32855877c765b1d198649c7fb6ea9a0208cbcbc1ef4690b1702c6640b665"
         }
     },
+    "extract_dir": "VNote-3.18.0-win64\\bin",
     "pre_install": "Remove-Item \"$dir\\vcredist_*exe\"",
     "bin": "vnote.exe",
     "shortcuts": [
@@ -24,36 +21,11 @@
             "VNote"
         ]
     ],
-    "checkver": {
-        "script": [
-            "# Using checkver script because 64-bit and 32-bit can use different version of Qt",
-            "# , and the 32-bit file can be above or below the 64-bit one",
-            "$url = 'https://github.com/vnotex/vnote/releases/latest'",
-            "",
-            "$cont = (Invoke-WebRequest $url).Content",
-            "$r = 'tag/v([\\d.]+)'",
-            "if (!($cont -match $r)) { error \"Could not match $r in $url\"; continue }",
-            "$ver = $matches[1]",
-            "",
-            "$assetUrl = \"https://github.com/vnotex/vnote/releases/expanded_assets/v$ver\"",
-            "$assetCont = (Invoke-WebRequest $assetUrl).Content",
-            "$r = \"vnote-win-x64-qt([\\w.]+)_v$ver.zip\"",
-            "if (!($assetCont -match $r)) { error \"Could not match $r in $url\"; continue }",
-            "$qt64bit = $matches[1]",
-            "$r = \"vnote-win-x86-qt([\\w.]+)_v$ver.zip\"",
-            "if (!($assetCont -match $r)) { error \"Could not match $r in $url\"; continue }",
-            "$qt32bit = $matches[1]",
-            "Write-Output $ver $qt64bit $qt32bit"
-        ],
-        "regex": "([\\d.]+) (?<qt64bit>[\\w.]+) (?<qt32bit>[\\w.]+)"
-    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vnotex/vnote/releases/download/v$version/vnote-win-x64-qt$matchQt64bit_v$version.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/vnotex/vnote/releases/download/v$version/vnote-win-x86-qt$matchQt32bit_v$version.zip"
+                "url": "https://github.com/vnotex/vnote/releases/download/v$version/VNote-$version-win64.zip",
+                "extract_dir": "VNote-$version-win64\\bin"
             }
         }
     }

--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.18.0",
+    "version": "3.18.1",
     "description": "A Vim-inspired note-taking platform",
     "homepage": "https://app.vnote.fun",
     "license": "LGPL-3.0-only",
@@ -8,12 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v3.18.0/VNote-3.18.0-win64.zip",
-            "hash": "f20f32855877c765b1d198649c7fb6ea9a0208cbcbc1ef4690b1702c6640b665"
+            "url": "https://github.com/vnotex/vnote/releases/download/v3.18.1/VNote-3.18.1-win64.zip",
+            "hash": "f7e45cae82c8a0e8e03dc72c67adb0f6467bdea7b67f7682b92836e87b8605d5",
+            "extract_dir": "VNote-3.18.1-win64\\bin"
         }
     },
-    "extract_dir": "VNote-3.18.0-win64\\bin",
-    "pre_install": "Remove-Item \"$dir\\vcredist_*exe\"",
     "bin": "vnote.exe",
     "shortcuts": [
         [
@@ -21,6 +20,9 @@
             "VNote"
         ]
     ],
+    "checkver": {
+        "github": "https://github.com/vnotex/vnote"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Drop 32 bit support because Qt6 only comes with 64 bit in Windows environment. https://doc.qt.io/qt-6.2/windows.html

To install the runtime libraries on the end-user's system, you need to include the appropriate Visual C++ Redistributable Package (VCRedist) executable with your application and ensure that it is executed when the user installs your application.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
