### PR TITLE
(chore): matchVer instead of matchHead in jetbrains apps

### DIFF
--- a/bucket/clion.json
+++ b/bucket/clion.json
@@ -41,7 +41,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.jetbrains.com/cpp/CLion-$matchHead.win.zip"
+                "url": "https://download.jetbrains.com/cpp/CLion-$matchVer.win.zip"
             }
         },
         "hash": {

--- a/bucket/clion.json
+++ b/bucket/clion.json
@@ -1,5 +1,5 @@
 {
-    "version": "2024.2-242.20224.384",
+    "version": "2024.2.0.1-242.20224.413",
     "description": "Cross-Platform IDE for C and C++ by JetBrains.",
     "homepage": "https://www.jetbrains.com/cpp/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.jetbrains.com/cpp/CLion-2024.2.win.zip",
-            "hash": "7791bb703eee8bb8a88833b632698d78574dd41cd648d1840bb5aa3b72eb5d29",
+            "url": "https://download.jetbrains.com/cpp/CLion-2024.2.0.1.win.zip",
+            "hash": "8d3fd2d4e0dc15241499d92a795c4cb6f6132e3ecffe88fe57bdeb35650414f7",
             "bin": [
                 [
                     "IDE\\bin\\clion64.exe",

--- a/bucket/datagrip.json
+++ b/bucket/datagrip.json
@@ -6,8 +6,8 @@
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/datagrip/datagrip-2024.2.1.exe#/dl.7z",
-    "hash": "de6369f29021fb761d5bc67907304d1e29ace82b7e6c1d5089354719c4ed107d",
+    "url": "https://download.jetbrains.com/datagrip/datagrip-2024.2.1.win.zip",
+    "hash": "18104db1d3ea06653a523824407d6f5daf5c55eb18a27c4a8a96cd8c87d6383b",
     "extract_to": "IDE",
     "installer": {
         "script": [

--- a/bucket/datagrip.json
+++ b/bucket/datagrip.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/datagrip/datagrip-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/goland.json
+++ b/bucket/goland.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.306",
+    "version": "2024.2.0.1-242.20224.424",
     "description": "Cross-Platform IDE for Go by JetBrains.",
     "homepage": "https://www.jetbrains.com/goland/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/go/goland-2024.2.exe#/dl.7z",
-    "hash": "c045fe2cd0cdfb8331b4c6e21dd61317106410e2d02088cb4f03662e9bc3ae1e",
+    "url": "https://download.jetbrains.com/go/goland-2024.2.0.1.win.zip",
+    "hash": "68ee4180a0ba46b022f59018af4fa37a3c0ed4fd921ba3e84481768e9b4361bb",
     "extract_to": "IDE",
     "installer": {
         "script": [

--- a/bucket/goland.json
+++ b/bucket/goland.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/go/goland-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/go/goland-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea-ultimate.json
+++ b/bucket/idea-ultimate.json
@@ -49,7 +49,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIU-$matchHead.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIU-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea-ultimate.json
+++ b/bucket/idea-ultimate.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.300",
+    "version": "2024.2.0.2-242.20224.419",
     "description": "Cross-Platform IDE for Java by JetBrains.",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIU-2024.2.win.zip",
-    "hash": "5a20f3aef62d4adcf6075e81499522bad6f1a7706f3743ddc8c08145a6e20751",
+    "url": "https://download.jetbrains.com/idea/ideaIU-2024.2.0.2.win.zip",
+    "hash": "d7a26c30cab300e9726e83b0835184583f1bcfcaab48bef4be0f4c8a6d7144d9",
     "extract_to": "IDE",
     "pre_install": "Get-ChildItem \"$persist_dir\\IDE\\bin\\idea*.exe.vmoptions\" -ErrorAction SilentlyContinue | Copy-Item -Destination \"$dir\\IDE\\bin\"",
     "installer": {

--- a/bucket/idea.json
+++ b/bucket/idea.json
@@ -49,7 +49,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIC-$matchHead.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIC-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea.json
+++ b/bucket/idea.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.300",
+    "version": "2024.2.0.2-242.20224.419",
     "description": "Cross-Platform IDE for Java by JetBrains (Community edition).",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
         "identifier": "Apache-2.0",
         "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIC-2024.2.win.zip",
-    "hash": "3efc0d4d0f3950d81d2d7143ea3dfe2b42b16ed352779251d116bae6e9582c15",
+    "url": "https://download.jetbrains.com/idea/ideaIC-2024.2.0.2.win.zip",
+    "hash": "effcdced1c743ebc796b9452e2c1c44103f97f6515f8c2066359e1e0ea22e4c4",
     "extract_to": "IDE",
     "installer": {
         "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"

--- a/bucket/phpstorm.json
+++ b/bucket/phpstorm.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.361",
+    "version": "2024.2.0.1-242.20224.427",
     "description": "Cross-Platform IDE for PHP by JetBrains.",
     "homepage": "https://www.jetbrains.com/phpstorm/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/webide/PhpStorm-2024.2.exe#/dl.7z",
-    "hash": "bd4a1d5919b24bbbb6d5beedd720e18a22916511e3cdbc7705815d003ac752cf",
+    "url": "https://download.jetbrains.com/webide/PhpStorm-2024.2.0.1.win.zip",
+    "hash": "f3a4e0a04dc54402ee394f70f1dca2852fc6d33fb8e07f5ad20d2b50105826ef",
     "extract_to": "IDE",
     "installer": {
         "script": [

--- a/bucket/phpstorm.json
+++ b/bucket/phpstorm.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/webide/PhpStorm-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/pycharm-professional.json
+++ b/bucket/pycharm-professional.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.347",
+    "version": "2024.2.0.1-242.20224.428",
     "description": "Cross-Platform IDE for Python by JetBrains.",
     "homepage": "https://www.jetbrains.com/pycharm/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/python/pycharm-professional-2024.2.exe#/dl.7z",
-    "hash": "21900e6eae669abb957690bb4d1ee4cbb5ad0ee47526999f58040fc97aba2272",
+    "url": "https://download.jetbrains.com/python/pycharm-professional-2024.2.0.1.win.zip",
+    "hash": "bf3f868bcb5b66b1a28f02e6fe36410f3608fe83aa55e6cab9af8440ab43aee8",
     "extract_to": "IDE",
     "pre_install": [
         "Get-ChildItem \"$persist_dir\\IDE\\bin\\pycharm*.exe.vmoptions\" -ErrorAction SilentlyContinue | Copy-Item -Destination \"$dir\\IDE\\bin\"",

--- a/bucket/pycharm-professional.json
+++ b/bucket/pycharm-professional.json
@@ -61,7 +61,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/python/pycharm-professional-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/pycharm.json
+++ b/bucket/pycharm.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.347",
+    "version": "2024.2.0.1-242.20224.428",
     "description": "Cross-Platform IDE for Python by JetBrains (Community edition).",
     "homepage": "https://www.jetbrains.com/pycharm/",
     "license": {
         "identifier": "Apache-2.0",
         "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
     },
-    "url": "https://download.jetbrains.com/python/pycharm-community-2024.2.exe#/dl.7z",
-    "hash": "155bd522f300157be1eb509601c5e96ae63aa261ffd7d0686ae8ee57fceeb194",
+    "url": "https://download.jetbrains.com/python/pycharm-community-2024.2.0.1.win.zip",
+    "hash": "feda4f6bdde324f54337f5d398e872050752d0b97c78631e331dbb7cbab6ecaa",
     "extract_to": "IDE",
     "installer": {
         "script": [

--- a/bucket/pycharm.json
+++ b/bucket/pycharm.json
@@ -55,7 +55,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/python/pycharm-community-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/python/pycharm-community-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/rider.json
+++ b/bucket/rider.json
@@ -1,5 +1,5 @@
 {
-    "version": "2024.2.1-242.20224.418",
+    "version": "2024.2.2-242.20224.431",
     "description": "Cross-Platform IDE for .NET by JetBrains.",
     "homepage": "https://www.jetbrains.com/rider/",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.1.win.zip",
-            "hash": "de92d4fdc7b789b2ea67eb6e5f22244ac008ecd03fcd110c30dfa5c16bf7d02e"
+            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.2.win.zip",
+            "hash": "12f29b8ee13140c65129ee1469311a97fb1476e6fd84118ed8ad40d7f28f28cf"
         },
         "arm64": {
-            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.1-aarch64.win.zip",
-            "hash": "1a5b943602ab5a9958208d32eb3a349765594a3965a08bbf55b33b8812bc6d5c"
+            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.2-aarch64.win.zip",
+            "hash": "28519eec5cdb67def26a8f7208ced8f22169aa34ecfda9ef3bb8dcb6ca1791e5"
         }
     },
     "extract_to": "IDE",

--- a/bucket/rider.json
+++ b/bucket/rider.json
@@ -44,10 +44,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead.win.zip"
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchVer.win.zip"
             },
             "arm64": {
-                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchHead-aarch64.win.zip"
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$matchVer-aarch64.win.zip"
             }
         },
         "hash": {

--- a/bucket/rubymine.json
+++ b/bucket/rubymine.json
@@ -52,7 +52,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/ruby/RubyMine-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/rubymine.json
+++ b/bucket/rubymine.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.338",
+    "version": "2024.2.0.1-242.20224.425",
     "description": "Cross-Platform IDE for Ruby on Rails by JetBrains.",
     "homepage": "https://www.jetbrains.com/ruby/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.exe#/dl.7z",
-    "hash": "f53e83d2a46b1dce354081d2aa1090135c0172c3c602bde292c10b06c0067aec",
+    "url": "https://download.jetbrains.com/ruby/RubyMine-2024.2.0.1.win.zip",
+    "hash": "8bf623aa729bdd5c95cdb94b36aa474af86b25d26b5caa6bfaadef30d670927b",
     "extract_to": "IDE",
     "installer": {
         "script": [

--- a/bucket/webstorm.json
+++ b/bucket/webstorm.json
@@ -58,7 +58,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/webstorm/WebStorm-$matchHead.exe#/dl.7z",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/webstorm.json
+++ b/bucket/webstorm.json
@@ -1,13 +1,13 @@
 {
-    "version": "2024.2-242.20224.342",
+    "version": "2024.2.0.1-242.20224.426",
     "description": "Cross-Platform IDE for JavaScript by JetBrains.",
     "homepage": "https://www.jetbrains.com/webstorm/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.2.exe#/dl.7z",
-    "hash": "3b272b780515801e59fa275c25738b603f2714701ee757fd584fe5847eea485c",
+    "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.2.0.1.win.zip",
+    "hash": "a5ee856ac4ddd8a6ae56eab0b94e2acde961d03b70ec93bacdcaeaf044ab1a18",
     "extract_to": "IDE",
     "pre_install": [
         "Get-ChildItem \"$persist_dir\\IDE\\bin\\webstorm*.exe.vmoptions\" -ErrorAction SilentlyContinue | Copy-Item -Destination \"$dir\\IDE\\bin\"",


### PR DESCRIPTION
# fix: matchVer instead of matchHead in jetbrains apps
<!-- Provide a general summary of your changes in the title above -->

Jetbrains apps are not auto updating well due to `$matchHead` returning only first two or three digits seperated by a dot (e.g. `3.7.1-rc.1` = `3.7.1`, ` 3.7.1.2-rc.1` = `3.7.1` or `3.7-rc.1` = `3.7`)

Currently we have 4 digits versions, for example: [IDEA Ultimate 2024.2.0.2](https://download.jetbrains.com/idea/ideaIU-2024.2.0.2.win.zip) this PR address the issue using `$matchVer`

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #13863


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
