### PR TITLE
vscode: revert 1.96.0-insider -> 1.95.3

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.96.0-insider",
+    "version": "1.95.3",
     "description": "Lightweight but powerful source code editor",
     "homepage": "https://code.visualstudio.com/",
     "license": {
@@ -14,12 +14,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://update.code.visualstudio.com/1.96.0-insider/win32-x64-archive/stable#/dl.7z",
-            "hash": "fa3706257e28ce26c931fa782c70f742c52744bd406efa9fa0eb8e62b9cb26ba"
+            "url": "https://update.code.visualstudio.com/1.95.3/win32-x64-archive/stable#/dl.7z",
+            "hash": "6d6fcd71fee97a3e110770032d7c8494145f15a92598813f031ceb09449c3f1d"
         },
         "arm64": {
-            "url": "https://update.code.visualstudio.com/1.96.0-insider/win32-arm64-archive/stable#/dl.7z",
-            "hash": "c4c2452d4cf71284dfb784d6468c0bc9385f9ecb0b3bbf598a12f1b91c50bd50"
+            "url": "https://update.code.visualstudio.com/1.95.3/win32-arm64-archive/stable#/dl.7z",
+            "hash": "02a99982963d1910bf24a26cc0edfd8ae502e7aa377a7f015eb297df2238ea86"
         }
     },
     "env_add_path": "bin",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Reverted manifest to previous version `1.95.3` from erroneous insiders version.

Validated file checksums are still correct. A more permanent fix is required and an investigation as to why this keeps happening.

Relates to #14427

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
