### PR TITLE
totalcommander: Add sftpplug.ini to persist

### DIFF
--- a/bucket/totalcommander.json
+++ b/bucket/totalcommander.json
@@ -48,7 +48,8 @@
         "contplug.ini",
         "fsplugin.ini",
         "lsplugin.ini",
-        "pkplugin.ini"
+        "pkplugin.ini",
+        "sftpplug.ini"
     ],
     "checkver": {
         "url": "https://www.ghisler.com/download.htm",


### PR DESCRIPTION
After update TotalCommander this file got lost and all connections are gone.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
