### PR TITLE
gitify@6.3.0: fix filename that has changed

### DIFF
--- a/bucket/gitify.json
+++ b/bucket/gitify.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/gitify-app/gitify/releases/download/v6.3.0/Gitify-Setup-6.3.0.exe#/dl.7z",
+            "url": "https://github.com/gitify-app/gitify/releases/download/v6.3.0/Gitify.Setup.6.3.0.exe#/dl.7z",
             "hash": "sha512:a05d200900785ed5e8d63951eac96d1fce91e6f40ae3786e31863470fc9ed36f13bceca7ca6ab7405b44c6dbc525f7cb2a4910f331bef681aff10554a7688aa6",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" -Removal",
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/gitify-app/gitify/releases/download/v$version/Gitify-Setup-$version.exe#/dl.7z"
+                "url": "https://github.com/gitify-app/gitify/releases/download/v$version/Gitify.Setup.$version.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
Gitify 6.3.0 filename has changed from the previous `Gitify-Setup-6.2.0.exe` to `Gitify.Setup.6.3.0.exe`. This PR fixes it and the autoupdate URL as well.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
