### PR TITLE
vivid: Add version 0.10.1

### DIFF
--- a/bucket/vivid.json
+++ b/bucket/vivid.json
@@ -2,20 +2,21 @@
     "version": "0.10.1",
     "description": "A themeable LS_COLORS generator with a rich filetype database",
     "homepage": "https://github.com/sharkdp/vivid",
-    "license": "MIT|Apache-2.0",
+    "license": "MIT OR Apache-2.0",
     "notes": [
         "vivid generates LS_COLORS for colorizing file listings in terminals.",
-        "Requires GNU coreutils (ls) or compatible tools to display colors:",
-        "  scoop install coreutils",
-        "  scoop install extras/exa",
-        "  scoop install extras/lsd",
+        "Tools that use LS_COLORS on Windows include ls (GNU coreutils), eza and lsd:",
+        "  scoop install main/coreutils",
+        "  scoop install main/eza",
+        "  scoop install main/lsd",
         "",
-        "Usage: export LS_COLORS=\"$(vivid generate molokai)\"",
-        "Available themes: vivid themes"
+        "POSIX shells:   export LS_COLORS=\"$(vivid generate molokai)\"",
+        "PowerShell:     $env:LS_COLORS = (vivid.exe generate molokai)",
+        "View available themes: vivid themes"
     ],
     "suggest": {
         "GNU coreutils": "coreutils",
-        "Modern ls alternatives": ["extras/exa", "extras/lsd", "extras/eza"]
+        "Modern ls alternatives": ["eza", "lsd"]
     },
     "architecture": {
         "64bit": {
@@ -44,3 +45,4 @@
         }
     }
 }
+

--- a/bucket/vivid.json
+++ b/bucket/vivid.json
@@ -1,0 +1,46 @@
+{
+    "version": "0.10.1",
+    "description": "A themeable LS_COLORS generator with a rich filetype database",
+    "homepage": "https://github.com/sharkdp/vivid",
+    "license": "MIT|Apache-2.0",
+    "notes": [
+        "vivid generates LS_COLORS for colorizing file listings in terminals.",
+        "Requires GNU coreutils (ls) or compatible tools to display colors:",
+        "  scoop install coreutils",
+        "  scoop install extras/exa",
+        "  scoop install extras/lsd",
+        "",
+        "Usage: export LS_COLORS=\"$(vivid generate molokai)\"",
+        "Available themes: vivid themes"
+    ],
+    "suggest": {
+        "GNU coreutils": "coreutils",
+        "Modern ls alternatives": ["extras/exa", "extras/lsd", "extras/eza"]
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sharkdp/vivid/releases/download/v0.10.1/vivid-v0.10.1-x86_64-pc-windows-msvc.zip",
+            "hash": "c26978625c5e3c26f33ce056272db545573c56008f3b3b5dd0860cb6b6e521db",
+            "extract_dir": "vivid-v0.10.1-x86_64-pc-windows-msvc"
+        },
+        "32bit": {
+            "url": "https://github.com/sharkdp/vivid/releases/download/v0.10.1/vivid-v0.10.1-i686-pc-windows-msvc.zip",
+            "hash": "eea061ac8d3d8c07fcd20267f0d5c6361357ca9b490cf36dec500ef561290869",
+            "extract_dir": "vivid-v0.10.1-i686-pc-windows-msvc"
+        }
+    },
+    "bin": "vivid.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sharkdp/vivid/releases/download/v$version/vivid-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "vivid-v$version-x86_64-pc-windows-msvc"
+            },
+            "32bit": {
+                "url": "https://github.com/sharkdp/vivid/releases/download/v$version/vivid-v$version-i686-pc-windows-msvc.zip",
+                "extract_dir": "vivid-v$version-i686-pc-windows-msvc"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a manifest for [vivid](https://github.com/sharkdp/vivid?tab=readme-ov-file) version 0.10.1.

Close ScoopInstaller/Main#7223 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

## Summary

- support 32bit and 64bit
- choose msvc as default in convention and for broader compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the vivid tool to the package collection for easy Windows installation.
  * Supports both 64-bit and 32-bit MSVC builds with verified downloads.
  * Automatic release tracking and autoupdate support for seamless updates.
  * Installs vivid.exe for immediate command-line use.

* **Documentation**
  * Includes usage notes and suggested prerequisites to guide setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->