### PR TITLE
powertoys@0.82.1: Fix for the tag change

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysUserSetup-0.82.1-x64.exe",
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.82.1/PowerToysUserSetup-0.82.1-x64.exe",
             "hash": "b594c9a32125079186dce776431e2dc77b896774d2aee2acf51bab8791683485"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysUserSetup-0.82.1-arm64.exe",
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.82.1/PowerToysUserSetup-0.82.1-arm64.exe",
             "hash": "41c1d9c0e8fa7effce6f605c92c143ae933f8c999a2933a4d9d1115b16f14f67"
         }
     },


### PR DESCRIPTION
I'm a dev lead in PowerToys. Proof in : https://github.com/microsoft/PowerToys/blob/main/COMMUNITY.md#powertoys-core-team

![image](https://github.com/user-attachments/assets/667dcfee-eebd-4230-b37a-e887e6ddb2d8)

We wrongly released the 0.82.1 tag as "V0.82.1" instead of "v0.82.1". We've just corrected that. Downloads should now contain lowercase "v": https://github.com/microsoft/PowerToys/releases/tag/v0.82.1

This PR reflects that correction.

Relates to #13612

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
