### PR TITLE
chromium: Update to version 140.0.7339.128-r1496484 and fix autoupdate

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,13 +1,13 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "139.0.7258.139-r1477651",
+    "version": "140.0.7339.128-r1496484",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v139.0.7258.139-r1477651/chrome.7z",
-            "hash": "sha1:CA4CC7FC65E2489C288381561FCF5CB6EB555312"
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v140.0.7339.128-r1496484/chrome.7z",
+            "hash": "sha1:814f481b7349682d9f1e23b89e7305c6a45907fd"
         }
     },
     "extract_dir": "Chrome-bin",


### PR DESCRIPTION
Chromium releases here [Releases](https://github.com/Hibbiki/chromium-win64/releases) have removed the `nosync` variant and thus renamed `chrome.sync.7z` to just `chrome.7z`. This pull request fixes the rename in the autoupdate section of the manifest.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Chromium to version 140.0.7339.128 for 64-bit.
  * Refreshed download source to the latest artifact and updated checksum for integrity.
  * Aligned autoupdate configuration to the new artifact naming, ensuring future updates fetch the correct package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->