### PR TITLE
fork@2.6.0: fix extract_dir

### DIFF
--- a/bucket/fork.json
+++ b/bucket/fork.json
@@ -12,7 +12,7 @@
     ],
     "url": "https://cdn.fork.dev/update/win/Fork-2.6.0-full.nupkg",
     "hash": "sha1:666d81403f2469a24843b161c325577eeedd3d1b",
-    "extract_dir": "lib\\net45",
+    "extract_dir": "lib\\app",
     "post_install": [
         "Remove-Item \"$dir\\*\" -Include 'Fork_ExecutionStub.exe', 'PortableGit-*.7z', 'lib', '7z.*' -Recurse",
         "$exepath = \"$dir\\Fork.exe\".Replace('\\', '\\\\')",


### PR DESCRIPTION
The latest version of the fork modified the file structure of the installation package, and this pull request has addressed the issue.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
