### PR TITLE
processing4@1306-4.4.6|chore: pin extract_dir name (no longer has version in name)

### DIFF
--- a/bucket/processing4.json
+++ b/bucket/processing4.json
@@ -9,7 +9,7 @@
             "hash": "dbf271f13c4b32dcd6626953ff3258e7e2c5665717bc01ff1871cbe448ed9f8e"
         }
     },
-    "extract_dir": "processing-4.4.6",
+    "extract_dir": "Processing",
     "bin": "Processing.exe",
     "shortcuts": [
         [
@@ -32,7 +32,7 @@
             "64bit": {
                 "url": "https://github.com/processing/processing4/releases/download/processing-$version/processing-$preReleaseVersion-windows-x64-portable.zip"
             }
-        },
-        "extract_dir": "processing-$preReleaseVersion"
+        }
     }
 }
+


### PR DESCRIPTION
Closes #15994

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
