### PR TITLE
dosbox-staging@0.82.0: Add drives folder to persist list

### DIFF
--- a/bucket/dosbox-staging.json
+++ b/bucket/dosbox-staging.json
@@ -23,6 +23,7 @@
     ],
     "persist": [
         "dosbox-staging.conf",
+        "drives",
         "glshaders",
         "mt32-roms",
         "soundfonts"


### PR DESCRIPTION
This PR adds the `drives` folder to the `persist` list of `dosbox-staging`, version 0.82.0. This is to enable persistence for the drives used in the automount feature, described in the default configuration file:

```
#                   automount: Mount 'drives/[c]' directories as drives on startup, where [c] is a lower-case
#                              drive letter from 'a' to 'y' (enabled by default). The 'drives' folder can be
#                              provided relative to the current directory or via built-in resources.
#                              Mount settings can be optionally provided using a [c].conf file along-side
#                              the drive's directory, with content as follows:
#                                [drive]
#                                type    = dir, overlay, floppy, or cdrom
#                                label   = custom_label
#                                path    = path-specification, ie: path = %%path%%;c:\tools
#                                override_drive = mount the directory to this drive instead (default empty)
#                                verbose = true or false
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
