### PR TITLE
glazewm: Update to version 3.7.0

### DIFF
--- a/bucket/glazewm.json
+++ b/bucket/glazewm.json
@@ -1,18 +1,19 @@
 {
-    "version": "2.1.1",
+    "version": "3.7.0",
     "description": "A tiling window manager for Windows inspired by i3 and Polybar.",
     "homepage": "https://github.com/glzr-io/glazewm",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/glzr-io/glazewm/releases/download/v2.1.1/GlazeWM_x64_2.1.1.exe#/GlazeWM.exe",
-            "hash": "a534b649cf0076ad024688681ad01cbaf44e23caca1fc46f9a208202ff640c2c"
+            "url": "https://github.com/glzr-io/glazewm/releases/download/v3.7.0/standalone-glazewm-v3.7.0-x64.msi",
+            "hash": "733C09B3D19BF68FD5A522EE8F068F48CADE8EC7422A4AA8A0D18B2BEEBE3494"
         },
-        "32bit": {
-            "url": "https://github.com/glzr-io/glazewm/releases/download/v2.1.1/GlazeWM_x86_2.1.1.exe#/GlazeWM.exe",
-            "hash": "0cbe283e9890b0b465e24196b8525c6c64feb83b4652f5b8985da71668d85827"
+        "arm64": {
+            "url": "https://github.com/glzr-io/glazewm/releases/download/v3.7.0/standalone-glazewm-v3.7.0-arm64.msi",
+            "hash": "C1C91D4E29863A9454C336101D57042A97613138F6403B1F718D018AD52BF517"
         }
     },
+    "extract_dir": "PFiles64\\glzr.io\\GlazeWM",
     "bin": "GlazeWM.exe",
     "shortcuts": [
         [
@@ -24,10 +25,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/glzr-io/glazewm/releases/download/v$version/GlazeWM_x64_$version.exe#/GlazeWM.exe"
+                "url": "https://github.com/glzr-io/glazewm/releases/download/v$version/standalone-glazewm-v$version-x64.msi"
             },
-            "32bit": {
-                "url": "https://github.com/glzr-io/glazewm/releases/download/v$version/GlazeWM_x86_$version.exe#/GlazeWM.exe"
+            "arm64": {
+                "url": "https://github.com/glzr-io/glazewm/releases/download/v$version/standalone-glazewm-v$version-arm64.msi"
             }
         }
     }


### PR DESCRIPTION
- `glazewm.json` now installs GlazeWM [v3.7.0](https://github.com/glzr-io/glazewm/releases/tag/v3.7.0), featuring performance improvements and support for `.msi` installations on x64 and ARM64 devices. 
- The manifest has been updated to use the `.msi` installation method, as the `.exe` installer does not appear to work with Scoop, likely due to administrative permission requirements.

https://github.com/ScoopInstaller/Scoop/issues/5809
this is still an issue.. If the user needs GlazeWM to run in UIAccess mode then they can choose to install glazewm-np.json which I've also sent a pull request for on nonportable official. 

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14401, #14112 and #13963
<!-- or -->
Relates to [comment on glazewm open issues](https://github.com/glzr-io/glazewm/issues/645#issuecomment-2514472050)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
