### PR TITLE
tex-fmt: Add manifest

### DIFF
--- a/bucket/tex-fmt.json
+++ b/bucket/tex-fmt.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.4.5",
+    "description": "An extremely fast LaTeX formatter written in Rust.",
+    "homepage": "https://github.com/WGUNDERWOOD/tex-fmt",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/WGUNDERWOOD/tex-fmt/releases/download/v0.4.5/tex-fmt-x86_64-windows.zip",
+            "hash": "ac3e2eb020403a63c0a58b5b7f63e1c89b3b05b64c5eff9c670d84cdb96884d5"
+        },
+        "32bit": {
+            "url": "https://github.com/WGUNDERWOOD/tex-fmt/releases/download/v0.4.5/tex-fmt-i686-windows.zip",
+            "hash": "0a7da51c4c09b80d9a0de1c7b4032e46822fa69d99f83aa4cef8f190a4d0599e"
+        },
+        "arm64": {
+            "url": "https://github.com/WGUNDERWOOD/tex-fmt/releases/download/v0.4.5/tex-fmt-aarch64-windows.zip",
+            "hash": "90e17b3b21fb4fe10d6e672506a4df163a88788a42ccac2a8f521a526122c9e5"
+        }
+    },
+    "bin": "tex-fmt.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/WGUNDERWOOD/tex-fmt/releases/download/$version/tex-fmt-x86_64-windows.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/WGUNDERWOOD/tex-fmt/releases/download/$version/tex-fmt-i686-windows.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/WGUNDERWOOD/tex-fmt/releases/download/$version/tex-fmt-aarch64-windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
add tex-fmt manifest: An extremely fast LaTeX formatter written in Rust.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
