### PR TITLE
sirikali: Add 64bit arch

### DIFF
--- a/bucket/sirikali.json
+++ b/bucket/sirikali.json
@@ -3,9 +3,18 @@
     "description": "A Qt/C++ GUI front end to sshfs, ecryptfs-simple, cryfs, gocryptfs, securefs, fscrypt and encfs",
     "homepage": "https://mhogomchungu.github.io/sirikali/",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/mhogomchungu/sirikali/releases/download/1.7.0/SiriKali-1.7.0.zip",
-    "hash": "83b4e20fd7e2b1401d00f340952ee3d290c06ab0f92f3fc6e94de1a1e159aaa4",
-    "extract_dir": "SiriKali-1.7.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mhogomchungu/sirikali/releases/download/1.7.0/SiriKaliQt6-1.7.0.zip",
+            "hash": "990e9c1c9d3033ab3cbc06b75bbc983d9d9c985758176a4fbb678b05fc56ccd8",
+            "extract_dir": "SiriKaliQt6-1.7.0"
+        },
+        "32bit": {
+            "url": "https://github.com/mhogomchungu/sirikali/releases/download/1.7.0/SiriKali-1.7.0.zip",
+            "hash": "83b4e20fd7e2b1401d00f340952ee3d290c06ab0f92f3fc6e94de1a1e159aaa4",
+            "extract_dir": "SiriKali-1.7.0"
+        }
+    },
     "shortcuts": [
         [
             "sirikali.exe",
@@ -20,7 +29,15 @@
         "github": "https://github.com/mhogomchungu/sirikali"
     },
     "autoupdate": {
-        "url": "https://github.com/mhogomchungu/sirikali/releases/download/$version/SiriKali-$version.zip",
-        "extract_dir": "SiriKali-$version"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mhogomchungu/sirikali/releases/download/$version/SiriKaliQt6-$version.zip",
+                "extract_dir": "SiriKaliQt6-$version"
+            },
+            "32bit": {
+                "url": "https://github.com/mhogomchungu/sirikali/releases/download/$version/SiriKali-$version.zip",
+                "extract_dir": "SiriKali-$version"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://github.com/mhogomchungu/sirikali/releases/tag/1.7.0
>```
>Note on Windows builds:
>
>   SiriKaliQt6-1.7.0 builds are 64 bit and have minimum requirement of windows 10.
>   SiriKali-1.7.0 builds are 32 bit and have minimum requirement of windows 7.
>```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
