### PR TITLE
glazewm@3.8.1: Fix wrong binary added to PATH

### DIFF
--- a/bucket/glazewm.json
+++ b/bucket/glazewm.json
@@ -14,7 +14,7 @@
         }
     },
     "extract_dir": "PFiles64\\glzr.io\\GlazeWM",
-    "bin": "GlazeWM.exe",
+    "bin": "cli\\GlazeWM.exe",
     "shortcuts": [
         [
             "GlazeWM.exe",


### PR DESCRIPTION
addresses https://github.com/glzr-io/glazewm/issues/951

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
