### PR TITLE
calibre: change download url to github

### DIFF
--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.calibre-ebook.com/8.2.100/calibre-portable-installer-8.2.100.exe",
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v8.2.100/calibre-portable-installer-8.2.100.exe",
             "hash": "sha512:199ec4ed503dfb221982b766d2a6cc734b1c83d336a7755329015588da9e1c2264f2a8c467e407506b76e238a2816a6cbf5f7af0c2a35c13eb83b949819cece9"
         }
     },
@@ -71,7 +71,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.calibre-ebook.com/$version/calibre-portable-installer-$version.exe",
+                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-portable-installer-$version.exe",
                 "hash": {
                     "url": "https://calibre-ebook.com/signatures/calibre-portable-installer-$version.exe.sha512"
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

```bash
$ curl https://download.calibre-ebook.com/8.2.100/calibre-portable-installer-8.2.100.exe
curl: (35) schannel: failed to receive handshake, SSL/TLS connection failed
```

Seem like the official website not response as expect, change URL to GitHub.