### PR TITLE
Fix bad  permissions of calibre when installing as administrator - issue #14282

### DIFF
--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -13,7 +13,8 @@
         "script": [
             "Start-Process \"$dir\\calibre-portable-installer-$version.exe\" @(\"$env:TEMP\") -Wait",
             "Move-Item \"$env:TEMP\\Calibre Portable\\**\" \"$dir\"",
-            "Remove-Item \"$env:TEMP\\Calibre Portable\""
+            "Remove-Item \"$env:TEMP\\Calibre Portable\"",
+            "Icacls $dir /t /c /reset"
         ]
     },
     "bin": [


### PR DESCRIPTION
Fixes the problem of regular user unreadable calibre install. 

Comments from issue

> 
> Possible Solution
> The problem is its being unpacked in Temp storage and then moved.
> The temp storage of the Administrator accoun to does not give files Users readable permissions.
> 
> I have fixed this in a pull-request by running this afterwards:
> 
> Icacls $dir /t /c /reset
> 
> I have tested it on my environment and it works fine.
> 
> I have also tested behaviour of windows writing files to temp-storage, and then manually copying to scoop-install-dir, and can see that all files and folders recursively do not get the user-readable permission after copy, so a recursive reset is required.
> 
> I'm running an up2date win11.
> 

Scoop and Buckets Version
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14282

- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
