### PR TITLE
kmeans-colors: Add version 0.6.0

### DIFF
--- a/bucket/kmeans-colors.json
+++ b/bucket/kmeans-colors.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.6.0",
+    "description": "k-means clustering library and binary to find dominant colors in images",
+    "homepage": "https://github.com/okaneco/kmeans-colors",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/okaneco/kmeans-colors/releases/download/0.6.0-binary/kmeans_colors-0.6.0-binary-windows-x86_64.tar.gz",
+            "hash": "0d9060a8af1ebe19812618760b8e9f1f7907d925e523085b1a68d0ba9bcaa270"
+        }
+    },
+    "bin": "kmeans_colors.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/okaneco/kmeans-colors/releases/download/$version-binary/kmeans_colors-$version-binary-windows-x86_64.tar.gz",
+                "hash": {
+                    "url": "https://github.com/okaneco/kmeans-colors/releases/download/$version-binary/kmeans_colors-$version-binary-windows-x86_64.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/kmeans-colors.json
+++ b/bucket/kmeans-colors.json
@@ -16,7 +16,7 @@
             "64bit": {
                 "url": "https://github.com/okaneco/kmeans-colors/releases/download/$version-binary/kmeans_colors-$version-binary-windows-x86_64.tar.gz",
                 "hash": {
-                    "url": "https://github.com/okaneco/kmeans-colors/releases/download/$version-binary/kmeans_colors-$version-binary-windows-x86_64.sha256"
+                    "url": "$baseurl/kmeans_colors-$version-binary-windows-x86_64.sha256"
                 }
             }
         }

--- a/bucket/kmeans-colors.json
+++ b/bucket/kmeans-colors.json
@@ -2,7 +2,7 @@
     "version": "0.6.0",
     "description": "k-means clustering library and binary to find dominant colors in images",
     "homepage": "https://github.com/okaneco/kmeans-colors",
-    "license": "MIT",
+    "license": "Apache-2.0|MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/okaneco/kmeans-colors/releases/download/0.6.0-binary/kmeans_colors-0.6.0-binary-windows-x86_64.tar.gz",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14623

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

It says on the `README.md` that the crate is licensed under either MIT or Apache. How can I reflect this fact on the manifest? Currently I used only "MIT" for the field.