### PR TITLE
NetSpeedTray: Add new package

### DIFF
--- a/bucket/NetSpeedTray.json
+++ b/bucket/NetSpeedTray.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0.6",
+    "description": "A lightweight, highly customizable system tray application that monitors and displays real-time network speeds.",
+    "homepage": "https://github.com/erez-c137/NetSpeedTray",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/erez-c137/NetSpeedTray/releases/download/v1.0.6/NetSpeedTray-1.0.6-Setup.exe",
+            "hash": "f5839d9ea8a0b7b6fdc1c5a2770a8bc8b5e80e94a37484b4b36c9955e954a560"
+        }
+    },
+    "installer": {
+        "args": [
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/DIR=$dir" 
+        ]
+    },
+    "uninstaller": {
+        "file": "unins000.exe",
+        "args": "/VERYSILENT"
+    },
+    "shortcuts": [
+        [
+            "NetSpeedTray.exe",
+            "NetSpeedTray"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/erez-c137/NetSpeedTray/releases/download/v$version/NetSpeedTray-$version-Setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the manifest for NetSpeedTray, a lightweight and customizable network speed monitor for the Windows taskbar.

The application has been tested to install and uninstall correctly using this manifest.

Relates to N/A

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)