### PR TITLE
freecad: Update to version 1.0.0

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0-conda-py311",
+    "version": "1.0.0",
     "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
@@ -19,13 +19,12 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/5736080/releases",
-        "regex": "FreeCAD_(?<prefix>[\\w.-]+)-Windows-x86_64-(?<suffix>[\\w.-]+)\\.7z",
-        "replace": "${1}-${2}"
+        "regex": "FreeCAD_([\\d.]+)-conda-Windows-x86_64-(?<suffix>[\\w.-]+)\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD_$matchPrefix-Windows-x86_64-$matchSuffix.7z"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD_$version-conda-Windows-x86_64-$matchSuffix.7z"
             }
         },
         "hash": {

--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.21.2",
+    "version": "1.0.0-conda-py311",
     "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.21.2/FreeCAD-0.21.2-Windows-x86_64.7z",
-            "hash": "06a8f162e3fa9bd8cc98c0cf117d1b3507b9a6564d3da0d16bc5e5c11d7e7880"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/1.0.0/FreeCAD_1.0.0-conda-Windows-x86_64-py311.7z",
+            "hash": "c32c43897172c2669ade854a4e71b9e158e7e86dfaf728e2aba0b6e3104347ae"
         }
     },
     "pre_install": "pushd $dir ; mv */* . ; rm FreeCAD_* ; popd",
@@ -19,13 +19,13 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/5736080/releases",
-        "regex": "FreeCAD-([\\d.]+)-Windows-x86_64((-\\d+)?)\\.7z",
-        "replace": "${1}${2}"
+        "regex": "FreeCAD_(?<prefix>[\\w.-]+)-Windows-x86_64-(?<suffix>[\\w.-]+)\\.7z",
+        "replace": "${1}-${2}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD-$matchHead-Windows-x86_64$matchTail.7z"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$matchHead/FreeCAD_$matchPrefix-Windows-x86_64-$matchSuffix.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
Update [freecad](https://github.com/FreeCAD/FreeCAD/releases) to version 1.0.0



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
