### PR TITLE
twinkle-tray: Fix pre_install script

### DIFF
--- a/bucket/twinkle-tray.json
+++ b/bucket/twinkle-tray.json
@@ -9,7 +9,7 @@
             "hash": "faa51d75927d9b3bb395bfa0214681ad4a85113ac25f01a1dd8759f659d83e71",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall Twinkle Tray.exe\" -Recurse -Force"
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall Twinkle Tray.exe\" -Recurse -Force -ErrorAction SilentlyContinue"
             ]
         }
     },

--- a/bucket/twinkle-tray.json
+++ b/bucket/twinkle-tray.json
@@ -1,15 +1,18 @@
 {
     "version": "1.17.0",
-    "description": "A monitor brightness controller based on DDC/CI",
-    "homepage": "https://github.com/xanderfrangos/twinkle-tray",
-    "license": "MIT",
+    "description": "Easily manage the brightness of your monitors in Windows from the system tray",
+    "homepage": "https://twinkletray.com/",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/xanderfrangos/twinkle-tray/blob/master/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/xanderfrangos/twinkle-tray/releases/download/v1.17.0/Twinkle.Tray.v1.17.0.exe#/dl.7z",
             "hash": "faa51d75927d9b3bb395bfa0214681ad4a85113ac25f01a1dd8759f659d83e71",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall Twinkle Tray.exe\" -Recurse -Force"
             ]
         }
     },
@@ -25,7 +28,9 @@
             "Twinkle Tray"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/xanderfrangos/twinkle-tray"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/twinkle-tray.json
+++ b/bucket/twinkle-tray.json
@@ -2,10 +2,7 @@
     "version": "1.17.0",
     "description": "Easily manage the brightness of your monitors in Windows from the system tray",
     "homepage": "https://twinkletray.com/",
-    "license": {
-        "identifier": "MIT",
-        "url": "https://github.com/xanderfrangos/twinkle-tray/blob/master/LICENSE"
-    },
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/xanderfrangos/twinkle-tray/releases/download/v1.17.0/Twinkle.Tray.v1.17.0.exe#/dl.7z",


### PR DESCRIPTION
Closes #14685

This PR does the following:
- Updates description to match upstream
- Changes homepage to project homepage
- Adds the license url
- Updates `pre_install` script to fix previously failing 'Remove-Item' command

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved 64-bit install cleanup to remove a stray uninstaller for cleaner installs.

- Chores
  - Updated app description and pointed homepage to the official site.
  - Switched update checking to GitHub for more reliable version detection.
  - Confirmed license remains MIT.

- New Features
  - Added a packaged launch entry and a user-visible shortcut for easier app access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->