### PR TITLE
xan@0.49.3 - Fix update and added checksums

### DIFF
--- a/bucket/xan.json
+++ b/bucket/xan.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.49.1",
+    "version": "0.49.3",
     "description": "xan is a command line tool that can be used to process CSV files directly from the shell.",
     "homepage": "https://github.com/medialab/xan",
     "license": "Unlincense|MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/medialab/xan/releases/download/0.49.1/xan_0.49.1_x86_64-pc-windows-gnu.zip",
-            "hash": "46c4ed34dec373e04f09c8d64e15bb03b409761516917725a8230a73a927cb32"
+            "url": "https://github.com/medialab/xan/releases/download/0.49.3/xan-x86_64-pc-windows-msvc.zip",
+            "hash": "74a1f9d446c8386463fd7d0076c5ae064fd8ebd0d49b189450c98bd7f0e79654"
         }
     },
     "bin": "xan.exe",
@@ -14,11 +14,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/medialab/xan/releases/download/$version/xan_$version_x86_64-pc-windows-gnu.zip"
+                "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.zip"
             }
         },
         "hash": {
-            "url": "$url.sha256sum"
+            "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.sha256sum"
         }
     }
 }

--- a/bucket/xan.json
+++ b/bucket/xan.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.49.3",
+    "version": "0.50.0",
     "description": "xan is a command line tool that can be used to process CSV files directly from the shell.",
     "homepage": "https://github.com/medialab/xan",
     "license": "Unlincense|MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/medialab/xan/releases/download/0.49.3/xan-x86_64-pc-windows-msvc.zip",
-            "hash": "74a1f9d446c8386463fd7d0076c5ae064fd8ebd0d49b189450c98bd7f0e79654"
+            "url": "https://github.com/medialab/xan/releases/download/0.50.0/xan-x86_64-pc-windows-msvc.zip",
+            "hash": "e92f49fcc78d1ce8512f6f9307d44ddce299e63ae09f05a9ccbd31dcd570cacf"
         }
     },
     "bin": "xan.exe",
@@ -14,11 +14,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.zip",
+                "hash": {
+                    "url": "$baseurl/xan-x86_64-pc-windows-msvc.sha256"
+                }
             }
-        },
-        "hash": {
-            "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.sha256"
         }
     }
 }

--- a/bucket/xan.json
+++ b/bucket/xan.json
@@ -18,7 +18,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.sha256sum"
+            "url": "https://github.com/medialab/xan/releases/download/$version/xan-x86_64-pc-windows-msvc.sha256"
         }
     }
 }


### PR DESCRIPTION
This fixes xan updates (one of the previous versions do not provide executables and the file names changed). Also, it gets the checksums which are not included in the releases.

Closes #15370

- [X ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
