### PR TITLE
unigetui@3.3.5: Switch to ZIP package, add architecture field to support 64-bit only

### DIFF
--- a/bucket/unigetui.json
+++ b/bucket/unigetui.json
@@ -1,34 +1,37 @@
 {
     "version": "3.3.5",
-    "description": "A GUI to manage Winget and Scoop packages",
-    "homepage": "https://github.com/marticliment/UniGetUI",
+    "description": "GUI for the most common CLI package managers, such as WinGet, Scoop, Chocolatey, Pip, Npm, .NET Tool, PowerShell Gallery and more.",
+    "homepage": "https://www.marticliment.com/unigetui/",
     "license": "MIT",
     "suggest": {
         "scoop-search": "main/scoop-search"
     },
-    "url": "https://github.com/marticliment/UniGetUI/releases/download/3.3.5/UniGetUI.x64.zip",
-    "hash": "e4f44b6c3b548813dbca3741c897657cf9974067847b79a12f69ed2ee4e67d1f",
-    "pre_install": [
-        "if (-not (Test-Path \"$dir\\ForceUniGetUIPortable\")) {",
-        "    New-Item -Path \"$dir\\ForceUniGetUIPortable\" -ItemType File | Out-Null",
-        "}"
-    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/marticliment/UniGetUI/releases/download/3.3.5/UniGetUI.x64.zip",
+            "hash": "e4f44b6c3b548813dbca3741c897657cf9974067847b79a12f69ed2ee4e67d1f"
+        }
+    },
+    "pre_install": "Set-Content -Value $null -Path \"$dir\\ForceUniGetUIPortable\"",
     "shortcuts": [
         [
             "UniGetUI.exe",
             "UniGetUI"
         ]
     ],
-    "persist": [
-        "ForceUniGetUIPortable",
-        "Settings"
-    ],
-    "checkver": "github",
+    "persist": "Settings",
+    "checkver": {
+        "github": "https://github.com/marticliment/UniGetUI"
+    },
     "autoupdate": {
-        "url": "https://github.com/marticliment/UniGetUI/releases/download/$version/UniGetUI.x64.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/marticliment/UniGetUI/releases/download/$version/UniGetUI.x64.zip"
+            }
+        },
         "hash": {
             "url": "https://github.com/marticliment/UniGetUI/releases/tag/$version",
-            "regex": "$sha256.*?$basename"
+            "regex": "sha256: <code>$sha256</code>"
         }
     }
 }


### PR DESCRIPTION
~~UniGetUI.Installer.exe does not seem to be using InnoSetup anymore (innounp doesn't manage to unpack it).~~

- Closes #16053
- Relates to #14863

This PR makes the following changes:
- Update autoupdate to use the zip package instead of Inno Setup package.
- Update homepage & description.
- Add architecture field to fix [incorrect architecture support](https://www.marticliment.com/unigetui/). Move URL & hash under architecture.64bit.
- Simplify persist & pre_install.

<!-- Sep -->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched installation to a portable 64-bit ZIP, enabling easier setup and portability.
  * User data now persists across updates (ForceUniGetUIPortable and Settings).

* **Chores**
  * Updated download source and checksum to the ZIP distribution.
  * Streamlined update checks to pull versions directly from GitHub.
  * Simplified manifest by removing legacy installer-specific fields and scripts.
  * Adjusted auto-update hash matching to align with the ZIP artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->