### PR TITLE
dual-monitor-tools: Upgrade homepage to HTTPS

### DIFF
--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -1,7 +1,7 @@
 {
     "version": "2.11",
     "description": "Set of utilities for managing multiple monitor setups.",
-    "homepage": "http://dualmonitortool.sourceforge.net/",
+    "homepage": "https://dualmonitortool.sourceforge.net/",
     "license": "GPL-3.0-only",
     "url": "https://downloads.sourceforge.net/project/dualmonitortool/dualmonitortool/2.11/DualMonitorTools-2.11.zip",
     "hash": "sha1:da92ee85a8c8918934f6e581ab05e351c00cc21e",


### PR DESCRIPTION
dual-monitor-tools: Upgrade homepage to HTTPS

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
