### PR TITLE
RunHiddenConsole: Add version 1.0.2

### DIFF
--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0.2",
+    "description": "Hide console window for windows console programs",
+    "notes": "This is a simple utility to hide the console window for windows programs. It is useful for running programs in the background without the console window showing up.",
+    "homepage": "https://github.com/rise-worlds/RunHiddenConsole",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.2/RunHiddenConsole-x64-v1.0.2.zip",
+            "hash": "23e76d8d64af132bc239e778f30b0f12af7aae31e9f51a4c6338ede6175ceb95"
+        },
+        "32bit": {
+            "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.2/RunHiddenConsole-x86-v1.0.2.zip",
+            "hash": "b1ccd9345c3d182e2277ae4b3f6826bd624884e0d41e0b8acc8fd8b1c6741c9d"
+        }
+    },
+    "bin": [
+        "RunHiddenConsole.exe"
+    ],
+    "checkver": {
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases",
+        "regex": "assets/v([\\d\\.\\-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x64-v$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x86-v$version.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/hashes.txt"
+        }
+    }
+}


### PR DESCRIPTION
add RunHiddenConsole, version 1.0.2

`RunHiddenConsole` is a lightweight program for hiding the console window on Windows. 
It functions similarly to appending '&' at the end of a Linux command line, allowing the program to run in the background without blocking the console.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
