### PR TITLE
git-credential-manager: Update urls

### DIFF
--- a/bucket/git-credential-manager.json
+++ b/bucket/git-credential-manager.json
@@ -1,9 +1,9 @@
 {
     "version": "2.6.0",
     "description": "Secure Git credential helper",
-    "homepage": "https://github.com/GitCredentialManager/git-credential-manager",
+    "homepage": "https://github.com/git-ecosystem/git-credential-manager",
     "license": "MIT",
-    "url": "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v2.6.0/gcm-win-x86-2.6.0.zip",
+    "url": "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.6.0/gcm-win-x86-2.6.0.zip",
     "hash": "3bfba8e61483ddaad66811a4ec32689026619d4b2e6511e740e5227bc4965a41",
     "bin": "git-credential-manager.exe",
     "shortcuts": [
@@ -14,6 +14,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/GitCredentialManager/git-credential-manager/releases/download/v$version/gcm-win-x86-$version.zip"
+        "url": "https://github.com/git-ecosystem/git-credential-manager/releases/download/v$version/gcm-win-x86-$version.zip"
     }
 }


### PR DESCRIPTION
git-credential-manager: The "GitCredentialManager" Github org has been renamed to "git-ecosystem". Update manifest URLs to match.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
