### PR TITLE
brackets: Upgrade homepage to use HTTPS

### DIFF
--- a/bucket/brackets.json
+++ b/bucket/brackets.json
@@ -1,7 +1,7 @@
 {
     "version": "2.2.1",
     "description": "A modern, open source text editor that understands web design.",
-    "homepage": "http://brackets.io/",
+    "homepage": "https://brackets.io/",
     "license": "MIT",
     "url": "https://github.com/brackets-cont/brackets/releases/download/v2.2.1/Brackets-2.2.1.exe#/dl.exe",
     "hash": "a4a4a80f65ee2d8ec77ff4179ebcb940d63ee4f69d3f7de85d5b99df7b246890",


### PR DESCRIPTION
brackets: Upgrade homepage to use HTTPS

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
