### PR TITLE
googlechrome@137.0.7151.120: Fix download URL

### DIFF
--- a/bucket/googlechrome.json
+++ b/bucket/googlechrome.json
@@ -16,9 +16,7 @@
             "hash": "582c0cf1918346a01742df847bad6416a325d80d1393ad837f999cb5f831a884"
         }
     },
-    "installer": {
-        "script": "Move-Item -Path \"$dir\\Chrome-bin\\*\" -Destination \"$dir\"; Remove-Item \"$dir\\Chrome-bin\""
-    },
+    "extract_dir": "Chrome-bin",
     "bin": [
         [
             "chrome.exe",

--- a/bucket/googlechrome.json
+++ b/bucket/googlechrome.json
@@ -8,16 +8,16 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/fso2u5tvxnf2tmkcnbcfn4zchq_137.0.7151.120/137.0.7151.120_chrome_installer.exe#/dl.7z",
+            "url": "https://dl.google.com/release2/chrome/fso2u5tvxnf2tmkcnbcfn4zchq_137.0.7151.120/137.0.7151.120_chrome_installer_uncompressed.exe#/dl.7z",
             "hash": "692d5608cfe4b54d8c1729930b4c571e939d129624037f141a31be038e1d4587"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/mxtsosczbkcftx3sehopj5kmfm_137.0.7151.120/137.0.7151.120_chrome_installer.exe#/dl.7z",
+            "url": "https://dl.google.com/release2/chrome/mxtsosczbkcftx3sehopj5kmfm_137.0.7151.120/137.0.7151.120_chrome_installer_uncompressed.exe#/dl.7z",
             "hash": "582c0cf1918346a01742df847bad6416a325d80d1393ad837f999cb5f831a884"
         }
     },
     "installer": {
-        "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+        "script": "Move-Item -Path \"$dir\\Chrome-bin\\*\" -Destination \"$dir\"; Remove-Item \"$dir\\Chrome-bin\""
     },
     "bin": [
         [
@@ -41,14 +41,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+                "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer_uncompressed.exe#/dl.7z",
                 "hash": {
                     "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
                     "xpath": "/chromechecker/stable64[version='$version']/sha256"
                 }
             },
             "32bit": {
-                "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+                "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer_uncompressed.exe#/dl.7z",
                 "hash": {
                     "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
                     "xpath": "/chromechecker/stable32[version='$version']/sha256"


### PR DESCRIPTION
Reference: https://scoop.sh/UpdateTracker/googlechrome/chrome.min.xml (content update: https://github.com/ScoopInstaller/UpdateTracker/commit/f7bbf67ac8d543a717d4f16f8d2b11deb3baa716)

Related work: ScoopInstaller/Versions#2355 , ScoopInstaller/Versions#2356 and ScoopInstaller/Versions#2357  


Add _uncompressed before .exe
As the installer is not compressed, we can get Chrome-bin directly from dl.7z . So the install process is just to copy files inside Chrome-bin to $dir then remove Chrome-bin

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #15630
Closes #15631 (duplicated)
Closes #15632 (duplicated)
Closes #15636 (duplicated)
Closes #15643 (duplicated)
Closes #15645 (duplicated)


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
