### PR TITLE
ibazel: Add version 0.26.10

### DIFF
--- a/bucket/ibazel.json
+++ b/bucket/ibazel.json
@@ -14,11 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/bazelbuild/bazel-watcher/releases/download/v$version/ibazel_windows_amd64.exe#/ibazel.exe",
-                "hash": {
-                    "url": "https://github.com/bazelbuild/bazel-watcher/releases/expanded_assets/v$version",
-                    "regex": "ibazel_windows_amd64\\.exe.*sha256:($sha256)"
-                }
+                "url": "https://github.com/bazelbuild/bazel-watcher/releases/download/v$version/ibazel_windows_amd64.exe#/ibazel.exe"
             }
         }
     }


### PR DESCRIPTION
Added a manifest for [ibazel](https://github.com/bazelbuild/bazel-watcher).

Closes #16078

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows 64-bit ibazel package (v0.26.10) for easy installation.
  * Enabled automatic update tracking from GitHub releases to keep the package current.
  * Implemented checksum verification for secure downloads.
  * Configured the package so the tool is runnable via the ibazel command.
  * Added metadata to support reliable installation and update automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->