### PR TITLE
fix-print-spooler: Implement standard order in manifest

### DIFF
--- a/bucket/fix-print-spooler.json
+++ b/bucket/fix-print-spooler.json
@@ -1,7 +1,7 @@
 {
     "version": "1.3",
-    "homepage": "https://www.sordum.org/fix-print-spooler",
     "description": "A small tool for fixing or disabling the Print Spooler service in Windows.",
+    "homepage": "https://www.sordum.org/fix-print-spooler",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.sordum.org/eula/"


### PR DESCRIPTION
fix-print-spooler: Implement standard order in manifest

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
