### PR TITLE
webcord: Update to version 4.11.0, temporarily remove 32bit & arm64 version

### DIFF
--- a/bucket/webcord.json
+++ b/bucket/webcord.json
@@ -1,20 +1,12 @@
 {
-    "version": "4.10.3",
+    "version": "4.11.0",
     "description": "A Discord and Fosscord web-based client.",
     "homepage": "https://github.com/SpacingBat3/WebCord",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SpacingBat3/WebCord/releases/download/v4.10.3/WebCord-win32-x64-4.10.3.zip",
-            "hash": "51d34783e5baa090c89b09e29040cbf31400525311c736d7d8ef11f298118241"
-        },
-        "32bit": {
-            "url": "https://github.com/SpacingBat3/WebCord/releases/download/v4.10.3/WebCord-win32-ia32-4.10.3.zip",
-            "hash": "c1ce641d7b3eb3cead9d057edb50848d42bbd0fbba8afe3eab54e05acd2549a9"
-        },
-        "arm64": {
-            "url": "https://github.com/SpacingBat3/WebCord/releases/download/v4.10.3/WebCord-win32-arm64-4.10.3.zip",
-            "hash": "ce724e8c152ab5424acbe1e6ed8208069624292a6b15e48c6a2be2ed56d54b66"
+            "url": "https://github.com/SpacingBat3/WebCord/releases/download/v4.11.0/WebCord-win32-x64-4.11.0.zip",
+            "hash": "1cfc840118a1f47b43d0cde22aff2956de67408810bbacd63d9367e31c6826b3"
         }
     },
     "shortcuts": [
@@ -28,12 +20,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/SpacingBat3/WebCord/releases/download/v$version/WebCord-win32-x64-$version.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/SpacingBat3/WebCord/releases/download/v$version/WebCord-win32-ia32-$version.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/SpacingBat3/WebCord/releases/download/v$version/WebCord-win32-arm64-$version.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `webcord`: Update to version 4.11.0, **temporarily** remove 32bit & arm64 version.

[WebCord#691: win32-arm64/ia32 release artifacts not generated since v4.10.4 due to npm bug](https://github.com/SpacingBat3/WebCord/issues/691)

Closes #15868

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)