### PR TITLE
tftpd: Update to 4.71

### DIFF
--- a/bucket/tftpd.json
+++ b/bucket/tftpd.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.64",
+    "version": "4.70",
     "description": "Lightweight multi-threaded TFTP, DNS, SNTP, SYSLOG and DHCP server",
     "homepage": "https://pjo2.github.io/tftpd64/",
-    "license": "EUPL-1.1",
+    "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://bitbucket.org/phjounin/tftpd64/downloads/tftpd64.464.zip",
-            "hash": "029fca7a53d6b1e6ca8a62a8cb94429c3013a1f327a052dd79c69947b6027822",
+            "url": "https://github.com/PJO2/tftpd64/releases/download/v4.70/tftpd64_portable_v4.70.zip",
+            "hash": "sha256:2527220ad785ccaa2be4390efcf02a45e536ffce149d96c316494db1f820fcf3",
             "bin": [
                 "tftpd64.exe",
                 [
@@ -22,8 +22,8 @@
             ]
         },
         "32bit": {
-            "url": "https://bitbucket.org/phjounin/tftpd64/downloads/tftpd32.464.zip",
-            "hash": "b1fd2cad7c41347b426ecd454c05ebdaed68126fd6654bf7fa332207c44ebb41",
+            "url": "https://github.com/PJO2/tftpd64/releases/download/v4.70/tftpd32_portable_v4.70.zip",
+            "hash": "sha256:6891e976865727e5665a46acc8c47430fbb0b94dff566c45d2940049dd488ffe",
             "bin": [
                 "tftpd32.exe",
                 [
@@ -40,14 +40,16 @@
         }
     },
     "persist": "tftpd32.ini",
-    "checkver": "Tftpd64-([\\d.]+)-setup",
+    "checkver": {
+        "github": "https://github.com/PJO2/tftpd64/"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://bitbucket.org/phjounin/tftpd64/downloads/tftpd64.$cleanVersion.zip"
+                "url": "https://github.com/PJO2/tftpd64/releases/download/v$version/tftpd64_portable_v$version.zip"
             },
             "32bit": {
-                "url": "https://bitbucket.org/phjounin/tftpd64/downloads/tftpd32.$cleanVersion.zip"
+                "url": "https://github.com/PJO2/tftpd64/releases/download/v$version/tftpd32_portable_v$version.zip"
             }
         }
     }


### PR DESCRIPTION
Updates manifest to latest version of tftpd (4.71).

Uses Github releases instead of Bitbucket as the Bitbucket repository no longer exists.

Also changes the license from `EUPL-1.1` to `GPL-2.0-only` as per the repository's [license.md](https://github.com/PJO2/tftpd64/blob/v4.71/license.md).

Closes #15449
