### PR TITLE
sdl2(-image|-mixer|-ttf): Update checkver and pin to 2.x releases

### DIFF
--- a/bucket/sdl2-image.json
+++ b/bucket/sdl2-image.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.8.5",
+    "version": "2.8.8",
     "description": "SDL_image is an image loading library that is used with the SDL library, and almost as portable. It allows a programmer to use multiple image formats without having to code all the loading and conversion algorithms themselves.",
     "homepage": "https://github.com/libsdl-org/SDL_image",
     "license": "Zlib",
     "url": [
-        "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.5/SDL2_image-devel-2.8.5-VC.zip",
-        "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.5/SDL2_image-2.8.5.zip"
+        "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-devel-2.8.8-VC.zip",
+        "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-2.8.8.zip"
     ],
     "hash": [
-        "f1f1e9bd1bd6d92ac3c93730784f40bcf4b66857ca5e2d0fd3b2fe05d1900c34",
-        "1ad911966aabf194a8a5e5744f5e67de2b61cc6e2c399de0abb80e05ce526b2c"
+        "076cebe070c5762bff0c854d2307078e53348d0225e04748feeb7c944453a86e",
+        "def4c7cba37a2f2cce83cfeff053220b2e1481c3c00d59638b1c526ae58545ac"
     ],
     "installer": {
         "script": [
@@ -116,7 +116,7 @@
     },
     "checkver": {
         "url": "https://github.com/libsdl-org/SDL_image/releases",
-        "regex": "release-([\\d.]+)"
+        "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {
         "url": [

--- a/bucket/sdl2-image.json
+++ b/bucket/sdl2-image.json
@@ -115,7 +115,7 @@
         ]
     },
     "checkver": {
-        "url": "https://github.com/libsdl-org/SDL_image/releases",
+        "url": "https://api.github.com/repositories/331517360/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/sdl2-mixer.json
+++ b/bucket/sdl2-mixer.json
@@ -115,7 +115,7 @@
         ]
     },
     "checkver": {
-        "url": "https://github.com/libsdl-org/SDL_mixer/releases",
+        "url": "https://api.github.com/repositories/337915185/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/sdl2-mixer.json
+++ b/bucket/sdl2-mixer.json
@@ -116,7 +116,7 @@
     },
     "checkver": {
         "url": "https://github.com/libsdl-org/SDL_mixer/releases",
-        "regex": "release-([\\d.]+)"
+        "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {
         "url": [

--- a/bucket/sdl2-ttf.json
+++ b/bucket/sdl2-ttf.json
@@ -116,8 +116,8 @@
         ]
     },
     "checkver": {
-        "github": "https://github.com/libsdl-org/SDL_ttf",
-        "regex": "release-(?<version>[\\d.]+)"
+        "url": "https://github.com/libsdl-org/SDL_ttf/releases",
+        "regex": "release-(?<version>2.[\\d.]+)"
     },
     "autoupdate": {
         "url": [

--- a/bucket/sdl2-ttf.json
+++ b/bucket/sdl2-ttf.json
@@ -116,8 +116,8 @@
         ]
     },
     "checkver": {
-        "url": "https://github.com/libsdl-org/SDL_ttf/releases",
-        "regex": "release-(?<version>2.[\\d.]+)"
+        "url": "https://api.github.com/repositories/337745832/releases",
+        "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {
         "url": [

--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.30.12",
+    "version": "2.32.2",
     "description": "SDL (Simple DirectMedia Layer) is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
     "homepage": "https://www.libsdl.org",
     "license": "Zlib",
     "url": [
-        "https://github.com/libsdl-org/SDL/releases/download/release-2.30.12/SDL2-devel-2.30.12-VC.zip",
-        "https://github.com/libsdl-org/SDL/releases/download/release-2.30.12/SDL2-2.30.12.zip"
+        "https://github.com/libsdl-org/SDL/releases/download/release-2.32.2/SDL2-devel-2.32.2-VC.zip",
+        "https://github.com/libsdl-org/SDL/releases/download/release-2.32.2/SDL2-2.32.2.zip"
     ],
     "hash": [
-        "1ca980f9964fb44cf94be235c9818fa1dc8e3f76b08096d751b2d689e5e37d02",
-        "aa2808d0f2dc6b383c6689bf6d166e2de62db4d58be989e4b052acb31df0fba3"
+        "85f13b84c73c044cff543ab98d9dbda252dd757b8202aa63fba02a9a162736a8",
+        "926718a165e9927e2045c0f0e2b02f6d8d73101ff82d27a066855fdd9a5fb952"
     ],
     "installer": {
         "script": [
@@ -79,8 +79,8 @@
         ]
     },
     "checkver": {
-        "github": "https://github.com/libsdl-org/SDL",
-        "regex": "tag/release-([\\d.]+)"
+        "url": "https://github.com/libsdl-org/SDL/releases",
+        "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {
         "url": [

--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.32.2",
+    "version": "2.32.4",
     "description": "SDL (Simple DirectMedia Layer) is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
     "homepage": "https://www.libsdl.org",
     "license": "Zlib",
     "url": [
-        "https://github.com/libsdl-org/SDL/releases/download/release-2.32.2/SDL2-devel-2.32.2-VC.zip",
-        "https://github.com/libsdl-org/SDL/releases/download/release-2.32.2/SDL2-2.32.2.zip"
+        "https://github.com/libsdl-org/SDL/releases/download/release-2.32.4/SDL2-devel-2.32.4-VC.zip",
+        "https://github.com/libsdl-org/SDL/releases/download/release-2.32.4/SDL2-2.32.4.zip"
     ],
     "hash": [
-        "85f13b84c73c044cff543ab98d9dbda252dd757b8202aa63fba02a9a162736a8",
-        "926718a165e9927e2045c0f0e2b02f6d8d73101ff82d27a066855fdd9a5fb952"
+        "28681dbef9c31a2bb4af6cbda90fdabc27c7415d65b9393da83d5abd12c4a265",
+        "030bd2768653bf11cefef06aaa99e61e850326871d283b81d324fb7242b6c702"
     ],
     "installer": {
         "script": [
@@ -79,7 +79,7 @@
         ]
     },
     "checkver": {
-        "url": "https://github.com/libsdl-org/SDL/releases",
+        "url": "https://api.github.com/repositories/330008801/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
This pull request includes updating `checkver` for SDL and its related packages' 2.x releases correctly, not for v3 releases.

Closes #15128

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
