### PR TITLE
github@3.4.15: Switch to GH release artifacts

### DIFF
--- a/bucket/github.json
+++ b/bucket/github.json
@@ -5,16 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://central.github.com/deployments/desktop/desktop/latest/win32#/dl.7z_",
-            "hash": "c15bbdcc4b781c264d82d57a26d54ab5a3958259cebe0766758794389f3cac0d"
+            "url": "https://github.com/desktop/desktop/releases/download/release-3.4.15/GitHubDesktop-3.4.15-x64-full.nupkg",
+            "hash": "ad135720b46ee594ef89b51342c4a51cc8d200a5f424753836b9a49e4456b586"
         }
     },
-    "pre_install": [
-        "Expand-7zipArchive \"$dir\\$fname\" \"$dir\\extract\"",
-        "Get-Item \"$dir\\extract\\GitHubDesktop*.nupkg\" | Rename-Item -NewName 'github.nupkg'",
-        "Expand-7zipArchive \"$dir\\extract\\github.nupkg\" \"$dir\" -ExtractDir 'lib\\net45'",
-        "Remove-Item \"$dir\\extract\", \"$dir\\$fname\" -Force -Recurse"
-    ],
+    "extract_dir": "lib\\net45",
     "bin": "GitHubDesktop.exe",
     "shortcuts": [
         [
@@ -29,8 +24,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://central.github.com/deployments/desktop/desktop/latest/win32#/dl.7z_"
+                "url": "https://github.com/desktop/desktop/releases/download/release-$version/GitHubDesktop-$version-x64-full.nupkg"
             }
+        },
+        "hash": {
+            "url": "$baseurl/GitHub.Desktop-$version-checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Since the current version of manifest uses GH to check new version but another source as (unversioned) download link it regularly results in [hash check failed](https://github.com/ScoopInstaller/Extras/issues?q=github%20AND%20%22hash%20check%20failed%22) issues after version update (see [history of commits](https://github.com/ScoopInstaller/Extras/commits/master/bucket/github.json)) when a new release has already been published, but the corresponding binary has not yet been uploaded to the site.

Looks like using GH release artifacts will fix this issue.

This PR:
 - switches download/autoupdate urls to use GH release artifacts;
 - uses .nupkg instead of .exe to avoid additional extraction via `pre_install`;
 - adds hash autoupdate.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
