### PR TITLE
miniforge3: Add version 24.7.1-2

### DIFF
--- a/bucket/miniforge3.json
+++ b/bucket/miniforge3.json
@@ -1,5 +1,5 @@
 {
-    "version": "24.11.0-0",
+    "version": "25.3.0-1",
     "description": "A conda-forge distribution",
     "homepage": "https://github.com/conda-forge/miniforge",
     "license": "BSD-3-Clause",
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/conda-forge/miniforge/releases/download/24.11.0-0/Mambaforge-24.11.0-0-Windows-x86_64.exe",
-            "hash": "5bb092e9fa1bed273ab0493303c2afdd4ab7f441b525652ed1b339f0499a603b"
+            "url": "https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Windows-x86_64.exe",
+            "hash": "b14ad50d85a218268a14cad7469cabb4e5364f75d34add3792449ec935ddf3ab"
         }
     },
     "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
@@ -25,7 +25,7 @@
         ]
     },
     "env_add_path": [
-        "scripts",
+        "Scripts",
         "Library\\bin"
     ],
     "bin": [
@@ -39,7 +39,7 @@
     "persist": "envs",
     "uninstaller": {
         "script": [
-            "Start-Process -Wait \"$dir\\Uninstall-Mambaforge.exe\" -ArgumentList '/S'",
+            "Start-Process -Wait \"$dir\\Uninstall-Miniforge3.exe\" -ArgumentList '/S'",
             "# Workaround for 'envs' being deleted by the uninstaller. This does not affect persist.",
             "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
         ]
@@ -51,7 +51,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/conda-forge/miniforge/releases/download/$version/Mambaforge-$version-Windows-x86_64.exe",
+                "url": "https://github.com/conda-forge/miniforge/releases/download/$version/Miniforge3-$version-Windows-x86_64.exe",
                 "hash": {
                     "url": "$url.sha256"
                 }

--- a/deprecated/mambaforge.json
+++ b/deprecated/mambaforge.json
@@ -1,0 +1,53 @@
+{
+    "version": "24.3.0-0",
+    "description": "A conda-forge distribution",
+    "homepage": "https://github.com/conda-forge/miniforge",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "'mambaforge' has been deprecated in favour of 'miniforge'",
+        "To install newer versions, run: scoop install miniforge3",
+        "* Known issue:",
+        "  - The App may fail to install when 'Long Paths' are not enabled, Check it by executing `scoop checkup`. (#11570)",
+        "------",
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\""
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Windows-x86_64.exe",
+            "hash": "371da29c8611ed273274f2ca4714f83e60ce37cb535e74bf45526f7cc9ad32ae"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "Move-Item \"$dir\\$fname\" \"$dir\\..\\$fname\"",
+            "Start-Process -Wait \"$dir\\..\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
+            "Remove-Item \"$dir\\..\\$fname\""
+        ]
+    },
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "persist": "envs",
+    "uninstaller": {
+        "script": [
+            "Start-Process -Wait \"$dir\\Uninstall-Mambaforge.exe\" -ArgumentList '/S'",
+            "# Workaround for 'envs' being deleted by the uninstaller. This does not affect persist.",
+            "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/conda-forge/miniforge",
+        "regex": "tag/([\\d.-]+)"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Supersedes #11986. Notable differences include a more up-to-date version, and deprecation of mambaforge in favour of miniforge3 as per the developers since July 2024.

Closes #11983
Closes #11986

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
