### PR TITLE
onecommander: Update version to 3.91.1.0

### DIFF
--- a/bucket/onecommander.json
+++ b/bucket/onecommander.json
@@ -1,13 +1,13 @@
 {
-    "version": "3.89.1.0",
+    "version": "3.91.1.0",
     "description": "A modern dual-pane file manager with tabs, columns view, built-in preview, editable themes, and more.",
     "homepage": "https://onecommander.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://onecommander.com/license.txt"
     },
-    "url": "https://onecommander.com/OneCommander3.89.1.0.zip",
-    "hash": "2741216193de0c25da4c109b5b138c25b9d1b20254eb73808a9edb5d62c3fc5c",
+    "url": "https://onecommander.com/OneCommander3.91.1.0.zip",
+    "hash": "72f55c0158c0ff2853448e88ebddc90472ed59b10a2a0357dc9085b53cb314b6",
     "shortcuts": [
         [
             "OneCommander.exe",

--- a/bucket/onecommander.json
+++ b/bucket/onecommander.json
@@ -20,12 +20,9 @@
         "Logs",
         "Resources"
     ],
-    "bin": [
-        "OneCommander.exe"
-    ],
+    "bin": "OneCommander.exe",
     "checkver": {
-        "url": "https://onecommander.com/version.txt",
-        "regex": "([\\w.-]+)"
+        "regex": "OneCommander([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "url": "https://onecommander.com/OneCommander$version.zip"


### PR DESCRIPTION
This is my first effort at updating anything greater than a URL or a typo for the Scoop project.

If I did a good job, please thank me.

If I did a bad job, please thank me for my attempt and be kind in your help to show me how I can do better in the future!

Please note that I've marked this as "relate to #14342" instead of completely fixing it, because getting the latest version required a manual update of the Scoop manifest.  The Scoop manifest auto-update mechanism is not working.  I'm not sure if that's an oversight of the upstream developer, if the official `checkver` URL changed, or if another reason applies.

Relates to #14342

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
