### PR TITLE
openai-translator@0.4.32: fix shortcuts

### DIFF
--- a/bucket/openai-translator.json
+++ b/bucket/openai-translator.json
@@ -12,7 +12,7 @@
     "post_install": "@('$PLUGINSDIR', '$TEMP', 'uninstall.exe') | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
     "shortcuts": [
         [
-            "OpenAI Translator.exe",
+            "app.exe",
             "OpenAI Translator"
         ]
     ],


### PR DESCRIPTION
The main exe had been rename to app.exe

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
