### PR TITLE
beaver-notes@3.8.0: Fix checkver + hash extraction + installer logic

### DIFF
--- a/bucket/beaver-notes.json
+++ b/bucket/beaver-notes.json
@@ -1,23 +1,18 @@
 {
     "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-    "version": "3.7.0",
+    "version": "3.8.0",
     "description": "A privacy-focused note-taking application",
     "homepage": "https://beavernotes.com/",
     "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/3.7.0/Beaver-notes.3.7.0.portable.exe#/dl.7z",
-            "hash": "dfc1b8576512f9f13527a62073f6c59cada548b105c3061ff2684c6337b40c8f"
-        },
-        "arm64": {
-            "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/3.7.0/Beaver-notes.3.7.0.portable.arm64.exe#/dl.7z",
-            "hash": "832e161da398f7bd61e1fd7baed683ff19ad169aee679cff07dfae2af3fb28e9"
-        }
-    },
+    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/3.8.0/Beaver-notes-3.8.0-portable.exe#/dl.7z",
+    "hash": "64b52605d04cfd3a8888fd4b1f12175e88fc9046450fa7fa171d366906ee412b",
     "pre_install": [
-        "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app*.7z\" -DestinationPath \"$dir\"",
-        "$ScriptBlock = [scriptblock]{Remove-Item -Path \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse}",
-        "Try {$ScriptBlock.Invoke()} Catch {Start-Sleep -Milliseconds 50; $ScriptBlock.Invoke()}"
+        "if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') {",
+        "    Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" -DestinationPath \"$dir\"",
+        "}",
+        "else {",
+        "    Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\"",
+        "}"
     ],
     "shortcuts": [
         [
@@ -42,21 +37,9 @@
         "github": "https://github.com/Beaver-Notes/Beaver-Notes"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes.$version.portable.exe#/dl.7z",
-                "hash": {
-                    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/$version",
-                    "regex": "$version.portable.exe.+?\\n.+?($sha256)"
-                }
-            },
-            "arm64": {
-                "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes.$version.portable.arm64.exe#/dl.7z",
-                "hash": {
-                    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/$version",
-                    "regex": "$version.portable.arm64.exe.+?\\n.+?($sha256)"
-                }
-            }
+        "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/$version/Beaver-notes-$version-portable.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/checksums.sha256"
         }
     }
 }

--- a/bucket/beaver-notes.json
+++ b/bucket/beaver-notes.json
@@ -12,7 +12,9 @@
         "}",
         "else {",
         "    Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\"",
-        "}"
+        "}",
+        "$ScriptBlock = [scriptblock]{Remove-Item -Path \"$dir\\`$PLUGINSDIR\" -Force -Recurse}",
+        "Try {$ScriptBlock.Invoke()} Catch {Start-Sleep -Milliseconds 50; $ScriptBlock.Invoke()}"
     ],
     "shortcuts": [
         [
@@ -20,7 +22,6 @@
             "Beaver Notes"
         ]
     ],
-    "persist": "data",
     "post_uninstall": [
         "if ($purge) {",
         "    $Directories = [string[]](",

--- a/bucket/beaver-notes.json
+++ b/bucket/beaver-notes.json
@@ -4,15 +4,17 @@
     "description": "A privacy-focused note-taking application",
     "homepage": "https://beavernotes.com/",
     "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "pre_install": "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\""
+        },
+        "arm64": {
+            "pre_install": "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" -DestinationPath \"$dir\""
+        }
+    },
     "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/3.8.0/Beaver-notes-3.8.0-portable.exe#/dl.7z",
     "hash": "64b52605d04cfd3a8888fd4b1f12175e88fc9046450fa7fa171d366906ee412b",
-    "pre_install": [
-        "if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') {",
-        "    Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" -DestinationPath \"$dir\"",
-        "}",
-        "else {",
-        "    Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\"",
-        "}",
+    "post_install": [
         "$ScriptBlock = [scriptblock]{Remove-Item -Path \"$dir\\`$PLUGINSDIR\" -Force -Recurse}",
         "Try {$ScriptBlock.Invoke()} Catch {Start-Sleep -Milliseconds 50; $ScriptBlock.Invoke()}"
     ],


### PR DESCRIPTION
New changes from Beaver Notes v3.7.0 -> v3.8.0:

* ARM64 and X64 are now in the same `.exe` file.
    ![image](https://github.com/user-attachments/assets/5fd3e9c0-c938-49c3-b071-4896f8b97772)
* Checksum is now in a dedicated `checksums.sha256` file in GitHub releases.

I also noticed the persisted `data` directory was not in use.

And making a shortcut with `--user-data-dir="$dir\data"` seemed to work, but Beaver Notes would give an error message each time it launched.

Ref:

* <https://github.com/Beaver-Notes/Beaver-Notes/issues/268>
* <https://github.com/Beaver-Notes/Beaver-Notes/issues/271>
* <https://github.com/Beaver-Notes/Beaver-Notes/issues/273>

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
