### PR TITLE
cherry-studio: Add version 0.9.24

### DIFF
--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.19",
+    "version": "0.9.21",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.19-setup.exe",
-            "hash": "4ee976fd292b2decd8cf2888ae63325a47ac459eadaf193a50c1873a85ccab20"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.21-setup.exe",
+            "hash": "d2aa33c9cf6f56c2a56dfd7b3dd8f72cf573110264c9e2a91a9bd6881ed5cf5d"
         }
     },
     "installer": {

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.24",
+    "version": "0.9.27",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.24-setup.exe",
-            "hash": "ed1daba71c86dbda39002ba4a80103671ca7ce3f0b314afb7c431776e77b1d36"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.27-setup.exe",
+            "hash": "f25f929ef970b61223dfcb0d83eb689c703584cbdc0d7eed4a7fa539b3964e38"
         }
     },
     "installer": {

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.21",
+    "version": "0.9.24",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.21-setup.exe",
-            "hash": "d2aa33c9cf6f56c2a56dfd7b3dd8f72cf573110264c9e2a91a9bd6881ed5cf5d"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.24-setup.exe",
+            "hash": "ed1daba71c86dbda39002ba4a80103671ca7ce3f0b314afb7c431776e77b1d36"
         }
     },
     "installer": {
@@ -20,7 +20,6 @@
             "$appDataPath = \"$env:APPDATA\\CherryStudio\"",
             "$persistPath = \"$persist_dir\\CherryStudio\"",
             "if (Test-Path $appDataPath) {",
-            "    Copy-Item \"$appDataPath\\*\" -Destination $persistPath -Recurse -Force",
             "    Remove-Item $appDataPath -Recurse -Force",
             "}",
             "New-Item -ItemType Junction -Path \"$appDataPath\" -Target \"$persistPath\""

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,52 +1,48 @@
 {
-    "version": "0.9.27",
-    "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
-    "homepage": "https://cherry-ai.com/",
-    "license": {
-        "identifier": "Apache-2.0",
-        "url": "https://github.com/CherryHQ/cherry-studio/raw/refs/heads/main/LICENSE"
-    },
+    "version": "1.0.1",
+    "description": "A desktop client that supports for multiple LLM providers.",
+    "homepage": "https://cherry-ai.com",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.27-setup.exe",
-            "hash": "f25f929ef970b61223dfcb0d83eb689c703584cbdc0d7eed4a7fa539b3964e38"
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v1.0.1/Cherry-Studio-1.0.1-setup.exe#/dl.7z",
+            "hash": "sha512:0e603498946996fce945e5bd4e6cf9d7475589b6aaea033acc3d76d03d26fbca0475263ab8a774c52cccd94f83c0ab6a14128950002ade6867ae7d91b37e3406",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Unintall*\" -Recurse"
+            ]
         }
     },
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\Cherry-Studio-$version-setup.exe\" \"$dir\\temp\\\" -Removal",
-            "Expand-7zipArchive \"$dir\\temp\\`$PLUGINSDIR\\app-64.7z\" \"$dir\\\" -Removal",
-            "Remove-Item \"$dir\\temp\" -Recurse",
-            "$appDataPath = \"$env:APPDATA\\CherryStudio\"",
-            "$persistPath = \"$persist_dir\\CherryStudio\"",
-            "if (Test-Path $appDataPath) {",
-            "    Remove-Item $appDataPath -Recurse -Force",
-            "}",
-            "New-Item -ItemType Junction -Path \"$appDataPath\" -Target \"$persistPath\""
-        ]
-    },
-    "notes": "You'd better turn off update detection in Settings->About Us in Cherry Studio and use scoop to manage updates, otherwise it will cause some errors.",
     "shortcuts": [
         [
             "Cherry Studio.exe",
             "Cherry Studio"
         ]
     ],
-    "persist": "CherryStudio",
-    "uninstaller": {
-        "script": [
-            "if (Test-Path \"$env:LOCALAPPDATA\\cherrystudio-updater\" -PathType Container) {",
-            "    Remove-Item -Recurse -Force \"$env:LOCALAPPDATA\\cherrystudio-updater\"",
-            "}"
-        ]
-    },
+    "post_install": [
+        "if (Test-Path \"$persist_dir\\data\\*\") {",
+        "    New-Item \"$Env:AppData\\CherryStudio\" -ItemType Directory -Force | Out-Null",
+        "    Copy-Item \"$persist_dir\\data\\*\" \"$Env:AppData\\CherryStudio\" -Recurse",
+        "}"
+    ],
+    "pre_uninstall": [
+        "if (Test-Path \"$Env:AppData\\CherryStudio\\*\") {",
+        "    Remove-Item \"$persist_dir\\data\" -Recurse -Force",
+        "    Move-Item \"$Env:AppData\\CherryStudio\" \"$persist_dir\\data\" -Force",
+        "}"
+    ],
+    "persist": "data",
     "checkver": {
         "github": "https://github.com/CherryHQ/cherry-studio"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cherrystudio.ocool.online/Cherry-Studio-$version-setup.exe"
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-setup.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512: $base64"
+                }
             }
         }
     }

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.17",
+    "version": "0.9.19",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.17-setup.exe",
-            "hash": "bf8203074c56c36342206f44828f1ed3f8304bd20b173e72578b776b978765d8"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.19-setup.exe",
+            "hash": "4ee976fd292b2decd8cf2888ae63325a47ac459eadaf193a50c1873a85ccab20"
         }
     },
     "installer": {

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.4",
+    "version": "0.9.6",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.4-setup.exe",
-            "hash": "7949c26c8746a05105714591fab629790bde36cb4a517e0779f9f964350eddb2"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.6-setup.exe",
+            "hash": "e6bf28259c83f9aa35ddbf04f564472d955136632692a1ddc2f5623dcd3722bc"
         }
     },
     "installer": {

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.6",
+    "version": "0.9.10",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.6-setup.exe",
-            "hash": "e6bf28259c83f9aa35ddbf04f564472d955136632692a1ddc2f5623dcd3722bc"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.10-setup.exe",
+            "hash": "073512369638739f48030393ec1e23c7577cb7ea967e15041e7cdb9315d98422"
         }
     },
     "installer": {
@@ -36,9 +36,6 @@
     "persist": "CherryStudio",
     "uninstaller": {
         "script": [
-            "if (Test-Path \"$env:APPDATA\\CherryStudio\" -PathType Any) {",
-            "    Remove-Item -Recurse -Force \"$env:APPDATA\\CherryStudio\"",
-            "}",
             "if (Test-Path \"$env:LOCALAPPDATA\\cherrystudio-updater\" -PathType Container) {",
             "    Remove-Item -Recurse -Force \"$env:LOCALAPPDATA\\cherrystudio-updater\"",
             "}"

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,20 +1,17 @@
 {
-    "version": "0.9.3",
+    "version": "0.9.4",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
-
     "license": {
         "identifier": "Apache-2.0",
         "url": "https://github.com/CherryHQ/cherry-studio/raw/refs/heads/main/LICENSE"
     },
-
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v0.9.3/Cherry-Studio-0.9.3-setup.exe",
-            "hash": "BA693FCE05D9E220139D417FD0B3EFE527461D16398FDE39AC5263564D88114E"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.4-setup.exe",
+            "hash": "7949c26c8746a05105714591fab629790bde36cb4a517e0779f9f964350eddb2"
         }
     },
-
     "installer": {
         "script": [
             "Expand-7zipArchive \"$dir\\Cherry-Studio-$version-setup.exe\" \"$dir\\temp\\\" -Removal",
@@ -29,16 +26,14 @@
             "New-Item -ItemType Junction -Path \"$appDataPath\" -Target \"$persistPath\""
         ]
     },
-
+    "notes": "You'd better turn off update detection in Settings->About Us in Cherry Studio and use scoop to manage updates, otherwise it will cause some errors.",
     "shortcuts": [
         [
             "Cherry Studio.exe",
             "Cherry Studio"
         ]
     ],
-
     "persist": "CherryStudio",
-
     "uninstaller": {
         "script": [
             "if (Test-Path \"$env:APPDATA\\CherryStudio\" -PathType Any) {",
@@ -49,15 +44,13 @@
             "}"
         ]
     },
-
     "checkver": {
         "github": "https://github.com/CherryHQ/cherry-studio"
     },
-
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-setup.exe"
+                "url": "https://cherrystudio.ocool.online/Cherry-Studio-$version-setup.exe"
             }
         }
     }

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,0 +1,64 @@
+{
+    "version": "0.9.3",
+    "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
+    "homepage": "https://cherry-ai.com/",
+
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://github.com/CherryHQ/cherry-studio/raw/refs/heads/main/LICENSE"
+    },
+
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v0.9.3/Cherry-Studio-0.9.3-setup.exe",
+            "hash": "BA693FCE05D9E220139D417FD0B3EFE527461D16398FDE39AC5263564D88114E"
+        }
+    },
+
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\Cherry-Studio-$version-setup.exe\" \"$dir\\temp\\\" -Removal",
+            "Expand-7zipArchive \"$dir\\temp\\`$PLUGINSDIR\\app-64.7z\" \"$dir\\\" -Removal",
+            "Remove-Item \"$dir\\temp\" -Recurse",
+            "$appDataPath = \"$env:APPDATA\\CherryStudio\"",
+            "$persistPath = \"$persist_dir\\CherryStudio\"",
+            "if (Test-Path $appDataPath) {",
+            "    Copy-Item \"$appDataPath\\*\" -Destination $persistPath -Recurse -Force",
+            "    Remove-Item $appDataPath -Recurse -Force",
+            "}",
+            "New-Item -ItemType Junction -Path \"$appDataPath\" -Target \"$persistPath\""
+        ]
+    },
+
+    "shortcuts": [
+        [
+            "Cherry Studio.exe",
+            "Cherry Studio"
+        ]
+    ],
+
+    "persist": "CherryStudio",
+
+    "uninstaller": {
+        "script": [
+            "if (Test-Path \"$env:APPDATA\\CherryStudio\" -PathType Any) {",
+            "    Remove-Item -Recurse -Force \"$env:APPDATA\\CherryStudio\"",
+            "}",
+            "if (Test-Path \"$env:LOCALAPPDATA\\cherrystudio-updater\" -PathType Container) {",
+            "    Remove-Item -Recurse -Force \"$env:LOCALAPPDATA\\cherrystudio-updater\"",
+            "}"
+        ]
+    },
+
+    "checkver": {
+        "github": "https://github.com/CherryHQ/cherry-studio"
+    },
+
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-setup.exe"
+            }
+        }
+    }
+}

--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.10",
+    "version": "0.9.17",
     "description": "🍒 Cherry Studio is a desktop client that supports for multiple LLM providers",
     "homepage": "https://cherry-ai.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.10-setup.exe",
-            "hash": "073512369638739f48030393ec1e23c7577cb7ea967e15041e7cdb9315d98422"
+            "url": "https://cherrystudio.ocool.online/Cherry-Studio-0.9.17-setup.exe",
+            "hash": "bf8203074c56c36342206f44828f1ed3f8304bd20b173e72578b776b978765d8"
         }
     },
     "installer": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
Cherry Studio has 3.4k+ stars: https://github.com/CherryHQ/cherry-studio 

Note: cherry-studio has a standard installer but it stores user data in AppData. For portable processment, I use the (un)installer script and it might seems a little bit elaborate.