### PR TITLE
repack: add version 0.2.2

### DIFF
--- a/bucket/repak.json
+++ b/bucket/repak.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.2",
+    "description": "Unreal Engine .pak file library and CLI in rust",
+    "homepage": "https://github.com/trumank/repak",
+    "license": "MIT",
+    "url": "https://github.com/trumank/repak/releases/download/v0.2.2/repak_cli-x86_64-pc-windows-msvc.zip",
+    "hash": "b63ea4c243011901aea148de50b80f12fba858acb83cbf2e27c494b3acdb2b40",
+    "bin": "repak.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/trumank/repak/releases/download/v$version/repak_cli-x86_64-pc-windows-msvc.zip"
+    }
+}


### PR DESCRIPTION
Unreal Engine .pak file library and CLI in rust

https://github.com/trumank/repak

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
