### PR TITLE
NAPS2: fix broken autoupdate

### DIFF
--- a/bucket/naps2.json
+++ b/bucket/naps2.json
@@ -3,7 +3,7 @@
     "description": "Scan documents to PDF and more, as simply as possible",
     "homepage": "https://www.naps2.com/",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/cyanfish/naps2/releases/download/v8.1.1/naps2-8.1.1-win.zip",
+    "url": "https://github.com/cyanfish/naps2/releases/download/v8.1.1/naps2-8.1.1-win-x64.zip",
     "hash": "c5f5a77964016737a169506b7cb996d317a5cecf8f4325b679e966f6815421f9",
     "bin": [
         [

--- a/bucket/naps2.json
+++ b/bucket/naps2.json
@@ -22,6 +22,6 @@
         "github": "https://github.com/cyanfish/naps2"
     },
     "autoupdate": {
-        "url": "https://github.com/cyanfish/naps2/releases/download/v$version/naps2-$version-win.zip"
+        "url": "https://github.com/cyanfish/naps2/releases/download/v$version/naps2-$version-win-x64.zip"
     }
 }

--- a/bucket/naps2.json
+++ b/bucket/naps2.json
@@ -1,10 +1,10 @@
 {
-    "version": "7.5.3",
+    "version": "8.1.1",
     "description": "Scan documents to PDF and more, as simply as possible",
     "homepage": "https://www.naps2.com/",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/cyanfish/naps2/releases/download/v7.5.3/naps2-7.5.3-win.zip",
-    "hash": "6a56c6620dd680d35b8970b835fe57728a727976ace2f104225b045e097a6c7c",
+    "url": "https://github.com/cyanfish/naps2/releases/download/v8.1.1/naps2-8.1.1-win.zip",
+    "hash": "c5f5a77964016737a169506b7cb996d317a5cecf8f4325b679e966f6815421f9",
     "bin": [
         [
             "App\\NAPS2.Console.exe",


### PR DESCRIPTION
The NAPS2 autoupdate functionality has been broken for a while.  This PR is designed to fix it.