### PR TITLE
etcher: Update to version 1.19.21

### DIFF
--- a/bucket/etcher.json
+++ b/bucket/etcher.json
@@ -15,6 +15,9 @@
         "github": "https://github.com/balena-io/etcher"
     },
     "autoupdate": {
-        "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-win32-x64-$version.zip"
+        "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-win32-x64-$version.zip",
+        "hash": {
+            "url": "$baseurl/SHA256SUMS.Windows.x64.txt",
+        }
     }
 }

--- a/bucket/etcher.json
+++ b/bucket/etcher.json
@@ -1,23 +1,10 @@
 {
-    "version": "1.18.11",
+    "version": "1.19.21",
     "description": "balenaEtcher lets you flash OS images to SD cards & USB drives, safely and easily.",
     "homepage": "https://www.balena.io/etcher/",
     "license": "Apache-2.0",
-    "url": "https://github.com/balena-io/etcher/releases/download/v1.18.11/balenaEtcher-Setup-1.18.11.exe#/dl.7z",
-    "hash": "sha512:124ec711881e68d96a0fb4dc3c8ef424f54b536de7e0ae6ace615b3c0858ea6dd9f4aec448b29466a8b5ac0b934959a3ad8117cad3eb675247f19ac5d5c68be2",
-    "architecture": {
-        "64bit": {
-            "installer": {
-                "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR/app-64.7z\" \"$dir\""
-            }
-        },
-        "32bit": {
-            "installer": {
-                "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR/app-32.7z\" \"$dir\""
-            }
-        }
-    },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse",
+    "url": "https://github.com/balena-io/etcher/releases/download/v1.19.21/balenaEtcher-win32-x64-1.19.21.zip",
+    "hash": "341fa5a6d50cc631768a901155a3f654a486692c550eb97bc7475339c4d2e147",
     "shortcuts": [
         [
             "balenaEtcher.exe",
@@ -28,10 +15,6 @@
         "github": "https://github.com/balena-io/etcher"
     },
     "autoupdate": {
-        "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-Setup-$version.exe#/dl.7z",
-        "hash": {
-            "url": "$baseurl/latest.yml",
-            "regex": "sha512: $base64"
-        }
+        "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-win32-x64-$version.zip"
     }
 }

--- a/bucket/etcher.json
+++ b/bucket/etcher.json
@@ -1,7 +1,7 @@
 {
     "version": "1.19.21",
     "description": "balenaEtcher lets you flash OS images to SD cards & USB drives, safely and easily.",
-    "homepage": "https://www.balena.io/etcher/",
+    "homepage": "https://etcher.balena.io/",
     "license": "Apache-2.0",
     "url": "https://github.com/balena-io/etcher/releases/download/v1.19.21/balenaEtcher-win32-x64-1.19.21.zip",
     "hash": "341fa5a6d50cc631768a901155a3f654a486692c550eb97bc7475339c4d2e147",

--- a/bucket/etcher.json
+++ b/bucket/etcher.json
@@ -17,7 +17,7 @@
     "autoupdate": {
         "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-win32-x64-$version.zip",
         "hash": {
-            "url": "$baseurl/SHA256SUMS.Windows.x64.txt",
+            "url": "$baseurl/SHA256SUMS.Windows.x64.txt"
         }
     }
 }


### PR DESCRIPTION
Update etcher manifest to latest version:
- update autoupdate url to latest naming convention
- remove `architecture` block as latest version is 64-bit only
- remove `installer` fields as latest version is available in zip file format

Closes #13640

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
