### PR TITLE
roughgrep@3.16.2: remove extract_dir

### DIFF
--- a/bucket/roughgrep.json
+++ b/bucket/roughgrep.json
@@ -5,7 +5,6 @@
     "license": "MIT",
     "url": "https://github.com/vivainio/RoughGrep/releases/download/v3.16.2/RoughGrep-3.16.2.zip",
     "hash": "379e1cc0faf8a5bcb892e48cf9d7019ef35670dfdc97db77f4ba3f3eeefe2110",
-    "extract_dir": "RoughGrep",
     "bin": "rgg.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
As all the files are now in the root of the archive, extract_dir is no longer necessary

Closes #15705

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
