### PR TITLE
cdex: Upgrade download URL to use HTTPS

### DIFF
--- a/bucket/cdex.json
+++ b/bucket/cdex.json
@@ -3,7 +3,7 @@
     "description": "Open-source Digital Audio CD Extractor",
     "homepage": "https://cdex.mu/",
     "license": "GPL-3.0-or-later",
-    "url": "http://mirror.cdex.mu/CDex-2.24.exe#/dl.7z_",
+    "url": "https://mirror.cdex.mu/CDex-2.24.exe#/dl.7z_",
     "hash": "49f8e02b42034e69d6f03fc105c79e2a077e9902ad9cf426afbeb62524062e67",
     "pre_install": [
         "# Exclude $PLUGINSDIR and $0 first because Antivirus softwares (e.g. Avira, PC-Cillin) detects these files as ADwares.",


### PR DESCRIPTION
cdex: Upgrade download URL to use HTTPS

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
