### PR TITLE
Added Cromite browser to the bucket

### DIFF
--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -38,7 +38,7 @@
 	"persist": "USER_DATA",
 	"checkver": {
 		"github": "https://github.com/uazo/cromite",
-		"regex": "/releases/tag/(?:v|V)?([\\d\\.]+(?:-[\\w]+)?)"
+		"regex": "releases/tag/([vV]?([\\d\\.]+(?:-[\\w]+)?))"
 	},
 	"autoupdate": {
 		"architecture": {

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -43,7 +43,7 @@
 	"autoupdate": {
 		"architecture": {
 			"64bit": {
-				"url": "https://github.com/uazo/cromite/releases/download/$version/chrome-win.zip"
+				"url": "https://github.com/uazo/cromite/releases/tag/$version/chrome-win.zip"
 			}
 		}
 	}

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -43,7 +43,7 @@
 	"autoupdate": {
 		"architecture": {
 			"64bit": {
-				"url": "https://github.com/uazo/cromite/releases/download/$version/chrome-win.zip"
+				"url": "https://github.com/uazo/cromite/releases/download/v$version/chrome-win.zip"
 			}
 		}
 	}

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -1,0 +1,50 @@
+{
+	"version": "v131.0.6778.109-32fa8435523f71f1d2b6ac2facdea91e874c6904",
+	"description": "Cromite a Bromite fork with ad blocking and privacy enhancements; take back your browser!",
+	"homepage": "https://www.cromite.org/",
+	"license": {
+		"identifier": "GPL-3.0-only",
+		"url": "https://github.com/uazo/cromite/blob/master/LICENSE"
+	},
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/uazo/cromite/releases/download/v131.0.6778.109-32fa8435523f71f1d2b6ac2facdea91e874c6904/chrome-win.zip",
+			"hash": "6f5c6ce8c6c4d0bf4caad49d01ac45e17d006ac7e382f9f2c259eaa88698b836"
+		}
+	},
+	"bin": [
+		[
+			"bin\\chrome.exe",
+			"cromite",
+			"--user-data-dir=\"$dir\\USER_DATA\""
+		]
+	],
+	"shortcuts": [
+		[
+			"chrome.exe",
+			"Cromite",
+			"--user-data-dir=\"$dir\\User Data\""
+		]
+	],
+	"post_install": [
+		"if (!(Test-Path \"$dir\\USER_DATA\\*\") -and (Test-Path \"$env:LocalAppData\\Cromite\\User Data\")) {",
+		"    info '[Portable Mode]: Copying user data...'",
+		"    Copy-Item \"$env:LocalAppData\\Cromite\\User Data\\*\" \"$dir\\USER_DATA\" -Recurse",
+		"}"
+	],
+	"env_set": {
+		"CHROME_EXECUTABLE": "$dir\\chrome.exe"
+	},
+	"persist": "USER_DATA",
+	"checkver": {
+		"github": "https://github.com/uazo/cromite",
+		"regex": "releases/tag/v(?<main>\\d+\\.\\d+\\.\\d+\\.\\d+)-(?<commit>[a-f0-9]{40})"
+	},
+	"autoupdate": {
+		"architecture": {
+			"64bit": {
+				"url": "https://github.com/uazo/cromite/releases/download/$version/chrome-win.zip"
+			}
+		}
+	}
+}

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -38,7 +38,7 @@
 	"persist": "USER_DATA",
 	"checkver": {
 		"github": "https://github.com/uazo/cromite",
-		"regex": "releases/tag/v(?<main>\\d+\\.\\d+\\.\\d+\\.\\d+)-(?<commit>[a-f0-9]{40})"
+		"regex": "/releases/tag/(?:v|V)?([\\d\\.]+(?:-[\\w]+)?)"
 	},
 	"autoupdate": {
 		"architecture": {

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -43,7 +43,7 @@
 	"autoupdate": {
 		"architecture": {
 			"64bit": {
-				"url": "https://github.com/uazo/cromite/releases/tag/$version/chrome-win.zip"
+				"url": "https://github.com/uazo/cromite/releases/download/$version/chrome-win.zip"
 			}
 		}
 	}


### PR DESCRIPTION
I added Cromite browser to the bucket. Cromite is a fork of Chromium, that has cross-platform binaries, including Android. It is a great addition along Thorium, ungoogled-chromium, Woolyss, and so.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
