### PR TITLE
php(-nts)-xdebug@3.4.0-8.4: update to work with PHP 8.4 + fix post_install config step

### DIFF
--- a/bucket/php-nts-xdebug.json
+++ b/bucket/php-nts-xdebug.json
@@ -17,15 +17,18 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php-nts\\cli\\conf.d\"",
+        "$phpcli = \"$persist_dir\\..\\php\\cli\"",
         "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if (!(Test-Path \"$phpconfd\\xdebug.ini\")) {",
-        "    ensure $phpconfd | Out-Null",
-        "    Write-Output \"Enabling extension '$phpconfd\\xdebug.ini'\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
+        "if (!(Test-Path \"$phpcli\")) {",
         "    Write-Host -f Yellow \"PHP was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
         "    Write-Host -f Cyan \"$ini`n`n\"",
+        "} else {",
+        "    if (Test-Path \"$phpcli\\conf.d\\xdebug.ini\") {",
+        "        Write-Output \"Enabling extension $phpcli\\conf.d\\xdebug.ini\"",
+        "        Add-Content -Value $ini -Path \"$phpcli\\conf.d\\xdebug.ini\"",
+        "    } else {",
+        "        Write-Output \"No XDebug config was added, as xdebug.ini already exists in $phpcli\\conf.d\\xdebug.ini\"",
+        "    }",
         "}"
     ],
     "checkver": {

--- a/bucket/php-nts-xdebug.json
+++ b/bucket/php-nts-xdebug.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.0-8.3",
+    "version": "3.4.0-8.4",
     "description": "An extension for PHP to assist with debugging and development. (Non-Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.3-vs16-nts-x86_64.dll#/php_xdebug.dll",
-            "hash": "d434c3c7dcea7e45b1f4b37bcbf39d58233f7e5c72f15445d0c168ceb9ae04e9"
+            "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.4-vs17-nts-x86_64.dll#/php_xdebug.dll",
+            "hash": "da7017e5b67c8aa6edbc29ee3126413a3a282f05199b417c0d6d2d14624029b0"
         }
     },
     "post_install": [
@@ -30,15 +30,15 @@
     ],
     "checkver": {
         "url": "https://xdebug.org/download",
-        "regex": "php_xdebug-([\\d.]+-8\\.3)-vs16-nts-x86_64\\.dll"
+        "regex": "php_xdebug-([\\d.]+-8\\.4)-vs17-nts-x86_64\\.dll"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-nts-x86_64.dll#/php_xdebug.dll",
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs17-nts-x86_64.dll#/php_xdebug.dll",
                 "hash": {
                     "url": "https://xdebug.org/download",
-                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files/php_xdebug-$version-vs16-nts-x86_64\\.dll"
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files/php_xdebug-$version-vs17-nts-x86_64\\.dll"
                 }
             }
         }

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -12,7 +12,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.4-vs17-x86_64.dll",
+            "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.4-vs17-x86_64.dll#/php_xdebug.dll",
             "hash": "5938faf48ef5c1706278b304460553f98238b95c4e36e0c372a514e1eaa5b6ca"
         }
     },

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.0-8.3",
+    "version": "3.4.0-8.4",
     "description": "An extension for PHP to assist with debugging and development. (Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.3-vs16-x86_64.dll#/php_xdebug.dll",
-            "hash": "be8af451c594ff8feb45f4833788e4a665739c8a3b518dcbc563a47960631c0f"
+            "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.4-vs17-x86_64.dll",
+            "hash": "5938faf48ef5c1706278b304460553f98238b95c4e36e0c372a514e1eaa5b6ca"
         }
     },
     "post_install": [
@@ -30,15 +30,15 @@
     ],
     "checkver": {
         "url": "https://xdebug.org/download",
-        "regex": "php_xdebug-([\\d.]+-8\\.3)-vs16-x86_64\\.dll"
+        "regex": "php_xdebug-([\\d.]+-8\\.4)-vs17-x86_64\\.dll"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll",
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs17-x86_64.dll#/php_xdebug.dll",
                 "hash": {
                     "url": "https://xdebug.org/download.php",
-                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files\\/php_xdebug-$version-vs16-x86_64\\.dll"
+                    "regex": "SHA256:&nbsp;([0-9a-f]+)\" href='\\/files\\/php_xdebug-$version-vs17-x86_64\\.dll"
                 }
             }
         }

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -17,15 +17,18 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php\\cli\\conf.d\"",
+        "$phpcli = \"$persist_dir\\..\\php\\cli\"",
         "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if (!(Test-Path \"$phpconfd\\xdebug.ini\")) {",
-        "    ensure $phpconfd | Out-Null",
-        "    Write-Output \"Enabling extension '$phpconfd\\xdebug.ini'\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
+        "if (!(Test-Path \"$phpcli\")) {",
         "    Write-Host -f Yellow \"PHP was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
         "    Write-Host -f Cyan \"$ini`n`n\"",
+        "} else {",
+        "    if (Test-Path \"$phpcli\\conf.d\\xdebug.ini\") {",
+        "        Write-Output \"Enabling extension $phpcli\\conf.d\\xdebug.ini\"",
+        "        Add-Content -Value $ini -Path \"$phpcli\\conf.d\\xdebug.ini\"",
+        "    } else {",
+        "        Write-Output \"No XDebug config was added, as xdebug.ini already exists in $phpcli\\conf.d\\xdebug.ini\"",
+        "    }",
         "}"
     ],
     "checkver": {


### PR DESCRIPTION
Closes #14575 and #13142

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
