### PR TITLE
v2rayn@7.12.7: Remove reliance on Xray core

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -3,7 +3,6 @@
     "description": "A V2Ray client for Windows, support Xray & v2fly core",
     "homepage": "https://github.com/2dust/v2rayN",
     "license": "GPL-3.0-only",
-    "depends": "xray",
     "suggest": {
         ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts",
         "v2fly-core": "v2ray"
@@ -20,18 +19,6 @@
             "extract_dir": "v2rayN-windows-arm64"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$dir\\bin\\Xray\")) { New-Item \"$dir\\bin\\Xray\" -ItemType Directory | Out-Null }",
-        "foreach ($form in @('*.exe', '*.dat')) {",
-        "    foreach ($_ in Get-ChildItem \"$(appdir xray $global)\\current\" -File) {",
-        "        $name = $_.Name",
-        "        if ($name -Like $form) {",
-        "            Write-Host \"Creating hardlink for $name\"",
-        "            New-Item -ItemType HardLink -Path \"$dir\\bin\\Xray\" -Name $name -Target \"$(appdir xray $global)\\current\\$name\" | Out-Null",
-        "        }",
-        "    }",
-        "}"
-    ],
     "bin": "v2rayN.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
This PR makes the following changes:
- `v2rayn@7.12.7`: Remove reliance on Xray core, since it is [contained](https://github.com/2dust/v2rayN/wiki/Release-files-introduction) in v2rayN releases.

Relates to #14692
Closes #15726
Closes #15728

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)