### PR TITLE
another-redis-desktop-manager: Fix download and autoupdate URLs

### DIFF
--- a/bucket/another-redis-desktop-manager.json
+++ b/bucket/another-redis-desktop-manager.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.7.0/Another-Redis-Desktop-Manager.1.7.0.exe#/dl.7z",
+            "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.7.0/Another-Redis-Desktop-Manager-win-1.7.0-x64.exe#/dl.7z",
             "hash": "sha512:18b59199956c583bf4f96595dfa1bd40d5c5a827db1ee57bbf22f84e67479e355710987f9db2852016e584d4945aae6f94f3271b150308cd200ee492bae378f8"
         }
     },
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v$version/Another-Redis-Desktop-Manager.$version.exe#/dl.7z",
+                "url": "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v$version/Another-Redis-Desktop-Manager-win-$version-x64.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/latest.yml",
                     "regex": "sha512:\\s+$base64"


### PR DESCRIPTION
Updated download and checkver URLs to match new naming scheme from the developer.

Closes #14444

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
