### PR TITLE
gimp: transition 2.x -> 3.x

### DIFF
--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -11,45 +11,38 @@
             "Push-Location \"$dir\"",
             "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
             "if ($architecture -eq '64bit') {",
-            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "   Get-ChildItem -Filter '*,*' -Recurse | Remove-Item",
             "} else {",
-            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "}",
-            "$pyenv = Get-Content 'lib\\gimp\\2.0\\environ\\pygimp.env' -Raw",
-            "$pyenv + '__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content 'lib\\gimp\\2.0\\environ\\pygimp.env'",
-            "$pyint = Get-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp' -Raw",
-            "$pyint = $pyint -Replace '(python|python2)=(.*)', \"`$1=$dir\\bin\\pythonw.exe\"",
-            "$pyint = $pyint -Replace 'py::python2', 'py::python'",
-            "$pyint | Set-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp'",
-            "Pop-Location",
-            "Copy-Item \"$bucketsdir\\extras\\scripts\\gimp\\default.env\" \"$dir\\lib\\gimp\\2.0\\environ\\\" | Out-Null"
+            "$pyint = Get-Content 'lib\\gimp\\3.0\\interpreters\\pygimp.interp' -Raw",
+            "$pyint = $pyint -Replace '(python|python3)=(.*)', \"`$1=$dir\\bin\\pythonw.exe\"",
+            "$pyint = $pyint -Replace 'py::python3', 'py::python'",
+            "$pyint | Set-Content 'lib\\gimp\\3.0\\interpreters\\pygimp.interp'",
+            "Pop-Location"
         ]
     },
     "bin": [
-        "bin\\gimp-console-2.10.exe",
+        "bin\\gimp-console-3.exe",
         [
-            "bin\\gimp-console-2.10.exe",
+            "bin\\gimp-console-3.exe",
             "gimp-console"
         ],
         [
-            "bin\\gimp-console-2.10.exe",
+            "bin\\gimp-console-3.exe",
             "gimp"
         ],
-        "bin\\gimptool-2.0.exe",
+        "bin\\gimptool-3.exe",
         [
-            "bin\\gimptool-2.0.exe",
+            "bin\\gimptool-3.exe",
             "gimptool"
         ]
     ],
     "shortcuts": [
         [
-            "bin\\gimp-2.10.exe",
+            "bin\\gimp-3.exe",
             "GIMP"
         ]
     ],

--- a/scripts/gimp/default.env
+++ b/scripts/gimp/default.env
@@ -2,4 +2,4 @@
 # FOOPATH=/path/to/foo/stuff
 
 PATH=${gimp_installation_dir}\bin
-PYTHONPATH=${gimp_installation_dir}\lib\gimp\2.0\python;${gimp_plug_in_dir}\plug-ins\python-console
+PYTHONPATH=${gimp_installation_dir}\lib\gimp\3.0\python;${gimp_plug_in_dir}\plug-ins\python-console


### PR DESCRIPTION
Relates to #15097

Changed the version number to the best of my knowledge and now it installs and runs for me (haven't worked much with it).

* I need some help with understanding the python path in `default.env`
* There are binaries with `,1` and `,2` but also `,3`. I don't know what `,3` is. It "works" for me/64 bit architecture... not sure for the other architectures.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
