### PR TITLE
session: Update to version 1.16.6, switch to the actual repo

### DIFF
--- a/bucket/session.json
+++ b/bucket/session.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.14.3",
+    "version": "1.16.6",
     "description": "End-to-end encrypted messenger",
     "homepage": "https://getsession.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oxen-io/session-desktop/releases/download/v1.14.3/session-desktop-win-x64-1.14.3.exe#/dl.7z",
-            "hash": "sha512:743a10ea82a1583cc1548877187e9cd3e1ddc41102512beaa9493cb801832ae20c3323fef8fa4b580c29c0c3bdf081fb3011531af1ee53dc15c6cef49f3cddd7",
+            "url": "https://github.com/session-foundation/session-desktop/releases/download/v1.16.6/session-desktop-win-x64-1.16.6.exe#/dl.7z",
+            "hash": "sha512:c5398e3092031908a68e8b5aa8fac67fee4d04a732300619a4fd7c4630af45359241fced39536af0afe0d11b7b568d738f3d1a6ac70a9919b1004f460452f492",
             "installer": {
                 "script": [
                     "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -23,12 +23,12 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/oxen-io/session-desktop"
+        "github": "https://github.com/session-foundation/session-desktop"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/oxen-io/session-desktop/releases/download/v$version/session-desktop-win-x64-$version.exe#/dl.7z"
+                "url": "https://github.com/session-foundation/session-desktop/releases/download/v$version/session-desktop-win-x64-$version.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
- Switch to the actual repo.
- Update to latest version.

As indicated in the [deprecation note](https://github.com/oxen-io/session-desktop#repository-deprecated):

> This repository is now deprecated. However, Session Desktop is still actively developed [here](https://github.com/session-foundation/session-desktop). This is in line with announcements from [Session](https://getsession.org/blog/introducing-the-session-technology-foundation) and the [OPTF](https://optf.ngo/blog/the-optf-and-session), indicating that the OPTF has handed over the stewardship of the Session Project to the [Session Technology Foundation](https://session.foundation/), a Swiss-based foundation dedicated to advancing digital rights and innovation.


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
