### PR TITLE
openai-translator@0.4.33: Fix shortcut

### DIFF
--- a/bucket/openai-translator.json
+++ b/bucket/openai-translator.json
@@ -12,7 +12,7 @@
     "post_install": "@('$PLUGINSDIR', '$TEMP', 'uninstall.exe') | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
     "shortcuts": [
         [
-            "app.exe",
+            "OpenAI Translator.exe",
             "OpenAI Translator"
         ]
     ],


### PR DESCRIPTION
The shortcut is "OpenAI Translator.exe" now, other than "app.exe".
