### PR TITLE
oss-browser: Update to version 1.19.0, fix checkver & autoupdate

### DIFF
--- a/bucket/oss-browser.json
+++ b/bucket/oss-browser.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.9.5",
+    "version": "1.19.0",
     "description": "Alibaba cloud (Aliyun) oss file manager.",
     "homepage": "https://github.com/aliyun/oss-browser",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://oss-attachment.cn-hangzhou.oss.aliyun-inc.com/oss-browser/1.9.5/oss-browser-win32-x64.zip",
-            "hash": "9b3e96edc3946317cbab30e7a6fee6ac8504d214737b2449d5a83c3c2db496a7",
+            "url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/1.19.0/oss-browser-win32-x64.zip",
+            "hash": "bd6311c50051966c8b165e52c7729b518df5f09f51d8c05a4552efb3cc72ebba",
             "extract_dir": "oss-browser-win32-x64"
         },
         "32bit": {
-            "url": "https://oss-attachment.cn-hangzhou.oss.aliyun-inc.com/oss-browser/1.9.5/oss-browser-win32-ia32.zip",
-            "hash": "2d01ad6e8fb3fd0b8f5c338a58364dc366232b1cfd5b5924b54fd8f9cf55aafd",
+            "url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/1.19.0/oss-browser-win32-ia32.zip",
+            "hash": "12cf2fe7d08878e5c54db97b8dcd18e404b3f8c2bec5f657f15ae747d228813c",
             "extract_dir": "oss-browser-win32-ia32"
         }
     },
@@ -23,16 +23,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/aliyun/oss-browser/master/all-releases.md",
+        "url": "https://raw.githubusercontent.com/aliyun/oss-browser/develop/all-releases.md",
         "regex": "/([\\d.]+)/oss-browser-win32-x64\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://oss-attachment.cn-hangzhou.oss.aliyun-inc.com/oss-browser/$version/oss-browser-win32-x64.zip"
+				"url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/$version/oss-browser-win32-x64.zip"
             },
             "32bit": {
-                "url": "https://oss-attachment.cn-hangzhou.oss.aliyun-inc.com/oss-browser/$version/oss-browser-win32-ia32.zip"
+				"url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/$version/oss-browser-win32-ia32.zip"
             }
         }
     }

--- a/bucket/oss-browser.json
+++ b/bucket/oss-browser.json
@@ -29,10 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-				"url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/$version/oss-browser-win32-x64.zip"
+                "url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/$version/oss-browser-win32-x64.zip"
             },
             "32bit": {
-				"url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/$version/oss-browser-win32-ia32.zip"
+                "url": "https://oss-attachment.oss-cn-zhangjiakou.aliyuncs.com/ossbrowser/$version/oss-browser-win32-ia32.zip"
             }
         }
     }


### PR DESCRIPTION
The oss-browser repository has changed the default branch to `develop`. Checkver does not detect the new version with the current manifest file.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).