### PR TITLE
picocrypt: Change repo and update to version 1.37

### DIFF
--- a/bucket/picocrypt.json
+++ b/bucket/picocrypt.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.33",
+    "version": "1.37",
     "description": "A small encryption tool with a focus on security, simplicity, and reliability.",
-    "homepage": "https://github.com/HACKERALERT/Picocrypt",
+    "homepage": "https://github.com/Picocrypt/Picocrypt",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/HACKERALERT/Picocrypt/releases/download/1.33/Picocrypt.exe",
-            "hash": "ee1b99bbc3a83b2f7734a4251baac3868670edf730096d75cc3ac0f88cb42809"
+            "url": "https://github.com/Picocrypt/Picocrypt/releases/download/1.37/Picocrypt.exe",
+            "hash": "3bbf02b17fddccb087dc768ba8431e548460e413a208795301d4b15ee19dc98b"
         }
     },
     "shortcuts": [
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/HACKERALERT/Picocrypt/releases/download/$version/Picocrypt.exe"
+                "url": "https://github.com/Picocrypt/Picocrypt/releases/download/$version/Picocrypt.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Picocrypt recently moved their repository to https://github.com/Picocrypt (as seen in the [readme](https://github.com/HACKERALERT/Picocrypt/blob/main/README.md))

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
