### PR TITLE
abdownloadmanager: Update post_install and persist

### DIFF
--- a/bucket/abdownloadmanager.json
+++ b/bucket/abdownloadmanager.json
@@ -10,12 +10,20 @@
         }
     },
     "extract_dir": "ABDownloadManager",
+    "post_install": [
+        "if (Test-Path $env:USERPROFILE\\.abdm) {",
+        "    Write-Host \"`r`nMove config from non-portable version...\"",
+        "    Copy-Item -Path $env:USERPROFILE\\.abdm\\* -Destination \"$persist_dir\\.abdm\" -Force -Recurse | Out-Null",
+        "    Remove-Item $env:USERPROFILE\\.abdm -Force -Recurse",
+        "}"
+    ],
     "shortcuts": [
         [
             "ABDownloadManager.exe",
             "ABDownloadManager"
         ]
     ],
+    "persist": ".abdm",
     "checkver": {
         "github": "https://github.com/amir1376/ab-download-manager"
     },


### PR DESCRIPTION
Closes #15026

> The app now supports full portability by creating an .abdm directory in the installation folder.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
