### PR TITLE
synfig-studio: Update to version 1.5.3

### DIFF
--- a/bucket/synfig-studio.json
+++ b/bucket/synfig-studio.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.4.5",
+    "version": "1.5.3",
     "description": "2D Animation Software",
     "homepage": "https://www.synfig.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://www.fosshub.com/Synfig.html/SynfigStudio-1.4.5-2024.05.19-win64-f4b8d.zip",
-            "hash": "1610ec2eb2352ab6583d73218c498c27822d0645978abbb23873ad99cd07103a"
+            "url": "https://github.com/synfig/synfig/releases/download/v1.5.3/SynfigStudio-1.5.3-2024.08.23-win64-3b7c5.zip",
+            "hash": "SHA256:6aed32d3d1a43db91d1b46a0c23008d067aa530b3c34a60bdaea1e810c2c9f14"
         },
         "32bit": {
-            "url": "https://www.fosshub.com/Synfig.html/SynfigStudio-1.4.5-2024.05.19-win32-f4b8d.zip",
-            "hash": "d7629302add7d87ffc4d07895299f916040643a88c8096b45c094402da5e2287"
+            "url": "https://github.com/synfig/synfig/releases/download/v1.5.3/SynfigStudio-1.5.3-2024.08.23-win32-3b7c5.zip",
+            "hash": "SHA256:b58c2a3c371084fd516d7ce24e3b585069472a2ca07bc398718c0d24a1f391aa"
         }
     },
     "bin": "bin\\synfig.exe",
@@ -23,16 +23,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.fosshub.com/Synfig.html",
-        "regex": "SynfigStudio-([\\d.]+)-(?<date>[\\d.]+)-win64-(?<sha>[\\da-f]+)"
+        "url": "https://github.com/synfig/synfig/releases",
+        "regex": "SynfigStudio-([\\d.]+)-(?<date>[\\d.]+)-win64-(?<sha>[\\da-f]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.fosshub.com/Synfig.html/SynfigStudio-$version-$matchDate-win64-$matchSha.zip"
+                "url": "https://github.com/synfig/synfig/releases/download/v$version/SynfigStudio-$version-$matchDate-win64-$matchSha.zip"
             },
             "32bit": {
-                "url": "https://www.fosshub.com/Synfig.html/SynfigStudio-$version-$matchDate-win32-$matchSha.zip"
+                "url": "https://github.com/synfig/synfig/releases/download/v$version/SynfigStudio-$version-$matchDate-win32-$matchSha.zip"
             }
         }
     }

--- a/bucket/synfig-studio.json
+++ b/bucket/synfig-studio.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/synfig/synfig/releases/download/v1.5.3/SynfigStudio-1.5.3-2024.08.23-win64-3b7c5.zip",
-            "hash": "SHA256:6aed32d3d1a43db91d1b46a0c23008d067aa530b3c34a60bdaea1e810c2c9f14"
+            "hash": "6aed32d3d1a43db91d1b46a0c23008d067aa530b3c34a60bdaea1e810c2c9f14"
         },
         "32bit": {
             "url": "https://github.com/synfig/synfig/releases/download/v1.5.3/SynfigStudio-1.5.3-2024.08.23-win32-3b7c5.zip",
-            "hash": "SHA256:b58c2a3c371084fd516d7ce24e3b585069472a2ca07bc398718c0d24a1f391aa"
+            "hash": "b58c2a3c371084fd516d7ce24e3b585069472a2ca07bc398718c0d24a1f391aa"
         }
     },
     "bin": "bin\\synfig.exe",
@@ -34,6 +34,9 @@
             "32bit": {
                 "url": "https://github.com/synfig/synfig/releases/download/v$version/SynfigStudio-$version-$matchDate-win32-$matchSha.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksum-sha256.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

### Changes
- Updated `synfig-studio` to version 1.5.3
- Changed download URLs to use GitHub Releases instead of FossHub
- Updated SHA256 hashes

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
