### PR TITLE
smartgit: Update description

### DIFF
--- a/bucket/smartgit.json
+++ b/bucket/smartgit.json
@@ -1,6 +1,6 @@
 {
     "version": "23.1.4.2",
-    "description": "A graphical Git client with support for SVN and Pull Requests for GitHub and Bitbucket.",
+    "description": "A graphical Git client for Windows, macOS, Linux.",
     "homepage": "https://www.syntevo.com/smartgit/",
     "license": {
         "identifier": "Proprietary",


### PR DESCRIPTION
SmartGit doesn't not support SVN anymore.

- [X ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
