### PR TITLE
fvm: Update env var to FVM_CACHE_PATH instead of FVM_HOME

### DIFF
--- a/bucket/fvm.json
+++ b/bucket/fvm.json
@@ -22,7 +22,7 @@
     ],
     "bin": "fvm.bat",
     "env_set": {
-        "FVM_HOME": "$dir"
+        "FVM_CACHE_PATH": "$dir"
     },
     "persist": [
         "versions",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Update fvm to use FVM_CACHE_PATH instead of FVM_HOME since this has changed in [fvm 3.0.0](https://github.com/leoafarias/fvm/releases/tag/3.0.0).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
