### PR TITLE
tailscale@1.82.0: Fix could not find 'Tailscale'

### DIFF
--- a/bucket/tailscale.json
+++ b/bucket/tailscale.json
@@ -45,7 +45,7 @@
             "if ($cmd -eq 'uninstall') { reg import \"$dir\\remove-startup.reg\" }"
         ]
     },
-    "extract_dir": "Tailscale",
+    "extract_dir": "PFiles64\\Tailscale",
     "bin": [
         "tailscale.exe",
         "tailscale-ipn.exe",

--- a/bucket/tailscale.json
+++ b/bucket/tailscale.json
@@ -10,15 +10,18 @@
     "architecture": {
         "64bit": {
             "url": "https://pkgs.tailscale.com/stable/tailscale-setup-1.82.0-amd64.msi",
-            "hash": "32b8ad3ca2202d090bebe8e2d8108bcdd8c9371d4840ebf7c03288a9af133715"
+            "hash": "32b8ad3ca2202d090bebe8e2d8108bcdd8c9371d4840ebf7c03288a9af133715",
+            "extract_dir": "PFiles64\\Tailscale"
         },
         "32bit": {
             "url": "https://pkgs.tailscale.com/stable/tailscale-setup-1.82.0-x86.msi",
-            "hash": "48b1a37bfdc93e6cd9101cdb0433cfba0f66579506127dc0a8ccbf5b3cc4120b"
+            "hash": "48b1a37bfdc93e6cd9101cdb0433cfba0f66579506127dc0a8ccbf5b3cc4120b",
+            "extract_dir": "PFiles\\Tailscale"
         },
         "arm64": {
             "url": "https://pkgs.tailscale.com/stable/tailscale-setup-1.82.0-arm64.msi",
-            "hash": "88bc19c311de33b19df9b98e2a30d6413f003dc6db1168df85ec094cdbdef3f1"
+            "hash": "88bc19c311de33b19df9b98e2a30d6413f003dc6db1168df85ec094cdbdef3f1",
+            "extract_dir": "PFiles64\\Tailscale"
         }
     },
     "pre_install": "if (!(is_admin)) {error 'This package requires admin rights to install'; break}",
@@ -45,7 +48,6 @@
             "if ($cmd -eq 'uninstall') { reg import \"$dir\\remove-startup.reg\" }"
         ]
     },
-    "extract_dir": "PFiles64\\Tailscale",
     "bin": [
         "tailscale.exe",
         "tailscale-ipn.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix the problem that raise `Could not find 'Tailscale'! (error 16)` exception during extracting the MSI installer.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #15172
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
