### PR TITLE
exifglass@1.9.0.0: Fix extract_dir

### DIFF
--- a/bucket/exifglass.json
+++ b/bucket/exifglass.json
@@ -8,7 +8,7 @@
         "64bit": {
             "url": "https://github.com/d2phap/ExifGlass/releases/download/1.9.0.0/ExifGlass_1.9.0.0_x64.zip",
             "hash": "11de3afe01a30b07bda14041ad65ba09aead1cabcef7e75466083881f236ed6e",
-            "extract_dir": "ExifGlass_1.9.0.0_net9_x64"
+            "extract_dir": "ExifGlass_1.9.0.0_x64"
         }
     },
     "shortcuts": [
@@ -24,7 +24,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/d2phap/ExifGlass/releases/download/$version/ExifGlass_$version_x64.zip",
-                "extract_dir": "ExifGlass_$version_net9_x64"
+                "extract_dir": "ExifGlass_$version_x64"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `exifglass@1.9.0.0`: Fix extract_dir.

Closes #15940

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)