### PR TITLE
hoppscotch@25.2.0-0: change the executable name

### DIFF
--- a/bucket/hoppscotch.json
+++ b/bucket/hoppscotch.json
@@ -15,7 +15,7 @@
     "extract_dir": "PFiles\\Hoppscotch",
     "shortcuts": [
         [
-            "Hoppscotch.exe",
+            "hoppscotch-desktop.exe",
             "Hoppscotch"
         ]
     ],


### PR DESCRIPTION
"Hoppscotch.exe" to "hoppscotch-desktop.exe" to fix the shortcut,

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
