### PR TITLE
processhacker@3.2.25011.2103: fix update

### DIFF
--- a/bucket/processhacker.json
+++ b/bucket/processhacker.json
@@ -1,34 +1,40 @@
 {
-    "version": "2.39",
+    "version": "3.2.25011.2103",
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
-    "homepage": "http://processhacker.sourceforge.net/",
-    "license": "GPL-3.0-only",
+    "homepage": "https://systeminformer.sourceforge.io/",
+    "license": "MIT",
+    "notes": "Process Hacker is renamed to System Informer starting with version 3.2.25011.2103",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/processhacker2/processhacker2/releases/download/v2.39/processhacker-2.39-bin.zip",
-            "hash": "2afb5303e191dde688c5626c3ee545e32e52f09da3b35b20f5e0d29a418432f5",
-            "extract_dir": "x64"
+            "url": "https://github.com/winsiderss/systeminformer/releases/download/v3.2.25011.2103/systeminformer-3.2.25011-release-bin.zip",
+            "hash": "7e72019361eec58479604597dbfcd911c6d23c45da22c0bedc2bc319ab5b331a",
+            "extract_dir": "amd64"
+        },
+        "arm64": {
+            "url": "https://github.com/winsiderss/systeminformer/releases/download/v3.2.25011.2103/systeminformer-3.2.25011-release-bin.zip",
+            "hash": "7e72019361eec58479604597dbfcd911c6d23c45da22c0bedc2bc319ab5b331a",
+            "extract_dir": "arm64"
         },
         "32bit": {
-            "url": "https://github.com/processhacker2/processhacker2/releases/download/v2.39/processhacker-2.39-bin.zip",
-            "hash": "2afb5303e191dde688c5626c3ee545e32e52f09da3b35b20f5e0d29a418432f5",
-            "extract_dir": "x86"
+            "url": "https://github.com/winsiderss/systeminformer/releases/download/v3.2.25011.2103/systeminformer-3.2.25011-release-bin.zip",
+            "hash": "7e72019361eec58479604597dbfcd911c6d23c45da22c0bedc2bc319ab5b331a",
+            "extract_dir": "i386"
         }
     },
     "bin": [
-        "processhacker.exe",
+        "systeminformer.exe",
         "peview.exe"
     ],
     "shortcuts": [
         [
-            "processhacker.exe",
-            "Process Hacker"
+            "systeminformer.exe",
+            "System Informer"
         ]
     ],
     "checkver": {
-        "github": "https://github.com/processhacker2/processhacker2"
+        "github": "https://github.com/winsiderss/systeminformer"
     },
     "autoupdate": {
-        "url": "https://github.com/processhacker2/processhacker2/releases/download/v$version/processhacker-$version-bin.zip"
+        "url": "https://github.com/winsiderss/systeminformer/releases/download/v$version/systeminformer-$matchHead-release-bin.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Process Hacker released a new version 3.2.25011.2103, and is renamed to System Informer, which broke autoupdate.
This pr updates version, fixes autoupdate, and informs user for the rename.

The package name remains unchanged, as there are some issues preventing adding a new app named `systeminformer`:
- If we just rename the package, users will be forced to uninstall and reinstall the app for updating, and they are not informed with the update.
- If we add a duplicate package, it will be harder and more confusing to maintain (e.g. when autoupdate breaks again)
- If we create a meta-package that just depends on `processhacker`, it cannot be auto updated, as the current auto update process in scoop will update hashes, which is not present in meta-packages.
It will require manual maintenance, and the misaligned version between two packages will introduce more confusion (e.g. the user already updates to a newer version of System Informer app by updating `processhacker` package, but the `systeminformer` package remains old version when listed).

Renaming the app would be left for another pr (maybe in conjunction with a pr for scoop itself to introduce better support for meta-packages).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Relates to #15556 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
