### PR TITLE
capframex@1.7.4: Update download & autoupdate urls

### DIFF
--- a/bucket/capframex.json
+++ b/bucket/capframex.json
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CXWorld/CapFrameX/releases/download/v1.7.4/release_1.7.4_portable.zip",
-            "hash": "e0580075628a5c39f71e4b3c57523819b70f2796586de35f00342b5d622e786c"
+            "url": "https://github.com/CXWorld/CapFrameX/releases/download/v1.7.4_release/release_1.7.4_portable.zip",
+            "hash": "bcda7067baf42272803a1bf3d5c4c54b869dbc5d9e9f5a49afa4f15c19e62ede"
         }
     },
     "bin": "CapFrameX.exe",
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CXWorld/CapFrameX/releases/download/v$version/release_$version_portable.zip"
+                "url": "https://github.com/CXWorld/CapFrameX/releases/download/v$version_release/release_$version_portable.zip"
             }
         }
     }


### PR DESCRIPTION
The version naming style changes from $version to $version_release.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14664

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
