### PR TITLE
gitextensions@5.0.0.17897: Update to x64 and new naming

### DIFF
--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -1,10 +1,14 @@
 {
-    "version": "4.2.1.17611",
+    "version": "5.0.0.17897",
     "description": "A graphical user interface for Git that allows you to control Git without using the commandline.",
     "homepage": "https://gitextensions.github.io/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/gitextensions/gitextensions/releases/download/v4.2.1/GitExtensions-Portable-4.2.1.17611-b0c0b2848.zip",
-    "hash": "372c9cef9b2b19c8bba9ea9424b9262f68edfbe61e4711d6d5f0f904462f871b",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gitextensions/gitextensions/releases/download/v5.0/GitExtensions-Portable-x64-5.0.0.17897-2a3b78b86.zip",
+            "hash": "2e59d233026bee40d7b92e12fbb042b05f3fc83ffa3af9fdfc752a215e1e9f66"
+        }
+    },
     "pre_install": "if (!(Test-Path \"$persist_dir\\GitExtensions.settings\")) { New-Item \"$dir\\GitExtensions.settings\" | Out-Null }",
     "bin": [
         "GitExtensions.exe",
@@ -23,9 +27,13 @@
     "checkver": {
         "url": "https://api.github.com/repositories/85953/releases",
         "jsonpath": "$..browser_download_url",
-        "regex": "/v(?<tag>[\\d.]+)/GitExtensions-Portable-([\\d.]+)-(?<commit>[\\w]+)\\.zip"
+        "regex": "/v(?<tag>[\\d.]+)/GitExtensions-Portable-(?:x[\\d.]+)-(?<version>[\\d.]+)-(?<commit>[\\w]+).zip"
     },
     "autoupdate": {
-        "url": "https://github.com/gitextensions/gitextensions/releases/download/v$matchTag/GitExtensions-Portable-$version-$matchCommit.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gitextensions/gitextensions/releases/download/v$matchTag/GitExtensions-Portable-x64-$version-$matchCommit.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
- Added x64 `architecture` values
- Updated `checkver.regex` to match new naming scheme
- Added x64 `architecture` to `autoupdate` section with new URL pattern

Closes #14021

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
