### PR TITLE
regedix: remove dependency `dotnet-7.0-desktopruntime`

### DIFF
--- a/bucket/regedix.json
+++ b/bucket/regedix.json
@@ -3,7 +3,6 @@
     "description": "Windows Registry editor. Breadcrumb navigation, favorites, dark theme...",
     "homepage": "https://regedix.webrox.fr/",
     "license": "GPL-3.0",
-    "depends": "dotnet-7.0-desktopruntime",
     "architecture": {
         "64bit": {
             "url": "https://regedix.webrox.fr/download.php?v=2.0.0.0&file=2.0.0.0/Regedix-2.0.0-x64.exe#/regedix.exe",


### PR DESCRIPTION
`dotnet-7.0-desktopruntime` does not exist in any bucket, and dotnet runtimes & SDKs are usually installed globally.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
