### PR TITLE
pixieditor: Add version 2.0.1.7

### DIFF
--- a/bucket/pixieditor.json
+++ b/bucket/pixieditor.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.0.1.7",
+    "description": "A universal 2D editor for Procedural Art, Pixel art, Painting, Image Editing, Vector Art, and Animations",
+    "homepage": "https://pixieditor.net/",
+    "license": "LGPL-3.0",
+    "suggest": {
+        ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts"
+    },
+    "extract_dir": "PixiEditor",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PixiEditor/PixiEditor/releases/download/2.0.1.7/PixiEditor.2.0.1.7.x64-win.zip",
+            "hash": "f3c13abfb4130d09f4fa1cbbaea2b57f46794f4f376fc00850bef011757eefcf"
+        }
+    },
+    "shortcuts": [
+        [
+            "PixiEditor.exe",
+            "PixiEditor"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/PixiEditor/PixiEditor"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PixiEditor/PixiEditor/releases/download/$version/PixiEditor.$version.x64-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #16002

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

The newest version atm is 2.0.1.9, which should be updated automatically.