### PR TITLE
v2rayn: Remove 32 bit, fix 64bit and arm64 downloads, update to 7.2.3

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.60",
+    "version": "7.2.3",
     "description": "A V2Ray client for Windows, support Xray & v2fly core",
     "homepage": "https://github.com/2dust/v2rayN",
     "license": "GPL-3.0-only",
@@ -10,16 +10,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/6.60/v2rayN.zip",
-            "hash": "fc1243faee5ebdf501d1416ae8567a993638c9ead92f94c4121feb6771f549d5"
-        },
-        "32bit": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/6.60/v2rayN-32.zip",
-            "hash": "049cd293cd5bf2f7cfd5b3306428d9216323623de3301bc29f336b9ed0de42b2"
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN.-windows-64.zip",
+            "hash": "55c91299b1741435e44abf409692df1f8a8160f11a1921cac2aeb4b7e16458d5"
         },
         "arm64": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/6.60/v2rayN-arm64.zip",
-            "hash": "31816af0a576c9540d1c73174ff193c12b5384d3f1fc16ac5aaee461778da397"
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN-windows-arm64.zip",
+            "hash": "d259583dceb1ae3b39cb250f0acfffddbfb946d9be556f368c4125959339a049"
         }
     },
     "extract_dir": "v2rayN",
@@ -47,13 +43,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-32.zip"
+                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-64.zip"
             },
             "arm64": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-arm64.zip"
+                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-arm64.zip"
             }
         }
     }

--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -20,7 +20,6 @@
             "extract_dir": "v2rayN-windows-arm64"
         }
     },
-    "extract_dir": "v2rayN",
     "pre_install": [
         "if (!(Test-Path \"$dir\\bin\\Xray\")) { New-Item \"$dir\\bin\\Xray\" -ItemType Directory | Out-Null }",
         "foreach ($form in @('*.exe', '*.dat')) {",

--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -10,7 +10,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN.-windows-64.zip",
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN-windows-64.zip",
             "hash": "55c91299b1741435e44abf409692df1f8a8160f11a1921cac2aeb4b7e16458d5"
         },
         "arm64": {

--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -11,7 +11,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN-windows-64.zip",
-            "hash": "55c91299b1741435e44abf409692df1f8a8160f11a1921cac2aeb4b7e16458d5"
+            "hash": "55c91299b1741435e44abf409692df1f8a8160f11a1921cac2aeb4b7e16458d5",
+            "extract_dir": "v2rayN-windows-64"
         },
         "arm64": {
             "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN-windows-arm64.zip",

--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -16,7 +16,8 @@
         },
         "arm64": {
             "url": "https://github.com/2dust/v2rayN/releases/download/7.2.3/v2rayN-windows-arm64.zip",
-            "hash": "d259583dceb1ae3b39cb250f0acfffddbfb946d9be556f368c4125959339a049"
+            "hash": "d259583dceb1ae3b39cb250f0acfffddbfb946d9be556f368c4125959339a049",
+            "extract_dir": "v2rayN-windows-arm64"
         }
     },
     "extract_dir": "v2rayN",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Remove 32 bit support as the project no longer ships 32bit
fix 64bit and arm64 downloads by adjusting download names
update to 7.2.3
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14474

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
