### PR TITLE
Update download link and rename stremio.json to stremio-stable.json

### DIFF
--- a/bucket/stremio-stable.json
+++ b/bucket/stremio-stable.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.stremio.com/",
     "license": "Proprietary",
     "notes": "Register 'URL:Stremio Protocol' via `reg import \"$dir\\install-context.reg\"`",
-    "url": "https://dl.strem.io/shell-win/v4.4.168/Stremio+4.4.168.exe#/dl.7z",
+    "url": "https://www.strem.io/download?platform=windows&four=true#/dl.7z",
     "hash": "44ecc6a7624b2fdf03cb9b419f111892515fb036fe23f88e51456dce69066046",
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",
     "post_install": [
@@ -34,6 +34,6 @@
         "reverse": true
     },
     "autoupdate": {
-        "url": "https://dl.strem.io/shell-win/v$version/Stremio+$version.exe#/dl.7z"
+        "url": "https://www.strem.io/download?platform=windows&four=true#/dl.7z"
     }
 }


### PR DESCRIPTION
Since Stremio published the new beta version for Windows the link for download the stable one has been modified.