### PR TITLE
keepass: add KeePass.config.xml to persist

### DIFF
--- a/bucket/keepass.json
+++ b/bucket/keepass.json
@@ -14,6 +14,7 @@
         ]
     ],
     "persist": [
+        "KeePass.config.xml",
         "Plugins",
         "Languages"
     ],


### PR DESCRIPTION
This adds KeePass.config.xml to the persist.

As I laid out in issue #15887, the current manifest doesn't save user settings. The history on this is messy, and it seems like the correct fix just never made it in.

This PR implements the simple, standard solution. Let me know if I've missed anything.

---

Closes #15887

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)