### PR TITLE
pdf2zh :  Add version 1.9.5 

### DIFF
--- a/bucket/pdf2zh
+++ b/bucket/pdf2zh
@@ -1,0 +1,20 @@
+{
+    "version": "1.9.5",
+    "description": "PDF scientific paper translation with preserved formats",
+    "homepage": "https://github.com/Byaidu/PDFMathTranslate/",
+    "url": "https://github.com/Byaidu/PDFMathTranslate/releases/download/v1.9.5/pdf2zh-v1.9.5-win64.zip",
+    "notes": "",
+    "bin": "pdf2zh.exe",
+    "shortcuts": [
+        [
+            "pdf2zh.exe",
+            "pdf2zh"
+        ]
+    ],
+    "hash": "",
+    "extract_dir": "pdf2zh/build",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Byaidu/PDFMathTranslate/releases/download/v$version/pdf2zh-v$version-win64.zip"
+    }
+}


### PR DESCRIPTION
Create pdf2zh @  1.9.5  (PDFMathTranslate)
https://github.com/Byaidu/PDFMathTranslate

PDF scientific paper translation and bilingual comparison.


