### PR TITLE
cudatext@1.228.0.3: Update homepage

### DIFF
--- a/bucket/cudatext.json
+++ b/bucket/cudatext.json
@@ -1,7 +1,7 @@
 {
     "version": "1.228.0.3",
     "description": "Text editor",
-    "homepage": "http://uvviewsoft.com/cudatext/",
+    "homepage": "https://cudatext.github.io",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
cudatext: Replace redirecting homepage HTTP URL with HTTPS target

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CudaText homepage link to https://cudatext.github.io (replacing the outdated http URL). Users following the app/package homepage link will now be directed to the current official site, improving accuracy and security (HTTPS). No functional changes to the application; this is an informational update to ensure users reach the correct project page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->