### PR TITLE
vcxsrv: Update to version 21.1.16.1, deprecate 32bit version

### DIFF
--- a/bucket/vcxsrv.json
+++ b/bucket/vcxsrv.json
@@ -1,16 +1,12 @@
 {
-    "version": "21.1.13.0",
+    "version": "21.1.16.1",
     "description": "Windows X-server based on the xorg git sources (like xming or cygwin's xwin)",
     "homepage": "https://github.com/marchaesen/vcxsrv",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/marchaesen/vcxsrv/releases/download/21.1.13/vcxsrv-64.21.1.13.0.installer.exe#/dl.7z",
-            "hash": "970243b0e2c652949225d250bf37e87e2f321435d4d3757e94ff762e4578a281"
-        },
-        "32bit": {
-            "url": "https://github.com/marchaesen/vcxsrv/releases/download/21.1.13/vcxsrv.21.1.13.0.installer.exe#/dl.7z",
-            "hash": "4893864aa258700ad9b35730634e1eeacbb17b6a03bb89fa0c30934ce1d0bddd"
+            "url": "https://github.com/marchaesen/vcxsrv/releases/download/21.1.16.1/vcxsrv-64.21.1.16.1.installer.exe#/dl.7z",
+            "hash": "df7fed8f49665d0592528ab6be9d07111ea73c6848283d128b77690e05b8f90b"
         }
     },
     "bin": [
@@ -43,9 +39,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/marchaesen/vcxsrv/releases/download/$matchTag/vcxsrv-64.$version.installer.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/marchaesen/vcxsrv/releases/download/$matchTag/vcxsrv.$version.installer.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
removed 32bit installer, updates to current version

Closes #15167

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
