### PR TITLE
duplicati@2.1.0.5: update to stable release, add architecture, change license

### DIFF
--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -1,8 +1,8 @@
 {
-    "version": "2.0.8.1_beta_2024-05-07",
+    "version": "2.1.0.5_stable_2025-03-04",
     "homepage": "https://www.duplicati.com/",
     "description": "A free, open source, backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers.",
-    "license": "LGPL-2.1",
+    "license": "MIT",
     "notes": [
         "If you want Dupilicati to run at the startup of your system, run: (requires administrator privileges)",
         "start \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'install'",
@@ -10,8 +10,16 @@
         "To remove Duplicati from startup, run: (requires administrator privileges)",
         "start \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'uninstall'"
     ],
-    "url": "https://github.com/duplicati/duplicati/releases/download/v2.0.8.1-2.0.8.1_beta_2024-05-07/duplicati-2.0.8.1_beta_2024-05-07.zip",
-    "hash": "516d83a78123f876a85e012d8adfccb31e77cdaf9bf85d527ce30b5541094675",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-x86-gui.zip",
+            "hash": "26a88ff3834cee5ef342e76a5c8b580f5b3f359bad4cb41e4fd8e50fedf8e3a9"
+        },
+        "64bit": {
+            "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-x64-gui.zip",
+            "hash": "6589d9ba26a4a788b99508c7d734407e4fd4fae10e0e241abdb20f132954138d"
+        }
+    },
     "bin": [
         "Duplicati.CommandLine.exe",
         [
@@ -37,9 +45,16 @@
     ],
     "checkver": {
         "url": "https://github.com/duplicati/duplicati/tags",
-        "regex": "v(?<half>[\\d.]+)-([\\d.]+_beta_[\\d-]+)"
+        "regex": "v(?<half>[\\d.]+)-([\\d.]+_stable_[\\d-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/duplicati/duplicati/releases/download/v$matchHalf-$version/duplicati-$version.zip"
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x86-gui.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x64-gui.zip"
+            }
+        }
     }
 }

--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -18,6 +18,10 @@
         "64bit": {
             "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-x64-gui.zip",
             "hash": "6589d9ba26a4a788b99508c7d734407e4fd4fae10e0e241abdb20f132954138d"
+        },
+        "arm64": {
+            "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-arm64-gui.zip",
+            "hash": "3090b41af4e15b83c59335fd04362a8d04b1542f7cd4c6eaec1c5adbe7978ced"
         }
     },
     "bin": [
@@ -54,6 +58,9 @@
             },
             "64bit": {
                 "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x64-gui.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-arm64-gui.zip"
             }
         }
     }

--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -13,15 +13,18 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-x86-gui.zip",
-            "hash": "26a88ff3834cee5ef342e76a5c8b580f5b3f359bad4cb41e4fd8e50fedf8e3a9"
+            "hash": "26a88ff3834cee5ef342e76a5c8b580f5b3f359bad4cb41e4fd8e50fedf8e3a9",
+            "extract_dir": "duplicati-2.1.0.5_stable_2025-03-04-win-x86-gui"
         },
         "64bit": {
             "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-x64-gui.zip",
-            "hash": "6589d9ba26a4a788b99508c7d734407e4fd4fae10e0e241abdb20f132954138d"
+            "hash": "6589d9ba26a4a788b99508c7d734407e4fd4fae10e0e241abdb20f132954138d",
+            "extract_dir": "duplicati-2.1.0.5_stable_2025-03-04-win-x64-gui"
         },
         "arm64": {
             "url": "https://github.com/duplicati/duplicati/releases/download/v2.1.0.5_stable_2025-03-04/duplicati-2.1.0.5_stable_2025-03-04-win-arm64-gui.zip",
-            "hash": "3090b41af4e15b83c59335fd04362a8d04b1542f7cd4c6eaec1c5adbe7978ced"
+            "hash": "3090b41af4e15b83c59335fd04362a8d04b1542f7cd4c6eaec1c5adbe7978ced",
+            "extract_dir": "duplicati-2.1.0.5_stable_2025-03-04-win-arm64-gui"
         }
     },
     "bin": [
@@ -54,13 +57,16 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x86-gui.zip"
+                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x86-gui.zip",
+                "extract_dir": "duplicati-$version-win-x86-gui"
             },
             "64bit": {
-                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x64-gui.zip"
+                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-x64-gui.zip",
+                "extract_dir": "duplicati-$version-win-x64-gui"
             },
             "arm64": {
-                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-arm64-gui.zip"
+                "url": "https://github.com/duplicati/duplicati/releases/download/v$version/duplicati-$version-win-arm64-gui.zip",
+                "extract_dir": "duplicati-$version-win-arm64-gui"
             }
         }
     }


### PR DESCRIPTION
- update version to latest build
- update regex to use `stable` release since `beta` has been retired
  - a separate manifest can be created for `canary` if desired but is not included here
- support for 32-bit and 64-bit architectures
- license is MIT now

Closes #14856 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 
