### PR TITLE
winscp: fix download url & autoupdate url

### DIFF
--- a/bucket/winscp.json
+++ b/bucket/winscp.json
@@ -3,7 +3,7 @@
     "description": "Copy files between a local computer and remote servers using FTP, FTPS, SCP, SFTP, WebDAV or S3 file transfer protocols.",
     "homepage": "https://winscp.net",
     "license": "GPL-3.0-or-later",
-    "url": "https://downloads.sourceforge.net/project/winscp/WinSCP/6.3.6/WinSCP-6.3.6-Portable.zip",
+    "url": "https://winscp.net/download/files/2024121010384f27afb78c423c0f4cfca448cad9ccab/WinSCP-6.3.6-Portable.zip",
     "hash": "064cc4f93eac25fc741e19c8b91d63287ed9d478a6541d3ee035c8fd870d2587",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\winscp.ini\")) {",
@@ -32,7 +32,7 @@
         "regex": "WinSCP-([\\d.]+)-Portable\\.zip"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/winscp/WinSCP/$version/WinSCP-$version-Portable.zip",
+        "url": "https://winscp.net/download/files/2024121010384f27afb78c423c0f4cfca448cad9ccab/WinSCP-$version-Portable.zip",
         "hash": {
             "url": "https://winscp.net/download/WinSCP-$version-ReadMe.txt",
             "regex": "(?sm)$basename.*?SHA-256: $sha256"


### PR DESCRIPTION
I replaced the Sourceforge URL with the one provided by WinSCP directly.

Relates to #5318, #4418, #827

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
