### PR TITLE
stirling-pdf@0.36.5: not an executable program

### DIFF
--- a/bucket/stirling-pdf.json
+++ b/bucket/stirling-pdf.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.36.5",
-    "description": "#1 Locally hosted web application that allows you to perform various operations on PDF files",
+    "version": "0.36.4",
+    "description": "locally hosted web application that allows you to perform various operations on PDF files",
     "homepage": "https://github.com/Stirling-Tools/Stirling-PDF/",
     "license": {
         "identifier": "GPL-3.0-or-later",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v0.36.5/Stirling-PDF-win-installer.exe",
-            "hash": "2a1dda62ce0806c262b107fa61ee95d0ac05fcd0ea582a104b7b762d243b5f60"
+            "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v0.36.4/Stirling-PDF.exe",
+            "hash": "172f7ac36a4d7efd240bc290543eb2e4a44677966b014d0189b85c945acf5e0c"
         }
     },
     "shortcuts": [
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v$version/Stirling-PDF-win-installer.exe"
+                "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v$version/Stirling-PDF.exe"
             }
         }
     }


### PR DESCRIPTION
The newest version(0.36.5) of stirling-pdf is an installer instead of an executable program. So I rollback to version of 0.36.4

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
