### PR TITLE
eclipse-mat: Update to version 1.16.1

### DIFF
--- a/bucket/affine.json
+++ b/bucket/affine.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.23.2",
+    "version": "0.24.0",
     "description": "A privacy-focussed, local-first, open-source, and ready-to-use alternative for Notion & Miro.",
     "homepage": "https://affine.pro/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/toeverything/AFFiNE/releases/download/v0.23.2/affine-0.23.2-stable-windows-x64.exe#/dl.7z",
-            "hash": "sha512:64c189e2312f6b0e9c1059fa27b1101f806aa52994b81457be63c84c7f3e0e23a187ea3bd256f657f24a32402f7b8e610499db8ebdc92027a01d61006500db67"
+            "url": "https://github.com/toeverything/AFFiNE/releases/download/v0.24.0/affine-0.24.0-stable-windows-x64.exe#/dl.7z",
+            "hash": "706e891e835b484ba494601255cadf800997bb48838a9baf28c9954732275cca"
         },
         "arm64": {
-            "url": "https://github.com/toeverything/AFFiNE/releases/download/v0.23.2/affine-0.23.2-stable-windows-arm64.exe#/dl.7z",
-            "hash": "sha512:fc4f05cb5f774250a4b3bef1b125f2c2f7c01481ee66e9fe08689ce0258ca37ac9e42dfc8605ee3605abf2cf80450bd40400716436cfa9e003c579033fb0b33a"
+            "url": "https://github.com/toeverything/AFFiNE/releases/download/v0.24.0/affine-0.24.0-stable-windows-arm64.exe#/dl.7z",
+            "hash": "3424d03278cbbe46f51d8ff01f5975c05215ab8b5949a2e5055833e5c1d853e0"
         }
     },
     "pre_install": [

--- a/bucket/aptakube.json
+++ b/bucket/aptakube.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.12.5",
+    "version": "1.12.6",
     "description": "Modern, lightweight and multi-cluster Kubernetes GUI",
     "homepage": "https://aptakube.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aptakube/aptakube/releases/download/1.12.5/Aptakube_1.12.5_x64.zip",
-            "hash": "a82eb53b7072b1c9c9ffdd4618dfbfb9edd0ca0643aa4035ecbf0d75639d7a7b"
+            "url": "https://github.com/aptakube/aptakube/releases/download/1.12.6/Aptakube_1.12.6_x64.zip",
+            "hash": "12038040d8a63fce8731ebd0821710d042a803adb34e69f3aa68db873e8ed269"
         }
     },
     "bin": [

--- a/bucket/eclipse-mat.json
+++ b/bucket/eclipse-mat.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.15.0.20231206",
+    "version": "1.16.1.20250109",
     "description": "Eclipse Memory Analyzer",
     "homepage": "https://www.eclipse.org/mat/",
     "license": "EPL-1.0",
     "architecture": {
         "64bit": {
-            "url": "http://download.eclipse.org/mat/1.15.0/rcp/MemoryAnalyzer-1.15.0.20231206-win32.win32.x86_64.zip",
-            "hash": "sha512:9158fe030a590e1d978fd5eb293584b8b33cf8c48d3b00708d0017f20fab038cff5682f76b72cff256c9ba8397e1e3b3e97106ad2252f92dc033c10ff767d342"
+            "url": "https://download.eclipse.org/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.20250109-win32.win32.x86_64.zip",
+            "hash": "sha512:f899270435de88e0c675192439a1d663a22e1996cda4189942611fcfdf668d2c64c872b8009460f285176bea5137fd3a4f8991e2a2f583e2de2f23219f5e1a22"
         }
     },
     "extract_dir": "mat",
@@ -18,13 +18,13 @@
     ],
     "persist": "workspace",
     "checkver": {
-        "url": "https://www.eclipse.org/mat/downloads.php",
+        "url": "https://eclipse.dev/mat/download/",
         "regex": "/mat/(?<short>[\\d.]+)/rcp/MemoryAnalyzer-([\\d.]+)-win32"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.eclipse.org/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip"
+                "url": "https://download.eclipse.org/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip"
             }
         },
         "hash": {

--- a/bucket/element.json
+++ b/bucket/element.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.11.108",
+    "version": "1.11.109",
     "description": "A decentralised, encrypted chat & collaboration powered by matrix.org",
     "homepage": "https://element.io",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://packages.riot.im/desktop/update/win32/x64/element-desktop-1.11.108-full.nupkg",
-            "hash": "sha1:390d38df59633e403c13f90b5ac4cd930b7f6e70"
+            "url": "https://packages.riot.im/desktop/update/win32/x64/element-desktop-1.11.109-full.nupkg",
+            "hash": "sha1:acb6a871a6d432ab7647063807403353e657f497"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/postman.json
+++ b/bucket/postman.json
@@ -1,5 +1,5 @@
 {
-    "version": "11.57.6",
+    "version": "11.58.0",
     "description": "Complete API development environment.",
     "homepage": "https://www.getpostman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/11.57.6/Postman-win64-11.57.6-Setup.exe#/dl.7z",
-            "hash": "sha1:c7fa1f661775c97bc4fd332f49836b9c514c244d"
+            "url": "https://dl.pstmn.io/download/11.58.0/Postman-win64-11.58.0-Setup.exe#/dl.7z",
+            "hash": "sha1:e82a35e57696c2c7cda56d7b1aaf070b95b06ca0"
         }
     },
     "installer": {

--- a/bucket/treesheets.json
+++ b/bucket/treesheets.json
@@ -1,13 +1,13 @@
 {
-    "version": "2332",
+    "version": "2333",
     "description": "A free form data organizer and a replacement for spreadsheets, mind mappers, outliners, PIMs, text editors and small databases.",
     "homepage": "https://strlen.com/treesheets",
     "license": "ZLIB",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aardappel/treesheets/releases/download/2332/TreeSheets-2332-win64.zip",
-            "hash": "fdb9b125b54323a80f3a71d7d240ab33269ef9ca50981a360cf0855a35fed791",
-            "extract_dir": "TreeSheets-2332-win64"
+            "url": "https://github.com/aardappel/treesheets/releases/download/2333/TreeSheets-2333-win64.zip",
+            "hash": "3a11e8628983c6c1f8c2971d43766acac828186a2d8c1def984adff3d46df156",
+            "extract_dir": "TreeSheets-2333-win64"
         }
     },
     "pre_install": [

--- a/bucket/ucheck.json
+++ b/bucket/ucheck.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.3.3",
+    "version": "6.3.4",
     "description": "Update your software in 2 clicks. Stay away from malware.",
     "homepage": "https://www.adlice.com/ucheck/",
     "license": {
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://download.adlice.com/api?action=download&app=ucheck&type=x64#/UCheck_portable64.exe",
-            "hash": "c70585f5291114d799dbe4bd9858ce5a6ce0d6976287ac37069038240c6a5616",
+            "hash": "8b6a59f327c3594fbe1076d84e6ca1a7783d4595783e9a084596f88cb9d77dd6",
             "bin": "UCheck_portable64.exe",
             "shortcuts": [
                 [
@@ -20,7 +20,7 @@
         },
         "32bit": {
             "url": "https://download.adlice.com/api?action=download&app=ucheck&type=x86#/UCheck_portable32.exe",
-            "hash": "ea1443f2e06de9cc4893a2d7ec919178e29c55f9fcfc19829cf1e031c58a86c3",
+            "hash": "ce513ff724d8cc60b9fd1630837337723318bc82ebe51768a9c558cc2708123e",
             "bin": "UCheck_portable32.exe",
             "shortcuts": [
                 [

--- a/bucket/wavebox.json
+++ b/bucket/wavebox.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.138.14.2",
+    "version": "10.139.10.2",
     "description": "Wavebox 10. A distraction-free browser for fast and focused working across all web apps.",
     "homepage": "https://wavebox.io/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.wavebox.app/stable/win/Install%20Wavebox%2010.138.14.2.exe#/dl.7z",
-            "hash": "779f03a6039de3616151e2b8f879fbbeeb14acb920b99a25e392fad80b77eb0f"
+            "url": "https://download.wavebox.app/stable/win/Install%20Wavebox%2010.139.10.2.exe#/dl.7z",
+            "hash": "62565e7d4f9ed464cc5251211cc537da5b2ec4f1005552a9b7e9fa0dd6057456"
         }
     },
     "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal",


### PR DESCRIPTION
eclipse-mat@1.15.0  can't be updated. eclipse update address had changed, need to be correct,and update to 1.16.1

the orginal update address "https://www.eclipse.org/mat/downloads.php" can't be accessed now. so that no update more than two years.
