### PR TITLE
SysInternals: Fix Manifest

### DIFF
--- a/bucket/sysinternals.json
+++ b/bucket/sysinternals.json
@@ -1,5 +1,5 @@
 {
-    "version": "2024.7.23",
+    "version": "20241216",
     "description": "A set of utilities to manage, diagnose, troubleshoot, and monitor a Windows environment.",
     "homepage": "https://docs.microsoft.com/en-us/sysinternals/",
     "license": {
@@ -10,15 +10,17 @@
     "hash": "c6c6fc3a965a8e4bc0943ee4586cce86789913ddd25e808bfb61426776253863",
     "checkver": {
         "script": [
-            "$resp = Invoke-WebRequest 'https://techcommunity.microsoft.com/plugins/custom/microsoft/o365/custom-blog-rss?board=Sysinternals-Blog'",
-            "$resp.Content -match '(\\d{1,2}) (\\w{3}) (\\d{4})'",
-            "$year = $Matches[3]; $month = $Matches[2]; $day = $Matches[1] ",
-            "$months = @{'Jan'='1';'Feb'='2';'Mar'='3';'Apr'='4';'May'='5';'Jun'='6';'Jul'='7';'Aug'='8';'Sep'='9';'Oct'='10';'Nov'='11';'Dec'='12'}",
-            "$month = $months.$month",
-            "Write-Output $year $month $day"
+            "try {",
+            "    $resp = Invoke-WebRequest 'https://raw.githubusercontent.com/MicrosoftDocs/sysinternals/main/sysinternals/downloads/sysinternals-suite.md'",
+            "    # scrape information from a line like 'ms.date: 12/16/2024'",
+            "    $lines = $resp.Content.Split([Environment]::NewLine)",
+            "    $lines | Select-String -Pattern 'ms.date: (?<month>\\d+)/(?<day>\\d+)/(?<year>\\d+)' | Write-Output",
+            "} catch {",
+            "    throw $_.Exception",
+            "}"
         ],
-        "regex": "(\\d+) (\\d+) (\\d+)",
-        "replace": "${1}.${2}.${3}"
+        "regex": "ms.date: (?<month>\\d+)/(?<day>\\d+)/(?<year>\\d+)",
+        "replace": "${year}${month}${day}"
     },
     "autoupdate": {
         "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip"
@@ -63,7 +65,6 @@
                 ],
                 "Contig64.exe",
                 "Coreinfo.exe",
-                "ctrl2cap.exe",
                 "Dbgview.exe",
                 "Desktops.exe",
                 [
@@ -431,7 +432,6 @@
                 "Clockres.exe",
                 "Contig.exe",
                 "Coreinfo.exe",
-                "ctrl2cap.exe",
                 "Dbgview.exe",
                 "Desktops.exe",
                 "disk2vhd.exe",


### PR DESCRIPTION
- fix Scoop manifest
  - checkver script, regex, replace
  - {64bit,32bit} bin, removed ctrl2cap.exe which is no longer part of the suite

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14593

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

# Reasoning

The URL used in the "checkver" no longer works and in fact produces a 404 response; so the assumed version '2024.7.23' (in the manifest stays fixed till eternity) is stale - unfortunately the existing checkver script does not care to check for any errors:

Furthermore the utility "ctrl2cap.exe" is no longer part of the suite.
        

# Changes
- checkver old ; the URL no longer works (I imagine for quite some time); now the only reason why installation fails is that "ctrl2cap.exe" is no longer part of the suite and installation fails upon shim creation

OLD: 
https://github.com/ScoopInstaller/Extras/blob/0a413e614e6387b350791850b32c53fa613a73d7/bucket/sysinternals.json#L11-L22

- changed the URL, use a new one that retrieves an md file that conveys version information
- changed checkver script to bail out on response errors
- simplified scraping of the version information
- {64bit,32bit} bin, removed ctrl2cap.exe which is no longer part of the suite


