### PR TITLE
Update godot.json updating hashes for virustotal compatibility

### DIFF
--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -6,15 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_win64.exe.zip",
-            "hash": "sha512:266978b803f7532edc69bdd5d8c4fdced0ea97aef1224a8879616398a2559e135520e186add06b532aa92bdfeecf6ac024634024de4b3abd69f6c34e6d6d0563"
+            "hash": "sha256:1c729738f42e43036a7147838aa9fa56d62101cf90884f315e1ab525e8e69d61"
         },
         "32bit": {
             "url": "https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_win32.exe.zip",
-            "hash": "sha512:b851838fa3b17d51fe4ffc511e82765e6d30f01563c1f21f8689cfa38b0c4e1a04e0448575b3136d0ebacded1966cbd0a9b244fcf082db567be97d726f2bb205"
+            "hash": "sha256:f26ec321388b537a568dcc97d2d43902e2aff4afa308d81af6605103e5ec5c9c"
         },
         "arm64": {
             "url": "https://github.com/godotengine/godot/releases/download/4.4.1-stable/Godot_v4.4.1-stable_windows_arm64.exe.zip",
-            "hash": "sha512:c2d1c46a68e3d130e930e45cf4789eeb7942438736355da2d0c6a3fcfee34ec9477705c2bfa01dcff56d75e570a65bd21b411ec2871616ae23beec62f11c39a7"
+            "hash": "sha256:81d259f24de16549445baeb77a2ca7797aa531f552a03c479316d0542f9f298e"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Updating the hash from 512 to 256 for virustotal compatiblity.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
