### PR TITLE
qbittorrent: Add file associations

### DIFF
--- a/bucket/qbittorrent.json
+++ b/bucket/qbittorrent.json
@@ -6,6 +6,10 @@
         "identifier": "GPL-2.0-only",
         "url": "https://github.com/qbittorrent/qBittorrent/blob/master/COPYING"
     },
+    "notes": [
+        "For file associations, run:",
+        "'reg import \"$dir\\install-associations.reg\"'"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-5.1.4/qbittorrent_5.1.4_x64_setup.exe#/dl.7z",
@@ -32,6 +36,16 @@
         "        Write-Host \"Or you can move them to an absolute download path in qbittorrent-portable and cleanly (re)install qbittorrent to let migration script to take care of them.\" -ForegroundColor Yellow",
         "        Copy-Item \"$persist_dir\\..\\qbittorrent-portable\\profile\\qBittorrent\\config\" \"$persist_dir\\profile\\qBittorrent\\config\" -Recurse | Out-Null",
         "        Copy-Item \"$persist_dir\\..\\qbittorrent-portable\\profile\\qBittorrent\\data\" \"$persist_dir\\profile\\qBittorrent\\data\" -Recurse | Out-Null",
+        "    }",
+        "}"
+    ],
+    "post_install": [
+        "'install-associations', 'uninstall-associations' | ForEach-Object {",
+        "    if (Test-Path \"$bucketsdir\\extras\\scripts\\qbittorrent\\$_.reg\") {",
+        "        $qbitPath = \"$dir\".Replace('\\', '\\\\')",
+        "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\qbittorrent\\$_.reg\").Replace('$qbit', $qbitPath)",
+        "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
+        "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
         "    }",
         "}"
     ],

--- a/bucket/qbittorrent.json
+++ b/bucket/qbittorrent.json
@@ -57,7 +57,9 @@
         ]
     ],
     "persist": "profile",
-    "post_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }",
+    "uninstaller": {
+        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }"
+    },
     "checkver": {
         "sourceforge": "qbittorrent/qbittorrent-win32"
     },

--- a/bucket/qbittorrent.json
+++ b/bucket/qbittorrent.json
@@ -8,7 +8,7 @@
     },
     "notes": [
         "For file associations, run:",
-        "'reg import \"$dir\\install-associations.reg\"'"
+        "reg import \"$dir\\install-associations.reg\""
     ],
     "architecture": {
         "64bit": {
@@ -41,9 +41,9 @@
     ],
     "post_install": [
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
-        "    if (Test-Path \"$bucketsdir\\extras\\scripts\\qbittorrent\\$_.reg\") {",
+        "    if (Test-Path \"$bucketsdir\\$bucket\\scripts\\qbittorrent\\$_.reg\") {",
         "        $qbitPath = \"$dir\".Replace('\\', '\\\\')",
-        "        $content = (Get-Content \"$bucketsdir\\extras\\scripts\\qbittorrent\\$_.reg\").Replace('$qbit', $qbitPath)",
+        "        $content = (Get-Content \"$bucketsdir\\$bucket\\scripts\\qbittorrent\\$_.reg\").Replace('$qbit', $qbitPath)",
         "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
         "    }",
@@ -57,6 +57,7 @@
         ]
     ],
     "persist": "profile",
+    "post_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }",
     "checkver": {
         "sourceforge": "qbittorrent/qbittorrent-win32"
     },

--- a/scripts/qbittorrent/install-associations.reg
+++ b/scripts/qbittorrent/install-associations.reg
@@ -1,0 +1,50 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\qBittorrent]
+"InstallLocation"="$qbit"
+
+; Register qBittorrent as possible default program for .torrent files and magnet links
+[HKEY_CURRENT_USER\Software\qBittorrent\Capabilities]
+"ApplicationDescription"="A BitTorrent client in Qt"
+"ApplicationName"="qBittorrent"
+
+[HKEY_CURRENT_USER\Software\qBittorrent\Capabilities\FileAssociations]
+".torrent"="qBittorrent.File.Torrent"
+
+[HKEY_CURRENT_USER\Software\qBittorrent\Capabilities\UrlAssociations]
+"magnet"="qBittorrent.Url.Magnet"
+
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"qBittorrent"="Software\\qBittorrent\\Capabilities"
+
+; Register qBittorrent ProgIDs
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent]
+@="Torrent File"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent\DefaultIcon]
+@="\"$qbit\\qbittorrent.exe\",1"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent\shell\open\command]
+@="\"$qbit\\qbittorrent.exe\" \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet]
+@="Magnet URI"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet\DefaultIcon]
+@="\"$qbit\\qbittorrent.exe\",1"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet\shell\open\command]
+@="\"$qbit\\qbittorrent.exe\" \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\.torrent]
+"Content Type"="application/x-bittorrent"
+"PerceivedType"="application"
+@="qBittorrent.File.Torrent"
+
+[HKEY_CURRENT_USER\Software\Classes\magnet]
+@="URL:Magnet URI"
+"Content Type"="application/x-magnet"
+"URL Protocol"=""
+
+[HKEY_CURRENT_USER\Software\Classes\magnet\shell\open\command]
+@="\"$qbit\\qbittorrent.exe\" \"%1\""

--- a/scripts/qbittorrent/uninstall-associations.reg
+++ b/scripts/qbittorrent/uninstall-associations.reg
@@ -1,0 +1,12 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\qBittorrent]
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"qBittorrent"=-
+[-HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent]
+[-HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet]
+[-HKEY_CURRENT_USER\Software\Classes\.torrent]
+[-HKEY_CURRENT_USER\Software\Classes\magnet]
+
+; Delete associations that Windows Explorer did on its own.
+[-HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.torrent]


### PR DESCRIPTION
To sum up, qBittorrent installed via scoop from extras, currently does not register associations of any kind. This results simply in, e.g. magnet links not being opened in the app or at all. There is a possibility to manually associate torrent files to the app, but there is no _simple_ way to register magnets.
I modified @[glassez](https://github.com/glassez)'s registry file from [this PR @ qbittorrent](https://github.com/qbittorrent/qBittorrent/pull/19446#issuecomment-1674389079) to properly recognize magnet links and torrent files and also, to be adjusted whether it's a global (LOCAL_MACHINE) or user (CURRENT_USER) installation.
A little bit inspired by notepadplusplus and vscode manifests.

Edit: ~~(*) For it to work right now, simply replace `extras` in lines 44 and 46 for whatever your imported bucket name is. This way, we don't have to redo the commit to adjust bucket name.~~

To try out:
1. Add new bucket - `scoop bucket add qbit https://github.com/itsHardStyl3r/Extras`
2. Edit: ~~Manually replace the word "extras" to "qbit" in lines 44 and 46 in `/bucket/qbittorrent.json`~~. (See (*))
3. Install qBittorrent from aforementioned bucket - `scoop install qbit/qbittorrent`
4. Run the command `reg import {reg_file}` or run the file install-associations.reg.
5. You should be able to launch .torrent files and magnet links in qBittorrent.

Both global and user installation work, thoroughly tested on my computer. Open to suggestions and contributions.

Closes https://github.com/ScoopInstaller/Extras/issues/14838.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * qBittorrent can be registered as the default handler for torrent files and Magnet links.
  * Installation guidance notes added to assist association setup.

* **Chores**
  * Automated install and uninstall steps added to apply and remove file/URL associations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->