### PR TITLE
ultravnc@1.4.3.6: Persist settings and secure encryption plugin

### DIFF
--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -13,9 +13,20 @@
             "extract_dir": "32"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\UltraVnc.ini\")) { New-Item \"$dir\\UltraVnc.ini\" | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\options.vnc\")) { New-Item \"$dir\\options.vnc\" | Out-Null }"
+    ],
+    "post_install": [
+        "if (!(Test-Path \"$persist_dir\\SecureVNCPlugin64.dsm\")) { Copy-Item \"$persist_dir\\SecureVNCPlugin64.dsm\" \"$dir\\SecureVNCPlugin64.dsm\" | Out-Null }"
+    ],
     "bin": [
         "vncviewer.exe",
         "winvnc.exe"
+    ],
+    "persist": [
+        "UltraVnc.ini",
+        "options.vnc"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
This PR add 
1. a `pre-install` hook in combination with a `persist` section to persist the `options.vnc` and `UltraVnc.ini` settings.
2. a `post-install` hook to install the `SecureVNCPlugin64.dsm` plugin if present in the persist folder

- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
