### PR TITLE
musicbee: fix download url from majorgeeks

### DIFF
--- a/bucket/musicbee.json
+++ b/bucket/musicbee.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://musicbee.fandom.com/wiki/FAQ#Are_there_any_limitations_on_using_MusicBee.3F"
     },
-    "url": "https://files1.majorgeeks.com/10afebdbffcd4742c81a3cb0f6ce4092156b4375/multimedia/MusicBeePortable_3_5.zip",
+    "url": "https://files1.majorgeeks.com/6c3bcf93d7e4ff1a87bb079e23abeadb594ed026/multimedia/MusicBeePortable_3_5.zip",
     "hash": "a1da2ff921922fe4323f062a0032b6182b5dd000d6b5df34998614377aa3977a",
     "pre_install": [
         "(Get-ChildItem \"$dir\" 'MusicBee*.exe').FullName | Expand-7zipArchive -DestinationPath \"$dir\" -Removal",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes the URL From Major Geeks for music bee, may want to look into a different source for the package if the hash changes again.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14486


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
