### PR TITLE
eclipse-mat: Update to version 1.16.1.20250109, fix checkver & autoupdate

### DIFF
--- a/bucket/eclipse-mat.json
+++ b/bucket/eclipse-mat.json
@@ -11,7 +11,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?file=/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.20250109-win32.win32.x86_64.zip&r=1#dl.zip",
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.20250109-win32.win32.x86_64.zip",
             "hash": "sha512:f899270435de88e0c675192439a1d663a22e1996cda4189942611fcfdf668d2c64c872b8009460f285176bea5137fd3a4f8991e2a2f583e2de2f23219f5e1a22"
         }
     },
@@ -30,12 +30,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?file=/mat/$matchHead/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip&r=1#dl.zip"
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/$matchHead/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip"
             }
         },
         "hash": {
             "url": "https://www.eclipse.org/downloads/sums.php?file=%2Fmat%2F$matchHead%2Frcp%2FMemoryAnalyzer-$version-win32.win32.x86_64.zip&type=sha512",
-            "regex": "$sha512.*?MemoryAnalyzer"
+            "regex": "$sha512.*?$basename"
         }
     }
 }


### PR DESCRIPTION
- Relates to #15971

Homepage updated




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Version bumped to 1.16.1.20250109
  * License updated to EPL-2.0
  * Homepage moved to the new eclipse.dev domain
  * Download URL and checksum updated; update/checker URLs and patterns modernized

* **New Features**
  * Added JDK suggestions (OpenJDK 17 and OpenJDK) for streamlined setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->