### PR TITLE
openscad@2021.01: Remove shortcut and shim after uninstallation

### DIFF
--- a/bucket/openscad.json
+++ b/bucket/openscad.json
@@ -16,8 +16,14 @@
     "extract_dir": "openscad-2021.01",
     "post_install": [
         "# OpenSCAD can't be started from a symlinked directory. See: https://github.com/openscad/openscad/issues/1309",
-        "startmenu_shortcut \"$original_dir/openscad.exe\" 'OpenSCAD'",
-        "shim \"$original_dir\\openscad.exe\" $false 'openscad'"
+        "startmenu_shortcut \"$original_dir\\openscad.exe\" 'OpenSCAD' $null $null $global",
+        "shim \"$original_dir\\openscad.exe\" $global 'openscad'"
+    ],
+    "post_uninstall": [
+        "# Remove shortcut and shim",
+        "rm_shim 'openscad' \"$(shimdir $global)\"",
+        "Remove-Item \"$(shortcut_folder $global)\\openscad.lnk\" -Force -ErrorAction SilentlyContinue",
+        "Write-Host \"Removing shortcut $(friendly_path \"$(shortcut_folder $global)\\openscad.lnk\")\""
     ],
     "checkver": {
         "url": "https://www.openscad.org/inc/win_release_links.js",


### PR DESCRIPTION
#### Description
Openscad shortcut and shim are generated by the post_install script.
https://github.com/ScoopInstaller/Extras/blob/0165c10b9a4dba1a6c061da41c423ac525e9650d/bucket/openscad.json#L17-L21
However, there is no script to remove them after uninstallation.
#### Changes
This PR makes the following changes:
- `openscad@2021.01`: Remove shortcut and shim after uninstallation.

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)