### PR TITLE
mpc-be|mpc-hc-fork: Fix intended hardlinks becoming junctions

### DIFF
--- a/bucket/mpc-be.json
+++ b/bucket/mpc-be.json
@@ -36,14 +36,15 @@
         }
     },
     "pre_install": [
-        "@('mpc-be64.ini', 'mpc-be.ini', 'Default.mpcpl') | ForEach-Object {",
+        "@('mpc-be64.ini', 'mpc-be.ini', 'default.mpcpl', 'favorites.mpc_lst') | ForEach-Object {",
+        "    if ((Get-Item \"$persist_dir\\$_\" 2>$null).PSIsContainer) { Remove-Item \"$persist_dir\\$_\" }",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}"
     ],
     "persist": [
         "mpc-be64.ini",
         "mpc-be.ini",
-        "Default.mpcpl",
+        "default.mpcpl",
         "favorites.mpc_lst"
     ],
     "checkver": {

--- a/bucket/mpc-hc-fork.json
+++ b/bucket/mpc-hc-fork.json
@@ -33,7 +33,8 @@
         }
     },
     "pre_install": [
-        "@('mpc-hc64.ini', 'mpc-hc.ini') | ForEach-Object {",
+        "@('mpc-hc64.ini', 'mpc-hc.ini', 'default.mpcpl') | ForEach-Object {",
+        "    if ((Get-Item \"$persist_dir\\$_\" 2>$null).PSIsContainer) { Remove-Item \"$persist_dir\\$_\" }",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
         "}"
     ],


### PR DESCRIPTION
Both manifests suffered from the well-known issue that "persist" always creates directory junctions by default.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
