### PR TITLE
raspberry-pi-imager@1.9.4: Switch to innosetup installer

### DIFF
--- a/bucket/raspberry-pi-imager.json
+++ b/bucket/raspberry-pi-imager.json
@@ -6,7 +6,6 @@
     "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v1.9.4/imager-1.9.4.exe",
     "hash": "3d750fe364b10ed2d5299f1f4d6c12ebacf3b56c6d7177c8e5801b0825c4556d",
     "innosetup": true,
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninst*\" -Recurse",
     "bin": "rpi-imager.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
raspberry-pi-imager@1.9.4 switches to Inno Installer, requiring the manifest to specify that. Also requires downloading the actual exe file rather than a 7z file from the download URL. Everything else works as it was.

Closes #15573

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
