### PR TITLE
musicbee: fix url for 3.5.8698

### DIFF
--- a/bucket/musicbee.json
+++ b/bucket/musicbee.json
@@ -6,8 +6,8 @@
         "identifier": "Freeware",
         "url": "https://musicbee.fandom.com/wiki/FAQ#Are_there_any_limitations_on_using_MusicBee.3F"
     },
-    "url": "https://files1.majorgeeks.com/ed0615a119266925c3a938833d146f605678ed10/multimedia/MusicBeePortable_3_5.zip",
-    "hash": "a1da2ff921922fe4323f062a0032b6182b5dd000d6b5df34998614377aa3977a",
+    "url": "https://files1.majorgeeks.com/ad9fb614274c4d3baafc0dd8dced88660177d4b1/multimedia/MusicBeeSetup_3_5.zip",
+    "hash": "be27f1149654924dddd106254493137280f3e8098ec1029435c02fdda092bdb5",
     "pre_install": [
         "(Get-ChildItem \"$dir\" 'MusicBee*.exe').FullName | Expand-7zipArchive -DestinationPath \"$dir\" -Removal",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse",


### PR DESCRIPTION
Updated majorgeeks url, longterm a better source is needed in future that doesn't get deactivated frequently.

Closes #14955

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
