### PR TITLE
wireshark@4.6.2: Disable built-in updater, fix pre_install script, add arm64 support

### DIFF
--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -13,6 +13,10 @@
         "If this is the first time you opted to install USBPcap, please restart and run: $dir\\enable-usbpcap.ps1"
     ],
     "architecture": {
+        "arm64": {
+            "url": "https://www.wireshark.org/download/win64/Wireshark-4.6.2-arm64.exe#/dl.7z",
+            "hash": "ed0f03cc3d4a0815731ca3c8531a5ec05e5a0d965a2c868d1d4c995d025f3758"
+        },
         "64bit": {
             "url": "https://www.wireshark.org/download/win64/Wireshark-4.6.2-x64.exe#/dl.7z",
             "hash": "373a93e9b5ffa3559938424a2aabd3338786cff7bef084641c2c5e5bfb44325e"
@@ -61,13 +65,16 @@
     },
     "autoupdate": {
         "architecture": {
+            "arm64": {
+                "url": "https://www.wireshark.org/download/win64/Wireshark-$version-arm64.exe#/dl.7z"
+            },
             "64bit": {
-                "url": "https://www.wireshark.org/download/win64/Wireshark-$version-x64.exe#/dl.7z",
-                "hash": {
-                    "url": "https://www.wireshark.org/download/SIGNATURES-$version.txt",
-                    "regex": "SHA256\\($basename\\)=$sha256"
-                }
+                "url": "https://www.wireshark.org/download/win64/Wireshark-$version-x64.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "https://www.wireshark.org/download/SIGNATURES-$version.txt",
+            "regex": "SHA256\\($basename\\)=$sha256"
         }
     }
 }

--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -19,7 +19,7 @@
         }
     },
     "pre_install": [
-        "'$PLUGINSDIR', 'vc_redist*', 'uninstall-wireshark.exe' | ForEach-Object { \"$dir/$_\" } | Remove-Item -Recurse",
+        "'$PLUGINSDIR', 'vc_redist*', 'uninstall-wireshark.exe' | ForEach-Object { \"$dir/$_\" } | Remove-Item -Recurse -ErrorAction Ignore",
         "'npcap', 'USBPcapSetup' | ForEach-Object { Rename-Item \"$dir/$_-*.exe\" \"$_-installer.exe\" }",
         "$data = \"$persist_dir/Data\"",
         "$preferences = \"$data/preferences\"",

--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -18,16 +18,19 @@
             "hash": "373a93e9b5ffa3559938424a2aabd3338786cff7bef084641c2c5e5bfb44325e"
         }
     },
-    "installer": {
-        "script": [
-            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\vc_redist*\", \"$dir\\uninstall-wireshark.exe\" -Recurse",
-            "Get-ChildItem \"$dir\\npcap-*.exe\" | Rename-Item -NewName 'npcap-installer.exe'",
-            "Get-ChildItem \"$dir\\USBPcapSetup-*.exe\" | Rename-Item -NewName 'USBPcapSetup-installer.exe'"
-        ]
-    },
+    "pre_install": [
+        "'$PLUGINSDIR', 'vc_redist*', 'uninstall-wireshark.exe' | ForEach-Object { \"$dir/$_\" } | Remove-Item -Recurse",
+        "'npcap', 'USBPcapSetup' | ForEach-Object { Rename-Item \"$dir/$_-*.exe\" \"$_-installer.exe\" }",
+        "$data = \"$persist_dir/Data\"",
+        "$preferences = \"$data/preferences\"",
+        "if (!(Test-Path $preferences)) {",
+        "    $null = New-Item -ItemType Directory $data -ErrorAction Ignore",
+        "    'gui.update.enabled: FALSE' | Out-File -Encoding utf8 $preferences",
+        "}"
+    ],
     "post_install": [
-        "Get-ChildItem \"$bucketsdir\\extras\\scripts\\wireshark\" | Copy-Item -Force -Destination \"$dir\"",
-        "& \"$dir\\enable-usbpcap.ps1\" 2>$null   # Attempt try to enable USBPcap if already installed"
+        "Copy-Item -Force \"$bucketsdir/extras/scripts/wireshark/*\" \"$dir\"",
+        "& \"$dir/enable-usbpcap.ps1\" 2>$null   # Attempt try to enable USBPcap if already installed"
     ],
     "bin": [
         "capinfos.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes #16720

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native ARM64 support for downloads and updates.

* **Chores**
  * Replaced installer step with a pre-install cleanup/setup sequence to improve install reliability.
  * Updated post-install actions to use the new environment paths while preserving device enablement steps.
  * Streamlined update metadata: added ARM64 update entry and moved validation hash to a unified top-level location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->