### PR TITLE
halloy@2024.9: Fix extract_dir

### DIFF
--- a/bucket/halloy.json
+++ b/bucket/halloy.json
@@ -9,7 +9,7 @@
             "hash": "0bf99b8ec79e945d36eac7775549765939800676091a59f878b94bed5a642380"
         }
     },
-    "extract_dir": "PFiles/Halloy",
+    "extract_dir": "PFiles64/Halloy",
     "installer": {
         "script": [
             "if (!(Test-Path \"$persist_dir\\config.toml\")) {",


### PR DESCRIPTION
The folder in the MSI has changed name in this release, I have updated "extract_dir" to the new path

Closes #13733

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
