### PR TITLE
tinynvidiaupdatechecker@1.19.1: added .net runtime as suggestion

### DIFF
--- a/bucket/tinynvidiaupdatechecker.json
+++ b/bucket/tinynvidiaupdatechecker.json
@@ -6,6 +6,9 @@
     "url": "https://github.com/ElPumpo/TinyNvidiaUpdateChecker/releases/download/v1.19.1/TinyNvidiaUpdateChecker.exe",
     "hash": "6ed0220a11a7beaf8a5943164715b4c51933f03d97f4dfd1752751fe791490d4",
     "bin": "TinyNvidiaUpdateChecker.exe",
+    "suggest": {
+        ".NET Desktop Runtime": "extras/windowsdesktop-runtime"
+    },
     "shortcuts": [
         [
             "TinyNvidiaUpdateChecker.exe",


### PR DESCRIPTION
Since tinynvidiaupdatechecker requires the .net desktop runtime, I added it as a suggestion.

Sorry for not creating an issue before submitting, it seemed so easy of a change so might as well.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
