### PR TITLE
pysolfc: Add version 3.1.0

### DIFF
--- a/bucket/pysolfc.json
+++ b/bucket/pysolfc.json
@@ -1,0 +1,26 @@
+{
+    "version": "3.1.0",
+    "description": "A collection of more than 1000 solitaire card games",
+    "homepage": "https://pysolfc.sourceforge.io/",
+    "license": "GPL-3.0",
+    "notes": "",
+    "url": "https://downloads.sourceforge.net/project/pysolfc/files/PySolFC/PySolFC-3.1.0/PySolFC_3.1.0_setup_full.exe",
+    "hash": "sha1:05c0c3489b75b99ec9e2fb35253dcb32f392e4bf",
+    "innosetup": true,
+    "post_install": "if (-not (Test-Path -Path $persist_dir\\config)) { New-Item -Path $dir\\config -ItemType Directory }",
+    "bin": "pysol.exe",
+    "shortcuts": [
+        [
+            "pysol.exe",
+            "PySol Fan Club Edition"
+        ]
+    ],
+    "persist": "config",
+    "checkver": {
+        "github": "https://github.com/shlomif/PySolFC",
+        "regex": "pysolfc-([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/pysolfc/files/PySolFC/PySolFC-$version/PySolFC_$version_setup_full.exe"
+    }
+}


### PR DESCRIPTION
From capella-bucket,
Closes #14608

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
