### PR TITLE
clash-verge-rev: Fix shotcuts name and uninstall script

### DIFF
--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -20,6 +20,10 @@
             "New-Item \"$env:USERPROFILE\\.config\\clash-verge\" -ItemType Junction -Target \"$persist_dir\" | Out-Null"
         ]
     },
+    "pre_uninstall": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+        "Start-Process \"$dir\\resources\\uninstall-service.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden'; Start-Sleep -Seconds 3"
+    ],
     "uninstaller": {
         "script": "Remove-Item \"$env:USERPROFILE\\.config\\clash-verge\" -Recurse -Force -ErrorAction 'SilentlyContinue'"
     },

--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -25,7 +25,7 @@
     },
     "shortcuts": [
         [
-            "Clash Verge.exe",
+            "clash-verge.exe",
             "Clash Verge"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The shortcuts name was wrong. Also, the services must be uninstalled, or it will prevent to remove related files.


Relates to https://github.com/ScoopInstaller/Extras/pull/14460#issuecomment-2510626853
Closes #14495
Closes #14500

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
