### PR TITLE
smartgit@24.1.0: Manually update to new version

### DIFF
--- a/bucket/smartgit.json
+++ b/bucket/smartgit.json
@@ -1,5 +1,5 @@
 {
-    "version": "23.1.4.2",
+    "version": "24.1.0",
     "description": "A graphical Git client with support for SVN and Pull Requests for GitHub and Bitbucket.",
     "homepage": "https://www.syntevo.com/smartgit/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.syntevo.com/downloads/smartgit/smartgit-portable-23_1_4_2.7z",
-            "hash": "sha1:c021ae9cca4aa26fb7625ad21a2bfe173ebcf1f1"
+            "url": "https://downloads.syntevo.com/downloads/smartgit/smartgit-portable-24_1_0.7z",
+            "hash": "sha1:1c5f6e18cab769126a33eb905cf6bc974d6f627f"
         }
     },
     "extract_dir": "SmartGit",


### PR DESCRIPTION
The initial release of SmartGit 24.1 has the suffix "GA", thus the regex won't detect the new version.

- [ X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
