### PR TITLE
godot: default to console

### DIFF
--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -14,10 +14,10 @@
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*_console.exe\" | Rename-Item -NewName 'godot.console.exe'",
         "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot.exe'"
     ],
-    "bin": "godot.exe",
+    "bin": [["godot.console.exe", "godot"]],
     "shortcuts": [
         [
             "godot.exe",


### PR DESCRIPTION
This defaults godot to the console binary. I found it strange that `godot --help` did nothing - since scoop is a terminal installer I think being console-first makes sense. If this is too breaking (not sure if anyone's depending on that behavior) we could also just add `godot-cli` as the console alias.

Closes: #13248 
Related: #13484 (draft) -- I don't address portability in this PR

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
