### PR TITLE
typstyle: Add version 0.11.35

### DIFF
--- a/bucket/typstyle.json
+++ b/bucket/typstyle.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.11.35",
+    "description": "Beautiful and reliable typst code formatter.",
+    "homepage": "https://github.com/Enter-tainer/typstyle",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.11.35/typstyle-x86_64-pc-windows-msvc.exe",
+            "hash": "44264718b3864b70e6c66a4d8b7658c31369c0b0890fe5e2c467c4cc39b01e86"
+        },
+        "arm64": {
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.11.35/typstyle-aarch64-pc-windows-msvc.exe",
+            "hash": "2c02ed92d1fb8432b20218c60de1ae8a3222a35eeabc306d21af4d8c1bc4985d"
+        }
+    },
+    "bin": "typstyle.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe"
+            }
+        }
+    }
+}

--- a/bucket/typstyle.json
+++ b/bucket/typstyle.json
@@ -5,11 +5,11 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.11.35/typstyle-x86_64-pc-windows-msvc.exe",
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.11.35/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe",
             "hash": "44264718b3864b70e6c66a4d8b7658c31369c0b0890fe5e2c467c4cc39b01e86"
         },
         "arm64": {
-            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.11.35/typstyle-aarch64-pc-windows-msvc.exe",
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.11.35/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe",
             "hash": "2c02ed92d1fb8432b20218c60de1ae8a3222a35eeabc306d21af4d8c1bc4985d"
         }
     },
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe"
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe"
             },
             "arm64": {
-                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe"
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe"
             }
         }
     }


### PR DESCRIPTION
This pr add support for [typstyle](https://github.com/Enter-tainer/typstyle), a beautiful and reliable typst code formatter.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
