### PR TITLE
inky@0.15.1: Fix extraction configuration, add CLI shim

### DIFF
--- a/bucket/inky.json
+++ b/bucket/inky.json
@@ -6,13 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/inkle/inky/releases/download/0.15.1/Inky_windows_64.zip",
-            "hash": "6c09fad772b01e7218234ad7f585871949186de0df7485e92d92ced6358390b6",
-            "extract_dir": "Inky-win32-x64"
+            "hash": "6c09fad772b01e7218234ad7f585871949186de0df7485e92d92ced6358390b6"
         },
         "32bit": {
             "url": "https://github.com/inkle/inky/releases/download/0.15.1/Inky_windows_32.zip",
-            "hash": "309d6c4455238739d2288586fbb0375aeaad4152e51c6ff765df42fc812f39ec",
-            "extract_dir": "Inky-win32-ia32"
+            "hash": "309d6c4455238739d2288586fbb0375aeaad4152e51c6ff765df42fc812f39ec"
         }
     },
     "shortcuts": [
@@ -21,6 +19,7 @@
             "Inky"
         ]
     ],
+    "bin": "Inky.exe",
     "checkver": {
         "github": "https://github.com/inkle/inky"
     },


### PR DESCRIPTION
Zip structure has changed and `extract_dir` isn't needed anymore, so this PR removes it. Also, this adds an Inky shim to allow launching the GUI app from the command line, because that's handy.

Closes #13689
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
