### PR TITLE
zaproxy@2.16.1: Suggest Java 17

### DIFF
--- a/bucket/zaproxy.json
+++ b/bucket/zaproxy.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.zaproxy.org",
     "license": "Apache-2.0",
     "suggest": {
-        "JRE": "java/temurin11-jre"
+        "JRE": "java/temurin17-jre"
     },
     "url": "https://github.com/zaproxy/zaproxy/releases/download/v2.16.1/ZAP_2.16.1_Crossplatform.zip",
     "hash": "e90ca63b2fb213f2d5a53036a48d90a4c5c38b8a5c51768e75598a578c071415",


### PR DESCRIPTION
Both 2.16 and now 2.16.1 [require Java 17+](https://www.zaproxy.org/docs/desktop/releases/2.16.0/#update-to-a-minimum-of-java-17).

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
