### PR TITLE
codeblocks: Uprade homepage to use HTTPS

### DIFF
--- a/bucket/codeblocks.json
+++ b/bucket/codeblocks.json
@@ -1,7 +1,7 @@
 {
     "version": "25.03",
     "description": "Free open-source C/C++/Fortran IDE (standalone version)",
-    "homepage": "http://www.codeblocks.org",
+    "homepage": "https://www.codeblocks.org",
     "license": "GPL-3.0-only",
     "notes": [
         "This is the standalone version of the Code::Blocks IDE (does not include compilers/debuggers)",


### PR DESCRIPTION
codeblocks: Uprade homepage to use HTTPS

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
