### PR TITLE
dotnet-core-uninstall: Add version 1.7.521001

### DIFF
--- a/bucket/dotnet-core-uninstall.json
+++ b/bucket/dotnet-core-uninstall.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+  "version": "1.7.521001",
+  "homepage": "https://learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool",
+  "license": "MIT",
+  "architecture": {
+    "32bit": {
+      "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
+      "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+    },
+    "64bit": {
+      "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
+      "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+    }
+  },
+  "extract_dir": "dotnet-core-uninstall",
+  "bin": "dotnet-core-uninstall.exe",
+  "checkver": {
+    "github": "https://github.com/dotnet/cli-lab"
+  },
+  "autoupdate": {
+    "url": "https://github.com/dotnet/cli-lab/releases/download/$version/dotnet-core-uninstall-$version.msi"
+  }
+}

--- a/bucket/dotnet-core-uninstall.json
+++ b/bucket/dotnet-core-uninstall.json
@@ -1,24 +1,31 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-  "version": "1.7.521001",
-  "homepage": "https://learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool",
-  "license": "MIT",
-  "architecture": {
-    "32bit": {
-      "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
-      "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "1.7.521001",
+    "homepage": "https://learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
+            "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+        },
+        "64bit": {
+            "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
+            "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+        }
     },
-    "64bit": {
-      "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
-      "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+    "extract_dir": "dotnet-core-uninstall",
+    "bin": "dotnet-core-uninstall.exe",
+    "checkver": {
+        "github": "https://github.com/dotnet/cli-lab"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/dotnet/cli-lab/releases/download/$version/dotnet-core-uninstall-$version.msi"
+            },
+            "64bit": {
+                "url": "https://github.com/dotnet/cli-lab/releases/download/$version/dotnet-core-uninstall-$version.msi"
+            }
+        }
     }
-  },
-  "extract_dir": "dotnet-core-uninstall",
-  "bin": "dotnet-core-uninstall.exe",
-  "checkver": {
-    "github": "https://github.com/dotnet/cli-lab"
-  },
-  "autoupdate": {
-    "url": "https://github.com/dotnet/cli-lab/releases/download/$version/dotnet-core-uninstall-$version.msi"
-  }
 }


### PR DESCRIPTION
Added dotnet-core-uninstall.

The MSI ( <https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi> ) says it's for x86 when opened in Orca, but it works fine on x64 too. I'm unsure how to say that it works for x86 and x64, but not ARM64, thus I added both `32bit` and `64bit` with the same content.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6094
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
