### PR TITLE
zebar: Add version 2.2.2

### DIFF
--- a/bucket/zebar.json
+++ b/bucket/zebar.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.8.1",
+    "description": "Zebar is a tool for creating customizable and cross-platform taskbars, desktop widgets, and popups.",
+    "homepage": "https://github.com/glzr-io/zebar",
+    "license": "GPL-3.0",
+    "checkver": {
+        "github": "https://github.com/glzr-io/zebar"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/glzr-io/zebar/releases/download/v1.8.1/zebar-v1.8.1-opt1-x64.msi",
+            "hash": "723b2bc6e19fa67d5f9f1b88ecf23b14247771e95db35897b749708e5d5e41cd"
+        }
+    },
+    "installer": {
+        "script": [
+            "$names = @('zebar.exe', 'resources')",
+            "foreach ($name in $names) {",
+            "Copy-Item \"$dir\\PFiles\\glzr.io\\Zebar\\$name\" \"$dir\" -Recurse -Force",
+            "}",
+            "Get-ChildItem \"$dir\" -Exclude $names | Remove-Item -Recurse -Force"
+        ]
+    },
+    "autoupdate": {
+        "notes": "Thanks for using autoupdate, please test your updates!",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/glzr-io/zebar/releases/download/v$version/zebar-v$version-opt1-x64.msi"
+            }
+        }
+    },
+    "bin": "zebar.exe"
+}

--- a/bucket/zebar.json
+++ b/bucket/zebar.json
@@ -1,32 +1,34 @@
 {
-    "version": "1.8.1",
+    "version": "2.2.2",
     "description": "Zebar is a tool for creating customizable and cross-platform taskbars, desktop widgets, and popups.",
     "homepage": "https://github.com/glzr-io/zebar",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/glzr-io/zebar/releases/download/v1.8.1/zebar-v1.8.1-opt1-x64.msi",
-            "hash": "723b2bc6e19fa67d5f9f1b88ecf23b14247771e95db35897b749708e5d5e41cd"
+            "url": "https://github.com/glzr-io/zebar/releases/download/v2.2.2/zebar-v2.2.2-opt1-x64.msi",
+            "hash": "354824b120d01a6788824e1bc4c3eed1b68bddf918d8f2e9de4d6b4a1e7d88f9"
+        },
+        "arm64": {
+            "url": "https://github.com/glzr-io/zebar/releases/download/v2.2.2/zebar-v2.2.2-opt2-arm64.msi",
+            "hash": "8a2f427332dc7ad5691470d1835b42e3d59d55bbc3621ef5bb57617a6f8efbb8"
         }
     },
-    "installer": {
-        "script": [
-            "$names = @('zebar.exe', 'resources')",
-            "foreach ($name in $names) {",
-            "Copy-Item \"$dir\\PFiles\\glzr.io\\Zebar\\$name\" \"$dir\" -Recurse -Force",
-            "}",
-            "Get-ChildItem \"$dir\" -Exclude $names | Remove-Item -Recurse -Force"
-        ]
-    },
+    "extract_dir": "PFiles\\glzr.io\\Zebar",
     "bin": "zebar.exe",
-    "checkver": {
-        "github": "https://github.com/glzr-io/zebar"
-    },
+    "shortcuts": [
+        [
+            "zebar.exe",
+            "Zebar"
+        ]
+    ],
+    "checkver": "github",
     "autoupdate": {
-        "notes": "Thanks for using autoupdate, please test your updates!",
         "architecture": {
             "64bit": {
                 "url": "https://github.com/glzr-io/zebar/releases/download/v$version/zebar-v$version-opt1-x64.msi"
+            },
+            "arm64": {
+                "url": "https://github.com/glzr-io/zebar/releases/download/v$version/zebar-v$version-opt2-arm64.msi"
             }
         }
     }

--- a/bucket/zebar.json
+++ b/bucket/zebar.json
@@ -3,9 +3,6 @@
     "description": "Zebar is a tool for creating customizable and cross-platform taskbars, desktop widgets, and popups.",
     "homepage": "https://github.com/glzr-io/zebar",
     "license": "GPL-3.0",
-    "checkver": {
-        "github": "https://github.com/glzr-io/zebar"
-    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/glzr-io/zebar/releases/download/v1.8.1/zebar-v1.8.1-opt1-x64.msi",
@@ -21,6 +18,10 @@
             "Get-ChildItem \"$dir\" -Exclude $names | Remove-Item -Recurse -Force"
         ]
     },
+    "bin": "zebar.exe",
+    "checkver": {
+        "github": "https://github.com/glzr-io/zebar"
+    },
     "autoupdate": {
         "notes": "Thanks for using autoupdate, please test your updates!",
         "architecture": {
@@ -28,6 +29,5 @@
                 "url": "https://github.com/glzr-io/zebar/releases/download/v$version/zebar-v$version-opt1-x64.msi"
             }
         }
-    },
-    "bin": "zebar.exe"
+    }
 }


### PR DESCRIPTION
This adds an auto-updating recipe for [zebar](https://github.com/glzr-io/zebar)

Closes #14041 


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
