### PR TITLE
miniconda3: update version to 25.1.1-2

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -56,7 +56,7 @@
             }
         },
         "hash": {
-            "url": "https://docs.anaconda.com/free/miniconda/miniconda-other-installer-links/",
+            "url": "https://repo.anaconda.com/miniconda/",
             "regex": "(?sm)$basename.*?>$sha256<"
         }
     }

--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -1,5 +1,5 @@
 {
-    "version": "24.9.2-0",
+    "version": "25.1.1-2",
     "description": "A cross-platform, Python-agnostic binary package manager",
     "homepage": "https://docs.anaconda.com/free/miniconda/",
     "license": "BSD-3-Clause",
@@ -11,8 +11,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py312_24.9.2-0-Windows-x86_64.exe#/setup.exe",
-            "hash": "3a8897cc5d27236ade8659f0e119f3a3ccaad68a45de45bfdd3102d8bec412ab"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py312_25.1.1-2-Windows-x86_64.exe#/setup.exe",
+            "hash": "fb936987b769759fc852af1b2a0e359ac14620c2b7bea8a90c6d920f2b754c4a"
         }
     },
     "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
@@ -46,7 +46,7 @@
     ],
     "persist": "envs",
     "checkver": {
-        "url": "https://docs.anaconda.com/free/miniconda/miniconda-other-installer-links/",
+        "url": "https://repo.anaconda.com/miniconda/",
         "regex": "Miniconda3-py(?<py>\\d+)_([\\d.-]+)-Windows"
     },
     "autoupdate": {


### PR DESCRIPTION
After performing the following steps:

1. Successfully replaced the installation source files and validated their cryptographic hashes.

2. Completed a standard installation process (no errors reported).

The uninstallation workflow exhibits unexpected behavior:

1. The uninstaller generates an executable `Un_A.exe` at `%LOCALAPPDATA%\Temp\~nsu.tmp\`.

2. The system automatically invokes `Un_A.exe` during uninstallation.

3. A console window appears, requiring manual user interaction (pressing Enter) to finalize the uninstallation.

Relates to #14903

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
