### PR TITLE
bambu-studio: Update to version 02.02.01.60, fix checkver & autoupdate

### DIFF
--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -1,12 +1,12 @@
 {
-    "version": "02.02.01.58",
+    "version": "02.02.01.60",
     "description": "Bambu Studio is an open-source, cutting-edge, feature-rich slicing software for BambuLab and other 3D printers",
     "homepage": "https://github.com/bambulab/BambuStudio",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bambulab/BambuStudio/releases/download/v02.02.01.58/Bambu_Studio_win-v02.02.01.58-20250826220055.zip",
-            "hash": "b65e249b392893c4322b31aea2d66b5f931efbe23a0d59c8d892465256354728"
+            "url": "https://github.com/bambulab/BambuStudio/releases/download/v02.02.01.60/Bambu_Studio-v02.02.01.60-20250828183151.zip",
+            "hash": "5bd6413f4f5772e3229d201c3da93424066dda77edd17466c822a4b9a59bab72"
         }
     },
     "shortcuts": [
@@ -17,13 +17,13 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/511797274/releases/latest",
-        "jsonpath": "$..assets[?(@.browser_download_url =~ /Bambu_Studio_win-.*\\.zip/i)].browser_download_url",
-        "regex": "download/(?<tag>[\\w.]+)/Bambu_Studio_win-v([\\d.]+)-(?<date>[0-9]+)\\.zip"
+        "jsonpath": "$..assets[?(@.browser_download_url =~ /Bambu_Studio(_win)?-(v|V)?[\\d.]+-\\d+\\.zip/i)].browser_download_url",
+        "regex": "download/(?<tag>(?:v|V)?(?<version>[\\d.]+))/(?<file>Bambu_Studio(?:_win)?)-\\k<tag>-(?<date>\\d+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/bambulab/BambuStudio/releases/download/$matchTag/Bambu_Studio_win-v$version-$matchDate.zip"
+                "url": "https://github.com/bambulab/BambuStudio/releases/download/$matchTag/$matchFile-$matchTag-$matchDate.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- bambu-studio:
  - Update to version 02.02.01.60.
  - Enhance checkver & autoupdate. It works well with both the hotfix and the standard version now.
    e.g. https://api.github.com/repositories/511797274/releases/tags/v02.02.01.58
    <img width="1139" height="118" alt="image" src="https://github.com/user-attachments/assets/89389c15-af85-4cbd-9992-f28ea4023096" />

Closes #16096

<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Bambu Studio to version 02.02.01.60 for 64-bit installations and refreshed the 64-bit release artifact and integrity information.

* **Bug Fixes**
  * Improved release asset detection to handle multiple naming variants.
  * Enhanced autoupdate URL construction to dynamically build download links, increasing resilience to upstream naming changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->