### PR TITLE
rabbitmqadmin-ng: Add version 2.2.1

### DIFF
--- a/bucket/rabbitmqadmin-ng.json
+++ b/bucket/rabbitmqadmin-ng.json
@@ -4,12 +4,19 @@
     "homepage": "https://github.com/rabbitmq/rabbitmqadmin-ng",
     "license": "MPL-2.0",
     "notes": "rabbitmqadmin v2 is a major revision of rabbitmqadmin",
-    "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.2.1/rabbitmqadmin-2.2.1-x86_64-pc-windows-msvc.exe",
-    "hash": "fd173cd201c8762f147e0ef2a90c8221e771d59d4516f94e65a1e21533e66873",
-    "bin": [
-        [ "rabbitmqadmin-2.2.1-x86_64-pc-windows-msvc.exe", "rabbitmqadmin" ]
-    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.2.1/rabbitmqadmin-2.2.1-x86_64-pc-windows-msvc.exe#/rabbitmqadmin.exe",
+            "hash": "fd173cd201c8762f147e0ef2a90c8221e771d59d4516f94e65a1e21533e66873"
+        }
+    },
+    "bin": "rabbitmqadmin.exe",
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v$version/rabbitmqadmin-$version-x86_64-pc-windows-msvc.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v$version/rabbitmqadmin-$version-x86_64-pc-windows-msvc.exe#/rabbitmqadmin.exe"
+            }
+        }
     }
 }

--- a/bucket/rabbitmqadmin-ng.json
+++ b/bucket/rabbitmqadmin-ng.json
@@ -3,7 +3,11 @@
     "description": "A command line tool for RabbitMQ that uses the HTTP API",
     "homepage": "https://github.com/rabbitmq/rabbitmqadmin-ng",
     "license": "Apache-2.0|MIT",
-    "notes": "rabbitmqadmin v2 is a major revision of rabbitmqadmin",
+    "notes": [
+        "If you are migrating from the original `rabbitmqadmin`,",
+        "please see Breaking or Potentially Breaking Changes:",
+        "https://github.com/rabbitmq/rabbitmqadmin-ng?tab=readme-ov-file#breaking-or-potentially-breaking-changes"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.2.1/rabbitmqadmin-2.2.1-x86_64-pc-windows-msvc.exe#/rabbitmqadmin.exe",

--- a/bucket/rabbitmqadmin-ng.json
+++ b/bucket/rabbitmqadmin-ng.json
@@ -2,7 +2,7 @@
     "version": "2.2.1",
     "description": "A command line tool for RabbitMQ that uses the HTTP API",
     "homepage": "https://github.com/rabbitmq/rabbitmqadmin-ng",
-    "license": "MPL-2.0",
+    "license": "Apache-2.0|MIT",
     "notes": "rabbitmqadmin v2 is a major revision of rabbitmqadmin",
     "architecture": {
         "64bit": {

--- a/bucket/rabbitmqadmin-ng.json
+++ b/bucket/rabbitmqadmin-ng.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.2.1",
+    "description": "A command line tool for RabbitMQ that uses the HTTP API",
+    "homepage": "https://github.com/rabbitmq/rabbitmqadmin-ng",
+    "license": "MPL-2.0",
+    "notes": "rabbitmqadmin v2 is a major revision of rabbitmqadmin",
+    "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.2.1/rabbitmqadmin-2.2.1-x86_64-pc-windows-msvc.exe",
+    "hash": "fd173cd201c8762f147e0ef2a90c8221e771d59d4516f94e65a1e21533e66873",
+    "bin": [
+        [ "rabbitmqadmin-2.2.1-x86_64-pc-windows-msvc.exe", "rabbitmqadmin" ]
+    ],
+    "autoupdate": {
+        "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v$version/rabbitmqadmin-$version-x86_64-pc-windows-msvc.exe"
+    }
+}


### PR DESCRIPTION
Related to the following:
rabbitmq.json

Replacement for:
rabbitmqadmin.json