### PR TITLE
podman-desktop: Add data/config persist

### DIFF
--- a/bucket/podman-desktop.json
+++ b/bucket/podman-desktop.json
@@ -13,8 +13,8 @@
             ],
             "post_install": [
                 "if ((Test-Path \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\") -and !(Test-Path \"$dir\\config\\*\")) {",
-                "    info '[Persist Data]: Copying data from default data directory to scoop persist directory . . .'",
-                "    Copy-Item \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\" \"$dir\\config\" -Recurse",
+                "    info '[Persist Data]: Moving data from default data directory to scoop persist directory . . .'",
+                "    Move-Item \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\" \"$dir\\config\" -Recurse",
                 "}"
             ],
             "env_set": {

--- a/bucket/podman-desktop.json
+++ b/bucket/podman-desktop.json
@@ -11,6 +11,15 @@
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse"
             ],
+            "post_install": [
+                "if ((Test-Path \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\") -and !(Test-Path \"$dir\\config\\*\")) {",
+                "    info '[Persist Data]: Copying data from default data directory to scoop persist directory . . .'",
+                "    Copy-Item \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\" \"$dir\\config\" -Recurse",
+                "}"
+            ],
+            "env_set": {
+                "PODMAN_DESKTOP_HOME_DIR": "$dir\\config"
+            },
             "shortcuts": [
                 [
                     "Podman Desktop.exe",
@@ -19,6 +28,7 @@
             ]
         }
     },
+    "persist": "config",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/podman-desktop.json
+++ b/bucket/podman-desktop.json
@@ -14,7 +14,7 @@
             "post_install": [
                 "if ((Test-Path \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\") -and !(Test-Path \"$dir\\config\\*\")) {",
                 "    info '[Persist Data]: Moving data from default data directory to scoop persist directory . . .'",
-                "    Move-Item \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\" \"$dir\\config\" -Recurse",
+                "    Move-Item \"$Env:UserProfile\\.local\\share\\containers\\podman-desktop\\*\" \"$dir\\config\" -ErrorAction Ignore",
                 "}"
             ],
             "env_set": {


### PR DESCRIPTION
Add the ability to preserve and purge data/config for Podman Desktop.

This PR also covered the migration process.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
