### PR TITLE
electronmail@5.3.2: Fix shortcut issue

### DIFF
--- a/bucket/electronmail.json
+++ b/bucket/electronmail.json
@@ -13,7 +13,7 @@
     "pre_install": "Expand-7zipArchive \"$dir\\app-64.7z\" $dir -Removal",
     "shortcuts": [
         [
-            "ElectronMail.exe",
+            "electron-mail.exe",
             "ElectronMail"
         ]
     ],


### PR DESCRIPTION
This PR makes the following changes:
- `electronmail@5.3.2`: Fix shortcut issue. [The executable is renamed back to `electron-mail`](https://github.com/vladimiry/ElectronMail/releases/tag/v5.3.2).
<img width="1206" height="454" alt="image" src="https://github.com/user-attachments/assets/45ba7465-890a-4cde-b436-dfb59a96a3a6" />

Closes #15941

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)