### PR TITLE
Obsidian: add bin to manifest

### DIFF
--- a/bucket/obsidian.json
+++ b/bucket/obsidian.json
@@ -26,6 +26,12 @@
             "Obsidian"
         ]
     ],
+    "bin": [
+        [
+            "obsidian.exe",
+            "obsidian"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/obsidianmd/obsidian-releases"
     },


### PR DESCRIPTION
add binadd bin to manifest
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
