### PR TITLE
beyondcompare: Add BCCommands.xml to persist

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -63,10 +63,11 @@
     "persist": [
         "BCPreferences.xml",
         "BCState.xml",
-        "BCColors.xml"
+        "BCColors.xml",
+        "BCCommands.xml"
     ],
     "pre_uninstall": [
-        "'BCPreferences.xml', 'BCState.xml', 'BCColors.xml', 'BC5Key.txt' | ForEach-Object {",
+        "'BCPreferences.xml', 'BCState.xml', 'BCColors.xml', 'BCCommands.xml', 'BC5Key.txt' | ForEach-Object {",
         "   if (Test-Path \"$dir\\$_\") {",
         "       Move-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force -ErrorAction SilentlyContinue",
         "   } else {",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
`BCCommands.xml` is used to save custom hotkeys and should be included in the persist folder. This PR makes it so.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
