### PR TITLE
qq-nt: Add version 9.9.16.241121

### DIFF
--- a/bucket/qq-nt.json
+++ b/bucket/qq-nt.json
@@ -1,20 +1,23 @@
 {
-    "homepage": "https://im.qq.com/pcqq/index.shtml",
+    "version": "9.9.16.241121",
     "description": "An instant messaging software service developed by Tencent",
-    "license": "Freeware",
-    "version": "9.9.16.241112",
+    "homepage": "https://im.qq.com/pcqq/index.shtml",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://ti.qq.com/agreement/index.html"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241112_x64_01.exe#/dl.7z",
-            "hash": "1a77884bc9e4ffcd7a30a1a118d4339d19b212c48bdfccdfa9f4b98e284cf99c"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241121_x64_01.exe#/dl.7z",
+            "hash": "59539f0c40f617a236c339830dbf52dd2dd0d3701306c3577fb927d90f070b6b"
         },
         "32bit": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241112_x86_01.exe#/dl.7z",
-            "hash": "eb3ab2d7037bd8364cb10715717c2924d3275207a4a9c79677926c0c1eb4863d"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241121_x86_01.exe#/dl.7z",
+            "hash": "2269a64bba7800cd82a3ea43359210bd6c35efac26b2d698c6b8ab46c5374f97"
         },
         "arm64": {
-            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241112_arm64_01.exe#/dl.7z",
-            "hash": "fd7b9f5601e69729e830f1cbdc8659e1d9d82c0532977185321a7624dc242d04"
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241121_arm64_01.exe#/dl.7z",
+            "hash": "6e217f12a0102d9763b418659327f87dc6de814424afa58e07be34b35c17abcb"
         }
     },
     "extract_dir": "Files",

--- a/bucket/qqnt.json
+++ b/bucket/qqnt.json
@@ -1,0 +1,52 @@
+{
+    "homepage": "https://im.qq.com/pcqq/index.shtml",
+    "description": "An instant messaging software service developed by Tencent",
+    "license": "Freeware",
+    "version": "9.9.16.241112",
+    "architecture": {
+        "64bit": {
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241112_x64_01.exe#/dl.7z",
+            "hash": "1a77884bc9e4ffcd7a30a1a118d4339d19b212c48bdfccdfa9f4b98e284cf99c"
+        },
+        "32bit": {
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241112_x86_01.exe#/dl.7z",
+            "hash": "eb3ab2d7037bd8364cb10715717c2924d3275207a4a9c79677926c0c1eb4863d"
+        },
+        "arm64": {
+            "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.16_241112_arm64_01.exe#/dl.7z",
+            "hash": "fd7b9f5601e69729e830f1cbdc8659e1d9d82c0532977185321a7624dc242d04"
+        }
+    },
+    "extract_dir": "Files",
+    "shortcuts": [
+        [
+            "QQ.exe",
+            "QQ"
+        ]
+    ],
+    "checkver": {
+        "script": [
+            "$url = 'https://im.qq.com/pcqq/index.shtml'",
+            "$resp = Invoke-WebRequest -Uri $url",
+            "$cont = $resp.Content",
+            "$pattern = 'https://qq-web.cdn-go.cn.*windowsDownloadUrl.js'",
+            "$jsUrl = [regex]::Match($cont, $pattern).Value",
+            "Invoke-WebRequest -Uri $jsUrl"
+        ],
+        "regex": "QQNT/Windows/QQ_([\\d\\.]+)_([\\d]+)_x86_01.exe",
+        "replace": "${1}.${2}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_x64_01.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_x86_01.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://dldir1.qq.com/qqfile/qq/QQNT/Windows/QQ_$match1_$match2_arm64_01.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Extras/issues/13886
Closes https://github.com/ScoopInstaller/Extras/issues/12803
Closes https://github.com/ScoopInstaller/Extras/pull/12866
Closes https://github.com/ScoopInstaller/Extras/pull/11546
<!-- or -->
Relates https://github.com/ScoopInstaller/Extras/pull/11329 
Relates https://github.com/ScoopInstaller/Extras/pull/11554 

seem like the script in https://github.com/ScoopInstaller/Extras/pull/11546 is not valid for current version qqnt, I'm not add persist script in my PR.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
