### PR TITLE
cryptomator@1.17.0: fix extract_dir

### DIFF
--- a/bucket/cryptomator.json
+++ b/bucket/cryptomator.json
@@ -12,7 +12,7 @@
             "hash": "3bae9567d445edb930c7f32f5fa2f288cfde459163ab3681c648161a34059295"
         }
     },
-    "extract_dir": "Cryptomator",
+    "extract_dir": "PFiles64/Cryptomator",
     "post_install": [
         "    # Change appdata settings folder",
         "(Get-Content \"$dir\\app\\Cryptomator.cfg\" -Encoding ASCII).replace('~/AppData/Roaming/Cryptomator', './data') | Set-Content \"$dir\\app\\Cryptomator.cfg\" -Encoding ASCII"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

update the extract_dir
```
Line |
 889 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'Cryptomator'! (error 16)
```
---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
