### PR TITLE
Add arm64 support for tabby

### DIFF
--- a/bucket/tabby.json
+++ b/bucket/tabby.json
@@ -1,4 +1,4 @@
-{
+t{
     "version": "1.0.209",
     "description": "A terminal for a more modern age",
     "homepage": "https://tabby.sh",
@@ -6,6 +6,19 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Eugeny/tabby/releases/download/v1.0.209/tabby-1.0.209-setup-x64.exe#/dl.7z",
+            "hash": "sha512:fc0c22dd8fcc8b9606773444e192de15bf8be5dc44f58d79da92d5146def278fab20ae53a1ff8e8334033625db03ba85f28abfa06c8594dc3a07aae132f75a63",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Unins*\" -Force -Recurse"
+            ],
+            "post_install": [
+                "if ((Test-Path $env:APPDATA\\Tabby) -and (-not (Test-Path \"$persist_dir\\data\\*\"))) {",
+                "    Copy-Item -Path $env:APPDATA\\Tabby\\* -Destination \"$persist_dir\\data\" -Recurse",
+                "}"
+            ]
+        },
+        "arm64": {
+            "url": "https://github.com/Eugeny/tabby/releases/download/v1.0.209/tabby-1.0.209-setup-arm64.exe#/dl.7z",
             "hash": "sha512:fc0c22dd8fcc8b9606773444e192de15bf8be5dc44f58d79da92d5146def278fab20ae53a1ff8e8334033625db03ba85f28abfa06c8594dc3a07aae132f75a63",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -33,6 +46,12 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/Eugeny/tabby/releases/download/v$version/tabby-$version-setup-x64.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest-x64.yml",
+                    "regex": "sha512: $base64"
+                },
+                "arm64": {
+                "url": "https://github.com/Eugeny/tabby/releases/download/v$version/tabby-$version-setup-arm64.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/latest-x64.yml",
                     "regex": "sha512: $base64"

--- a/bucket/tabby.json
+++ b/bucket/tabby.json
@@ -1,4 +1,4 @@
-t{
+{
     "version": "1.0.209",
     "description": "A terminal for a more modern age",
     "homepage": "https://tabby.sh",


### PR DESCRIPTION
This PR adds arm64 support for the Tabby terminal emulator. Tabby has official ARM64 Windows builds; however, said builds are not present in Scoop.

- [*] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
