### PR TITLE
staxrip@2.48.1: Update repack url

### DIFF
--- a/bucket/staxrip.json
+++ b/bucket/staxrip.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/staxrip/staxrip/releases/download/v2.48.1/StaxRip-v2.48.1-x64.7z",
-            "hash": "cb319253ece37413549710e9116e53a31c1613c081213b7dcf3ea1c3f9bc5105",
+            "url": "https://github.com/staxrip/staxrip/releases/download/v2.48.1/StaxRip-v2.48.1-x64-REPACK.7z",
+            "hash": "e4a1be2a1f6afeb55d7972786f34a18fa905cc9a1f52c752c3304d6596e14090",
             "extract_dir": "StaxRip-v2.48.1-x64"
         }
     },


### PR DESCRIPTION
This PR makes the following changes:
- `staxrip@2.48.1`: Fix url, fix hash.

https://github.com/staxrip/staxrip/releases/tag/v2.48.1

> StaxRip-v2.48.1-x64.7z
> Regular full archive. Do NOT extract it into an existing StaxRip folder! Extract it into a new location and copy over your Settings folder or start with fresh/new settings.
> ⚠️ Wrong build of SvtAv1EncApp included.
> StaxRip-v2.48.1-x64-REPACK.7z
> Regular full archive. Do NOT extract it into an existing StaxRip folder! Extract it into a new location and copy over your Settings folder or start with fresh/new settings.
> ℹ️ The normal version included an old version of SvtAv1EncApp. This REPACK includes the correct and latest version.

Closes #15740
Closes #15742
Closes #15744

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)