### PR TITLE
thunderbird-esr: Add version 128.3.2esr

### DIFF
--- a/bucket/thunderbird-esr.json
+++ b/bucket/thunderbird-esr.json
@@ -1,0 +1,69 @@
+{
+    "version": "128.3.1esr",
+    "description": "A free email application that’s easy to set up and customize.",
+    "homepage": "https://www.thunderbird.net",
+    "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Thunderbird Profile Manager', choose 'Scoop' then click 'Start Thunderbird'.",
+        "  - Visit 'about:profiles' page in Thunderbird to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-and-remove-thunderbird-profiles"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://archive.mozilla.org/pub/thunderbird/releases/128.3.1esr/win64/en-US/Thunderbird%20Setup%20128.3.1esr.exe#/dl.7z",
+            "hash": "sha512:10669a096d40ef2baa44b802b2f2cfb0435a9d71836887a02b2ecc285ee09b461cab1574d1e70d133d8b698a25dedf045a1d427a2a76a3ee829ac5f783a5dfd7"
+        },
+        "32bit": {
+            "url": "https://archive.mozilla.org/pub/thunderbird/releases/128.3.1esr/win32/en-US/Thunderbird%20Setup%20128.3.1esr.exe#/dl.7z",
+            "hash": "sha512:668fbe9245b17c2f9e7cd804c43a3955ce6df0103059225a54467ef43768975fa2231efbeb0b4b90f2cc8d239543984255f532d44e830542eef361a10b317377"
+        }
+    },
+    "extract_dir": "core",
+    "post_install": [
+        "thunderbird -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
+    ],
+    "bin": "thunderbird.exe",
+    "shortcuts": [
+        [
+            "thunderbird.exe",
+            "Thunderbird"
+        ],
+        [
+            "thunderbird.exe",
+            "Thunderbird Profile Manager",
+            "-P"
+        ]
+    ],
+    "persist": [
+        "distribution",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://product-details.mozilla.org/1.0/thunderbird_versions.json",
+        "jsonpath": "$.THUNDERBIRD_ESR"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://archive.mozilla.org/pub/thunderbird/releases/$version/win64/en-US/Thunderbird%20Setup%20$version.exe#/dl.7z",
+                "hash": {
+                    "url": "https://archive.mozilla.org/pub/thunderbird/releases/$version/SHA512SUMS",
+                    "regex": "$sha512\\s+win64/en-US/$basename"
+                }
+            },
+            "32bit": {
+                "url": "https://archive.mozilla.org/pub/thunderbird/releases/$version/win32/en-US/Thunderbird%20Setup%20$version.exe#/dl.7z",
+                "hash": {
+                    "url": "https://archive.mozilla.org/pub/thunderbird/releases/$version/SHA512SUMS",
+                    "regex": "$sha512\\s+win32/en-US/$basename"
+                }
+            }
+        }
+    }
+}

--- a/bucket/thunderbird-esr.json
+++ b/bucket/thunderbird-esr.json
@@ -1,12 +1,12 @@
 {
     "version": "128.3.1esr",
-    "description": "A free email application that’s easy to set up and customize.",
+    "description": "A free email application that’s easy to set up and customize (Extended Support Release)",
     "homepage": "https://www.thunderbird.net",
     "license": "MPL-2.0",
     "notes": [
         "To set profile 'Scoop-esr' as *DEFAULT*, or profiles/settings was lost after update:",
-        "  - Run 'Thunderbird-esr Profile Manager', choose 'Scoop-esr' then click 'Start Thunderbird'.",
-        "  - Visit 'about:profiles' page in Thunderbird to check *DEFAULT* profile.",
+        "  - Run 'Thunderbird ESR Profile Manager', choose 'Scoop-esr' then click 'Start Thunderbird'.",
+        "  - Visit 'about:profiles' page in Thunderbird ESR to check *DEFAULT* profile.",
         "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-and-remove-thunderbird-profiles"
     ],
     "architecture": {
@@ -28,7 +28,6 @@
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
         "}"
     ],
-    "bin": "",
     "bin": [
         [
             "thunderbird.exe",
@@ -38,11 +37,11 @@
     "shortcuts": [
         [
             "thunderbird.exe",
-            "Thunderbird-esr"
+            "Thunderbird ESR"
         ],
         [
             "thunderbird.exe",
-            "Thunderbird-esr Profile Manager",
+            "Thunderbird ESR Profile Manager",
             "-P"
         ]
     ],

--- a/bucket/thunderbird-esr.json
+++ b/bucket/thunderbird-esr.json
@@ -1,5 +1,5 @@
 {
-    "version": "128.3.1esr",
+    "version": "128.3.2esr",
     "description": "A free email application that’s easy to set up and customize (Extended Support Release)",
     "homepage": "https://www.thunderbird.net",
     "license": "MPL-2.0",
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/thunderbird/releases/128.3.1esr/win64/en-US/Thunderbird%20Setup%20128.3.1esr.exe#/dl.7z",
-            "hash": "sha512:10669a096d40ef2baa44b802b2f2cfb0435a9d71836887a02b2ecc285ee09b461cab1574d1e70d133d8b698a25dedf045a1d427a2a76a3ee829ac5f783a5dfd7"
+            "url": "https://archive.mozilla.org/pub/thunderbird/releases/128.3.2esr/win64/en-US/Thunderbird%20Setup%20128.3.2esr.exe#/dl.7z",
+            "hash": "sha512:97476c4901efff1db3f93f327d35d1bffc759fba2e5a253901027aa8bfe7629eb9e2216c6347259a5f496eef872a133d55649c51ecd1854efcc67b91b5f6e83a"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/thunderbird/releases/128.3.1esr/win32/en-US/Thunderbird%20Setup%20128.3.1esr.exe#/dl.7z",
-            "hash": "sha512:668fbe9245b17c2f9e7cd804c43a3955ce6df0103059225a54467ef43768975fa2231efbeb0b4b90f2cc8d239543984255f532d44e830542eef361a10b317377"
+            "url": "https://archive.mozilla.org/pub/thunderbird/releases/128.3.2esr/win32/en-US/Thunderbird%20Setup%20128.3.2esr.exe#/dl.7z",
+            "hash": "sha512:10d4b98341e544dc00095d6cc5f72ba3390daac8e4c27017a79bacf5f04c60fc6a2c4070ba8a0318d3f055f3031aeb4d80e7a9472bdda23e26b5a00d0700f20b"
         }
     },
     "extract_dir": "core",

--- a/bucket/thunderbird-esr.json
+++ b/bucket/thunderbird-esr.json
@@ -4,8 +4,8 @@
     "homepage": "https://www.thunderbird.net",
     "license": "MPL-2.0",
     "notes": [
-        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
-        "  - Run 'Thunderbird Profile Manager', choose 'Scoop' then click 'Start Thunderbird'.",
+        "To set profile 'Scoop-esr' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Thunderbird-esr Profile Manager', choose 'Scoop-esr' then click 'Start Thunderbird'.",
         "  - Visit 'about:profiles' page in Thunderbird to check *DEFAULT* profile.",
         "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-and-remove-thunderbird-profiles"
     ],
@@ -21,22 +21,28 @@
     },
     "extract_dir": "core",
     "post_install": [
-        "thunderbird -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "thunderbird-esr -CreateProfile \"Scoop-esr $persist_dir\\profile\"",
         "$Addition = \"$persist_dir\\addition\"",
         "if (Test-Path $Addition) {",
         "  info 'Copying additional items...'",
         "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
         "}"
     ],
-    "bin": "thunderbird.exe",
+    "bin": "",
+    "bin": [
+        [
+            "thunderbird.exe",
+            "thunderbird-esr"
+        ]
+    ],
     "shortcuts": [
         [
             "thunderbird.exe",
-            "Thunderbird"
+            "Thunderbird-esr"
         ],
         [
             "thunderbird.exe",
-            "Thunderbird Profile Manager",
+            "Thunderbird-esr Profile Manager",
             "-P"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Add thunderbird-esr to have 2 different app manifests, one for thunderbird and one for its esr versions only, as suggested by @aliesbelik.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14123 
<!-- or -->
Relates to #14203 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
