### PR TITLE
npiperelay: Update to 1.8.2

### DIFF
--- a/bucket/npiperelay.json
+++ b/bucket/npiperelay.json
@@ -25,7 +25,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/npiperelay_$version_checksums.txt",
+            "url": "$baseurl/npiperelay_checksums.txt",
             "regex": "$sha256\\s+$basename"
         }
     }


### PR DESCRIPTION
1. Switch to the actively maintained fork.
2. Update to latest version as of now.

Quoting the fork description here:
> Note: This is a fork of [jstarks/npiperelay](https://github.com/jstarks/npiperelay). The branch named master is kept "frozen" in sync with upstream, while the branch named fork is this project's default branch. The fork branch includes additional improvements on top of upstream, though the changes are conservative. The primary concern is just to keep the code updated and secure, considering the latest commit in upstream is back in mid 2020, relased as version 0.1.0. Releases here in my project are created from the fork branch, starting at version number 1.0.0. See [releases](https://github.com/albertony/npiperelay/releases) for details.

Please suggest if a new package should be created instead.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
