### PR TITLE
musicbee: improve persistence

### DIFF
--- a/bucket/musicbee.json
+++ b/bucket/musicbee.json
@@ -9,11 +9,17 @@
     "url": "https://www.videohelp.com/download/MusicBeePortable_3_6.zip",
     "hash": "aff35dc919b4a620847ca0c5269d1d75e93bf96bcabcbbdc0d058ce3e1d82c5d",
     "pre_install": [
-        "(Get-ChildItem \"$dir\" 'MusicBee*.exe').FullName | Expand-7zipArchive -DestinationPath \"$dir\" -Removal",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse",
-        "foreach ($user_folders in 'BBplugin', 'Equaliser', 'Plugins', 'Skins') {",
-        "   Copy-Item \"$persist_dir\\$user_folders\\*\" \"$dir\\$user_folders\" -ErrorAction 'SilentlyContinue' -Recurse",
-        "}"
+        "(Get-ChildItem \"$dir\" 'MusicBee*.exe').FullName | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
+    ],
+    "post_install": [
+        "# If plugins, skins, eq presets, etc. have updates, ensure they're copied after persisting.",
+        "@('BBplugin', 'Equaliser', 'Plugins', 'Skins') | ForEach-Object {",
+        "    if (Test-Path \"$dir\\$_.original\") {",
+        "        Copy-Item \"$dir\\$_.original\\*\" \"$persist_dir\\$_\" -Force -Recurse",
+        "        Remove-Item \"$dir\\$_.original\" -Force -Recurse | Out-Null",
+        "    }",
+        "}",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse"
     ],
     "bin": "MusicBee.exe",
     "shortcuts": [
@@ -23,13 +29,12 @@
         ]
     ],
     "persist": [
+        "AppData",
+        "BBplugin",
+        "Equaliser",
         "Library",
-        "AppData"
-    ],
-    "pre_uninstall": [
-        "foreach ($user_folders in 'BBplugin', 'Equaliser', 'Plugins', 'Skins') {",
-        "   Copy-Item \"$dir\\$user_folders\\*\" \"$persist_dir\\$user_folders\" -ErrorAction 'SilentlyContinue' -Recurse",
-        "}"
+        "Plugins",
+        "Skins"
     ],
     "checkver": {
         "url": "https://www.videohelp.com/software/MusicBee",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #15454

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


This PR tweaks the `pre_install` script, and adds a `post_install` script for MusicBee. The changes properly persist directories (BBplugins, Equaliser, Plugins, and Skins) that previously were only copied into MusicBee's persisted directory, but not symlinked back into the application directory, thus not properly persisting the data.

While persisting skins was my main concern, it was little extra work to ensure the other 3 directories mentioned were properly persisted as well. See #15454 for more details.

The `post_install` script loops over the 4 directories mentioned above and copies their contents into the same directories in the persisted data directory to ensure that if default content within them is ever updated, we get a copy in our persisted data.

Perhaps worth mentioning, I took inspiration from the rainmeter manifest and how it handles pre- and post-installation to make these changes.

I have tested these changes on my end and they work as expected. Feedback welcome.
