### PR TITLE
hdd-raw-copy-tool: Add version 1.20

### DIFF
--- a/bucket/hdd-raw-copy-tool.json
+++ b/bucket/hdd-raw-copy-tool.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.20",
+    "homepage": "https://hddguru.com/software/HDD-Raw-Copy-Tool/",
+    "license": "Freeware",
+    "url": "https://hddguru.com/software/HDD-Raw-Copy-Tool/HDDRawCopy1.20Portable.exe",
+    "hash": "7103A76EACE11CCB302CDCE6A9F999E0FE6F1EE532468E0ACBE5C3D86D942262",
+    "pre_install": [
+        "# Rename downloaded file",
+        "Rename-Item -Path \"$dir\\HDDRawCopy*.exe\" -NewName \"HDDRawCopy.exe\""
+    ],
+    "shortcuts": [
+        [
+            "HDDRawCopy.exe",
+            "HDD Raw Copy Tool"
+        ]
+    ]
+}


### PR DESCRIPTION
Closes #15729.

Checkver would fail as website is behind Cloudflare. HDDGuru excluded download links from this protection.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
