### PR TITLE
compiledb-go: Add version 1.3.0

### DIFF
--- a/bucket/compiledb-go.json
+++ b/bucket/compiledb-go.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.3.0",
+    "description": "Tool for generating Clang's JSON Compilation Database files for make-based build systems.",
+    "homepage": "https://github.com/fcying/compiledb-go",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fcying/compiledb-go/releases/download/v1.3.0/compiledb-windows-amd64.7z",
+            "hash": "15728334c4d3dcc8ecb81f20385d7e44906ec58ee5d7e5a18ee0e5d69e7e4f9c"
+        }
+    },
+    "bin": "compiledb.exe",
+    "shortcuts": [
+        [
+            "compiledb.exe",
+            "compiledb"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fcying/compiledb-go/releases/download/v$version/compiledb-windows-amd64.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
compiledb-go: Add version 1.3.0

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
