### PR TITLE
localsend@1.16.1: Add "bin" section to add to PATH

### DIFF
--- a/bucket/localsend.json
+++ b/bucket/localsend.json
@@ -9,6 +9,13 @@
             "hash": "4d9bd4639476c0e4d00dd9da30b7ca78a1dc6e3dafc69e2e8862fdafcc23e163"
         }
     },
+    "bin": [
+        "localsend_app.exe",
+        [
+            "localsend_app.exe",
+            "localsend"
+        ]
+    ],
     "shortcuts": [
         [
             "localsend_app.exe",


### PR DESCRIPTION
Localsend json was missing bin section, so it couldn't be started from command line.
Adding bin section to add to path.
Closes #14466

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
