### PR TITLE
powertoys@0.93.0: fix ImageResizerApplet path

### DIFF
--- a/scripts/powertoys/install-context.ps1
+++ b/scripts/powertoys/install-context.ps1
@@ -105,7 +105,7 @@ New-ItemProperty -Path $regPath -Name 'ThreadingModel' -Value 'Apartment' -Force
 
 if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell 3>$null }
 
-Add-AppxPackage -Path '{{scoop_dir}}\ImageResizerContextMenuPackage.msix' -ExternalLocation '{{scoop_dir}}' | Out-Null
+Add-AppxPackage -Path '{{scoop_dir}}\WinUI3Apps\ImageResizerContextMenuPackage.msix' -ExternalLocation '{{scoop_dir}}\WinUI3Apps' | Out-Null
 
 Add-AppxPackage -Path '{{scoop_dir}}\WinUI3Apps\PowerRenameContextMenuPackage.msix' -ExternalLocation '{{scoop_dir}}\WinUI3Apps' | Out-Null
 


### PR DESCRIPTION
Closes #15972

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
