### PR TITLE
schismtracker: Update to version 20250202

### DIFF
--- a/bucket/schismtracker.json
+++ b/bucket/schismtracker.json
@@ -1,20 +1,20 @@
 {
-    "version": "20241021",
+    "version": "20250202",
     "description": "An oldschool sample-based music composition tool",
     "homepage": "http://schismtracker.org",
     "license": "GPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/schismtracker/schismtracker/releases/download/20241021/schismtracker-20241021-windows-x86_64.zip",
-            "hash": "819b9778a0aaa2350248f09afe9cb8666723db1be96b996764f8ff11c5766d79"
+            "url": "https://github.com/schismtracker/schismtracker/releases/download/20250202/schismtracker-20250202-windows-x86_64.zip",
+            "hash": "9a4d479dc4715dd3c2489d635d9842270671c90e4575ee48fdfa5061a092a0eb"
         },
         "32bit": {
-            "url": "https://github.com/schismtracker/schismtracker/releases/download/20241021/schismtracker-20241021-windows-i686.zip",
-            "hash": "91b9c36279b133d5906d7508a9cdaa830a55c0742ae129097d5f8172dc8cca42"
+            "url": "https://github.com/schismtracker/schismtracker/releases/download/20250202/schismtracker-20250202-windows-i386.zip",
+            "hash": "ee2e62a8781546e6f81d7fb956f3576946cf9f218a22a05e5d57b6c22358922b"
         },
         "arm64": {
-            "url": "https://github.com/schismtracker/schismtracker/releases/download/20241021/schismtracker-20241021-windows-aarch64.zip",
-            "hash": "f26248441b962860c2e50ca5b54401e19ffd3eabc0186c69c5507d90e2844e66"
+            "url": "https://github.com/schismtracker/schismtracker/releases/download/20250202/schismtracker-20250202-windows-aarch64.zip",
+            "hash": "f857c1903fb4dd42db04403c85d16ab85d838bd363f56d8535df91815f28e145"
         }
     },
     "bin": "schismtracker.exe",
@@ -33,7 +33,7 @@
                 "url": "https://github.com/schismtracker/schismtracker/releases/download/$version/schismtracker-$version-windows-x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/schismtracker/schismtracker/releases/download/$version/schismtracker-$version-windows-i686.zip"
+                "url": "https://github.com/schismtracker/schismtracker/releases/download/$version/schismtracker-$version-windows-i386.zip"
             },
             "arm64": {
                 "url": "https://github.com/schismtracker/schismtracker/releases/download/$version/schismtracker-$version-windows-aarch64.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

In 20241225, schism had changed the name of the binary from i686 to i386, to reflect the architecture change (i686 is Pentium Pro or newer, i386 is much more broad).