### PR TITLE
wecom: Remove post_install script

### DIFF
--- a/bucket/wecom.json
+++ b/bucket/wecom.json
@@ -1,20 +1,19 @@
 {
-    "version": "4.1.28.6019",
+    "version": "4.1.30.6008",
     "description": "WeCom/WXWork/企业微信/WeChat-Work, a professional office management tool for enterprises created by Tencent",
     "homepage": "https://work.weixin.qq.com/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://work.weixin.qq.com/nl/eula"
     },
-    "url": "https://dldir1.qq.com/wework/work_weixin/WeCom_4.1.28.6019.exe#/dl.7z",
-    "hash": "316b8b6ab29389e1c886ec58db47577718db0b68bda36ab85198c7fa7a1251a9",
+    "url": "https://dldir1.qq.com/wework/work_weixin/WeCom_4.1.30.6008.exe#/dl.7z",
+    "hash": "7b7fda08fd744322a16e8c0ee8dd105ea2540e266065d8db1c823b457f516438",
     "installer": {
         "script": [
             "Remove-Item \"$dir\\`$*\" -Recurse -Force -ErrorAction SilentlyContinue",
             "Remove-Item \"$dir\\Uninstall*\" -Force -ErrorAction SilentlyContinue"
         ]
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\",\"$dir\\Uninstall*\" -Force -Recurse",
     "shortcuts": [
         [
             "WXWork.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

```
Installing 'wecom' (4.1.30.6008) [64bit] from 'extras' bucket
Loading WeCom_4.1.30.6008.exe from cache
Extracting WeCom_4.1.30.6008.exe ... done.
Running installer script...done.
Linking D:\scoop\apps\wecom\current => D:\scoop\apps\wecom\4.1.30.6008
Creating shortcut for WeCom (WXWork.exe)
Running post_install script...Remove-Item: Cannot find path 'D:\scoop\apps\wecom\current\$PLUGINSDIR' because it does not exist.
done.
```

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
