### PR TITLE
mpv: Add arm64 builds

### DIFF
--- a/bucket/mpv.json
+++ b/bucket/mpv.json
@@ -15,6 +15,10 @@
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-0.39.0-i686.7z",
             "hash": "sha1:412c6da0eb9b12f4ceea7a18cc99a52af6977e50"
+        },
+        "arm64": {
+            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-0.39.0-aarch64.7z",
+            "hash": "sha1:d6d7190faffec162953772fcb0d45addeebeec28"
         }
     },
     "env_add_path": ".",
@@ -36,6 +40,9 @@
             },
             "32bit": {
                 "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-$version-i686.7z"
+            },
+            "arm64": {
+                "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-$version-aarch64.7z"
             }
         }
     }


### PR DESCRIPTION
Adds the urls for aarch64 mpv builds and autoupdate

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
