### PR TITLE
ocenaudio@3.14: Fix download urls

### DIFF
--- a/bucket/ocenaudio.json
+++ b/bucket/ocenaudio.json
@@ -5,15 +5,15 @@
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v3.14",
-            "hash": "3a8d80a904b37103ec03d0226acfa75addc287201e02def009cd0c7f32b57586"
-        },
-        "32bit": {
-            "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v3.14",
-            "hash": "3a8d80a904b37103ec03d0226acfa75addc287201e02def009cd0c7f32b57586"
+            "url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_windows64.zip?version=v3.14",
+            "hash": "1b756d68657a803c61b70724aee0a9c437f027cb41761e90dfe3df318902c1f6",
+            "extract_dir": "ocenaudio"
         }
     },
-    "bin": "ocenaudio.exe",
+    "bin": [
+        "ocenaudio.exe",
+        "ocenaudio_cli.exe"
+    ],
     "shortcuts": [
         [
             "ocenaudio.exe",
@@ -25,10 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v$version"
-            },
-            "32bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v$version"
+                "url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_windows64.zip?version=v$version"
             }
         },
         "hash": {


### PR DESCRIPTION
- Removed 32 bit support
- Download link changed

![image](https://github.com/user-attachments/assets/42e12f46-ce05-4bfa-be6c-1cea76e0f756)


<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13680 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
