### PR TITLE
freedownloadmanager: Update to 6.24.2.5857

### DIFF
--- a/bucket/freedownloadmanager.json
+++ b/bucket/freedownloadmanager.json
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://files2.freedownloadmanager.org/$majorVersion/latest/fdm_x64_setup.exe"
+                "url": "https://files2.freedownloadmanager.org/$version/latest/fdm_x64_setup.exe"
             },
             "32bit": {
-                "url": "https://files2.freedownloadmanager.org/$majorVersion/fdm_x86_setup.exe"
+                "url": "https://files2.freedownloadmanager.org/$version/fdm_x86_setup.exe"
             }
         }
     }

--- a/bucket/freedownloadmanager.json
+++ b/bucket/freedownloadmanager.json
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://files2.freedownloadmanager.org/$version/latest/fdm_x64_setup.exe"
+                "url": "https://files2.freedownloadmanager.org/$majorVersion/latest/fdm_x64_setup.exe"
             },
             "32bit": {
-                "url": "https://files2.freedownloadmanager.org/$version/fdm_x86_setup.exe"
+                "url": "https://files2.freedownloadmanager.org/fdm$majorVersion_qt5/fdm_x86_setup.exe"
             }
         }
     }

--- a/bucket/freedownloadmanager.json
+++ b/bucket/freedownloadmanager.json
@@ -5,12 +5,12 @@
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://dn3.freedownloadmanager.org/6/latest/fdm_x64_setup.exe",
-            "hash": "0c4950be3e7d765fad2a533a75ee0b4a6541a35220624aadbee3d6ac5434cd36"
+            "url": "https://files2.freedownloadmanager.org/6/latest/fdm_x64_setup.exe",
+            "hash": "30076aedc98080722383bab085c775a0eb3aadae2d4ff1accd0945ac7571badb"
         },
         "32bit": {
-            "url": "https://dn3.freedownloadmanager.org/6/latest/fdm_x86_setup.exe",
-            "hash": "aca9718dc2d77224dcf9f8e530162d51150865d49e5a2b1b7da1bee515dc2eed"
+            "url": "https://files2.freedownloadmanager.org/fdm6_qt5/fdm_x86_setup.exe",
+            "hash": "8f22260ef41e7796a4750952c5ee026dd834272b6e001c6f267a6acc84a62ff4"
         }
     },
     "innosetup": true,
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dn3.freedownloadmanager.org/$majorVersion/latest/fdm_x64_setup.exe"
+                "url": "https://files2.freedownloadmanager.org/$majorVersion/latest/fdm_x64_setup.exe"
             },
             "32bit": {
-                "url": "https://dn3.freedownloadmanager.org/$majorVersion/latest/fdm_x86_setup.exe"
+                "url": "https://files2.freedownloadmanager.org/$majorVersion/fdm_x86_setup.exe"
             }
         }
     }


### PR DESCRIPTION
URLs correction ~~6.20.0.5510~~
Update the URLs to 6.24.2.5857
Update hashes
URL has changed to https://dn3.freedownloadmanager.org
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
