### PR TITLE
v2rayn: Create SymbolicLink in pre_install step of v2rayn

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -26,8 +26,8 @@
         "    foreach ($_ in Get-ChildItem \"$(appdir xray $global)\\current\" -File) {",
         "        $name = $_.Name",
         "        if ($name -Like $form) {",
-        "            Write-Host \"Creating hardlink for $name\"",
-        "            New-Item -ItemType HardLink -Path \"$dir\\bin\\Xray\" -Name $name -Target \"$(appdir xray $global)\\current\\$name\" | Out-Null",
+        "            Write-Host \"Creating SymbolicLink for $name\"",
+        "            New-Item -ItemType SymbolicLink -Path \"$dir\\bin\\Xray\" -Name $name -Target \"$(appdir xray $global)\\current\\$name\" | Out-Null",
         "        }",
         "    }",
         "}"


### PR DESCRIPTION
This pull request is not related to any issue as I have fixed it directly.

In the previous script, the pre_install step creates a hard link to xray in scoop, which will cause the software to not automatically update its dependencies when xray is updated by scoop. 

Changing the operation of creating a hard link to creating a symbolic link can solve this problem.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
