### PR TITLE
pdfarranger@1.12.0: fix extract_dir

### DIFF
--- a/bucket/pdfarranger.json
+++ b/bucket/pdfarranger.json
@@ -9,7 +9,7 @@
             "hash": "786ee03ea6c5153f0406271f266c8beac07aed14c0aefa277fa704a771b5f9ae"
         }
     },
-    "extract_dir": "pdfarranger-1.12.0",
+    "extract_dir": "pdf arranger-1.12.0",
     "bin": "pdfarranger.exe",
     "shortcuts": [
         [
@@ -24,6 +24,6 @@
                 "url": "https://github.com/pdfarranger/pdfarranger/releases/download/$version/pdfarranger-$version-windows-portable.zip"
             }
         },
-        "extract_dir": "pdfarranger-$version"
+        "extract_dir": "pdf arranger-$version"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

related to 
```
Extracting pdfarranger-1.12.0-windows-portable.zip ... Exception: G:\Applications\Scoop\apps\scoop\current\lib\core.ps1:889
Line |
 889 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'pdfarranger-1.12.0'! (error 16)
```

Modified the `extract_dir` field from `pdfarranger-1.12.0` to `pdf arranger-1.12.0`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
