### PR TITLE
proton-mail-export: Add version 1.0.4

### DIFF
--- a/bucket/proton-mail-export.json
+++ b/bucket/proton-mail-export.json
@@ -11,8 +11,7 @@
     },
     "bin": "proton-mail-export-cli.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/protonmail/proton-mail-export/releases",
-        "regex": "v([\\d+.]+)"
+        "github": "https://github.com/ProtonMail/proton-mail-export"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/proton-mail-export.json
+++ b/bucket/proton-mail-export.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.0.4",
+    "description": "Command-line tool that allows you to export all your emails as EML files, and their metadata as JSON files.",
+    "homepage": "https://proton.me/support/proton-mail-export-tool",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ProtonMail/proton-mail-export/releases/download/v1.0.4/proton-mail-export-cli-windows_x86_64.zip",
+            "hash": "a6a46c76bfbd34e22f2e11880761e656d8ab735c96391f081809b822870bf8bd"
+        }
+    },
+    "bin": "proton-mail-export-cli.exe",
+    "checkver": {
+        "url": "https://api.github.com/repos/protonmail/proton-mail-export/releases",
+        "regex": "v([\\d+.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ProtonMail/proton-mail-export/releases/download/v$version/proton-mail-export-cli-windows_x86_64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds proton-mail-export tool, a cli software to export (or restore) all your emails.

Closes #11420

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).