### PR TITLE
beaver-notes@3.9.0: Use portable mode

### DIFF
--- a/bucket/beaver-notes.json
+++ b/bucket/beaver-notes.json
@@ -4,6 +4,8 @@
     "description": "A privacy-focused note-taking application",
     "homepage": "https://beavernotes.com/",
     "license": "MIT",
+    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/3.9.0/Beaver-notes-3.9.0-portable.exe#/dl.7z",
+    "hash": "08e7994bd626ec5deaad2d3f74e7cc5bbc14d23e644c4f7c6b0e3573660b6059",
     "architecture": {
         "64bit": {
             "pre_install": "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\""
@@ -12,8 +14,6 @@
             "pre_install": "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" -DestinationPath \"$dir\""
         }
     },
-    "url": "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/3.9.0/Beaver-notes-3.9.0-portable.exe#/dl.7z",
-    "hash": "08e7994bd626ec5deaad2d3f74e7cc5bbc14d23e644c4f7c6b0e3573660b6059",
     "post_install": [
         "$ScriptBlock = [scriptblock]{Remove-Item -Path \"$dir\\`$PLUGINSDIR\" -Force -Recurse}",
         "Try {$ScriptBlock.Invoke()} Catch {Start-Sleep -Milliseconds 50; $ScriptBlock.Invoke()}"
@@ -21,20 +21,17 @@
     "shortcuts": [
         [
             "Beaver-notes.exe",
-            "Beaver Notes"
+            "Beaver Notes",
+            "--user-data-dir=\"$dir\\data\""
         ]
     ],
+    "persist": "data",
     "post_uninstall": [
-        "if ($purge) {",
-        "    $Directories = [string[]](",
-        "        ('{0}\\Beaver-notes' -f $env:APPDATA)",
-        "    )",
-        "    $Directories.ForEach{",
-        "        if ([System.IO.Directory]::Exists($_)) {",
-        "            $null = [System.IO.Directory]::Delete($_,$true)",
-        "        }",
-        "    }",
-        "}"
+        "info (",
+        "    \"`r`nThere might be leftovers from earlier versions or from installations outside Scoop in following locations:\" +",
+        "    \"`r`n* %APPDATA%\\Beaver-notes\" +",
+        "    \"`r`n* %LOCALAPPDATA%\\beaver-notes-updater\"",
+        ")"
     ],
     "checkver": {
         "github": "https://github.com/Beaver-Notes/Beaver-Notes"


### PR DESCRIPTION
## Context

With Beaver Notes v3.9.0 ( <https://github.com/Beaver-Notes/Beaver-Notes/releases/tag/3.9.0> ) portable mode with `--user-data-dir=` finally works ( <https://github.com/Beaver-Notes/Beaver-Notes/issues/273>) .

## Changes

* Use Beaver Notes portable mode
* Remove purge logic, instead output info about directories that might hold leftovers from previous versions or installations outside Scoop.

## Other

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
