### PR TITLE
Update googlechrome.json

### DIFF
--- a/bucket/googlechrome.json
+++ b/bucket/googlechrome.json
@@ -17,7 +17,12 @@
         }
     },
     "installer": {
-        "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+        "script": [
+            "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal",
+            "if (!(Test-Path \"$Env:USERPROFILE\\AppData\\Local\\Google\\Chrome\\User Data\")) {",
+            "    New-Item -Type SymbolicLink -Path \"$Env:USERPROFILE\\AppData\\Local\\Google\\Chrome\\User Data\" -Target \"$Env:USERPROFILE\\scoop\\persist\\googlechrome\\User Data\"",
+            "}"
+        ]
     },
     "bin": [
         [


### PR DESCRIPTION
Added a symbolic link to the User Data directory at "%LOCALAPPDATA%/Google/Chrome/User Data"

Relates to #11058 

This will check whether there's a symlink in the `~/AppData/Local/Google/Chrome`, and links it to the `scoop/persist/googlechrome/User Data` if not.

This will make chrome use the correct `User Data` directory when opening links from other apps (like windows terminal or vscode).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
