### PR TITLE
stirling-pdf: Use JAR to launch app

### DIFF
--- a/bucket/stirling-pdf.json
+++ b/bucket/stirling-pdf.json
@@ -1,33 +1,34 @@
 {
     "version": "0.39.0",
     "description": "#1 Locally hosted web application that allows you to perform various operations on PDF files",
-    "homepage": "https://github.com/Stirling-Tools/Stirling-PDF/",
-    "license": {
-        "identifier": "GPL-3.0-or-later",
-        "url": "https://github.com/Stirling-Tools/Stirling-PDF/blob/main/LICENSE"
+    "homepage": "https://stirlingpdf.com",
+    "license": "MIT",
+    "suggest": {
+        "Python": "python",
+        "QPDF": "qpdf",
+        "LibreOffice": "extras/libreoffice",
+        "Tesseract OCR": "tesseract",
+        "Weasyprint": "weasyprint"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v0.39.0/Stirling-PDF-win-installer.exe",
-            "hash": "a8b3a2f54d7a0011b3e7de9e8cbe29c0358405d6014bd6180249792bfd428c43"
+            "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v0.39.0/Stirling-PDF.jar",
+            "hash": "f7736a56a0ca394fb33a15fb7d5b0363ecf490f59c77e821258ad7a82c2fcb6d"
         }
     },
-    "shortcuts": [
-        [
-            "Stirling-PDF.exe",
-            "Stirling-PDF"
-        ]
-    ],
+    "bin": "Stirling-PDF.jar",
     "persist": [
         "configs",
         "customFiles",
         "logs"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/Stirling-Tools/Stirling-PDF"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v$version/Stirling-PDF-win-installer.exe"
+                "url": "https://github.com/Stirling-Tools/Stirling-PDF/releases/download/v$version/Stirling-PDF.jar"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Using JAR file to launch Stirling-PDF

- Closes https://github.com/ScoopInstaller/Extras/issues/14662


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
