### PR TITLE
tracy@0.11.1: Tracy artifacts changed slightly 

### DIFF
--- a/bucket/tracy.json
+++ b/bucket/tracy.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.11.0",
+    "version": "0.11.1",
     "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications",
     "homepage": "https://github.com/wolfpld/tracy",
     "license": "BSD-3-Clause",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wolfpld/tracy/releases/download/v0.11.0/windows-0.11.0.zip",
-            "hash": "392caf60ee74f04bb6eb979344670d8fd6cc48ffdbcd4525f3de63e268594e72"
+            "url": "https://github.com/wolfpld/tracy/releases/download/v0.11.0/windows-0.11.1.zip",
+            "hash": "e01e73903dd8babb634cb9ae48f3d5b52f3b519cf895548dd06538190554dc8a"
         }
     },
     "shortcuts": [

--- a/bucket/tracy.json
+++ b/bucket/tracy.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wolfpld/tracy/releases/download/v0.11.0/windows-0.11.1.zip",
+            "url": "https://github.com/wolfpld/tracy/releases/download/v0.11.1/windows-0.11.1.zip",
             "hash": "e01e73903dd8babb634cb9ae48f3d5b52f3b519cf895548dd06538190554dc8a"
         }
     },

--- a/bucket/tracy.json
+++ b/bucket/tracy.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.10",
+    "version": "0.11.0",
     "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications",
     "homepage": "https://github.com/wolfpld/tracy",
     "license": "BSD-3-Clause",
@@ -8,13 +8,13 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wolfpld/tracy/releases/download/v0.10/Tracy-0.10.7z",
-            "hash": "6b9e8bbad45c9b1d31c8bb4441c3bbe2e95156f4c901d43c0fc79297dd94c38c"
+            "url": "https://github.com/wolfpld/tracy/releases/download/v0.11.0/windows-0.11.0.zip",
+            "hash": "392caf60ee74f04bb6eb979344670d8fd6cc48ffdbcd4525f3de63e268594e72"
         }
     },
     "shortcuts": [
         [
-            "Tracy.exe",
+            "tracy-profiler.exe",
             "Tracy"
         ]
     ],
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/wolfpld/tracy/releases/download/v$version/Tracy-$version.7z"
+                "url": "https://github.com/wolfpld/tracy/releases/download/v$version/windows-$version.zip"
             }
         }
     }


### PR DESCRIPTION
The way that tracy organized its release artifacts has changed with v0.11.0

Relates to #10942 

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
