### PR TITLE
powertoys@0.90.1 : fixed issue "can not install different version of powertoys" by updating "autoupdate" part.

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -79,16 +79,16 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/$matchTag/PowerToysUserSetup-$version-x64.exe",
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysUserSetup-$version-x64.exe",
                 "hash": {
-                    "url": "https://github.com/microsoft/PowerToys/releases/tag/$matchTag",
+                    "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
                     "regex": ">$sha256<"
                 }
             },
             "arm64": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/$matchTag/PowerToysUserSetup-$version-arm64.exe",
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysUserSetup-$version-arm64.exe",
                 "hash": {
-                    "url": "https://github.com/microsoft/PowerToys/releases/tag/$matchTag",
+                    "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
                     "regex": ">(?:[a-fA-F0-9]{64})<[\\s\\S]*?>([a-fA-F0-9]{64})<"
                 }
             }


### PR DESCRIPTION
I tried to install an older version of `powertoys` via 
```
scoop install powertoys@0.87.1
```
But it failed with the following output:
```
WARN  Given version (0.87.1) does not match manifest (0.90.1)
WARN  Attempting to generate manifest for 'powertoys' (0.87.1)
Autoupdating powertoys
Searching hash for PowerToysUserSetup-0.87.1-x64.exe in https://github.com/microsoft/PowerToys/releases/tag/$matchTag
The remote server returned an error: (404) Not Found.
```
I guess this is because tag and version strings differ (`v0.87.1` vs `0.87.1`).
To fix this, I've made small changes to `autoupdate` part. Now it seems working.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [ x ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
