### PR TITLE
sonic-pi@4.6.0: fix shortcut path

### DIFF
--- a/bucket/sonic-pi.json
+++ b/bucket/sonic-pi.json
@@ -15,7 +15,7 @@
     "pre_install": "Expand-MsiArchive \"$dir\\$fname\" \"$dir\" -ExtractDir 'PFiles\\Sonic Pi' -Removal",
     "shortcuts": [
         [
-            "app\\gui\\qt\\build\\Release\\sonic-pi.exe",
+            "app\\gui\\build\\Release\\sonic-pi.exe",
             "Sonic Pi"
         ]
     ],


### PR DESCRIPTION
Removes `qt` from shortcut path.

Closes #15680
