### PR TITLE
shutup10: Change .ini to .cfg

### DIFF
--- a/bucket/shutup10.json
+++ b/bucket/shutup10.json
@@ -8,14 +8,14 @@
     },
     "url": "https://dl5.oo-software.com/files/ooshutup10/OOSU10.exe",
     "hash": "beb7becc38ccc7ed37c47fe607b25a966a5f71aabd36ab945c3cba15451dfa7b",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\OOSU10.ini\")) { New-Item \"$dir\\OOSU10.ini\" | Out-Null }",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\OOSU10.cfg\")) { New-Item \"$dir\\OOSU10.cfg\" | Out-Null }",
     "shortcuts": [
         [
             "OOSU10.exe",
             "O&O ShutUp10"
         ]
     ],
-    "persist": "OOSU10.ini",
+    "persist": "OOSU10.cfg",
     "checkver": "Version ([\\d.]+),",
     "autoupdate": {
         "url": "https://dl5.oo-software.com/files/ooshutup10/OOSU10.exe"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
ShutUp10 doesn't seem to use a .ini file anymore, but a .cfg (XML) file. This changes the persist instruction accordingly.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
