### PR TITLE
pari-gp: Add version 2.17.0

### DIFF
--- a/bucket/pari-gp.json
+++ b/bucket/pari-gp.json
@@ -13,7 +13,7 @@
             "hash": "64fd73581b0a947167ba8af7209059a1a216cceb7827aec6f05b00e3c9d6b3ec"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe\" -Recurse",
     "bin": "gp.exe",
     "checkver": {
         "url": "https://pari.math.u-bordeaux.fr/download.html",
@@ -22,19 +22,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-$dashVersion.exe#/dl.7z",
-                "hash": {
-                    "url": "https://pari.math.u-bordeaux.fr/download.html",
-                    "find": "$basename[\\S\\s]+?$sha256"
-                }
+                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-$dashVersion.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-$dashVersion.exe#/dl.7z",
-                "hash": {
-                    "url": "https://pari.math.u-bordeaux.fr/download.html",
-                    "find": "$basename[\\S\\s]+?$sha256"
-                }
+                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-$dashVersion.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "https://pari.math.u-bordeaux.fr/download.html",
+            "find": "$basename[\\S\\s]+?$sha256"
         }
     }
 }

--- a/bucket/pari.json
+++ b/bucket/pari.json
@@ -1,0 +1,43 @@
+{
+    "version": "2-15-5",
+    "description": "PARI/GP is a widely used computer algebra system designed for fast computations in number theory.",
+    "homepage": "https://pari.math.u-bordeaux.fr/",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-2-15-5.exe#/dl.7z",
+            "hash": "bd8d94230cf2f46af8eb4e403493a37c4a28ce7757cf8cb7cf847aaa35143333"
+        },
+        "32bit": {
+            "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-2-15-5.exe#/dl.7z",
+            "hash": "8d15cfb2a43a3270f0f38e60afa61d7f5ce6d63eeb8a26a4c26651390ecb0c9b"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
+	"bin": [
+		"gp.exe"
+	],
+    "checkver": {
+		"url": "https://pari.math.u-bordeaux.fr/download.html",
+		"regex": "pari-(\\d+).(\\d+).(\\d+).tar.gz",
+		"replace": "${1}-${2}-${3}"
+	},
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-$version.exe#/dl.7z",
+				"hash": {
+					"url": "https://pari.math.u-bordeaux.fr/download.html",
+					"find": "Stable 64-bit version: Pari64-$version.exe.+\\s+sha256sum:\\s+$sha256"
+				}
+            },
+            "32bit": {
+                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-$version.exe#/dl.7z",
+				"hash": {
+					"url": "https://pari.math.u-bordeaux.fr/download.html",
+					"find": "Stable 32-bit version: Pari32-$version.exe.+\\s+sha256sum:\\s+$sha256"
+				}
+            }
+        }
+    }
+}

--- a/bucket/pari.json
+++ b/bucket/pari.json
@@ -25,14 +25,14 @@
                 "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-$dashVersion.exe#/dl.7z",
                 "hash": {
                     "url": "https://pari.math.u-bordeaux.fr/download.html",
-                    "find": "Stable 64-bit version: Pari64-$dashVersion.exe .+\\s+sha256sum: $sha256"
+                    "find": "$basename[\\S\\s]+?$sha256"
                 }
             },
             "32bit": {
                 "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-$dashVersion.exe#/dl.7z",
                 "hash": {
                     "url": "https://pari.math.u-bordeaux.fr/download.html",
-                    "find": "Stable 32-bit version: Pari32-$dashVersion.exe .+\\s+sha256sum: $sha256"
+                    "find": "$basename[\\S\\s]+?$sha256"
                 }
             }
         }

--- a/bucket/pari.json
+++ b/bucket/pari.json
@@ -1,22 +1,20 @@
 {
-    "version": "2.15.5",
+    "version": "2.17.0",
     "description": "PARI/GP is a widely used computer algebra system designed for fast computations in number theory.",
     "homepage": "https://pari.math.u-bordeaux.fr/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-2-15-5.exe#/dl.7z",
-            "hash": "bd8d94230cf2f46af8eb4e403493a37c4a28ce7757cf8cb7cf847aaa35143333"
+            "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-2-17-0.exe#/dl.7z",
+            "hash": "3340d72f1fd66b658deec64a9be5a94b7d333dc1a15514fe5aef54887ae13386"
         },
         "32bit": {
-            "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-2-15-5.exe#/dl.7z",
-            "hash": "8d15cfb2a43a3270f0f38e60afa61d7f5ce6d63eeb8a26a4c26651390ecb0c9b"
+            "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-2-17-0.exe#/dl.7z",
+            "hash": "64fd73581b0a947167ba8af7209059a1a216cceb7827aec6f05b00e3c9d6b3ec"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
-    "bin": [
-        "gp.exe"
-    ],
+    "bin": "gp.exe",
     "checkver": {
         "url": "https://pari.math.u-bordeaux.fr/download.html",
         "regex": "pari-([\\d.]+).tar.gz"

--- a/bucket/pari.json
+++ b/bucket/pari.json
@@ -1,5 +1,5 @@
 {
-    "version": "2-15-5",
+    "version": "2.15.5",
     "description": "PARI/GP is a widely used computer algebra system designed for fast computations in number theory.",
     "homepage": "https://pari.math.u-bordeaux.fr/",
     "license": "GPL-3.0-only",
@@ -14,29 +14,28 @@
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
-	"bin": [
-		"gp.exe"
-	],
+    "bin": [
+        "gp.exe"
+    ],
     "checkver": {
-		"url": "https://pari.math.u-bordeaux.fr/download.html",
-		"regex": "pari-(\\d+).(\\d+).(\\d+).tar.gz",
-		"replace": "${1}-${2}-${3}"
-	},
+        "url": "https://pari.math.u-bordeaux.fr/download.html",
+        "regex": "pari-([\\d.]+).tar.gz"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-$version.exe#/dl.7z",
-				"hash": {
-					"url": "https://pari.math.u-bordeaux.fr/download.html",
-					"find": "Stable 64-bit version: Pari64-$version.exe.+\\s+sha256sum:\\s+$sha256"
-				}
+                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari64-$dashVersion.exe#/dl.7z",
+                "hash": {
+                    "url": "https://pari.math.u-bordeaux.fr/download.html",
+                    "find": "Stable 64-bit version: Pari64-$dashVersion.exe .+\\s+sha256sum: $sha256"
+                }
             },
             "32bit": {
-                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-$version.exe#/dl.7z",
-				"hash": {
-					"url": "https://pari.math.u-bordeaux.fr/download.html",
-					"find": "Stable 32-bit version: Pari32-$version.exe.+\\s+sha256sum:\\s+$sha256"
-				}
+                "url": "https://pari.math.u-bordeaux.fr/pub/pari/windows/Pari32-$dashVersion.exe#/dl.7z",
+                "hash": {
+                    "url": "https://pari.math.u-bordeaux.fr/download.html",
+                    "find": "Stable 32-bit version: Pari32-$dashVersion.exe .+\\s+sha256sum: $sha256"
+                }
             }
         }
     }


### PR DESCRIPTION
Added PARI/GP version 2.17.0 to Extras bucket

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
