### PR TITLE
Wait4X: Change the repository address

### DIFF
--- a/bucket/wait4x.json
+++ b/bucket/wait4x.json
@@ -5,25 +5,25 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/atkrad/wait4x/releases/download/v3.2.0/wait4x-windows-amd64.tar.gz",
+            "url": "https://github.com/wait4x/wait4x/releases/download/v3.2.0/wait4x-windows-amd64.tar.gz",
             "hash": "771c7cf74dbc542bd9e5cd604cde288dda92035879b0ea939db651ff37180dbe"
         },
         "arm64": {
-            "url": "https://github.com/atkrad/wait4x/releases/download/v3.2.0/wait4x-windows-arm64.tar.gz",
+            "url": "https://github.com/wait4x/wait4x/releases/download/v3.2.0/wait4x-windows-arm64.tar.gz",
             "hash": "693cbe9ae59470709f3d64c2476bc7d71777f521e47c8478fd0cddf23fd54c71"
         }
     },
     "bin": "wait4x.exe",
     "checkver": {
-        "github": "https://github.com/atkrad/wait4x"
+        "github": "https://github.com/wait4x/wait4x"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/atkrad/wait4x/releases/download/v$version/wait4x-windows-amd64.tar.gz"
+                "url": "https://github.com/wait4x/wait4x/releases/download/v$version/wait4x-windows-amd64.tar.gz"
             },
             "arm64": {
-                "url": "https://github.com/atkrad/wait4x/releases/download/v$version/wait4x-windows-arm64.tar.gz"
+                "url": "https://github.com/wait4x/wait4x/releases/download/v$version/wait4x-windows-arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
The repository address of Wait4X changed from "https://github.com/atkrad/wait4x" to "https://github.com/wait4x/wait4x".

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
