### PR TITLE
ansel: Add version 0.0.0+995

### DIFF
--- a/bucket/ansel.json
+++ b/bucket/ansel.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.0.0+995",
+    "description": "Photo-editing software and raw developer for digital artists, designed to help you achieve your own interpretation of raw digital photographs.",
+    "homepage": "https://ansel.photos/",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v0.0.0/ansel-0.0.0+995.gb0e0a126-win64.exe#/dl.7z",
+            "hash": "c3f42d542e4ede6232df2cb3d23d310d368e4ac8fb07cdf4f655583159a1725c"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst*\" -Force -Recurse",
+    "bin": [
+        "bin\\ansel.exe",
+        "bin\\ansel-cli.exe",
+        "bin\\ansel-generate-cache.exe",
+        "bin\\ansel-cltest.exe"
+    ],
+    "shortcuts": [
+        [
+            "bin\\ansel.exe",
+            "Ansel"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/aurelienpierreeng/ansel/releases/85945145",
+        "regex": "ansel-(?<vhead>[\\d\\.]+)(?:%2B|\\+)(?<vtail>[\\d]+)\\.g(?<commit>[a-fA-F0-9]{6,12})-win64",
+        "reverse": true,
+        "replace": "${vhead}+${vtail}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v$matchHead/ansel-$version.g$matchCommit-win64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #14497

Briefly want to note that the way artifacts are published is a bit strange. Release [`v0.0.0` on Github](https://github.com/aurelienpierreeng/ansel/releases/tag/v0.0.0) is a "rolling release" with new artifacts added when there's a new nightly build. There currently are no stable releases and the manifest should likely be updated once that becomes available. Still, there seems to be no timeline for that happening and the software is reasonably stable.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
