### PR TITLE
S3Browser@11.9.5: Fix shortcut

### DIFF
--- a/bucket/s3browser.json
+++ b/bucket/s3browser.json
@@ -14,7 +14,7 @@
     "bin": "s3browser-cli.exe",
     "shortcuts": [
         [
-            "s3browser-win32.exe",
+            "s3browser-ui.exe",
             "S3Browser"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
It seems that since recent versions the GUI executable file is renamed from `s3browser-win32.exe` to `s3browser-ui.exe`
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
