### PR TITLE
emacs@30.1: Add shim for emacsclient

### DIFF
--- a/bucket/emacs.json
+++ b/bucket/emacs.json
@@ -13,6 +13,7 @@
     "bin": [
         "bin\\runemacs.exe",
         "bin\\emacs.exe",
+        "bin\\emacsclient.exe",
         "bin\\emacsclientw.exe",
         "bin\\etags.exe",
         "bin\\ctags.exe"


### PR DESCRIPTION
This adds a shim for emacsclient, which is required for editor integration where the client process should not exit until server buffers have finished.

Closes #15714

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
