### PR TITLE
firewallappblocker@1.9: Fix `url`

### DIFF
--- a/bucket/firewallappblocker.json
+++ b/bucket/firewallappblocker.json
@@ -6,8 +6,8 @@
         "identifier": "Freeware",
         "url": "https://www.sordum.org/eula/"
     },
-    "url": "https://www.sordum.org/files/firewall-app-blocker/fab.zip",
-    "hash": "34d6f4486b70a21203361d9491c64b412368cf645c08c9a2586aef8dd91eecac",
+    "url": "https://www.sordum.org/files/download/firewall-app-blocker/fab.zip",
+    "hash": "489a7d6f66d03885523e183657e22ceb2ee827765f074a6d6f1ea2a13c3960e7",
     "extract_dir": "fab",
     "architecture": {
         "64bit": {
@@ -38,6 +38,6 @@
     "persist": "Fab.ini",
     "checkver": "Firewall App Blocker v([\\d.]+)",
     "autoupdate": {
-        "url": "https://www.sordum.org/files/firewall-app-blocker/fab.zip"
+        "url": "https://www.sordum.org/files/download/firewall-app-blocker/fab.zip"
     }
 }


### PR DESCRIPTION
Closes #14327

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
