### PR TITLE
openscad@2021.01: Fix a typo in the post_uninstall script

### DIFF
--- a/bucket/openscad.json
+++ b/bucket/openscad.json
@@ -22,7 +22,7 @@
     "post_uninstall": [
         "# Remove shortcut and shim",
         "rm_shim 'openscad' \"$(shimdir $global)\"",
-        "Write-Host \"Removing shortcut $(friendly_path \"$(shortcut_folder $global)\\openscad.lnk\")\"",
+        "Write-Host \"Removing shortcut $(friendly_path \"$(shortcut_folder $global)\\OpenSCAD.lnk\")\"",
         "Remove-Item \"$(shortcut_folder $global)\\OpenSCAD.lnk\" -Force -ErrorAction SilentlyContinue"
     ],
     "checkver": {


### PR DESCRIPTION
This PR makes the following changes:
- `openscad@2021.01`: Fix a typo in the post_uninstall script.
    - `openscad.lnk` should be `OpenSCAD.lnk`.

Relates to #15960

https://github.com/ScoopInstaller/Extras/blob/d87777308e911148abab4c8887db1709b8d39f6f/bucket/openscad.json#L25
```json
"Write-Host \"Removing shortcut $(friendly_path \"$(shortcut_folder $global)\\OpenSCAD.lnk\")\"",
```

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)