### PR TITLE
whkd: Add ARM64 builds

### DIFF
--- a/bucket/whkd.json
+++ b/bucket/whkd.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/LGUG2Z/whkd/releases/download/v0.2.2/whkd-0.2.2-x86_64-pc-windows-msvc.zip",
             "hash": "b32626ef1e1fa91f955048fd5da5b93a432c7ea42f307a017cdb486b8a21f410"
+        },
+        "arm64": {
+            "url": "https://github.com/LGUG2Z/whkd/releases/download/v0.2.2/whkd-0.2.2-aarch64-pc-windows-msvc.zip",
+            "hash": "23eacf3cf8d45ab572dd7abed25d44e16d1f2df59013acaa0ce47f96e32d0b52"
         }
     },
     "bin": "whkd.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/LGUG2Z/whkd/releases/download/v$version/whkd-$version-x86_64-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/LGUG2Z/whkd/releases/download/v$version/whkd-$version-aarch64-pc-windows-msvc.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Adds support for `whkd`'s aarch64 binaries.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
