### PR TITLE
qbittorrent-enhanced@5.1.1.10: fix pre_install

### DIFF
--- a/bucket/qbittorrent-enhanced.json
+++ b/bucket/qbittorrent-enhanced.json
@@ -9,7 +9,7 @@
             "hash": "dfd83fe350208d7372b1d1e95e17989c410755d128cb559c9b8d01fecf8606b5"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
     "bin": "qbittorrent.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

fix the error message:

```
Extracting qbittorrent_enhanced_5.1.1.10_x64_setup.exe ... done.
Running pre_install script...Remove-Item: Cannot find path 'G:\Applications\Scoop\apps\qbittorrent-enhanced\5.1.1.10\uninst.exe' because it does not exist.
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
