### PR TITLE
netpad-vnext: Add version 0.10.0

### DIFF
--- a/bucket/netpad-vnext.json
+++ b/bucket/netpad-vnext.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.10.0",
+    "description": "A cross-platform C# editor and playground.",
+    "homepage": "https://github.com/tareqimbasher/NetPad",
+    "license": "MIT",
+    "suggest": {
+        ".NET SDK": [
+            "main/dotnet-sdk",
+            "versions/dotnet-sdk-lts",
+            "versions/dotnet-sdk-preview",
+            "versions/dotnet5-sdk",
+            "versions/dotnet6-sdk",
+            "versions/dotnet7-sdk"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tareqimbasher/NetPad/releases/download/v0.10.0/netpad_vnext-0.10.0-win-x64.msi",
+            "hash": "sha256:f7af5e2585354eb6bedad558522d39befa9a4a75dd299d244415b78f7c53555e"
+        }
+    },
+    "extract_dir": "PFiles\\NetPad vNext",
+    "shortcuts": [["NetPad vNext.exe", "NetPad vNext"]],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tareqimbasher/NetPad/releases/download/v$version/netpad_vnext-$version-win-x64.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Related to #15804, https://github.com/tareqimbasher/NetPad/issues/275

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Also see #15991:
> Should vNext (Tauri shell) be added to the versions bucket or to the extras bucket (like `extras/godot` and `extras/godot-mono`)?
> vNext may supersede the old Electron version. (see [here](https://github.com/tareqimbasher/NetPad/releases/tag/v0.10.0))