### PR TITLE
ipfs-desktop@0.42.0: Use new setup package name

### DIFF
--- a/bucket/ipfs-desktop.json
+++ b/bucket/ipfs-desktop.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ipfs/ipfs-desktop/releases/download/v0.42.0/ipfs-desktop-setup-0.42.0.exe#/dl.7z",
+            "url": "https://github.com/ipfs/ipfs-desktop/releases/download/v0.42.0/ipfs-desktop-setup-0.42.0-win-x64.exe#/dl.7z",
             "hash": "sha512:8bc2a50d33e4150292febb5572d97a4f9e36fe65d49e5f79ba62b3b8b52ffc20177099d240cdf3c8badaa3cfbb90ea3a2c1b091e36fb970cd3228eb7cc663650",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",


### PR DESCRIPTION
The name of the Windows Setup exe has changed in v0.42.0.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
