### PR TITLE
eclipse-mat: Update to version 1.16.1

### DIFF
--- a/bucket/eclipse-mat.json
+++ b/bucket/eclipse-mat.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.15.0.20231206",
+    "version": "1.16.1.20250109",
     "description": "Eclipse Memory Analyzer",
     "homepage": "https://www.eclipse.org/mat/",
     "license": "EPL-1.0",
     "architecture": {
         "64bit": {
-            "url": "http://download.eclipse.org/mat/1.15.0/rcp/MemoryAnalyzer-1.15.0.20231206-win32.win32.x86_64.zip",
-            "hash": "sha512:9158fe030a590e1d978fd5eb293584b8b33cf8c48d3b00708d0017f20fab038cff5682f76b72cff256c9ba8397e1e3b3e97106ad2252f92dc033c10ff767d342"
+            "url": "https://download.eclipse.org/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.20250109-win32.win32.x86_64.zip",
+            "hash": "sha512:f899270435de88e0c675192439a1d663a22e1996cda4189942611fcfdf668d2c64c872b8009460f285176bea5137fd3a4f8991e2a2f583e2de2f23219f5e1a22"
         }
     },
     "extract_dir": "mat",
@@ -18,13 +18,13 @@
     ],
     "persist": "workspace",
     "checkver": {
-        "url": "https://www.eclipse.org/mat/downloads.php",
+        "url": "https://eclipse.dev/mat/download/",
         "regex": "/mat/(?<short>[\\d.]+)/rcp/MemoryAnalyzer-([\\d.]+)-win32"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.eclipse.org/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip"
+                "url": "https://download.eclipse.org/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
eclipse-mat@1.15.0 can't be updated. eclipse update address had changed, need to be correct,and update to 1.16.1

the orginal update address "https://www.eclipse.org/mat/downloads.php" can't be accessed now. so that no update more than two years.
