### PR TITLE
gimp@3.0.0: Update to work with 3.0

### DIFF
--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -1,10 +1,10 @@
 {
-    "version": "3.0.0",
+    "version": "3.0.0-1",
     "description": "GNU Image Manipulation Program",
     "homepage": "https://www.gimp.org",
     "license": "GPL-3.0-only",
-    "url": "https://download.gimp.org/mirror/pub/gimp/v3.0/windows/gimp-3.0.0-setup.exe",
-    "hash": "ab6f9aa481120097f032c39f07cb70990929878fa65bf4ec6d1669d7a616770a",
+    "url": "https://download.gimp.org/mirror/pub/gimp/v3.0/windows/gimp-3.0.0-setup-1.exe",
+    "hash": "c1101f6fe5103c2986bd39a8c4162b52ea915c1d8066c79a86497329afd01fe4",
     "innosetup": true,
     "installer": {
         "script": [
@@ -19,19 +19,6 @@
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "}",
-            "$defpath = \"`nPATH=`${gimp_installation_dir}\\bin`n\"",
-            "$defenv = Get-Content \"lib\\gimp\\$shortver\\environ\\default.env\" -Raw",
-            "$defenv += $defpath",
-            "$defenv += \"PYTHONPATH=`${gimp_installation_dir}\\lib\\gimp\\$shortver\\python;`${gimp_plug_in_dir}\\plug-ins\\python-console\"",
-            "$defenv | Set-Content \"lib\\gimp\\$shortver\\environ\\default.env\"",
-            "# Only worked for versions <2.99, installer no longer supplies 'pygimp.env'",
-            "# $pyenv = (Get-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\" -Raw) + '__COMPAT_LAYER=HIGHDPIAWARE'",
-            "# $pyenv | Set-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\"",
-            "'__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\"",
-            "$pyint = Get-Content \"lib\\gimp\\$shortver\\interpreters\\pygimp.interp\" -Raw",
-            "$pyint = $pyint -Replace '(python|python2)=(.*)', \"`$1=$dir\\bin\\pythonw.exe\"",
-            "$pyint = $pyint -Replace 'py::python2', 'py::python'",
-            "$pyint | Set-Content \"lib\\gimp\\$shortver\\interpreters\\pygimp.interp\"",
             "Pop-Location"
         ]
     },

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -8,48 +8,52 @@
     "innosetup": true,
     "installer": {
         "script": [
+            "$scriptver = ($fname -split '-' | Select-Object -First 1 -Skip 1).Split('.')",
+            "$shortver = $scriptver[0] + '.' + $scriptver[1]",
             "Push-Location \"$dir\"",
             "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
             "if ($architecture -eq '64bit') {",
-            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "   Get-ChildItem -Filter '*,*' -Recurse | Remove-Item",
             "} else {",
-            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "}",
-            "$pyenv = Get-Content 'lib\\gimp\\2.0\\environ\\pygimp.env' -Raw",
-            "$pyenv + '__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content 'lib\\gimp\\2.0\\environ\\pygimp.env'",
-            "$pyint = Get-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp' -Raw",
+            "$defpath = \"`nPATH=`${gimp_installation_dir}\\bin`n\"",
+            "$defenv = Get-Content \"lib\\gimp\\$shortver\\environ\\default.env\" -Raw",
+            "$defenv += $defpath",
+            "$defenv += \"PYTHONPATH=`${gimp_installation_dir}\\lib\\gimp\\$shortver\\python;`${gimp_plug_in_dir}\\plug-ins\\python-console\"",
+            "$defenv | Set-Content \"lib\\gimp\\$shortver\\environ\\default.env\"",
+            "# Only worked for versions <2.99, installer no longer supplies 'pygimp.env'",
+            "# $pyenv = (Get-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\" -Raw) + '__COMPAT_LAYER=HIGHDPIAWARE'",
+            "# $pyenv | Set-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\"",
+            "'__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\"",
+            "$pyint = Get-Content \"lib\\gimp\\$shortver\\interpreters\\pygimp.interp\" -Raw",
             "$pyint = $pyint -Replace '(python|python2)=(.*)', \"`$1=$dir\\bin\\pythonw.exe\"",
             "$pyint = $pyint -Replace 'py::python2', 'py::python'",
-            "$pyint | Set-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp'",
-            "Pop-Location",
-            "Copy-Item \"$bucketsdir\\extras\\scripts\\gimp\\default.env\" \"$dir\\lib\\gimp\\2.0\\environ\\\" | Out-Null"
+            "$pyint | Set-Content \"lib\\gimp\\$shortver\\interpreters\\pygimp.interp\"",
+            "Pop-Location"
         ]
     },
     "bin": [
-        "bin\\gimp-console-2.10.exe",
+        "bin\\gimp-console-3.0.exe",
         [
-            "bin\\gimp-console-2.10.exe",
+            "bin\\gimp-console-3.0.exe",
             "gimp-console"
         ],
         [
-            "bin\\gimp-console-2.10.exe",
+            "bin\\gimp-console-3.0.exe",
             "gimp"
         ],
-        "bin\\gimptool-2.0.exe",
+        "bin\\gimptool-3.0.exe",
         [
-            "bin\\gimptool-2.0.exe",
+            "bin\\gimptool-3.0.exe",
             "gimptool"
         ]
     ],
     "shortcuts": [
         [
-            "bin\\gimp-2.10.exe",
+            "bin\\gimp-3.0.exe",
             "GIMP"
         ]
     ],
@@ -62,6 +66,28 @@
         "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$matchHead-setup$matchTail.exe",
         "hash": {
             "url": "$baseurl/SHA256SUMS"
-        }
+        },
+        "bin": [
+            "bin\\gimp-console-$majorVersion.$minorVersion.exe",
+            [
+                "bin\\gimp-console-$majorVersion.$minorVersion.exe",
+                "gimp-console"
+            ],
+            [
+                "bin\\gimp-console-$majorVersion.$minorVersion.exe",
+                "gimp"
+            ],
+            "bin\\gimptool-$majorVersion.$minorVersion.exe",
+            [
+                "bin\\gimptool-$majorVersion.$minorVersion.exe",
+                "gimptool"
+            ]
+        ],
+        "shortcuts": [
+            [
+                "bin\\gimp-$majorVersion.$minorVersion.exe",
+                "GIMP"
+            ]
+        ]
     }
 }


### PR DESCRIPTION
Version number was hardcoded in parts of the manifest, causing it to fail.

Copied parts from versions/gimp-dev.json.

Removed parts of installer script that fixed available twain library versions because they failed; fixed in gimp installer?

NB: I'm not a scoop or PS expert... but it works for me 😉.

<!--
Relates to #15113, #15112, #15105, #15104, #15103, #15098, #15097, #15096, #15086
-->

- [ x ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
