### PR TITLE
Backrest: Add version 1.5.0

### DIFF
--- a/bucket/backrest.json
+++ b/bucket/backrest.json
@@ -1,15 +1,15 @@
 {
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Web UI and orchestrator for restic backup.",
     "homepage": "https://github.com/garethgeorge/backrest",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/garethgeorge/backrest/releases/download/v1.4.0/backrest_Windows_x86_64.zip",
-            "hash": "02ca768d20315013958e889137c6e3cde157128e62745f7fa646ee2f5ebfb336"
+            "url": "https://github.com/garethgeorge/backrest/releases/download/v1.5.0/backrest_Windows_x86_64.zip",
+            "hash": "9710538e948cea1f68eb0520e96519cb9de779636c5d9d56215d1c5baef40be2"
         },
         "arm64": {
-            "url": "https://github.com/garethgeorge/backrest/releases/download/v1.4.0/backrest_Windows_arm64.zip",
+            "url": "https://github.com/garethgeorge/backrest/releases/download/v1.5.0/backrest_Windows_arm64.zip",
             "hash": "d07642972014bca45dc964c188ee83a5b4857b3cc18cfb42e782664a609e8c98"
         }
     },

--- a/bucket/backrest.json
+++ b/bucket/backrest.json
@@ -34,7 +34,7 @@
             }
         },
         "hash": {
-            "url": "",
+            "url": "$baseurl/backrest_$version_checksums.txt",
             "regex": "$sha256\\s+$basename"
         }
     }

--- a/bucket/backrest.json
+++ b/bucket/backrest.json
@@ -1,0 +1,41 @@
+{
+    "version": "1.4.0",
+    "description": "Web UI and orchestrator for restic backup.",
+    "homepage": "https://github.com/garethgeorge/backrest",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/garethgeorge/backrest/releases/download/v1.4.0/backrest_Windows_x86_64.zip",
+            "hash": "02ca768d20315013958e889137c6e3cde157128e62745f7fa646ee2f5ebfb336"
+        },
+        "arm64": {
+            "url": "https://github.com/garethgeorge/backrest/releases/download/v1.4.0/backrest_Windows_arm64.zip",
+            "hash": "d07642972014bca45dc964c188ee83a5b4857b3cc18cfb42e782664a609e8c98"
+        }
+    },
+    "bin": [
+        "backrest.exe",
+        "backrest-windows-tray.exe"
+    ],
+    "shortcuts": [
+        [
+            "backrest.exe",
+            "Backrest"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/garethgeorge/backrest/releases/download/v$version/backrest_Windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/garethgeorge/backrest/releases/download/v$version/backrest_Windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "",
+            "regex": "$sha256\\s+$basename"
+        }
+    }
+}

--- a/bucket/backrest.json
+++ b/bucket/backrest.json
@@ -10,7 +10,7 @@
         },
         "arm64": {
             "url": "https://github.com/garethgeorge/backrest/releases/download/v1.5.0/backrest_Windows_arm64.zip",
-            "hash": "d07642972014bca45dc964c188ee83a5b4857b3cc18cfb42e782664a609e8c98"
+            "hash": "0db76e17aefd4511a23fe620b4aa5ea92a179d119505cd6b4e30ad1bfaa76d9c"
         }
     },
     "bin": [


### PR DESCRIPTION
Adds a manifest for the Backrest software. Tested with a local and global installation and uninstallation. Also checked the manifest updates automatically.

Closes #13978 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
