### PR TITLE
sejda-pdf@7.8.8: remove extract_dir, app now resides in the zip root

### DIFF
--- a/bucket/sejda-pdf.json
+++ b/bucket/sejda-pdf.json
@@ -12,7 +12,6 @@
             "hash": "b7a1c227e7e7b99b69362842ba28604fdee45dd1a5848d166a11650c7686a776"
         }
     },
-    "extract_dir": "Sejda PDF Desktop",
     "shortcuts": [
         [
             "Sejda PDF Desktop.exe",


### PR DESCRIPTION
Closes #15992


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
