### PR TITLE
prusaslicer: Update to version 2.9.1

### DIFF
--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.)",
     "homepage": "https://www.prusa3d.com/prusaslicer/",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.9.0/PrusaSlicer-2.9.0+win64.zip",
-            "hash": "facc698c7e44e329f67fd0d824aeba605c3457df52c8eac70f52bfe84094a18c",
-            "extract_dir": "PrusaSlicer-2.9.0"
+            "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.9.1/PrusaSlicer-2.9.1-win64.zip",
+            "hash": "503188c9c4330cc9b93836902834c2bbcae8ac5cc408c8684e8cc1f8219dbf18",
+            "extract_dir": "PrusaSlicer-2.9.1"
         }
     },
     "bin": "prusa-slicer-console.exe",
@@ -18,13 +18,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repositories/52882701/releases",
-        "regex": "PrusaSlicer-([\\d.]+)\\+win64\\.zip"
+        "url": "https://github.com/prusa3d/PrusaSlicer/releases/latest",
+        "regex": "/releases/tag/(?:version_|Version_)?([\\d.]+(-\\d+)?)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_$version/PrusaSlicer-$version+win64.zip",
+                "url": "https://github.com/prusa3d/PrusaSlicer/releases/download/version_$version/PrusaSlicer-$version-win64.zip",
                 "extract_dir": "PrusaSlicer-$version"
             }
         }

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -18,8 +18,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/prusa3d/PrusaSlicer/releases/latest",
-        "regex": "/releases/tag/(?:version_|Version_)?([\\d.]+(-\\d+)?)"
+        "url": "https://api.github.com/repositories/52882701/releases/latest",
+        "regex": "PrusaSlicer-([\\d.]+)-win64\\.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
updated the checkver to use github
updated the autoupdate URL
updated to PrusaSlicer to 2.9.1