### PR TITLE
winauth@3.6.2: Correcting the hashes for virustotal compatibility

### DIFF
--- a/bucket/winauth.json
+++ b/bucket/winauth.json
@@ -4,7 +4,7 @@
     "homepage": "https://winauth.github.io/winauth/",
     "license": "GPL-3.0-only",
     "url": "https://github.com/winauth/winauth/releases/download/3.6.2/WinAuth-3.6.2.zip",
-    "hash": "sha512:8288a970946c149382c1d8919905fda5381d04f24a4ceed1ec4f3fc7fda0a7c8f5c1fc062b7b312dca55531eecf04327ca0743afbb82ff08acedf4c7c9c4ed1f",
+    "hash": "3f34eb1ca342ad0783cd57c84f2f73c37df3ea880768dd415f509bfdbf02a785",
     "bin": "WinAuth.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Correcting the hashes for virustotal compatibility.
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
