### PR TITLE
ltspice: Add version 24.0.12.0

### DIFF
--- a/bucket/ltspice.json
+++ b/bucket/ltspice.json
@@ -1,0 +1,35 @@
+{
+    "version": "24.0.12.0",
+    "description": "A powerful, fast, and free SPICE simulator software, schematic capture and waveform viewer with enhancements and models for improving the simulation of analog circuits.",
+    "homepage": "https://www.analog.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.analog.com/en/resources/evaluation-hardware-and-software/analog-devices-software-license-agreement.html"
+    },
+    "url": "https://ltspice.analog.com/software/LTspice64.msi#/setup.msi_",
+    "hash": "62a9f20b630738e6ade20a37551baa91b20760bfb718807d8a2be4caa3421a36",
+    "installer": {
+        "script": "Start-Process \"MsiExec.exe\" -ArgumentList \"/i $dir\\setup.msi_ APPDIR=$dir ALLUSERS=2 MSIINSTALLPERUSER=1 /qn\" -Wait",
+        "keep": true
+    },
+    "shortcuts": [
+        [
+            "LTspice.exe",
+            "LTspice"
+        ]
+    ],
+    "uninstaller": {
+        "script": "Start-Process \"MsiExec.exe\" -ArgumentList \"/x $dir\\setup.msi_ APPDIR=$dir ALLUSERS=2 MSIINSTALLPERUSER=1 /qn\" -Wait"
+    },
+    "checkver": {
+        "url": "https://ltspice.analog.com/download/updates.txt",
+        "regex": "Version = ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://ltspice.analog.com/software/LTspice64.msi#/setup.msi_",
+        "hash": {
+            "url": "https://ltspice.analog.com/download/updates.txt",
+            "regex": "SHA256 = ([a-fA-F0-9]{64})"
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for the LTspice simulation software. Tested with a local and global installation and uninstallation. Also checked the manifest updates automatically. Closes #1910

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
