### PR TITLE
gopeed@1.8.0: Ensure user data persistence on upgrade

### DIFF
--- a/bucket/gopeed.json
+++ b/bucket/gopeed.json
@@ -3,18 +3,50 @@
     "description": "A modern download manager that supports all platforms",
     "homepage": "https://github.com/GopeedLab/gopeed",
     "license": "GPL-3.0-only",
+    "notes": [
+        "Starting from version 1.8.0, all user data is stored in the './storage' directory.",
+        "Upgrading Gopeed via Scoop will no longer result in the loss of user configuration."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/GopeedLab/gopeed/releases/download/v1.8.0/Gopeed-v1.8.0-windows-amd64-portable.zip",
             "hash": "cfcc9e147ac7d002876c8c8151245c2143a8163b22bf5f02280d6504e044c0b2"
         }
     },
+    "pre_install": [
+        "if ($cmd -eq \"install\") { return }",
+        "$threshold_version = [version]\"1.7.1\"",
+        "$parent_dir = Split-Path $dir -Parent",
+        "$version_dirs = Get-ChildItem -Path $parent_dir -Directory | Where-Object {",
+        "    $_.Name -notmatch '^_' -and ($_.Name -as [version])",
+        "} | Sort-Object LastWriteTime -Descending",
+        "if ($version_dirs.Count -lt 2) { return }",
+        "$previous_version = [version]$version_dirs[1].Name",
+        "if ($previous_version -gt $threshold_version) { return }",
+        "$storage_dir = Join-Path $persist_dir \"storage\"",
+        "if (-not (Test-Path $storage_dir)) {",
+        "    New-Item -Path $storage_dir -ItemType Directory -Force | Out-Null",
+        "}",
+        "'gopeed.db', 'logs', 'extensions' | ForEach-Object {",
+        "    $user_data_path = Join-Path $version_dirs[1].FullName $_",
+        "    if (Test-Path $user_data_path) {",
+        "        info \"Found $_ at $user_data_path.\"",
+        "        info \"Starting copy to $storage_dir...\"",
+        "        Copy-Item -Path $user_data_path -Destination $storage_dir -Force -Recurse",
+        "        info \"Successfully copied $_ to $storage_dir.\"",
+        "    } else {",
+        "        info \"Item not found: $user_data_path (skipped).\"",
+        "    }",
+        "}"
+        
+    ],
     "shortcuts": [
         [
             "gopeed.exe",
             "Gopeed"
         ]
     ],
+    "persist": "storage",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

This PR, building upon #16069, addresses the issue of user data loss when upgrading from versions prior to 1.8.0 to 1.8.0 itself and subsequent versions.

Below are some tests:

1\. Upgrade from 1.7.1 to 1.8.0
- For version 1.7.1, the `Gopeed.json` file should be directly copied from `workspace\Gopeed.json`. After installation, run the application to allow it to automatically generate user data. Once done, close the application, then replace the content of `Gopeed.json` with the content from this PR, and proceed with the upgrade.
```powershell
┏[ ~]
└─> scoop list gopeed
Installed apps matching 'gopeed':

Name   Version Source                                                      Updated             Info
----   ------- ------                                                      -------             ----
Gopeed 1.7.1   D:\Temporary\Software\Microsoft\Windows Sandbox\Gopeed.json 2025-09-02 22:58:02

┏[ ~]
└─> scoop update Gopeed
Gopeed: 1.7.1 -> 1.8.0
Updating one outdated app:
Updating 'Gopeed' (1.7.1 -> 1.8.0)
Downloading new version
Loading Gopeed-v1.8.0-windows-amd64-portable.zip from cache.
Checking hash of Gopeed-v1.8.0-windows-amd64-portable.zip ... ok.
Uninstalling 'Gopeed' (1.7.1)
Unlinking D:\Software\Scoop\Local\apps\Gopeed\current
Installing 'Gopeed' (1.8.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Gopeed.json'
Loading Gopeed-v1.8.0-windows-amd64-portable.zip from cache.
Extracting Gopeed-v1.8.0-windows-amd64-portable.zip ... done.
Running pre_install script...INFO  Found gopeed.db at D:\Software\Scoop\Local\apps\Gopeed\1.7.1\gopeed.db.
INFO  Starting copy to D:\Software\Scoop\Local\persist\Gopeed\storage...
INFO  Successfully copied gopeed.db to D:\Software\Scoop\Local\persist\Gopeed\storage.
INFO  Found logs at D:\Software\Scoop\Local\apps\Gopeed\1.7.1\logs.
INFO  Starting copy to D:\Software\Scoop\Local\persist\Gopeed\storage...
INFO  Successfully copied logs to D:\Software\Scoop\Local\persist\Gopeed\storage.
INFO  Item not found: D:\Software\Scoop\Local\apps\Gopeed\1.7.1\extensions (skipped).
done.
Linking D:\Software\Scoop\Local\apps\Gopeed\current => D:\Software\Scoop\Local\apps\Gopeed\1.8.0
Creating shortcut for Gopeed (gopeed.exe)
Persisting storage
'Gopeed' (1.8.0) was installed successfully!
Notes
-----
Starting from version 1.8.0, all user data is stored in the './storage' directory.
Upgrading Gopeed via Scoop will no longer result in the loss of user configuration.
```

2\. Forced upgrade to version 1.8.0
- Following the previous test, delete the folder corresponding to version 1.7.1 and then force an upgrade of Gopeed.
```powershell
┏[ ~]
└─> scoop update Gopeed -f
Gopeed: 1.8.0 -> 1.8.0
Updating one outdated app:
Updating 'Gopeed' (1.8.0 -> 1.8.0)
Downloading new version
Loading Gopeed-v1.8.0-windows-amd64-portable.zip from cache.
Checking hash of Gopeed-v1.8.0-windows-amd64-portable.zip ... ok.
Uninstalling 'Gopeed' (1.8.0)
Unlinking D:\Software\Scoop\Local\apps\Gopeed\current
Installing 'Gopeed' (1.8.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Gopeed.json'
Loading Gopeed-v1.8.0-windows-amd64-portable.zip from cache.
Extracting Gopeed-v1.8.0-windows-amd64-portable.zip ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\Gopeed\current => D:\Software\Scoop\Local\apps\Gopeed\1.8.0
Creating shortcut for Gopeed (gopeed.exe)
Persisting storage
'Gopeed' (1.8.0) was installed successfully!
Notes
-----
Starting from version 1.8.0, all user data is stored in the './storage' directory.
Upgrading Gopeed via Scoop will no longer result in the loss of user configuration.
```

3\. Install `Gopeed` directly
- The content of `Gopeed.json` used in the following commands is consistent with that in this PR.
```powershell
┏[ ~]
└─>  scoop list gopeed
Installed apps matching 'gopeed':

┏[ ~]
└─>  scoop install "D:\Temporary\Software\Microsoft\Windows Sandbox\Gopeed.json"
Installing 'Gopeed' (1.8.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Gopeed.json'
Loading Gopeed-v1.8.0-windows-amd64-portable.zip from cache.
Checking hash of Gopeed-v1.8.0-windows-amd64-portable.zip ... ok.
Extracting Gopeed-v1.8.0-windows-amd64-portable.zip ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\Gopeed\current => D:\Software\Scoop\Local\apps\Gopeed\1.8.0
Creating shortcut for Gopeed (gopeed.exe)
Persisting storage
'Gopeed' (1.8.0) was installed successfully!
Notes
-----
Starting from version 1.8.0, all user data is stored in the './storage' directory.
Upgrading Gopeed via Scoop will no longer result in the loss of user configuration.
```

4\. Persistence Status
```powershell
┏[ ~]
└─> Get-ChildItem -Path $(scoop prefix Gopeed) -Recurse -Force -ErrorAction SilentlyContinue |
   ForEach-Object {
       $it = Get-Item -LiteralPath $_.FullName -Force
       [PSCustomObject]@{
         Path     = $it.FullName
         LinkType = $it.LinkType
         Target   = $it.Target
       }
   } |
   Where-Object { $_.LinkType } |
   Sort-Object Path |
   Format-Table -AutoSize

Path                                                LinkType Target
----                                                -------- ------
D:\Software\Scoop\Local\apps\Gopeed\current\storage Junction D:\Software\Scoop\Local\persist\Gopeed\storage

┏[ ~]
└─> Get-Item -Path "$(scoop prefix Gopeed)\storage\*" | ForEach-Object {
     fsutil hardlink list $_
 }
\Software\Scoop\Local\persist\Gopeed\storage\logs
\Software\Scoop\Local\persist\Gopeed\storage\gopeed.db
```