### PR TITLE
Stellarium@24.3: add arm64 version

### DIFF
--- a/bucket/stellarium.json
+++ b/bucket/stellarium.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/Stellarium/stellarium/releases/download/v24.3/stellarium-24.3-qt5-win32.exe",
             "hash": "35ef9fe4c4217c5dd36d611b29382c5af61423edec9c7ef13c2b27ce6b80a5ad"
+        },
+        "arm64": {
+            "url": "https://github.com/Stellarium/stellarium/releases/download/v24.3/stellarium-24.3-qt6-arm64.exe",
+            "hash": "e73c4d4371436e6f9a90afb77985e4aa7775935f0bf6ddc3fba385e124cf6299"
         }
     },
     "innosetup": true,
@@ -32,6 +36,9 @@
             },
             "32bit": {
                 "url": "https://github.com/Stellarium/stellarium/releases/download/v$version/stellarium-$matchLong-qt5-win32.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/Stellarium/stellarium/releases/download/v$version/stellarium-$matchLong-qt6-arm64.exe"
             }
         },
         "hash": {

--- a/bucket/stellarium.json
+++ b/bucket/stellarium.json
@@ -10,7 +10,7 @@
         },
         "32bit": {
             "url": "https://github.com/Stellarium/stellarium/releases/download/v24.3/stellarium-24.3-qt5-win32.exe",
-            "hash": "35ef9fe4c4217c5dd36d611b29382c5af61423edec9c7ef13c2b27ce6b80a5ad"
+            "hash": "f2f1ac3b1509596209266bc69056b2738849308ea81a304e8887e0159c43b4ee"
         },
         "arm64": {
             "url": "https://github.com/Stellarium/stellarium/releases/download/v24.3/stellarium-24.3-qt6-arm64.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Stellarium already supports Windows ARM64 architecture, but hasn't be added to the scoop bucket yet.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
