### PR TITLE
obs-studio@31.1.0: Update obs-studio.json to match new url filename scheme

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "31.0.4",
+    "version": "31.1.0",
     "description": "Video recording and live streaming software",
     "homepage": "https://obsproject.com",
     "license": "GPL-2.0-only",
@@ -9,8 +9,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-31.0.4-Windows.zip",
-            "hash": "4b0c4e2490de69a52bc0202f3585f97019501853422cdbc02fa70ad87b6ff4d2",
+            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-31.1.0-Windows-x64.zip",
+            "hash": "551cb5c48b3103a4fc5a691eaa1e315e4fb40ffa1bc4e06b8eb4a01850af7f65",
             "shortcuts": [
                 [
                     "bin\\64bit\\obs64.exe",
@@ -36,7 +36,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Windows.zip",
+                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Windows-x64.zip",
                 "hash": {
                     "url": "https://github.com/obsproject/obs-studio/releases/$version",
                     "regex": "(?sm)$basename.*?$sha256"


### PR DESCRIPTION
Since release 31.1.0, OBS Studio adds a `-x64` suffix in their url filename for Windows, this PR just compliants to it.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
