### PR TITLE
eraser@6.2.0.2994: Fix msi ExtractDir

### DIFF
--- a/bucket/eraser.json
+++ b/bucket/eraser.json
@@ -8,10 +8,10 @@
     "extract_to": "_EXTRACTED",
     "architecture": {
         "64bit": {
-            "pre_install": "Expand-MsiArchive \"$dir\\_EXTRACTED\\Eraser (x64).msi\" -DestinationPath \"$dir\" -ExtractDir 'Eraser'"
+            "pre_install": "Expand-MsiArchive \"$dir\\_EXTRACTED\\Eraser (x64).msi\" -DestinationPath \"$dir\" -ExtractDir 'PFiles64\\Eraser'"
         },
         "32bit": {
-            "pre_install": "Expand-MsiArchive \"$dir\\_EXTRACTED\\Eraser (x86).msi\" -DestinationPath \"$dir\" -ExtractDir 'Eraser'"
+            "pre_install": "Expand-MsiArchive \"$dir\\_EXTRACTED\\Eraser (x86).msi\" -DestinationPath \"$dir\" -ExtractDir 'PFiles\\Eraser'"
         }
     },
     "post_install": "Remove-Item \"$dir\\_EXTRACTED\" -Force -Recurse",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13705

The msi files have a new `PFiles64`/`PFiles` intermediate directory, parent of the `Eraser` one, since v6.2.0.2994 while not up to v6.2.0.2993.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
