### PR TITLE
photodemon@2024.7: Fix extract_dir

### DIFF
--- a/bucket/photodemon.json
+++ b/bucket/photodemon.json
@@ -8,7 +8,6 @@
     },
     "url": "https://github.com/tannerhelland/PhotoDemon/releases/download/v2024.7/PhotoDemon-2024.7.zip",
     "hash": "8b2ee00a926beed6a9e2598c84c0f43afdcff0428ef76ce13c04087272c885f7",
-    "extract_dir": "PhotoDemon",
     "bin": "PhotoDemon.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Closes #13604

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
