### PR TITLE
cromite: Add version 134.0.6998.89

### DIFF
--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -1,6 +1,6 @@
 {
-    "version": "v131.0.6778.109-32fa8435523f71f1d2b6ac2facdea91e874c6904",
-    "description": "Cromite a Bromite fork with ad blocking and privacy enhancements; take back your browser!",
+    "version": "134.0.6998.89",
+    "description": "A Chromium fork based on Bromite with built-in support for ad blocking and an eye for privacy",
     "homepage": "https://www.cromite.org/",
     "license": {
         "identifier": "GPL-3.0-only",
@@ -8,24 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/uazo/cromite/releases/download/v131.0.6778.109-32fa8435523f71f1d2b6ac2facdea91e874c6904/chrome-win.zip",
-            "hash": "6f5c6ce8c6c4d0bf4caad49d01ac45e17d006ac7e382f9f2c259eaa88698b836"
+            "url": "https://github.com/uazo/cromite/releases/download/v134.0.6998.89-f13b33b73e22ecaa1ae9a567a8e0c74caf446678/chrome-win.zip",
+            "hash": "6c9d141af38ffe57659039a237f352832a91037628fdf179640aa9eee78955de"
         }
     },
-    "bin": [
-        [
-            "chrome-win\\chrome.exe",
-            "cromite",
-            "--user-data-dir=\"$dir\\User Data\""
-        ]
-    ],
-    "shortcuts": [
-        [
-            "chrome-win\\chrome.exe",
-            "Cromite",
-            "--user-data-dir=\"$dir\\User Data\""
-        ]
-    ],
+    "extract_dir": "chrome-win",
     "post_install": [
         "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$env:LocalAppData\\Cromite\\User Data\")) {",
         "    info '[Portable Mode]: Copying user data...'",
@@ -35,15 +22,29 @@
     "env_set": {
         "CHROME_EXECUTABLE": "$dir\\chrome.exe"
     },
+    "bin": [
+        [
+            "chrome.exe",
+            "cromite",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "shortcuts": [
+        [
+            "chrome.exe",
+            "Cromite",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
     "persist": "User Data",
     "checkver": {
         "github": "https://github.com/uazo/cromite",
-        "regex": "/releases/tag/v(([0-9|.]+)-([a-z0-9]+))"
+        "regex": "/releases/tag/v([\\d.]+)-(?<sha>[0-9a-f]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/uazo/cromite/releases/download/$version/chrome-win.zip"
+                "url": "https://github.com/uazo/cromite/releases/download/v$version-$matchSha/chrome-win.zip"
             }
         }
     }

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -1,0 +1,50 @@
+{
+    "version": "v131.0.6778.109-32fa8435523f71f1d2b6ac2facdea91e874c6904",
+    "description": "Cromite a Bromite fork with ad blocking and privacy enhancements; take back your browser!",
+    "homepage": "https://www.cromite.org/",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/uazo/cromite/blob/master/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/uazo/cromite/releases/download/v131.0.6778.109-32fa8435523f71f1d2b6ac2facdea91e874c6904/chrome-win.zip",
+            "hash": "6f5c6ce8c6c4d0bf4caad49d01ac45e17d006ac7e382f9f2c259eaa88698b836"
+        }
+    },
+    "bin": [
+        [
+            "chrome-win\\chrome.exe",
+            "cromite",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "shortcuts": [
+        [
+            "chrome-win\\chrome.exe",
+            "Cromite",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "post_install": [
+        "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$env:LocalAppData\\Cromite\\User Data\")) {",
+        "    info '[Portable Mode]: Copying user data...'",
+        "    Copy-Item \"$env:LocalAppData\\Cromite\\User Data\\*\" \"$dir\\User Data\" -Recurse",
+        "}"
+    ],
+    "env_set": {
+        "CHROME_EXECUTABLE": "$dir\\chrome.exe"
+    },
+    "persist": "User Data",
+    "checkver": {
+        "github": "https://github.com/uazo/cromite",
+        "regex": "releases/tag/([vV]?([\\d\\.]+(?:-[\\w]+)?))"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/uazo/cromite/releases/download/$version/chrome-win.zip"
+            }
+        }
+    }
+}

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -38,7 +38,7 @@
     "persist": "User Data",
     "checkver": {
         "github": "https://github.com/uazo/cromite",
-        "regex": "releases/tag/([vV]?([\\d\\.]+(?:-[\\w]+)?))"
+        "regex": "releases/tag/v(([0-9|.]+)-([a-z0-9]+))"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/cromite.json
+++ b/bucket/cromite.json
@@ -38,7 +38,7 @@
     "persist": "User Data",
     "checkver": {
         "github": "https://github.com/uazo/cromite",
-        "regex": "releases/tag/v(([0-9|.]+)-([a-z0-9]+))"
+        "regex": "/releases/tag/v(([0-9|.]+)-([a-z0-9]+))"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
I added Cromite browser to the bucket. Cromite is a fork of Chromium, that has cross-platform binaries, including Android. It is a great addition along Thorium, ungoogled-chromium, Woolyss, and so.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
