### PR TITLE
localsend@1.15.4: Change MIT to Apache-2.0 license

### DIFF
--- a/bucket/localsend.json
+++ b/bucket/localsend.json
@@ -2,7 +2,7 @@
     "version": "1.15.4",
     "description": "Share files to nearby devices. An open source cross-platform alternative to AirDrop.",
     "homepage": "https://localsend.org/",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/localsend/localsend/releases/download/v1.15.4/LocalSend-1.15.4-windows-x86-64.zip",


### PR DESCRIPTION
Updates the license to match the latest release (https://github.com/localsend/localsend/issues/1634)

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
