### PR TITLE
streamlink: Update to version 7.0.0-1

### DIFF
--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -1,23 +1,19 @@
 {
-    "version": "6.11.0-1",
+    "version": "7.0.0-1",
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",
     "license": "BSD-2-Clause",
     "notes": "You will find your config file here: '$dir\\config'. To customise it, read the docs here: https://streamlink.github.io/cli/config.html#syntax",
     "suggest": {
         "ffmpeg": "ffmpeg",
-        "VLC Player": "extras/vlc"
+        "VLC player": "extras/vlc",
+        "mpv player": "extras/mpv"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/streamlink/windows-builds/releases/download/6.11.0-1/streamlink-6.11.0-1-py312-x86_64.zip",
-            "hash": "5bb1193e228174b58264d414f04429f2488637195f6a6b246e901648d182367f",
-            "extract_dir": "streamlink-6.11.0-1-py312-x86_64"
-        },
-        "32bit": {
-            "url": "https://github.com/streamlink/windows-builds/releases/download/6.11.0-1/streamlink-6.11.0-1-py312-x86.zip",
-            "hash": "3a83e32359aacead7770cf0b7d95503cf438bf07680e37108e234eca6e618774",
-            "extract_dir": "streamlink-6.11.0-1-py312-x86"
+            "url": "https://github.com/streamlink/windows-builds/releases/download/7.0.0-1/streamlink-7.0.0-1-py312-x86_64.zip",
+            "hash": "0e5902a0d9ee868a84d58da8e392b0205dad641dba493749937b0359a8fdd974",
+            "extract_dir": "streamlink-7.0.0-1-py312-x86_64"
         }
     },
     "pre_install": [
@@ -48,10 +44,6 @@
             "64bit": {
                 "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py312-x86_64.zip",
                 "extract_dir": "streamlink-$version-py312-x86_64"
-            },
-            "32bit": {
-                "url": "https://github.com/streamlink/windows-builds/releases/download/$version/streamlink-$version-py312-x86.zip",
-                "extract_dir": "streamlink-$version-py312-x86"
             }
         }
     }


### PR DESCRIPTION
- Update to 7.0.0-1
- Drop x86
- Fix autoupdate
- Update suggested packages

----

`x86` has been dropped in `7.0.0-1`:
https://github.com/streamlink/windows-builds/blob/7.0.0-1/CHANGELOG.md

I also added `extras/mpv` to the suggested packages.