### PR TITLE
catime: Add version 1.0.3.1

### DIFF
--- a/bucket/catime.json
+++ b/bucket/catime.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0.3.1",
+  "url": "https://github.com/vladelaina/Catime/releases/download/v1.0.3.1/catime_1.0.3.1.exe",
+  "bin": "catime_1.0.3.1.exe",
+  "hash": "7be4e30cf5924520ac28bd06399d524877f718c2f7367f5e765c54d5f93d6397",
+  "description": "A simple timer application.",
+  "homepage": "https://github.com/vladelaina/Catime",
+  "license": "Apache-2.0",
+  "post_install": [
+    "$desktop = [System.Environment]::GetFolderPath('Desktop')",
+    "Copy-Item \"$dir\\catime_1.0.3.1.exe\" -Destination $desktop -Force",
+    "Remove-Item \"$dir\\*\" -Force -Recurse"
+  ],
+  "post_uninstall": [
+    "$desktop = [System.Environment]::GetFolderPath('Desktop')",
+    "$exePath = Join-Path $desktop 'catime_1.0.3.1.exe'",
+    "if (Test-Path $exePath) { Remove-Item $exePath -Force }"
+  ]
+}


### PR DESCRIPTION
Project address: https://github.com/vladelaina/Catime

A simple Windows countdown tool with Pomodoro clock functionality, featuring a transparent interface and a variety of customization options.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
