### PR TITLE
everythingtoolbar: Add version 1.4.1

### DIFF
--- a/bucket/everythingtoolbar.json
+++ b/bucket/everythingtoolbar.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.4.1",
+    "description": "Everything integration for the Windows taskbar.",
+    "homepage": "https://github.com/srwi/EverythingToolbar",
+    "license": "MIT",
+    "depends": "everything",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/srwi/EverythingToolbar/releases/download/1.4.1/EverythingToolbar-1.4.1.msi",
+            "hash": "e3b177af10305253c19486560b97bde36ae961f1475f308170641c0eb2b1f49c"
+        }
+    },
+    "post_install": "Start-Process \"$dir\\PFiles64\\EverythingToolbar\\EverythingToolbar.Launcher.exe\"",
+    "shortcuts": [
+        [
+            "PFiles64/EverythingToolbar/EverythingToolbar.Launcher.exe",
+            "EverythingToolbar"
+        ]
+    ],
+    "checkver": "github"
+}


### PR DESCRIPTION
EverythingToolbar supports two modes: Deskband mode (which has been discussed before in #8958) and Launcher mode. This PR adds the launcher variant of EverythingToolbar, which merely requires unpacking of the installer.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #8958

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
