### PR TITLE
openai-translator@0.4.32: fix shortcuts file name

### DIFF
--- a/bucket/openai-translator.json
+++ b/bucket/openai-translator.json
@@ -12,7 +12,7 @@
     "post_install": "@('$PLUGINSDIR', '$TEMP', 'uninstall.exe') | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
     "shortcuts": [
         [
-            "OpenAI Translator.exe",
+            "app.exe",
             "OpenAI Translator"
         ]
     ],


### PR DESCRIPTION
The shortcut name has been changed from `OpenAI Translator.exe` to `app.exe`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
