### PR TITLE
rawtherapee: Update to version 5.11

### DIFF
--- a/bucket/rawtherapee.json
+++ b/bucket/rawtherapee.json
@@ -2,7 +2,6 @@
     "version": "5.11",
     "description": "Raw image processor",
     "homepage": "https://rawtherapee.com",
-    "##": "Builds: https://www.rawtherapee.com/shared/builds/windows/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/rawtherapee.json
+++ b/bucket/rawtherapee.json
@@ -2,7 +2,7 @@
     "version": "5.11",
     "description": "Raw image processor",
     "homepage": "https://rawtherapee.com",
-    "##": "Builds: https://www.rawtherapee.com/shared/builds/windows/"
+    "##": "Builds: https://www.rawtherapee.com/shared/builds/windows/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/rawtherapee.json
+++ b/bucket/rawtherapee.json
@@ -2,6 +2,7 @@
     "version": "5.11",
     "description": "Raw image processor",
     "homepage": "https://rawtherapee.com",
+    "##": "Builds: https://www.rawtherapee.com/shared/builds/windows/"
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/rawtherapee.json
+++ b/bucket/rawtherapee.json
@@ -1,12 +1,12 @@
 {
-    "version": "5.10",
+    "version": "5.11",
     "description": "Raw image processor",
     "homepage": "https://rawtherapee.com",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://rawtherapee.com/shared/builds/windows/RawTherapee_5.10_win64.zip",
-            "hash": "fb7ce66ba8ac23fa429b7342f2fb06ef166707ea827f822180a3f1bb945f205c"
+            "url": "https://rawtherapee.com/shared/builds/windows/RawTherapee_5.11_win64_release.exe",
+            "hash": "02380970070fa1734fb17e29937dbd54a191dc9b8b2085c56dbc8a0b1e757551"
         }
     },
     "pre_install": [
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://rawtherapee.com/shared/builds/windows/RawTherapee_$version_win64.zip"
+                "url": "https://rawtherapee.com/shared/builds/windows/RawTherapee_$version_win64_release.exe"
             }
         },
         "hash": {

--- a/bucket/rawtherapee.json
+++ b/bucket/rawtherapee.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://rawtherapee.com/shared/builds/windows/RawTherapee_5.11_win64_release.exe",
-            "hash": "02380970070fa1734fb17e29937dbd54a191dc9b8b2085c56dbc8a0b1e757551"
+            "hash": "cf5515697c23f13e9b216163b45d2abf1de352276adf7f065d154e35c146c2ca"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Updates to 5.11 (which is now an `.exe`)
Builds: https://www.rawtherapee.com/shared/builds/windows/
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
