### PR TITLE
zen-browser: add version 1.0.1-a.2

### DIFF
--- a/bucket/zen-browser.json
+++ b/bucket/zen-browser.json
@@ -1,0 +1,58 @@
+{
+    "version": "1.0.1-a.2",
+    "description": "An open-source, privacy-focused web browser with a focus on speed and user experience.",
+    "homepage": "https://zen-browser.app",
+    "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Zen Profile Manager', choose 'Scoop' then click 'Start Zen Browser'.",
+        "  - Visit 'about:profiles' page in Zen Browser to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zen-browser/desktop/releases/download/1.0.1-a.2/zen.win-generic.zip",
+            "hash": "350f8d210bb0d0042baa708e3d8b497ae1266a6c3dd967b04436d1d561c1a230"
+        }
+    },
+    "extract_dir": "zen.win-generic\\zen",
+    "post_install": [
+        "zen -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
+    ],
+    "bin": "zen.exe",
+    "shortcuts": [
+        [
+            "zen.exe",
+            "Zen Browser"
+        ],
+        [
+            "zen.exe",
+            "Zen Browser Profile Manager",
+            "-P"
+        ],
+        [
+            "private_browsing.exe",
+            "Zen Browser Private Browsing"
+        ]
+    ],
+    "persist": [
+        "distribution",
+        "profile"
+    ],
+    "checkver": {
+        "github": "https://github.com/zen-browser/desktop",
+        "regex": "/releases/tag/(?:v|V)?([\\d.]+(-a[\\d.]+)?)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zen-browser/desktop/releases/download/$version/zen.win-generic.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [Zen Browser](https://zen-browser.app/), an open-source, privacy-focused web browser with a focus on speed and user experience.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
