### PR TITLE
VideoToAscii: Add version 1.1.2

### DIFF
--- a/bucket/videotoascii.json
+++ b/bucket/videotoascii.json
@@ -1,0 +1,27 @@
+{
+    "version": "{{VERSION}}",
+    "description": "Convert and play videos as animated ASCII art in the console.",
+    "homepage": "https://github.com/Der-Floh/Video-To-Ascii",
+    "license": "MIT",
+    "depends": "dotnet-sdk",
+    "suggest": {
+        "ffmpeg": "ffmpeg"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v{{VERSION}}/VideoToAscii-{{VERSION}}.zip",
+            "hash": "sha256:{{SHA256}}"
+        },
+        "32bit": {
+            "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v{{VERSION}}/VideoToAscii-{{VERSION}}.zip",
+            "hash": "sha256:{{SHA256}}"
+        }
+    },
+    "bin": "VideoToAscii.exe",
+    "checkver": {
+        "github": "https://github.com/Der-Floh/Video-To-Ascii"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v{{VERSION}}/VideoToAscii-{{VERSION}}.zip"
+    }
+}

--- a/bucket/videotoascii.json
+++ b/bucket/videotoascii.json
@@ -1,5 +1,5 @@
 {
-    "version": "{{VERSION}}",
+    "version": "1.1.2",
     "description": "Convert and play videos as animated ASCII art in the console.",
     "homepage": "https://github.com/Der-Floh/Video-To-Ascii",
     "license": "MIT",
@@ -9,12 +9,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v{{VERSION}}/VideoToAscii-{{VERSION}}.zip",
-            "hash": "sha256:{{SHA256}}"
+            "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v1.1.2/VideoToAscii-1.1.2.zip",
+            "hash": "sha256:444f74263b2a98b446a34f482aa9c76ed1c794d49cac611726db2849535b86c4"
         },
         "32bit": {
-            "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v{{VERSION}}/VideoToAscii-{{VERSION}}.zip",
-            "hash": "sha256:{{SHA256}}"
+            "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v1.1.2/VideoToAscii-1.1.2.zip",
+            "hash": "sha256:444f74263b2a98b446a34f482aa9c76ed1c794d49cac611726db2849535b86c4"
         }
     },
     "bin": "VideoToAscii.exe",
@@ -22,6 +22,6 @@
         "github": "https://github.com/Der-Floh/Video-To-Ascii"
     },
     "autoupdate": {
-        "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v{{VERSION}}/VideoToAscii-{{VERSION}}.zip"
+        "url": "https://github.com/Der-Floh/Video-To-Ascii/releases/download/v1.1.2/VideoToAscii-1.1.2.zip"
     }
 }


### PR DESCRIPTION
Added new tool VideoToAscii:
Convert and play videos as animated ASCII art in the console.
https://github.com/Der-Floh/Video-To-Ascii

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
