### PR TITLE
gopeed: Persist user data

### DIFF
--- a/bucket/gopeed.json
+++ b/bucket/gopeed.json
@@ -15,6 +15,7 @@
             "Gopeed"
         ]
     ],
+    "persist": "storage",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Prior to version 1.8.0, Gopeed's user data was fragmented and not persisted. The former issue was resolved in the Gopeed [1.8.0 update](https://github.com/GopeedLab/gopeed/releases#:~:text=feat%3A%20update%20storage%20directory%20path%20for%20Windows%20%40monkeyWie%20(%231087)), while the latter is fixed in this PR.
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
