### PR TITLE
windowsdesktop-runtime-lts: Update to version 8.0.15, fix checkver

### DIFF
--- a/bucket/windowsdesktop-runtime-lts.json
+++ b/bucket/windowsdesktop-runtime-lts.json
@@ -1,21 +1,21 @@
 {
-    "version": "8.0.14",
+    "version": "8.0.15",
     "description": "Microsoft .NET Desktop Runtime LTS (Long-term support)",
     "homepage": "https://dotnet.microsoft.com/download/dotnet",
     "license": "MIT",
     "notes": "You can now remove this installer with 'scoop uninstall windowsdesktop-runtime-lts'",
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/8.0.14/windowsdesktop-runtime-8.0.14-win-x64.exe",
-            "hash": "sha512:3997c2586be132c741176473f80d304c51d3bdd7d1f8987b20ab648cdd27f0c57141af0064eaf5b6a2cacc51f6872ee159e0171704dad222dbbfbedac49e553b"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/8.0.15/windowsdesktop-runtime-8.0.15-win-x64.exe",
+            "hash": "sha512:c5f12718adcd48cf8689f080de7799071cbe8f35b0fc9ce7a80f13812137c868004ccd5ea035d8e443216e70e15fdfcf013556c7cb3b1b02636acb0323b3574e"
         },
         "32bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/8.0.14/windowsdesktop-runtime-8.0.14-win-x86.exe",
-            "hash": "sha512:5d22529ef6c3138abd4461e30d3eb300aa3ea365386d013e3dc8e4347f0611f91e3df4d7b8d37e24f4a6efa1f5349254b3c3299fbe8fb232561af2de48c321d3"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/8.0.15/windowsdesktop-runtime-8.0.15-win-x86.exe",
+            "hash": "sha512:74b104a49fb956d5840a2e64e84d82214fe1b18ae043be8a55d9a01450f34ce1b8ba562e990eea9e69a65f0f95573d9ea26eed48232bdba2be28d1c330143804"
         },
         "arm64": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/8.0.14/windowsdesktop-runtime-8.0.14-win-arm64.exe",
-            "hash": "sha512:7b21cc96a0cc42f9ab701d7ed76aecc044c0906e03e82c5aeda102c757e14061a321c1d6fa2d0a273a43cb6dd7a4eb60bda10e5f5c5e3cb5154992c370382c05"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/8.0.15/windowsdesktop-runtime-8.0.15-win-arm64.exe",
+            "hash": "sha512:17c7ab6726c93d5e85a8f2d808ba64f42531f38d7dec65af1f3dd618c53103273ac129dcff33bb1689f8a4e45a5b252c0ad430ce3adfaddba93695276d757344"
         }
     },
     "pre_install": "if (!(is_admin)) { error 'Admin privileges are required.'; break }",
@@ -23,7 +23,8 @@
         "script": "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList '/install', '/quiet', '/norestart' -RunAs | Out-Null"
     },
     "checkver": {
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/LTS/latest.version",
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
+        "jsonpath": "$.releases-index[?(@.support-phase == 'active' && @.release-type == 'lts')].latest-runtime",
         "regex": "([\\d.]+)$"
     },
     "autoupdate": {


### PR DESCRIPTION
The latest version of `windowsdesktop-runtime-lts` is now `8.0.15`.

This PR makes the following changes:

- Update `windowsdesktop-runtime-lts` to version `8.0.15` & fix `checkver`.

Closes #15436

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
