### PR TITLE
paint.net@5.1: Add `UserFiles` to persist

### DIFF
--- a/bucket/paint.net.json
+++ b/bucket/paint.net.json
@@ -29,6 +29,7 @@
         "Effects",
         "FileTypes",
         "Shapes",
+        "UserFiles",
         "PaintDotNet.AppSettings.json"
     ],
     "checkver": {


### PR DESCRIPTION
Persists the `UserFiles` directory, which contains files such as palettes and effect presets.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
