### PR TITLE
kcc@6.1.0: Remove innosetup, add CLI tools

### DIFF
--- a/bucket/kcc.json
+++ b/bucket/kcc.json
@@ -10,13 +10,13 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ciromattia/kcc/releases/download/v6.1.0/KCC_6.1.0.exe",
+            "url": "https://github.com/ciromattia/kcc/releases/download/v6.1.0/KCC_6.1.0.exe#/KCC.exe",
             "hash": "072c0cf5d3a8e400f2fef65dac156fd14e2faaac88243d4de5bef5d6112c1bd5"
         }
     },
     "shortcuts": [
         [
-            "KCC_6.1.0.exe",
+            "KCC.exe",
             "Kindle Comic Converter"
         ]
     ],
@@ -24,14 +24,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_$version.exe"
+                "url": "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_$version.exe#/KCC.exe"
             }
-        },
-        "shortcuts": [
-            [
-                "KCC_$version.exe",
-                "Kindle Comic Converter"
-            ]
-        ]
+        }
     }
 }

--- a/bucket/kcc.json
+++ b/bucket/kcc.json
@@ -14,10 +14,9 @@
             "hash": "072c0cf5d3a8e400f2fef65dac156fd14e2faaac88243d4de5bef5d6112c1bd5"
         }
     },
-    "innosetup": true,
     "shortcuts": [
         [
-            "KCC.exe",
+            "KCC_6.1.0.exe",
             "Kindle Comic Converter"
         ]
     ],
@@ -27,6 +26,12 @@
             "64bit": {
                 "url": "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_$version.exe"
             }
-        }
+        },        
+        "shortcuts": [
+            [
+                "KCC_$version.exe",
+                "Kindle Comic Converter"
+            ]
+        ]
     }
 }

--- a/bucket/kcc.json
+++ b/bucket/kcc.json
@@ -10,10 +10,22 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ciromattia/kcc/releases/download/v6.1.0/KCC_6.1.0.exe#/KCC.exe",
-            "hash": "072c0cf5d3a8e400f2fef65dac156fd14e2faaac88243d4de5bef5d6112c1bd5"
+            "url": [
+                "https://github.com/ciromattia/kcc/releases/download/v6.1.0/KCC_6.1.0.exe#/KCC.exe",
+                "https://github.com/ciromattia/kcc/releases/download/v6.1.0/KCC_c2e_6.1.0.exe#/kcc-c2e.exe",
+                "https://github.com/ciromattia/kcc/releases/download/v6.1.0/KCC_c2p_6.1.0.exe#/kcc-c2p.exe"
+            ],
+            "hash": [
+                "072c0cf5d3a8e400f2fef65dac156fd14e2faaac88243d4de5bef5d6112c1bd5",
+                "e23fefdbaa3aead7df3921d6fc26e476a3406b0820d6d62a04f503903047de38",
+                "1ef84a40c71987946ba34ff19571b171c8a7fd59c7e10e541afb0adb8851a7c2"
+            ]
         }
     },
+    "bin": [
+        "kcc-c2e.exe",
+        "kcc-c2p.exe"
+    ],
     "shortcuts": [
         [
             "KCC.exe",
@@ -24,7 +36,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_$version.exe#/KCC.exe"
+                "url": [
+                    "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_$version.exe#/KCC.exe",
+                    "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_c2e_$version.exe#/kcc-c2e.exe",
+                    "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_c2p_$version.exe#/kcc-c2p.exe"
+                ]
             }
         }
     }

--- a/bucket/kcc.json
+++ b/bucket/kcc.json
@@ -26,7 +26,7 @@
             "64bit": {
                 "url": "https://github.com/ciromattia/kcc/releases/download/v$version/KCC_$version.exe"
             }
-        },        
+        },
         "shortcuts": [
             [
                 "KCC_$version.exe",


### PR DESCRIPTION
KCC wasn't installing for me, turns out it is a portable .exe file and not an InnoSetup installer, so I've updated it to just use it directly. I've also added the shortcut in `autoupdate` as it uses the version in the filename. Tested locally and installs fine.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).