### PR TITLE
raspberry-pi-imager@1.9.5: Fix `autoupdate/url` to reflect `url` change.

### DIFF
--- a/bucket/raspberry-pi-imager.json
+++ b/bucket/raspberry-pi-imager.json
@@ -3,7 +3,7 @@
     "description": "Tool for writing an Raspberry Pi OS images to SD cards.",
     "homepage": "https://www.raspberrypi.org/software",
     "license": "Apache-2.0",
-    "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v1.9.5/imager-1.9.5.exe#/dl.7z",
+    "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v1.9.5/imager-1.9.5.exe",
     "hash": "b3440b19bf7d86ca0f723132efee89c38659fd760951e95d584ba748be9e1259",
     "innosetup": true,
     "bin": "rpi-imager.exe",
@@ -18,6 +18,6 @@
         "github": "https://github.com/raspberrypi/rpi-imager"
     },
     "autoupdate": {
-        "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v$version/imager-$version.exe#/dl.7z"
+        "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v$version/imager-$version.exe"
     }
 }


### PR DESCRIPTION
At https://github.com/ScoopInstaller/Extras/commit/752e62ef03298ebb9882d118e840b797355e17f3, `#/dl.7z` in `url` is removed, in order to use innosetup. But `autoupdate/url` still has `#/dl.7z`. So, autoupdate breaks this manifest. This PR fixes `url` and `autoupdate/url` to remove `#/dl.7z`.

Closes #15768.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide]