### PR TITLE
notepad3@6.25.822.1: Enhance checkver to prevent downgrades

### DIFF
--- a/bucket/notepad3.json
+++ b/bucket/notepad3.json
@@ -55,7 +55,7 @@
         "Notepad3.ini"
     ],
     "checkver": {
-        "url": "https://github.com/rizonesoft/Notepad3/releases",
+        "github": "https://github.com/rizonesoft/Notepad3",
         "regex": "tag/RELEASE_([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

To prevent downgrade like https://github.com/ScoopInstaller/Extras/commit/a1920dbaf056c9d3a9bff4824972ea953cc26ce9.


- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched Notepad3 version checking to use the GitHub API for latest release detection.
* **Bug Fixes**
  * Improved reliability of version parsing and update checks for Notepad3, reducing failures when detecting the newest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->