### PR TITLE
komorebi@0.1.29: Update license

### DIFF
--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -18,7 +18,8 @@
         "komorebi.exe",
         "komorebic.exe",
         "komorebic-no-console.exe",
-        "komorebi-gui.exe"
+        "komorebi-gui.exe",
+        "komorebi-bar.exe"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -2,7 +2,7 @@
     "version": "0.1.29",
     "description": "A tiling window manager for Windows",
     "homepage": "https://github.com/LGUG2Z/komorebi",
-    "license": "PolyForm Strict",
+    "license": "Komorebi",
     "notes": "Check out the quickstart guide on https://lgug2z.github.io/komorebi",
     "suggest": {
         "whkd": "extras/whkd",

--- a/bucket/komorebi.json
+++ b/bucket/komorebi.json
@@ -2,7 +2,10 @@
     "version": "0.1.29",
     "description": "A tiling window manager for Windows",
     "homepage": "https://github.com/LGUG2Z/komorebi",
-    "license": "Komorebi",
+    "license": {
+        "identifier": "Komorebi",
+        "url": "https://github.com/LGUG2Z/komorebi/blob/master/LICENSE.md"
+    },
     "notes": "Check out the quickstart guide on https://lgug2z.github.io/komorebi",
     "suggest": {
         "whkd": "extras/whkd",


### PR DESCRIPTION
Ensures that the license accurately reflects the [new license used for v0.1.29](https://github.com/LGUG2Z/komorebi/blob/v0.1.29/LICENSE.md).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
