### PR TITLE
qq: Update to version 9.7.25.29411, fix checkver

### DIFF
--- a/bucket/qq.json
+++ b/bucket/qq.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.7.25.29410",
+    "version": "9.7.25.29411",
     "description": "An instant messaging tool that gives you the best way to keep in touch with your friends and family.",
     "homepage": "https://im.qq.com",
     "license": {
@@ -11,8 +11,8 @@
         "'%UserProfile%\\Documents\\Tencent Files'.",
         "Files produced at runtime are left in '%AppData%\\Tencent'."
     ],
-    "url": "https://dldir1.qq.com/qqfile/qq/PCQQ9.7.25/QQ9.7.25.29410.exe#/dl.7z",
-    "hash": "4f69e64cf966dfaed7dac1ae7015b52eb9eb4b0fb784e7297880236a393477d4",
+    "url": "https://dldir1.qq.com/qqfile/qq/PCQQ9.7.25/QQ9.7.25.29411.exe#/dl.7z",
+    "hash": "98badd9fbe175f3483a69a309532a05b6c0b548ba2562fbeb8eecbe738053421",
     "shortcuts": [
         [
             "Bin\\QQScLauncher.exe",
@@ -32,16 +32,8 @@
         ]
     },
     "checkver": {
-        "script": [
-            "$url = 'https://im.qq.com/pcqq/index.shtml'",
-            "$resp = Invoke-WebRequest -Uri $url",
-            "$cont = $resp.Content",
-            "$pattern = 'https://qq-web.cdn-go.cn.*windowsDownloadUrl.js'",
-            "$jsUrl = [regex]::Match($cont, $pattern).Value",
-            "Invoke-WebRequest -Uri $jsUrl"
-        ],
-        "regex": "PCQQ([\\d\\.]+)/QQ([\\d\\.]+).exe",
-        "replace": "${2}"
+        "url": "https://qq-web.cdn-go.cn/im.qq.com_new/latest/rainbow/windowsConfig.js",
+        "regex": "QQ(?<version>[\\d.]+)\\.exe"
     },
     "autoupdate": {
         "url": "https://dldir1.qq.com/qqfile/qq/PCQQ$matchHead/QQ$version.exe#/dl.7z"


### PR DESCRIPTION
This PR makes the following changes:
- `qq`: Update to version 9.7.25.29411, fix checkver.

Closes #15928
Relates to #15917

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)