### PR TITLE
(chore): matchVer instead of matchHead in jetbrains apps

### DIFF
--- a/bucket/clion.json
+++ b/bucket/clion.json
@@ -41,7 +41,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.jetbrains.com/cpp/CLion-$matchHead.win.zip"
+                "url": "https://download.jetbrains.com/cpp/CLion-$matchVer.win.zip"
             }
         },
         "hash": {

--- a/bucket/clion.json
+++ b/bucket/clion.json
@@ -1,5 +1,5 @@
 {
-    "version": "2024.2-242.20224.384",
+    "version": "2024.2.0.1-242.20224.413",
     "description": "Cross-Platform IDE for C and C++ by JetBrains.",
     "homepage": "https://www.jetbrains.com/cpp/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.jetbrains.com/cpp/CLion-2024.2.win.zip",
-            "hash": "7791bb703eee8bb8a88833b632698d78574dd41cd648d1840bb5aa3b72eb5d29",
+            "url": "https://download.jetbrains.com/cpp/CLion-2024.2.0.1.win.zip",
+            "hash": "8d3fd2d4e0dc15241499d92a795c4cb6f6132e3ecffe88fe57bdeb35650414f7",
             "bin": [
                 [
                     "IDE\\bin\\clion64.exe",

--- a/bucket/datagrip.json
+++ b/bucket/datagrip.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/datagrip/datagrip-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/goland.json
+++ b/bucket/goland.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/go/goland-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/go/goland-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea-ultimate.json
+++ b/bucket/idea-ultimate.json
@@ -49,7 +49,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIU-$matchHead.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIU-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea-ultimate.json
+++ b/bucket/idea-ultimate.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.300",
+    "version": "2024.2.0.2-242.20224.419",
     "description": "Cross-Platform IDE for Java by JetBrains.",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIU-2024.2.win.zip",
-    "hash": "5a20f3aef62d4adcf6075e81499522bad6f1a7706f3743ddc8c08145a6e20751",
+    "url": "https://download.jetbrains.com/idea/ideaIU-2024.2.0.2.win.zip",
+    "hash": "d7a26c30cab300e9726e83b0835184583f1bcfcaab48bef4be0f4c8a6d7144d9",
     "extract_to": "IDE",
     "pre_install": "Get-ChildItem \"$persist_dir\\IDE\\bin\\idea*.exe.vmoptions\" -ErrorAction SilentlyContinue | Copy-Item -Destination \"$dir\\IDE\\bin\"",
     "installer": {

--- a/bucket/idea.json
+++ b/bucket/idea.json
@@ -49,7 +49,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIC-$matchHead.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIC-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea.json
+++ b/bucket/idea.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.300",
+    "version": "2024.2.0.2-242.20224.419",
     "description": "Cross-Platform IDE for Java by JetBrains (Community edition).",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
         "identifier": "Apache-2.0",
         "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIC-2024.2.win.zip",
-    "hash": "3efc0d4d0f3950d81d2d7143ea3dfe2b42b16ed352779251d116bae6e9582c15",
+    "url": "https://download.jetbrains.com/idea/ideaIC-2024.2.0.2.win.zip",
+    "hash": "effcdced1c743ebc796b9452e2c1c44103f97f6515f8c2066359e1e0ea22e4c4",
     "extract_to": "IDE",
     "installer": {
         "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"

--- a/bucket/phpstorm.json
+++ b/bucket/phpstorm.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/webide/PhpStorm-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/pycharm-professional.json
+++ b/bucket/pycharm-professional.json
@@ -61,7 +61,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/python/pycharm-professional-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/pycharm.json
+++ b/bucket/pycharm.json
@@ -55,7 +55,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/python/pycharm-community-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/python/pycharm-community-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/rider.json
+++ b/bucket/rider.json
@@ -44,10 +44,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead.win.zip"
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchVer.win.zip"
             },
             "arm64": {
-                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead-aarch64.win.zip"
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchVer-aarch64.win.zip"
             }
         },
         "hash": {

--- a/bucket/rubymine.json
+++ b/bucket/rubymine.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/ruby/RubyMine-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/webstorm.json
+++ b/bucket/webstorm.json
@@ -58,7 +58,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/webstorm/WebStorm-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
# fix: matchVer instead of matchHead in jetbrains apps
<!-- Provide a general summary of your changes in the title above -->

Jetbrains apps are not auto updating well due to `$matchHead` returning only first two or three digits seperated by a dot (e.g. `3.7.1-rc.1` = `3.7.1`, ` 3.7.1.2-rc.1` = `3.7.1` or `3.7-rc.1` = `3.7`)

Currently we have 4 digits versions, for example: [IDEA Ultimate 2024.2.0.2](https://download.jetbrains.com/idea/ideaIU-2024.2.0.2.win.zip) this PR address the issue using `$matchVer`

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
