### PR TITLE
syncthingtray: Add arm64 version

### DIFF
--- a/bucket/syncthingtray.json
+++ b/bucket/syncthingtray.json
@@ -14,6 +14,10 @@
         "32bit": {
             "url": "https://github.com/Martchus/syncthingtray/releases/download/v1.7.5/syncthingtray-qt5-1.7.5-i686-w64-mingw32.exe.zip",
             "hash": "d4388b565702f6785dca120334beb2cfb70eff94cb8a9f0a8a966bf541fa89d7"
+        },
+        "arm64": {
+            "url": "https://github.com/Martchus/syncthingtray/releases/download/v1.7.5/syncthingtray-1.7.5-aarch64-w64-mingw32.exe.zip",
+            "hash": "bf75af9eb7210a8e0ed8519fa833c242c74e188ad7c1375ad2922df43c3c8fe2"
         }
     },
     "pre_install": [
@@ -46,6 +50,9 @@
             },
             "32bit": {
                 "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingtray-qt5-$version-i686-w64-mingw32.exe.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingtray-$version-aarch64-w64-mingw32.exe.zip"
             }
         }
     }


### PR DESCRIPTION
Adds ARM64 support to syncthingtray manifest

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #14894 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
