### PR TITLE
totalcommander: add version 11.50 and fix autoupdate links

### DIFF
--- a/bucket/totalcommander.json
+++ b/bucket/totalcommander.json
@@ -1,12 +1,12 @@
 {
-    "version": "11.03",
+    "version": "11.50",
     "description": "Total Commander is a Shareware file manager for Windows® 95/98/ME/NT/2000/XP/Vista/7/8/8.1/10, and Windows® 3.1.",
     "homepage": "https://www.ghisler.com",
     "license": "Shareware",
     "architecture": {
         "64bit": {
-            "url": "http://totalcommander.ch/win/tcmd1103x64.exe",
-            "hash": "d1b9e3a7e548eedbbe122287b8589f1eb42023f77e8f7d6856dc1644f038f617",
+            "url": "http://totalcommander.ch/1150/tcmd1150x64.exe",
+            "hash": "ef42b01256d7f0cc08177681e5bdf02d713613fa45a485c88a4cbdf34c1554d0",
             "bin": "TOTALCMD64.EXE",
             "shortcuts": [
                 [
@@ -16,8 +16,8 @@
             ]
         },
         "32bit": {
-            "url": "http://totalcommander.ch/win/tcmd1103x32.exe",
-            "hash": "a0195db6e709d0cae2dd1c546237fe15fdfd1f3c7094b9640449fb9021473979",
+            "url": "http://totalcommander.ch/1150/tcmd1150x32.exe",
+            "hash": "d74453979f1a0b13fa6eee183fc59ed0f0bf0084b41f082143221f3ca9300955",
             "bin": "TOTALCMD.EXE",
             "shortcuts": [
                 [
@@ -57,10 +57,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://totalcommander.ch/win/tcmd$cleanVersionx64.exe"
+                "url": "http://totalcommander.ch/$cleanVersion/tcmd$cleanVersionx64.exe"
             },
             "32bit": {
-                "url": "http://totalcommander.ch/win/tcmd$cleanVersionx32.exe"
+                "url": "http://totalcommander.ch/$cleanVersion/tcmd$cleanVersionx32.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

**TotalCommander** *x86* and *x64* executables are stored in versioned subfolders matching the `$cleanVersion` *checkver* variable, instead of *win* folder:
https://totalcommander.ch/1150/tcmd1150x64.exe
https://totalcommander.ch/1150/tcmd1150x86.exe
vs
http://totalcommander.ch/win/tcmd1150x64.exe
http://totalcommander.ch/win/tcmd1150x86.exe

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
