### PR TITLE
chatterino: fix checkver, update to 2.5.2

### DIFF
--- a/bucket/chatterino.json
+++ b/bucket/chatterino.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.5.1",
+    "version": "2.5.2",
     "description": "Twitch chat client",
     "homepage": "https://chatterino.com",
     "license": "MIT",
@@ -11,8 +11,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://chatterino.fra1.digitaloceanspaces.com/bin/2.5.1/Chatterino%20Portable.zip",
-            "hash": "4c6d84fd75b5d69eb998780626a3656ce684259d50cab68ab721f00d40fd6add"
+            "url": "https://chatterino.fra1.digitaloceanspaces.com/bin/2.5.2/Chatterino.Portable.zip",
+            "hash": "a574bf8647f948424d6bd6bb3aad334fc3550513b528b766181301fb7193faa4"
         }
     },
     "extract_dir": "chatterino2",
@@ -30,11 +30,11 @@
         "Misc",
         "ProfileAvatars"
     ],
-    "checkver": "/([\\d.]+)/Chatterino%20Portable",
+    "checkver": "/([\\d.]+)/Chatterino.Portable.zip",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://chatterino.fra1.digitaloceanspaces.com/bin/$version/Chatterino%20Portable.zip"
+                "url": "https://chatterino.fra1.digitaloceanspaces.com/bin/$version/Chatterino.Portable.zip"
             }
         },
         "extract_dir": "chatterino$majorVersion"


### PR DESCRIPTION
Format of Chatterino portable download path has changed

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
