### PR TITLE
Waterfox: repair checkver and autoupdate

### DIFF
--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -42,7 +42,7 @@
         "profile"
     ],
     "checkver": {
-        "github": "https://github.com/WaterfoxCo/Waterfox"
+        "github": "https://github.com/BrowserWorks/Waterfox"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -42,13 +42,12 @@
         "profile"
     ],
     "checkver": {
-        "github": "https://github.com/WaterfoxCo/Waterfox",
-        "regex": "G([\\d.]+)"
+        "github": "https://github.com/WaterfoxCo/Waterfox"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn1.waterfox.net/waterfox/releases/G$version/WINNT_x86_64/Waterfox%20Setup%20G$version.exe#/dl.7z",
+                "url": "https://cdn1.waterfox.net/waterfox/releases/$version/WINNT_x86_64/Waterfox%20Setup%20$version.exe#/dl.7z",
                 "hash": {
                     "url": "$url.sha512"
                 }

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.0.20",
+    "version": "6.5.2",
     "description": "The 100% fresh, free-range, ethical browser",
     "homepage": "https://www.waterfox.net",
     "license": "MPL-2.0",
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://cdn1.waterfox.net/waterfox/releases/G6.0.20/WINNT_x86_64/Waterfox%20Setup%20G6.0.20.exe#/dl.7z",
-            "hash": "sha512:4adabc51da7ec49c53631493c9543b056d774e0eb37e6a3dcee55a6cec9c0c2d8ee0d9236ba0fa5ea4389cb294fd378671c1b42c8837ac2d8b42e64bd24aee56"
+            "url": "https://cdn1.waterfox.net/waterfox/releases/6.5.2/WINNT_x86_64/Waterfox%20Setup%206.5.2.exe#/dl.7z",
+            "hash": "sha512:bb667dfc876c5051107706c92414912d4b44fa9ac8d1402701676741afa830bc799cd4617dcbb4cd544d4a33b96ce76d9b93bcd9bc03e2af59e780660cb1a9cb"
         }
     },
     "extract_dir": "core",


### PR DESCRIPTION
They removed G from new versions, so checkver and autoupdate was not working

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14449 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
