### PR TITLE
xl-converter@1.1.0: Use portable version and remove dep on VCRedist

### DIFF
--- a/bucket/xl-converter.json
+++ b/bucket/xl-converter.json
@@ -4,14 +4,13 @@
     "description": "Easy-to-use image converter for modern formats. Supports multithreading, drag 'n drop, and downscaling.",
     "homepage": "https://codepoems.eu/xl-converter/",
     "license": "GPL-3.0",
-    "depends": "extras/vcredist2022",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JacobDev1/xl-converter/releases/download/v1.1.0/xl-converter-win-1.1.0-x86_64.exe",
-            "hash": "9fe1d1bcabfe45fb3d3985e80e19f7d352815ffd110fab43e452ed7036b80411"
+            "url": "https://github.com/JacobDev1/xl-converter/releases/download/v1.1.0/xl-converter-win-1.1.0-x86_64-portable.7z",
+            "hash": "459502b36b929a429f11e32eab18bd5d2d29fb91782a4333855952e307504d22",
+            "extract_dir": "xl-converter-win-1.1.0-x86_64-portable"
         }
     },
-    "innosetup": true,
     "bin": "xl-converter.exe",
     "shortcuts": [
         [
@@ -37,7 +36,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JacobDev1/xl-converter/releases/download/v$version/xl-converter-win-$version-x86_64.exe"
+                "url": "https://github.com/JacobDev1/xl-converter/releases/download/v$version/xl-converter-win-$version-x86_64-portable.7z",
+                "extract_dir": "xl-converter-win-$version-x86_64-portable"
             }
         }
     }


### PR DESCRIPTION
Since v1.1.0 ( <https://github.com/JacobDev1/xl-converter/releases/tag/v1.1.0> ) XL Converter now:

* Has a portable .7z version, so we don't have to use the Inno .exe installer.
* Does not require VCRedist anymore, so we can remove `"depends": "extras/vcredist2022"`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
