### PR TITLE
beaver-notes@3.7.0: Fix hash extraction on autoupdate

### DIFF
--- a/bucket/beaver-notes.json
+++ b/bucket/beaver-notes.json
@@ -44,15 +44,19 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes.$version.portable.exe#/dl.7z"
+                "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes.$version.portable.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/$version",
+                    "regex": "$version.portable.exe.+?\\n.+?($sha256)"
+                }
             },
             "arm64": {
-                "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes.$version.portable.arm64.exe#/dl.7z"
+                "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes.$version.portable.arm64.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/$version",
+                    "regex": "$version.portable.arm64.exe.+?\\n.+?($sha256)"
+                }
             }
-        },
-        "hash": {
-            "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/$version",
-            "regex": "$sha256.*?$basename"
         }
     }
 }


### PR DESCRIPTION
Hash extraction on autoupdate broke when author changed formatting of the SHA256 checksums in the GitHub release info.

* Last working version 3.6.0: <https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/3.6.0>
* Broke on current version 3.7.0: <https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/3.7.0>

Could not use `$baseName` because filename of artifact vs. in the list of SHA256 checksums does not match, ref:

* <https://github.com/Beaver-Notes/Beaver-Notes/issues/268>

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
