### PR TITLE
7tt: Add startup entry

### DIFF
--- a/bucket/7tt.json
+++ b/bucket/7tt.json
@@ -7,11 +7,13 @@
     "hash": "1d144d8d909acdc149adeefd0434914dbc0c385aa45b70798927e1e564a2fcb3",
     "bin": "7+ Taskbar Tweaker.exe",
     "pre_install": [
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\inject.dll\", \"$dir\\uninstall.exe\" -Recurse -Force",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\inject.dll\", \"$dir\\uninstall.exe\" -ErrorAction SilentlyContinue -Recurse -Force",
         "if (!(Test-Path \"$persist_dir\\7+ Taskbar Tweaker.ini\")) {",
         "  Add-Content \"$dir\\7+ Taskbar Tweaker.ini\" \"[Config]`r`nupdcheckauto=0`r`nupdcheck=0\"",
         "}"
     ],
+    "post_install": "$null = New-ItemProperty -Path \"HK$(if ($global) { 'LM' } else { 'CU' }):/SOFTWARE/Microsoft/Windows/CurrentVersion/Run\" -Name '7 Taskbar Tweaker' -Value \"$([char][byte]34)$dir\\7+ Taskbar Tweaker.exe$([char][byte]34) -hidewnd\" -PropertyType String -Force",
+    "pre_uninstall": "Remove-ItemProperty \"HK$(if ($global) { 'LM' } else { 'CU' }):/SOFTWARE/Microsoft/Windows/CurrentVersion/Run\" '7 Taskbar Tweaker'",
     "persist": "7+ Taskbar Tweaker.ini",
     "shortcuts": [
         [


### PR DESCRIPTION
This mirrors the installer's startup handling, `post_install` is preferred as `$dir` won't set version numbers.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).