### PR TITLE
lightbulb: Correct license

### DIFF
--- a/bucket/lightbulb.json
+++ b/bucket/lightbulb.json
@@ -2,7 +2,7 @@
     "version": "2.6",
     "description": "Computer screen gamma adjuster based on the current time",
     "homepage": "https://github.com/Tyrrrz/LightBulb",
-    "license": "GPL-3.0-or-later",
+    "license": "MIT",
     "suggest": {
         ".NET Desktop Runtime": "extras/windowsdesktop-runtime"
     },


### PR DESCRIPTION
Hi, I've just noticed that the license field for `lightbulb` is wrong. There was a [license change](https://github.com/Tyrrrz/LightBulb/commit/a8b9582b1cb8d706bf8a619442fb8de86ef5961e) from GPL to MIT. This PR updates the info in the bucket.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)