### PR TITLE
everything-cmdpal: Add version 0.1.0

### DIFF
--- a/bucket/everything-cmdpal.json
+++ b/bucket/everything-cmdpal.json
@@ -1,5 +1,5 @@
 {
-    "version":"0.1.0.0",
+    "version":"0.1.0",
     "description":"Adds Everything search to Command Palette.",
     "homepage": "https://github.com/lin-ycv/EverythingCommandPalette",
     "license":"epl-2.0",
@@ -12,7 +12,8 @@
     },
     "architecture": {
         "64bit": {
-            "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_x64__yazqh14evg2ve.Msix#/ecp.msix"
+            "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_x64__yazqh14evg2ve.Msix#/ecp.msix",
+            "hash":"c8fed72e7ff3cf59a01447b3bf2e200b55e8f03ee9d1c0b6b84db4e6b072340a"
         }
     },
     "post_install": [
@@ -25,7 +26,11 @@
     "autoupdate":{
         "architecture":{
             "64bit":{
-                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/$matchRelease/VictorLin.EverythingCP_$version_x64__yazqh14evg2ve.Msix#/ecp.msix"
+                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version.0_x64__yazqh14evg2ve.Msix#/ecp.msix",
+                "hash":{
+                    "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/tag/v$version",
+                    "regex": "(?s)msix-x64.*?$sha256"
+                }
             }
         }
     }

--- a/bucket/everything-cmdpal.json
+++ b/bucket/everything-cmdpal.json
@@ -14,6 +14,10 @@
         "64bit": {
             "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_x64__yazqh14evg2ve.Msix#/ecp.msix",
             "hash":"c8fed72e7ff3cf59a01447b3bf2e200b55e8f03ee9d1c0b6b84db4e6b072340a"
+        },
+        "arm64": {
+            "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_arm64__yazqh14evg2ve.Msix#/ecp.msix",
+            "hash": "265cf2bd75d49081757c3da59aa8cd6e139470a88d2c3e6cecc52a0b010fc5dc"
         }
     },
     "post_install": [
@@ -26,10 +30,17 @@
     "autoupdate":{
         "architecture":{
             "64bit":{
-                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version.0_x64__yazqh14evg2ve.Msix#/ecp.msix",
+                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version_x64__yazqh14evg2ve.Msix#/ecp.msix",
                 "hash":{
                     "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/tag/v$version",
                     "regex": "(?s)msix-x64.*?$sha256"
+                }
+            },
+            "arm64": {
+                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version_arm64__yazqh14evg2ve.Msix#/ecp.msix",
+                "hash": {
+                    "url": "https://github.com/lin-ycv/EverythingPowerToys/releases/tag/v$version",
+                    "regex": "(?s)msix-arm64.*?$sha256"
                 }
             }
         }

--- a/bucket/everything-cmdpal.json
+++ b/bucket/everything-cmdpal.json
@@ -1,0 +1,32 @@
+{
+    "version":"0.1.0.0",
+    "description":"Adds Everything search to Command Palette.",
+    "homepage": "https://github.com/lin-ycv/EverythingCommandPalette",
+    "license":"epl-2.0",
+    "suggest":{
+        "Everything":[
+            "extras/everything",
+            "versions/everything-alpha"
+        ],
+        "PowerToys": "extras/powertoys"
+    },
+    "architecture": {
+        "64bit": {
+            "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_x64__yazqh14evg2ve.Msix#/ecp.msix"
+        }
+    },
+    "post_install": [
+        "Add-AppxPackage \"$dir\\ecp.msix\""
+    ],
+    "pre_uninstall":[
+        "get-appxpackage VictorLin.EverythingCP* | remove-appxpackage"
+    ],
+    "checkver":"github",
+    "autoupdate":{
+        "architecture":{
+            "64bit":{
+                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/$matchRelease/VictorLin.EverythingCP_$version_x64__yazqh14evg2ve.Msix#/ecp.msix"
+            }
+        }
+    }
+}

--- a/bucket/everything-cmdpal.json
+++ b/bucket/everything-cmdpal.json
@@ -1,5 +1,5 @@
 {
-    "version":"0.1.0",
+    "version":"0.2.0.0",
     "description":"Adds Everything search to Command Palette.",
     "homepage": "https://github.com/lin-ycv/EverythingCommandPalette",
     "license":"epl-2.0",
@@ -10,18 +10,25 @@
         ],
         "PowerToys": "extras/powertoys"
     },
-    "architecture": {
-        "64bit": {
-            "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_x64__yazqh14evg2ve.Msix#/ecp.msix",
-            "hash":"c8fed72e7ff3cf59a01447b3bf2e200b55e8f03ee9d1c0b6b84db4e6b072340a"
-        },
-        "arm64": {
-            "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.1.0/VictorLin.EverythingCP_0.1.0.0_arm64__yazqh14evg2ve.Msix#/ecp.msix",
-            "hash": "265cf2bd75d49081757c3da59aa8cd6e139470a88d2c3e6cecc52a0b010fc5dc"
+    "autoupdate":{
+        "architecture":{
+            "64bit":{
+                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version_x64__yazqh14evg2ve.Msix#/ecp.msix",
+                "hash":{
+                    "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/tag/v$version",
+                    "regex": "(?s)msix-x64.*?$sha256"
+                }
+            }
         }
-    },
+    }
+    "pre_install": [
+        "$package = Get-AppxPackage | Where-Object { ($_.Name -match 'Microsoft.WindowsAppRuntime.\\d+') -and ($_.Name -notlike '*CBS*') -and  ([version]$_.Version -ge [version]'6000.401.2352.0')}",
+        "if(-not ($package)) {switch($env:PROCESSOR_ARCHITECTURE){ 'ARM64' { $url = 'https://aka.ms/windowsappsdk/1.6/1.6.250228001/windowsappruntimeinstall-arm64.exe' } 'AMD64' { $url = 'https://aka.ms/windowsappsdk/1.6/1.6.250228001/windowsappruntimeinstall-x64.exe' } } Write-Host 'Windows App Runtime is NOT installed, installing package... (This may take a while)'; Invoke-WebRequest -Uri $url -OutFile 'war166.exe'; & '.\\war166.exe' --quiet}",
+        "Get-ChildItem -Path 'war166.exe' -ErrorAction SilentlyContinue | Remove-Item -Force"
+    ],
     "post_install": [
-        "Add-AppxPackage \"$dir\\ecp.msix\""
+        "Add-AppxPackage \"$dir\\ecp.msix\"",
+        "if(-not (get-appxpackage -Name VictorLin.EverythingCP*)) { get-appxpackage VictorLin.EverythingCP* | remove-appxpackage }"
     ],
     "pre_uninstall":[
         "get-appxpackage VictorLin.EverythingCP* | remove-appxpackage"
@@ -35,14 +42,8 @@
                     "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/tag/v$version",
                     "regex": "(?s)msix-x64.*?$sha256"
                 }
-            },
-            "arm64": {
-                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version_arm64__yazqh14evg2ve.Msix#/ecp.msix",
-                "hash": {
-                    "url": "https://github.com/lin-ycv/EverythingPowerToys/releases/tag/v$version",
-                    "regex": "(?s)msix-arm64.*?$sha256"
-                }
             }
         }
     }
 }
+

--- a/bucket/everything-cmdpal.json
+++ b/bucket/everything-cmdpal.json
@@ -10,25 +10,14 @@
         ],
         "PowerToys": "extras/powertoys"
     },
-    "autoupdate":{
-        "architecture":{
-            "64bit":{
-                "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v$version/VictorLin.EverythingCP_$version_x64__yazqh14evg2ve.Msix#/ecp.msix",
-                "hash":{
-                    "url": "https://github.com/lin-ycv/EverythingCommandPalette/releases/tag/v$version",
-                    "regex": "(?s)msix-x64.*?$sha256"
-                }
-            }
+    "architecture": {
+        "64bit": {
+            "url":"https://github.com/lin-ycv/EverythingCommandPalette/releases/download/v0.2.0.0/VictorLin.EverythingCP_0.2.0.0_x64__yazqh14evg2ve.Msix#/ecp.msix",
+            "hash":"26ffc9f734d4bc767fe574f309bd40109d52ebf26928949f1408ec0a4c1c7899"
         }
-    }
-    "pre_install": [
-        "$package = Get-AppxPackage | Where-Object { ($_.Name -match 'Microsoft.WindowsAppRuntime.\\d+') -and ($_.Name -notlike '*CBS*') -and  ([version]$_.Version -ge [version]'6000.401.2352.0')}",
-        "if(-not ($package)) {switch($env:PROCESSOR_ARCHITECTURE){ 'ARM64' { $url = 'https://aka.ms/windowsappsdk/1.6/1.6.250228001/windowsappruntimeinstall-arm64.exe' } 'AMD64' { $url = 'https://aka.ms/windowsappsdk/1.6/1.6.250228001/windowsappruntimeinstall-x64.exe' } } Write-Host 'Windows App Runtime is NOT installed, installing package... (This may take a while)'; Invoke-WebRequest -Uri $url -OutFile 'war166.exe'; & '.\\war166.exe' --quiet}",
-        "Get-ChildItem -Path 'war166.exe' -ErrorAction SilentlyContinue | Remove-Item -Force"
-    ],
+    },
     "post_install": [
-        "Add-AppxPackage \"$dir\\ecp.msix\"",
-        "if(-not (get-appxpackage -Name VictorLin.EverythingCP*)) { get-appxpackage VictorLin.EverythingCP* | remove-appxpackage }"
+        "Add-AppxPackage \"$dir\\ecp.msix\""
     ],
     "pre_uninstall":[
         "get-appxpackage VictorLin.EverythingCP* | remove-appxpackage"
@@ -46,4 +35,3 @@
         }
     }
 }
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds a manifest to enable Everything search integration with Command Palette (v0.2.0.0).

- Improvements
  - Installs the Everything Command Palette package during setup.
  - Removes the app package on uninstall for cleaner removal.
  - Suggests related tools (Everything and PowerToys) to complete the setup.
  - Enables automatic update checks via GitHub for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->