### PR TITLE
netpad: Add new manifest

### DIFF
--- a/bucket/netpad.json
+++ b/bucket/netpad.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.10.0",
+    "description": "A cross-platform C# editor and playground.",
+    "homepage": "https://github.com/tareqimbasher/NetPad",
+    "license": "MIT",
+    "suggest": {
+        ".NET SDK": [
+            "main/dotnet-sdk",
+            "versions/dotnet-sdk-lts",
+            "versions/dotnet-sdk-preview",
+            "versions/dotnet5-sdk",
+            "versions/dotnet6-sdk",
+            "versions/dotnet7-sdk"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tareqimbasher/NetPad/releases/download/v0.10.0/netpad-0.10.0-win-x64.zip",
+            "hash": "sha256:2c38637b8fc470570873c624bccdc7b35c801bd2ce91c4e07cb1351e83058ffe"
+        }
+    },
+    "shortcuts": [["NetPad.exe", "NetPad"]],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tareqimbasher/NetPad/releases/download/v$version/netpad-$version-win-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

Related to #15804, https://github.com/tareqimbasher/NetPad/issues/275

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

---

Should vNext (Tauri shell) be added to the versions bucket or to the extras bucket (like `extras/godot` and `extras/godot-mono`)?
vNext may supersede the old Electron version. (see [here](https://github.com/tareqimbasher/NetPad/releases/tag/v0.10.0))