### PR TITLE
ultravnc@1.4.3.6: Fix extract_dir

### DIFF
--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -7,10 +7,10 @@
     "hash": "bbb35b8199af7841080b5d34a559b76f9d824ff8c140a030db86dac5edccc7ae",
     "architecture": {
         "64bit": {
-            "extract_dir": "x64"
+            "extract_dir": "64"
         },
         "32bit": {
-            "extract_dir": "x86"
+            "extract_dir": "32"
         }
     },
     "bin": [


### PR DESCRIPTION
Change the folder names in the json to match the ones on the zip source.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13650 


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
