### PR TITLE
aida64extreme: Upgrade download & update links to use HTTPS

### DIFF
--- a/bucket/aida64extreme.json
+++ b/bucket/aida64extreme.json
@@ -6,7 +6,7 @@
         "identifier": "Shareware",
         "url": "https://www.aida64.com/licensing"
     },
-    "url": "http://download.aida64.com/aida64extreme770.zip",
+    "url": "https://download.aida64.com/aida64extreme770.zip",
     "hash": "9f9b6da918f63b39e38c8b4d4983104258beec754b606724573f4fb5bedce812",
     "pre_install": [
         "$FILE = 'aida64.ini'",
@@ -30,6 +30,6 @@
         "regex": "Version:\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://download.aida64.com/aida64extreme$majorVersion$minorVersion.zip"
+        "url": "https://download.aida64.com/aida64extreme$majorVersion$minorVersion.zip"
     }
 }


### PR DESCRIPTION
aida64extreme: Upgrade download & update links to use HTTPS

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
