### PR TITLE
google-earth-pro: Add version 7.3.6

### DIFF
--- a/bucket/google-earth-pro.json
+++ b/bucket/google-earth-pro.json
@@ -1,0 +1,45 @@
+{
+    "version": "7.3.6",
+    "description": "A computer program that renders a 3D representation of Earth based primarily on satellite imagery.",
+    "homepage": "https://www.google.com/enterprise/mapsearth/products/earthpro.html",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.google.com/help/terms_maps/"
+    },
+    "architecture": {
+        "32bit": {
+            "url": "https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-7.3.6.exe#/installer.exe",
+            "hash": "ebf093542cf10105c02fc7e6ee650e1b11293e9ecb74ce4e7d906e04613e292d"
+        },
+        "64bit": {
+            "url": "https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-7.3.6-x64.exe#/installer.exe",
+            "hash": "dfb78631d794fd32b09fdc3c9105594f0e100d2343d6f9681612a84fa3fc5325"
+        }
+    },
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\google-earth-pro\\expand-resource.ps1\" -filePath \"$dir\\$fname\" -resourceType \"BINARY\" -resourceName \"ID_MSI\" -outputFilePath \"$dir\\installer.msi\" -Removal",
+            "Expand-MsiArchive \"$dir\\installer.msi\" \"$dir\" -ExtractDir 'Google\\Google Earth Pro\\client' -Removal | Out-Null"
+        ]
+    },
+    "shortcuts": [
+        [
+            "googleearth.exe",
+            "Google Earth Pro"
+        ]
+    ],
+    "checkver": {
+        "url": "https://support.google.com/earth/answer/40901",
+        "regex": "Earth version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-$version.exe#/installer.exe"
+            },
+            "64bit": {
+                "url": "https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-$version-x64.exe#/installer.exe"
+            }
+        }
+    }
+}

--- a/scripts/google-earth-pro/expand-resource.ps1
+++ b/scripts/google-earth-pro/expand-resource.ps1
@@ -1,0 +1,85 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$filePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$resourceType,
+
+    [Parameter(Mandatory = $true)]
+    [string]$resourceName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$outputFilePath,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Removal
+)
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class Win32 {
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr FindResource(IntPtr hModule, string lpName, string lpType);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr LoadResource(IntPtr hModule, IntPtr hResInfo);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr LockResource(IntPtr hResData);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern uint SizeofResource(IntPtr hModule, IntPtr hResInfo);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, uint dwFlags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool FreeLibrary(IntPtr hModule);
+
+    public const uint LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
+}
+"@
+
+try {
+    $hModule = [Win32]::LoadLibraryEx($filePath, [IntPtr]::Zero, [Win32]::LOAD_LIBRARY_AS_DATAFILE)
+    if ($hModule -eq [IntPtr]::Zero) {
+        throw "Failed to load PE file: $filePath"
+    }
+
+    $hResInfo = [Win32]::FindResource($hModule, $resourceName, $resourceType)
+    if ($hResInfo -eq [IntPtr]::Zero) {
+        throw "Failed to find the specified resource: $resourceType, $resourceName"
+    }
+
+    $hResData = [Win32]::LoadResource($hModule, $hResInfo)
+    if ($hResData -eq [IntPtr]::Zero) {
+        throw "Failed to load the specified resource."
+    }
+
+    $pResourceData = [Win32]::LockResource($hResData)
+    if ($pResourceData -eq [IntPtr]::Zero) {
+        throw "Failed to lock the specified resource."
+    }
+
+    $resourceSize = [Win32]::SizeofResource($hModule, $hResInfo)
+    if ($resourceSize -eq 0) {
+        throw "Failed to get the size of the specified resource."
+    }
+
+    $buffer = New-Object byte[] $resourceSize
+    [Runtime.InteropServices.Marshal]::Copy($pResourceData, $buffer, 0, $resourceSize)
+
+    [System.IO.File]::WriteAllBytes($outputFilePath, $buffer)
+
+    if ($Removal) {
+        Remove-Item -Path $filePath -Force
+    }
+} catch {
+    abort $_.Exception.Message
+} finally {
+    if ($hModule -ne [IntPtr]::Zero) {
+        [Win32]::FreeLibrary($hModule) | Out-Null
+    }
+}


### PR DESCRIPTION
google-earth-pro: Add version 7.3.6

I encountered an issue with extracting MSI files in this case, so I wrote a simple script to extract resources from PE files. It would be great if you could add this script to decompress.ps1 to support files from non-standard installers.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
