### PR TITLE
enpass: Fix regex and update version 6.11.3.1771

### DIFF
--- a/bucket/enpass.json
+++ b/bucket/enpass.json
@@ -1,13 +1,13 @@
 {
-    "version": "6.11.2.1753",
+    "version": "6.11.3.1771",
     "description": "A cross-platform password management app to securely store passwords and other credentials in a virtual vault locked with a master password.",
     "homepage": "https://www.enpass.io",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.enpass.io/legal/"
     },
-    "url": "https://dl.enpass.io/stable/windows/setup/6.11.2.1753/Enpass-setup.exe",
-    "hash": "64dc0b63dfed3f0ff43565ef2e86251d7bfa64cd183d64ad1b28938d10f005e0",
+    "url": "https://dl.enpass.io/stable/windows/setup/6.11.3.1771/Enpass-setup.exe",
+    "hash": "93f10712c5bdad91bf9243b4efd78a143f84d4ae936ef8e259195e2175b2e5ec",
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\tmp\" -Removal",
@@ -40,7 +40,7 @@
     ],
     "checkver": {
         "url": "https://www.enpass.io/release-notes/windows-pc/",
-        "regex": ">Version (?<ver>[\\d.]+) \\((?<build>[\\d]+)\\)<",
+        "regex": ">Version (?<ver>[\\d.]+) ?\\((?<build>[\\d]+)\\)<",
         "replace": "${ver}.${build}"
     },
     "autoupdate": {


### PR DESCRIPTION
The regex of enpass `checkver` does not match the latest web page

Closes #14004


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
