### PR TITLE
mp3tag: Update the manifest

### DIFF
--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -8,20 +8,10 @@
     },
     "notes": [
         "If you want 'mp3tag' as a context menu option run the following commands:",
-        "For 64bit Windows OS users run,",
         "To Install:",
-        "start 'regsvr32' -Verb 'RunAs' -Args @(\"$dir\\Mp3tagShell.dll\", '/s')",
+        "$dir\\install-mp3tag-context.cmd",
         "To Uninstall:",
-        "start 'regsvr32' -Verb 'RunAs' -Args @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
-        "",
-        "For 32bit Windows OS users run,",
-        "To Install:",
-        "start 'regsvr32' -Verb 'RunAs' -Args @(\"$dir\\Mp3tagShell32.dll\", '/s')",
-        "To Uninstall:",
-        "start 'regsvr32' -Verb 'RunAs' -Args @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "",
-        "To find out if you have a have 32bit or 64bit Windows OS, run the following command:",
-        "(Get-CimInstance win32_operatingsystem).OSArchitecture"
+        "$dir\\uninstall-mp3tag-context.cmd"
     ],
     "architecture": {
         "64bit": {
@@ -34,8 +24,8 @@
         }
     },
     "pre_install": [
-        "'mp3tag.cfg', 'data\\columns.ini' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "foreach ($i in @('mp3tag.cfg', 'data\\columns.ini')) {",
+        "    if (!(Test-Path \"$persist_dir\\$i\")) { New-Item $(Join-Path $dir $i) | Out-Null }",
         "}",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Mp3tagUninst*\" -Recurse",
         "if (!(Test-Path \"$persist_dir\\data\\usrfields.ini\")) {",
@@ -43,28 +33,38 @@
         "}",
         "Copy-Item \"$persist_dir\\export\\*\" \"$dir\\export\" -Recurse -ErrorAction SilentlyContinue"
     ],
-    "bin": "mp3tag.exe",
+    "bin": "Mp3tag.exe",
     "shortcuts": [
         [
-            "mp3tag.exe",
+            "Mp3tag.exe",
             "Mp3tag"
         ]
     ],
     "persist": [
-        "data",
+        "data\\panels",
+        "data\\columns",
+        "data\\columns.ini",
+        "data\\usrfields.ini",
         "mp3tag.cfg"
     ],
+    "post_install": [
+        "$scriptsdir = Resolve-Path \"$bucketsdir\\*MyScoop*\\scripts\\mp3tag\"",
+        "$content = Get-Content \"$scriptsdir\\install-mp3tag-context.cmd\"",
+        "$content = $content.Replace('REPLACE_HERE', $dir)",
+        "[System.IO.File]::WriteAllLines(\"$dir\\install-mp3tag-context.cmd\", $content, [System.text.UTF8Encoding]($false))",
+        "Copy-Item \"$scriptsdir\\uninstall-mp3tag-context.cmd\" \"$dir\\uninstall-mp3tag-context.cmd\""
+    ],
     "pre_uninstall": [
-        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
-        "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
-        "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "if ($cmd -eq 'uninstall') {",
+        "    reg delete 'HKCU\\SOFTWARE\\Classes\\*\\shell\\&Mp3tag' /f",
+        "    reg delete 'HKCU\\SOFTWARE\\Classes\\*\\shell\\Mp3tag' /f",
+        "    reg delete 'HKCU\\SOFTWARE\\Classes\\Directory\\shell\\&Mp3tag' /f",
+        "    reg delete 'HKCU\\SOFTWARE\\Classes\\Directory\\shell\\Mp3tag' /f",
         "}"
     ],
     "checkver": {
         "url": "https://www.mp3tag.de/en/download.html",
-        "regex": "(?i)<h\\d>Mp3tag\\s+v(?<version>[\\d.]+[a-z]{0,1})</h\\d>"
+        "regex": "(?i)\\<h\\d\\>Mp3tag\\s+v(?<version>[\\d.]+[a-z]{0,1})\\</h\\d\\>"
     },
     "autoupdate": {
         "architecture": {

--- a/scripts/mp3tag/install-mp3tag-context.cmd
+++ b/scripts/mp3tag/install-mp3tag-context.cmd
@@ -1,0 +1,8 @@
+@echo off
+reg add "HKCU\SOFTWARE\Classes\*\shell\&Mp3tag" /v "MUIVerb" /t REG_SZ /d "&Mp3tag" /f
+reg add "HKCU\SOFTWARE\Classes\*\shell\&Mp3tag" /v "Icon" /t REG_SZ /d "REPLACE_HERE\Mp3tag.exe,0" /f
+reg add "HKCU\SOFTWARE\Classes\*\shell\&Mp3tag\command" /ve /t REG_SZ /d "REPLACE_HERE\Mp3tag.exe  \"%%1\"" /f
+reg add "HKCU\SOFTWARE\Classes\Directory\shell\&Mp3tag" /v "MUIVerb" /t REG_SZ /d "&Mp3tag" /f
+reg add "HKCU\SOFTWARE\Classes\Directory\shell\&Mp3tag" /v "Icon" /t REG_SZ /d "REPLACE_HERE\Mp3tag.exe,0" /f
+reg add "HKCU\SOFTWARE\Classes\Directory\shell\&Mp3tag\command" /ve /t REG_SZ /d "REPLACE_HERE\Mp3tag.exe  \"%%1\"" /f
+

--- a/scripts/mp3tag/uninstall-mp3tag-context.cmd
+++ b/scripts/mp3tag/uninstall-mp3tag-context.cmd
@@ -1,0 +1,5 @@
+@echo off
+reg delete "HKCU\SOFTWARE\Classes\*\shell\&Mp3tag" /f
+reg delete "HKCU\SOFTWARE\Classes\*\shell\Mp3tag" /f
+reg delete "HKCU\SOFTWARE\Classes\Directory\shell\&Mp3tag" /f
+reg delete "HKCU\SOFTWARE\Classes\Directory\shell\Mp3tag" /f


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Changed the context menu option to use registry files.
- Changed the `pre_install` and `pre_uninstall` process so the explorer will no longer restart after either process.
- Added a `post_install` process.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
