### PR TITLE
xl-converter@1.2.0: Change user data location

### DIFF
--- a/bucket/xl-converter.json
+++ b/bucket/xl-converter.json
@@ -18,17 +18,8 @@
             "XL Converter"
         ]
     ],
-    "post_uninstall": [
-        "if ($purge) {",
-        "    $Directories = [string[]](",
-        "        ('{0}\\xl-converter' -f $env:LOCALAPPDATA)",
-        "    )",
-        "    $Directories.ForEach{",
-        "        if ([System.IO.Directory]::Exists($_)) {",
-        "            $null = [System.IO.Directory]::Delete($_,$true)",
-        "        }",
-        "    }",
-        "}"
+    "persist": [
+        "_internal/user_data"
     ],
     "checkver": {
         "github": "https://github.com/JacobDev1/xl-converter"


### PR DESCRIPTION
XL Converter v1.2.0 (portable version) stores user data inside its own directory. My pull request:
- Makes the `user_data` directory persistent.
- Removes `post_install`.

Closes #14907

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
