### PR TITLE
vscode@1.95.3:Revert "vscode: Update to version 1.96.0-insider"

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.96.0-insider",
+    "version": "1.95.3",
     "description": "Lightweight but powerful source code editor",
     "homepage": "https://code.visualstudio.com/",
     "license": {
@@ -14,11 +14,11 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://update.code.visualstudio.com/1.96.0-insider/win32-x64-archive/stable#/dl.7z",
+            "url": "https://update.code.visualstudio.com/1.95.3/win32-x64-archive/stable#/dl.7z",
             "hash": "6d6fcd71fee97a3e110770032d7c8494145f15a92598813f031ceb09449c3f1d"
         },
         "arm64": {
-            "url": "https://update.code.visualstudio.com/1.96.0-insider/win32-arm64-archive/stable#/dl.7z",
+            "url": "https://update.code.visualstudio.com/1.95.3/win32-arm64-archive/stable#/dl.7z",
             "hash": "02a99982963d1910bf24a26cc0edfd8ae502e7aa377a7f015eb297df2238ea86"
         }
     },


### PR DESCRIPTION
This reverts commit d668213a2b8ae40730540336996078914246aa4d.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/ScoopInstaller/Extras/issues/14439
Closes https://github.com/ScoopInstaller/Extras/issues/14442
<!-- or -->

Seem like the vscode team release wrong version, action update wrong too, Revert

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
