### PR TITLE
wsl2-distro-manager@1.8.15: fix link to windows patched version

### DIFF
--- a/bucket/wsl2-distro-manager.json
+++ b/bucket/wsl2-distro-manager.json
@@ -5,8 +5,8 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bostrot/wsl2-distro-manager/releases/download/v1.8.15/wsl2-distro-manager-v1.8.15.zip",
-            "hash": "f7e6e96a9a06f9f4f7300f13cb0594acb3b2f073e51925ce0cbe5d12624c459a"
+            "url": "https://github.com/bostrot/wsl2-distro-manager/releases/download/v1.8.15/wsl2-distro-manager-v1.8.15+1.zip",
+            "hash": "1d6cd20e8f26dc69eee60f8a894c3584b1740178ce39e1a029f1b0b1d8257f40"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Closes #14539 

It just patches the manifest with the right url. And next auto update should be ok for 1.8.16

However, if the project do another time a patch release like this, then the problem from #14539 will happen again. 

Though it seems enough to do that for now to no complexify the manifest. 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
