### PR TITLE
inbac: Add version 2.1.0

### DIFF
--- a/bucket/inbac.json
+++ b/bucket/inbac.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.1.0",
+    "description": "Python application for fast interactive image cropping",
+    "homepage": "https://github.com/weclaw1/inbac",
+    "license": "MIT",
+    "url": "https://github.com/weclaw1/inbac/releases/download/2.1.0/inbac-Windows.zip",
+    "hash": "6f7b631bf0827e8801cb4ab77a0e6fe28ca503584fd83feaca6c9cb7298ad001",
+    "bin": "inbac.exe",
+    "shortcuts": [
+        [
+            "inbac.exe",
+            "inbac"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/weclaw1/inbac"
+    },
+    "autoupdate": {
+        "url": "https://github.com/weclaw1/inbac/releases/download/$version/inbac-Windows.zip"
+    }
+}

--- a/bucket/inbac.json
+++ b/bucket/inbac.json
@@ -12,9 +12,7 @@
             "inbac"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/weclaw1/inbac"
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/weclaw1/inbac/releases/download/$version/inbac-Windows.zip"
     }


### PR DESCRIPTION
Added an initial manifest to install [inbac](https://github.com/weclaw1/inbac), fast interactive image cropping tool.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
