### PR TITLE
cpu-z-arm64: Add version 1.04

### DIFF
--- a/bucket/cpu-z-arm64.json
+++ b/bucket/cpu-z-arm64.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.04",
+    "description": "System information software",
+    "homepage": "https://www.cpuid.com/softwares/cpu-z-arm64.html",
+    "license": "Freeware",
+    "url": "https://download.cpuid.com/cpu-z/arm64/cpuz-arm64_1.04.zip",
+    "hash": "979828afa84207950075a3eab24f8ec9b39218e2de528f52c8b64f89f36071fb",
+    "architecture": {
+        "arm64": {
+            "bin": [
+                [
+                    "cpuz_arm64.exe",
+                    "cpuz_arm64"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "cpuz_arm64.exe",
+                    "CPU-Z ARM64"
+                ]
+            ]
+        }
+    },
+    "checkver": "Version ([\\d.]+) for windows",
+    "autoupdate": {
+        "url": "https://download.cpuid.com/cpu-z/arm64/cpuz-arm64_$version.zip"
+    }
+}


### PR DESCRIPTION
Added as a seperated software because:
- this is what they did in their official site (<https://www.cpuid.com/softwares/cpu-z-arm64.html>). The name `cpu-z-arm64` is taken from the site url, too.
- It has different version number with x86/x64 version
- Theoretically, Windows on ARM users can run the x64 and arm64 version seperately for different purpose, the former for detecting the emulated chip info and the latter for the real CPU.

The shorcut name `CPU-Z ARM64` is take from the window title, in comparison with x64 version.

<img width="2880" height="1824" alt="image" src="https://github.com/user-attachments/assets/1c387353-e1f3-4a48-af07-55876ad9355e" />


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
