### PR TITLE
esearch: change executable name of esearch

### DIFF
--- a/bucket/esearch.json
+++ b/bucket/esearch.json
@@ -16,11 +16,11 @@
             "hash": "edd6f904217d6b211280c629f5feeb47afcf4937c293b9ee17c159a631a83606"
         }
     },
-    "bin": "eSearch.exe",
+    "bin": "e-search.exe",
     "shortcuts": [
         [
-            "eSearch.exe",
-            "eSearch"
+            "e-search.exe",
+            "e-search"
         ]
     ],
     "checkver": "github",

--- a/bucket/esearch.json
+++ b/bucket/esearch.json
@@ -20,7 +20,7 @@
     "shortcuts": [
         [
             "e-search.exe",
-            "e-search"
+            "eSearch"
         ]
     ],
     "checkver": "github",


### PR DESCRIPTION
The author of esearch change the executable name from "eSearch" to "e-search" in commit https://github.com/xushengfeng/eSearch/commit/7fdea38080970b5e1eb9cf93521be8c9fb570b34.
Therefore, change it in esearch.json is necessary.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- or -->
Before this patch, command `scoop install esearch` will cause an error

             $bin = (Get-Command $target).Source
                     ~~~~~~~~~~~~~~~~~~~
     CategoryInfo          : ObjectNotFound: (eSearch.exe:String) [Get-Command], CommandNotFoundException
     FullyQualifiedErrorId : CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand

After this patch, command `scoop install esearch` will be ok, and esearch will be installed successfully.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
