### PR TITLE
koodo-reader@1.7.0: Update urls

### DIFF
--- a/bucket/koodo-reader.json
+++ b/bucket/koodo-reader.json
@@ -1,19 +1,19 @@
 {
     "version": "1.7.0",
-    "homepage": "https://koodo.960960.xyz/en",
+    "homepage": "https://www.koodoreader.com",
     "description": "All-in-one ebook reader.",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/troyeguo/koodo-reader/releases/download/v1.7.0/Koodo-Reader-1.7.0-x64-Win.zip",
+            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v1.7.0/Koodo-Reader-1.7.0-x64-Win.zip",
             "hash": "09b38e75f8a25c212d9ac3d3cf4bc4cf125502ccbbdb13e999d65915155b5446"
         },
         "32bit": {
-            "url": "https://github.com/troyeguo/koodo-reader/releases/download/v1.7.0/Koodo-Reader-1.7.0-ia32-Win.zip",
+            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v1.7.0/Koodo-Reader-1.7.0-ia32-Win.zip",
             "hash": "a86b8125ec252bf10f600eab85164ae529093268f9ab086bdc143c9310cb22bb"
         },
         "arm64": {
-            "url": "https://github.com/troyeguo/koodo-reader/releases/download/v1.7.0/Koodo-Reader-1.7.0-arm64-Win.zip",
+            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v1.7.0/Koodo-Reader-1.7.0-arm64-Win.zip",
             "hash": "1dff53a064f4a548e2dfe041b6d241fb25135a45dc94d92c20362aa4049e8327"
         }
     },
@@ -24,18 +24,18 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/troyeguo/koodo-reader"
+        "github": "https://github.com/koodo-reader/koodo-reader"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/troyeguo/koodo-reader/releases/download/v$version/Koodo-Reader-$version-x64-Win.zip"
+                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-x64-Win.zip"
             },
             "32bit": {
-                "url": "https://github.com/troyeguo/koodo-reader/releases/download/v$version/Koodo-Reader-$version-ia32-Win.zip"
+                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-ia32-Win.zip"
             },
             "arm64": {
-                "url": "https://github.com/troyeguo/koodo-reader/releases/download/v$version/Koodo-Reader-$version-arm64-Win.zip"
+                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-arm64-Win.zip"
             }
         }
     }


### PR DESCRIPTION
The original repository has changed from https://github.com/troyeguo/koodo-reader to https://github.com/koodo-reader/koodo-reader. Although Github will handle the redirect for now, it's still necessary to match the latest change. Also the app has a new dedicated website at https://www.koodoreader.com. The old website could be sunset at any time.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
