### PR TITLE
pros@4.2.1

### DIFF
--- a/bucket/pros-toolchain.json
+++ b/bucket/pros-toolchain.json
@@ -1,0 +1,35 @@
+{
+    "version": "13.3.1",
+    "description": "ARM GCC toolchain for PROS VEX V5 development",
+    "homepage": "https://pros.cs.purdue.edu/",
+    "license": "MPL-2.0",
+    "url": "https://github.com/purduesigbots/toolchain/releases/download/13.3.1/pros-toolchain-windows-formatted.zip",
+    "hash": "71a5c056e4fea7687ba564e5294a5db560c2e27e27a61363b8282fae6a4cba72",
+    "installer": {
+        "script": [
+            "# Create tmp directory if it doesn't exist",
+            "if (!(Test-Path \"$dir\\tmp\")) {",
+            "    New-Item -ItemType Directory -Force -Path \"$dir\\tmp\" | Out-Null",
+            "    Write-Host 'Created tmp directory' -ForegroundColor Green",
+            "}"
+        ]
+    },
+    "post_install": [
+        "Write-Host 'PROS Toolchain has been installed successfully!' -ForegroundColor Green",
+        "Write-Host ''",
+        "Write-Host 'Environment variables set:' -ForegroundColor Yellow",
+        "Write-Host \"  PROS_TOOLCHAIN = $dir\\usr\"",
+        "Write-Host ''",
+        "Write-Host 'The toolchain is now ready for use with PROS CLI.' -ForegroundColor Blue"
+    ],
+    "env_set": {
+        "PROS_TOOLCHAIN": "$dir\\usr"
+    },
+    "checkver": {
+        "url": "https://api.github.com/repos/purduesigbots/toolchain/releases/latest",
+        "jsonpath": "$.tag_name"
+    },
+    "autoupdate": {
+        "url": "https://github.com/purduesigbots/toolchain/releases/download/$version/pros-toolchain-windows-formatted.zip"
+    }
+}

--- a/bucket/pros.json
+++ b/bucket/pros.json
@@ -1,0 +1,33 @@
+{
+    "version": "3.5.5",
+    "description": "An open source C/C++ development environment for the VEX V5 microcontroller",
+    "homepage": "https://pros.cs.purdue.edu/",
+    "license": "MPL-2.0",
+    "depends": "pros-toolchain",
+    "url": "https://github.com/purduesigbots/pros-cli/releases/download/3.5.5/pros_cli-3.5.5-win-64bit.zip",
+    "hash": "2162dc1bace1683216bef452049d2144a4a017827150b8a7da5ce82773cfd399",
+    "post_install": [
+        "Write-Host 'PROS CLI has been installed successfully!' -ForegroundColor Green",
+        "Write-Host ''",
+        "Write-Host 'Quick start:' -ForegroundColor Cyan",
+        "Write-Host '  pros --help         - Show help information'",
+        "Write-Host '  pros conductor new <project>  - Create a new PROS project'",
+        "Write-Host '  pros make           - Build your project'",
+        "Write-Host '  pros upload         - Upload to VEX V5 Brain'",
+        "Write-Host ''",
+        "Write-Host 'Visit https://pros.cs.purdue.edu/ for documentation' -ForegroundColor Blue"
+    ],
+    "env_add_path": ".",
+    "bin": [
+        "pros.exe",
+        "intercept-c++.exe",
+        "intercept-cc.exe"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/purduesigbots/pros-cli/releases/latest",
+        "jsonpath": "$.tag_name"
+    },
+    "autoupdate": {
+        "url": "https://github.com/purduesigbots/pros-cli/releases/download/$version/pros_cli-$version-win-64bit.zip"
+    }
+}


### PR DESCRIPTION
pros CLI: Added PROS CLI
pros-toolchain: Added PROS Toolchain (PROS CLI Dependency)

There are technically 2 packages in this pull request:
- PROS CLI@3.5.5
- PROS TOOLCHAIN@13.3.1 (PROS CLI dependency)

Closes #15724

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
