### PR TITLE
processing4@1297-4.3.4: Update autoupdate url and package

### DIFF
--- a/bucket/processing4.json
+++ b/bucket/processing4.json
@@ -9,17 +9,13 @@
             "hash": "0e96d57f33cd3381c2d95e44dc2a062e316f703a333d0f6d4d8d5af4007c8525"
         }
     },
-    "extract_dir": "processing-4.4.4",
+    "extract_dir": "Processing",
     "bin": [
-        "processing-java.exe",
-        [
-            "processing-java.exe",
-            "processing-cli"
-        ]
+        "Processing.exe"
     ],
     "shortcuts": [
         [
-            "processing.exe",
+            "Processing.exe",
             "Processing"
         ]
     ],

--- a/bucket/processing4.json
+++ b/bucket/processing4.json
@@ -1,15 +1,15 @@
 {
-    "version": "1297-4.3.4",
+    "version": "1304-4.4.4",
     "homepage": "https://processing.org/",
     "description": "A flexible software sketchbook and a language for learning how to code.",
     "license": "GPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/processing/processing4/releases/download/processing-1297-4.3.4/processing-4.3.4-windows-x64.zip",
-            "hash": "fd7ccc686ffc2f3a9116c3eb45fd7a5fab510c7c9ff67af215dbbed30642a98f"
+            "url": "https://github.com/processing/processing4/releases/download/processing-1304-4.4.4/processing-4.4.4-windows-x64-portable.zip",
+            "hash": "0e96d57f33cd3381c2d95e44dc2a062e316f703a333d0f6d4d8d5af4007c8525"
         }
     },
-    "extract_dir": "processing-4.3.4",
+    "extract_dir": "processing-4.4.4",
     "bin": [
         "processing-java.exe",
         [

--- a/bucket/processing4.json
+++ b/bucket/processing4.json
@@ -36,7 +36,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/processing/processing4/releases/download/processing-$version/processing-$preReleaseVersion-windows-x64.zip"
+                "url": "https://github.com/processing/processing4/releases/download/processing-$version/processing-$preReleaseVersion-windows-x64-portable.zip"
             }
         },
         "extract_dir": "processing-$preReleaseVersion"


### PR DESCRIPTION
This pull request aims to fix autoupdate for the package `processing4` and update it right away, as well as adjust to new zip context. This has been tested on my personal bucket https://github.com/itsHardStyl3r/scoop-personal/commit/510bc9d8d1f1faff48beb1a79dddeebdb2beebf4 with Excavator commit https://github.com/itsHardStyl3r/scoop-personal/commit/de0dcd17c3f41048e1284be81657337afb226f1c.

4.4.4 is the latest version as of writing this, verified at https://github.com/processing/processing4/releases.

Closes https://github.com/ScoopInstaller/Extras/issues/15491.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
