### PR TITLE
tinypxeserver@1.0.0.23: add Tiny PXE Server

### DIFF
--- a/bucket/tiny-pxe-server.json
+++ b/bucket/tiny-pxe-server.json
@@ -7,10 +7,12 @@
     "hash": "58668e213f751af1117b9240b29a46833ab36993c7315250d06473b5d443152c",
     "bin": "pxesrv.exe",
     "shortcuts": [
-        ["pxesrv.exe", "Tiny PXE Server"]
+        [
+            "pxesrv.exe",
+            "Tiny PXE Server"
+        ]
     ],
     "autoupdate": {
         "url": "https://erwan.labalec.fr/tinypxeserver/pxesrv.zip"
     }
 }
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Adds **Tiny PXE Server** (v 1.0.0.23) to the Extras bucket.  
Tiny PXE Server is a portable DHCP + TFTP + HTTP server handy for PXE-boot environments.

---

## Validation

| Check | Result |
|-------|--------|
| `scoop install .\tinypxeserver.json` | ✅ |
| App launches (`pxesrv.exe`) | ✅ |
| Shortcut created & works | ✅ |
| `scoop uninstall tinypxeserver` cleans up | ✅ |
| Hash matches upstream ZIP | ✅ |
| Static URL, autoupdate stanza present | ✅ |

---

- [x] Use conventional PR title (`tinypxeserver@1.0.0.23: add Tiny PXE Server`)
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
