### PR TITLE
resource-tuner: Update to version 2.25, fix installation issue

### DIFF
--- a/bucket/resource-tuner.json
+++ b/bucket/resource-tuner.json
@@ -1,14 +1,14 @@
 {
-    "version": "2.24",
+    "version": "2.25",
     "description": "Visual resource editor for EXE/DLL files. View and edit strings, bitmaps, dialogs and icons.",
-    "homepage": "http://www.restuner.com/",
+    "homepage": "https://www.restuner.com/",
     "license": {
         "identifier": "Proprietary",
-        "url": "http://www.restuner.com/order.htm"
+        "url": "https://www.restuner.com/order.htm"
     },
     "notes": "This app has a 30-day free trial",
-    "url": "http://www.heaventools.com/download/rtsetup.exe?r1=RestunerCom",
-    "hash": "f7d638cb8587338cc2844fa9bb25ed403312f098df7897dcfe867e35705dc5c2",
+    "url": "https://www.heaventools.com/download/rtsetup.exe",
+    "hash": "4371cea91eea3d3b78d422cc104a3497b580e7abde112203682b12a4e60c9f4d",
     "innosetup": true,
     "shortcuts": [
         [
@@ -18,6 +18,6 @@
     ],
     "checkver": "<h1>Resource Tuner ([\\d.]+)",
     "autoupdate": {
-        "url": "http://www.heaventools.com/download/rtsetup.exe?r1=RestunerCom"
+        "url": "https://www.heaventools.com/download/rtsetup.exe"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `resource-tuner`: Update to version 2.25, fix installation issue

Closes #15434

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
