### PR TITLE
clash-verge-rev: Update to Version 2.0.2

### DIFF
--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -29,14 +29,11 @@
             "Clash Verge"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/clash-verge-rev/clash-verge-rev"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64-setup.exe#/dl.7z"
-                        
+                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64-setup.exe#/dl.7z"    
             },
             "arm64": {
                 "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_arm64-setup.exe#/dl.7z"

--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -33,7 +33,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64-setup.exe#/dl.7z"    
+                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64-setup.exe#/dl.7z"
             },
             "arm64": {
                 "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_arm64-setup.exe#/dl.7z"

--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Continuation of Clash Verge - A Clash Meta GUI based on Tauri.",
     "homepage": "https://github.com/clash-verge-rev/clash-verge-rev",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.0.1/Clash.Verge_2.0.1_x64-setup.exe#/dl.7z",
-            "hash": "08ad9c2c334abce4eb9f4bba2b686d1dc77f3e7d3544310df5d56cce44379fcb"
+            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.0.2/Clash.Verge_2.0.2_x64-setup.exe#/dl.7z",
+            "hash": "a028e966784b98820e5adf392ed2cd8106de44d984d5aeecc2e3af395d402fd5"
         },
         "arm64": {
-            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.0.1/Clash.Verge_2.0.1_arm64-setup.exe#/dl.7z",
-            "hash": "625c2110de2959515f540b77da4712c12613bc85683b442e51ee776a4cf29832"
+            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.0.2/Clash.Verge_2.0.2_arm64-setup.exe#/dl.7z",
+            "hash": "bc858362ab967f12249851716769f063ffe64fa67ca13494b22d72d53c4e414b"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst*\" -Force -Recurse",

--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -1,17 +1,27 @@
 {
-    "version": "1.7.7",
+    "version": "2.0.1",
     "description": "Continuation of Clash Verge - A Clash Meta GUI based on Tauri.",
     "homepage": "https://github.com/clash-verge-rev/clash-verge-rev",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v1.7.7/Clash.Verge_1.7.7_x64_portable.zip",
-            "hash": "c3b8c63b908a2674811643cb89635ef89e32a1b9b39114ff087a01890a5d8ee0"
+            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.0.1/Clash.Verge_2.0.1_x64-setup.exe#/dl.7z",
+            "hash": "08ad9c2c334abce4eb9f4bba2b686d1dc77f3e7d3544310df5d56cce44379fcb"
         },
         "arm64": {
-            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v1.7.7/Clash.Verge_1.7.7_arm64_portable.zip",
-            "hash": "f54e2b0d6e746f26b7c5d0c430106f7703b96f612d1da9736b286e1131db941a"
+            "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.0.1/Clash.Verge_2.0.1_arm64-setup.exe#/dl.7z",
+            "hash": "625c2110de2959515f540b77da4712c12613bc85683b442e51ee776a4cf29832"
         }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst*\" -Force -Recurse",
+    "installer": {
+        "script": [
+            "ensure \"$persist_dir\" | Out-Null",
+            "New-Item \"$env:USERPROFILE\\.config\\clash-verge\" -ItemType Junction -Target \"$persist_dir\" | Out-Null"
+        ]
+    },
+    "uninstaller": {
+        "script": "Remove-Item \"$env:USERPROFILE\\.config\\clash-verge\" -Recurse -Force -ErrorAction 'SilentlyContinue'"
     },
     "shortcuts": [
         [
@@ -19,24 +29,17 @@
             "Clash Verge"
         ]
     ],
-    "persist": ".config",
-    "post_install": [
-        "if (!(Test-Path \"$persist_dir\\.config\\PORTABLE\")) {",
-        "    New-Item -Path \"$persist_dir\\.config\\PORTABLE\" -ItemType file | Out-Null",
-        "}"
-    ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process \"$dir\\resources\\uninstall-service.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden'; Start-Sleep -Seconds 3"
-    ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/clash-verge-rev/clash-verge-rev"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64_portable.zip"
+                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_x64-setup.exe#/dl.7z"
+                        
             },
             "arm64": {
-                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_arm64_portable.zip"
+                "url": "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v$version/Clash.Verge_$version_arm64-setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
clash-verge-rev: Update to Version 2.0.1
Because the portable version has many problems, releases no longer provides a portable version
replace `portable` version with setup.exe


<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- or -->
Relates to #13429 #13397 
Closes #14464

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
