### PR TITLE
v2rayn@7.11.3: switch to desktop build(Avalonia UI), remove dependencies

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -3,35 +3,18 @@
     "description": "A V2Ray client for Windows, support Xray & v2fly core",
     "homepage": "https://github.com/2dust/v2rayN",
     "license": "GPL-3.0-only",
-    "depends": "xray",
-    "suggest": {
-        ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts",
-        "v2fly-core": "v2ray"
-    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/7.11.3/v2rayN-windows-64.zip",
-            "hash": "2014a3878bb144d746889329a10a4a55e9a6ac827f4323e6a078741a9db1ae07",
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.11.3/v2rayN-windows-64-desktop.zip",
+            "hash": "9fbac3838e005162f6a7a17b29ed47c1feca7b0a327a89b82ad74e5516e2fe9e",
             "extract_dir": "v2rayN-windows-64"
         },
         "arm64": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/7.11.3/v2rayN-windows-arm64.zip",
-            "hash": "fdefbdeef4133d21f45843c55a5eabc58b124efb0f76b003b32e40511a99e608",
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.11.3/v2rayN-windows-arm64-desktop.zip",
+            "hash": "5ded01014b4a80237aa2489855b69490e3e2227582ce85a7c6b73af700f3cc53",
             "extract_dir": "v2rayN-windows-arm64"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$dir\\bin\\Xray\")) { New-Item \"$dir\\bin\\Xray\" -ItemType Directory | Out-Null }",
-        "foreach ($form in @('*.exe', '*.dat')) {",
-        "    foreach ($_ in Get-ChildItem \"$(appdir xray $global)\\current\" -File) {",
-        "        $name = $_.Name",
-        "        if ($name -Like $form) {",
-        "            Write-Host \"Creating hardlink for $name\"",
-        "            New-Item -ItemType HardLink -Path \"$dir\\bin\\Xray\" -Name $name -Target \"$(appdir xray $global)\\current\\$name\" | Out-Null",
-        "        }",
-        "    }",
-        "}"
-    ],
     "bin": "v2rayN.exe",
     "shortcuts": [
         [
@@ -44,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-64.zip"
+                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-64-desktop.zip"
             },
             "arm64": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-arm64.zip"
+                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-arm64-desktop.zip"
             }
         }
     }


### PR DESCRIPTION
The desktop build (Avalonia UI) has a better UI and also doesn't need "Xray" and ".NET Desktop Runtime".

This PR makes the following changes to `v2ray`:

1. Switch to desktop build.
2. Remove dependencies.


Closes #15258

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
