### PR TITLE
chatall: Update homepage from redirecting HTTP link to HTTPS target

### DIFF
--- a/bucket/chatall.json
+++ b/bucket/chatall.json
@@ -1,7 +1,7 @@
 {
     "version": "1.85.110",
     "description": "Concurrently chat with ChatGPT, Bing Chat, bard, Alpaca, Vincuna, Claude, ChatGLM, MOSS, iFlytek Spark, ERNIE and more, discover the best answers",
-    "homepage": "http://chatall.ai",
+    "homepage": "https://github.com/ai-shifu/ChatALL",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
chatall: Update homepage from redirecting HTTP link to HTTPS target

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
