### PR TITLE
googlechrome: Add arm64 and update source url

### DIFF
--- a/bucket/googlechrome.json
+++ b/bucket/googlechrome.json
@@ -8,13 +8,17 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/aclczb5bjdhbdipy7respylybp4a_138.0.7204.101/138.0.7204.101_chrome_installer_uncompressed.exe#/dl.7z",
+            "url": "https://github.com/Bush2021/chrome_installer/releases/download/138.0.7204.101/x64_138.0.7204.101_chrome_installer_uncompressed.exe#/dl.7z",
             "hash": "d02e25d8901c73c23326982a0e35cea6f8d87dc1049d33dd47f88b410380cc1b"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/ecwwfkzewp3q4cwmmrrytrchba_138.0.7204.101/138.0.7204.101_chrome_installer_uncompressed.exe#/dl.7z",
+            "url": "https://github.com/Bush2021/chrome_installer/releases/download/138.0.7204.101/x64_138.0.7204.101_chrome_installer_uncompressed.exe#/dl.7z",
             "hash": "b4fd27690e95b51eaa2ec92fff8c05f87e2f251b4152e4a2d9f98d054bb7a0bf"
-        }
+        },
+        "arm64": {
+            "url": "https://github.com/Bush2021/chrome_installer/releases/download/138.0.7204.101/arm64_138.0.7204.101_chrome_installer_uncompressed.exe#/dl.7z",
+            "hash": "57db767287f9d65b49c75d3a72f36852766ce720e71ddb30eeb7cc57d5bf0367"
+        },
     },
     "extract_dir": "Chrome-bin",
     "bin": [
@@ -33,25 +37,19 @@
         "CHROME_EXECUTABLE": "$dir\\chrome.exe"
     },
     "checkver": {
-        "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
-        "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+        "url": "https://github.com/Bush2021/chrome_installer"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer_uncompressed.exe#/dl.7z",
-                "hash": {
-                    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
-                    "xpath": "/chromechecker/stable64[version='$version']/sha256"
-                }
+                "url": "https://github.com/Bush2021/chrome_installer/releases/download/$version/x64_$version_chrome_installer_uncompressed.exee#/dl.7z"
             },
             "32bit": {
-                "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer_uncompressed.exe#/dl.7z",
-                "hash": {
-                    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
-                    "xpath": "/chromechecker/stable32[version='$version']/sha256"
-                }
-            }
+                "url": "https://github.com/Bush2021/chrome_installer/releases/download/$version/x32_$version_chrome_installer_uncompressed.exee#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/Bush2021/chrome_installer/releases/download/$version/arm64_$version_chrome_installer_uncompressed.exee#/dl.7z"
+            },
         }
     }
 }


### PR DESCRIPTION
use https://github.com/Bush2021/chrome_installer to track updates instead of relying on additional xml parsing

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
