### PR TITLE
neeview: Update to version 42.6, switch to github releases

### DIFF
--- a/bucket/neeview.json
+++ b/bucket/neeview.json
@@ -1,13 +1,13 @@
 {
-    "version": "42.5",
-    "description": "An image viewer that allows you to view images of folders and compressed files as if you read books.",
-    "homepage": "https://bitbucket.org/neelabo/neeview/wiki/Home",
+    "version": "42.6",
+    "description": "An image viewer that allows you to browse images in folders and compressed files like a book. Powerful customization is available.",
+    "homepage": "https://neelabo.github.io/NeeView",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://bitbucket.org/neelabo/neeview/downloads/NeeView42.5.zip",
-            "hash": "5c29f64f648e6809f9f883553b7a7f9b9f2874ede0337e2c03458fdafc774c8f",
-            "extract_dir": "NeeView42.5"
+            "url": "https://github.com/neelabo/NeeView/releases/download/42.6/NeeView42.6.zip",
+            "hash": "7817b3282949e844b1e009e3185c7c7c7111111f98ebc739108e01b22bf5b560",
+            "extract_dir": "NeeView42.6"
         }
     },
     "bin": "NeeView.exe",
@@ -19,13 +19,12 @@
     ],
     "persist": "Profile",
     "checkver": {
-        "url": "https://api.bitbucket.org/2.0/repositories/neelabo/neeview/refs/tags?sort=-target.date",
-        "jsonpath": "$.values[0].name"
+        "github": "https://github.com/neelabo/NeeView"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://bitbucket.org/neelabo/neeview/downloads/NeeView$version.zip",
+                "url": "https://github.com/neelabo/NeeView/releases/download/$version/NeeView$version.zip",
                 "extract_dir": "NeeView$version"
             }
         }


### PR DESCRIPTION
The NeeView project has moved from Bitbucket to GitHub.
Update the app manifest, and bump the version to the latest.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #14854

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
