### PR TITLE
onecommander@3.89.1.0: Add bin section

### DIFF
--- a/bucket/onecommander.json
+++ b/bucket/onecommander.json
@@ -20,6 +20,9 @@
         "Logs",
         "Resources"
     ],
+    "bin": [
+        "OneCommander.exe"
+    ],
     "checkver": {
         "url": "https://onecommander.com/version.txt",
         "regex": "([\\w.-]+)"


### PR DESCRIPTION
This allows us to run a few commands from the [cli](https://onecommander.com/help/3._Full_reference_guide/Starting_from_Command_line.html)


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
