### PR TITLE
clash-nyanpasu@1.6.1: Remove `pre_uninstall`

### DIFF
--- a/bucket/clash-nyanpasu.json
+++ b/bucket/clash-nyanpasu.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.5.1",
+    "version": "1.6.1",
     "description": "Clash Nyanpasu! (∠・ω< )⌒☆ An opinionated Clash GUI based on Tauri.",
     "homepage": "https://github.com/LibNyanpasu/clash-nyanpasu",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LibNyanpasu/clash-nyanpasu/releases/download/v1.5.1/Clash.Nyanpasu_1.5.1_x64_portable.zip",
-            "hash": "934f7acad4b7280521720ac5861599d72735aa020d9d17f91787098f40689e37"
+            "url": "https://github.com/LibNyanpasu/clash-nyanpasu/releases/download/v1.6.1/Clash.Nyanpasu_1.6.1_x64_portable.zip",
+            "hash": "1dcb6dae8bf473a0c6fd3fac0cc1cfeb4cc98c9865ac9f3493f8e96da77565b4"
         }
     },
     "shortcuts": [
@@ -20,10 +20,6 @@
         "if (!(Test-Path \"$persist_dir\\.config\\PORTABLE\")) {",
         "    New-Item -Path \"$persist_dir\\.config\\PORTABLE\" -ItemType file | Out-Null",
         "}"
-    ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process \"$dir\\resources\\uninstall-service.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden'; Start-Sleep -Seconds 3"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/clash-nyanpasu.json
+++ b/bucket/clash-nyanpasu.json
@@ -1,11 +1,11 @@
 {
     "version": "1.6.1",
     "description": "Clash Nyanpasu! (∠・ω< )⌒☆ An opinionated Clash GUI based on Tauri.",
-    "homepage": "https://github.com/LibNyanpasu/clash-nyanpasu",
+    "homepage": "https://github.com/libNyanpasu/clash-nyanpasu",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LibNyanpasu/clash-nyanpasu/releases/download/v1.6.1/Clash.Nyanpasu_1.6.1_x64_portable.zip",
+            "url": "https://github.com/libNyanpasu/clash-nyanpasu/releases/download/v1.6.1/Clash.Nyanpasu_1.6.1_x64_portable.zip",
             "hash": "99525f1d5338e2edb3037661b6f81b5eeee359d8a2e0801c1606a547bc084bcf"
         }
     },
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/LibNyanpasu/clash-nyanpasu/releases/download/v$version/Clash.Nyanpasu_$version_x64_portable.zip"
+                "url": "https://github.com/libNyanpasu/clash-nyanpasu/releases/download/v$version/Clash.Nyanpasu_$version_x64_portable.zip"
             }
         }
     }


### PR DESCRIPTION
Remove `pre_uninstall`

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

```
PS C:\Users\xxx> scoop uninstall -p clash-nyanpasu
Uninstalling 'clash-nyanpasu' (1.6.1).
Running pre_uninstall script...Start-Process:
Line |
   2 |  Start-Process "$dir\resources\uninstall-service.exe" -Wait -Verb 'Run …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | This command cannot be run due to the error: An error occurred trying to start process 'D:\scoop\apps\clash-nyanpasu\1.6.1\resources\uninstall-service.exe' with working directory 'C:\Users\xxx'.
done.
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] The system cannot find the file specified

There is no such `uninstall-service.exe` in the current version