### PR TITLE
mpv-git: Update to 20241213 using Github Releases

### DIFF
--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -1,5 +1,5 @@
 {
-    "version": "20241124",
+    "version": "20241213",
     "description": "Video player based on MPlayer/mplayer2 (builds by shinchiro)",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
@@ -12,12 +12,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/64bit/mpv-x86_64-20241124-git-2d813de.7z",
-            "hash": "sha1:19794ebf058e076f5d8691a8550015dd616e3d8a"
+            "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20241213/mpv-x86_64-20241213-git-dbb3291.7z",
+            "hash": "ed4c6a870d3dc7994c3f8c43b5b74865373383bd41808709c73495e7f2059d6c"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/32bit/mpv-i686-20241124-git-2d813de.7z",
-            "hash": "sha1:6f9bc362a29e168ca3fb5658213cbfe434e7ccfe"
+            "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20241213/mpv-i686-20241213-git-dbb3291.7z",
+            "hash": "46d1272e85b009e586ae373730e3b09555d6df42398342127ac79aff36ecd292"
         }
     },
     "pre_install": "Remove-Item \"$dir\\updater.bat\"",
@@ -30,16 +30,17 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "sourceforge": "mpv-player-windows/64bit",
+        "url": "https://api.github.com/repositories/141023757/releases/latest",
+        "jsonpath": "$.assets..browser_download_url",
         "regex": "mpv-x86_64-(\\d+)-git-(?<commit>[\\da-f]+)\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/mpv-player-windows/64bit/mpv-x86_64-$version-git-$matchCommit.7z"
+                "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-x86_64-$version-git-$matchCommit.7z"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/mpv-player-windows/32bit/mpv-i686-$version-git-$matchCommit.7z"
+                "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-i686-$version-git-$matchCommit.7z"
             }
         }
     }


### PR DESCRIPTION
The previous Sourceforge mirror has not been receiving recent builds by shinchiro. This PR updates the checkver source to use the Github releases API source. All the MPV builds are done with Github Actions and automatically released nightly. This is a more direct source than downloading from Sourceforge.
The build repository https://github.com/shinchiro/mpv-winbuild-cmake/
The repo is directly linked to on https://mpv.io/installation/ as a source of Windows binaries. They are no-longer linking to Sourceforge.

<!-- Provide a general summary of your changes in the title above -->

Further updates could be made to modernize this manifest, e.g. #11123 
It is also unclear if the change in #9662 of adding the mpv(-git) install directory to PATH is still necessary in 202[45]. 
I personally dislike it and prefer not to pollute PATH, but I also don't use the package that caused the original issue in #9662. 
I have left that as is for this PR.

It is likely that the `mpv.json` (non-git builds) will need to be migrated from Sourceforge as well, however there has yet to be a full MPV release since the current v0.39.0, so we have yet to see where the next version will be released (Github releases or Sourceforge mirror). 
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [ x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
