### PR TITLE
czkawka-gui: Update to version 10.0.0, fix autoupdate

### DIFF
--- a/bucket/czkawka-gui.json
+++ b/bucket/czkawka-gui.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.0.0",
+    "version": "10.0.0",
     "description": "Find duplicates, empty folders, similar images, unnecessary files, etc.",
     "homepage": "https://github.com/qarmin/czkawka",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qarmin/czkawka/releases/download/9.0.0/windows_czkawka_gui_46.zip",
-            "hash": "ba07838fd1ac29a9483bfc8a015d79948b1108fdcdfd0fcd63bb2a112e103689"
+            "url": "https://github.com/qarmin/czkawka/releases/download/10.0.0/windows_czkawka_gui_gtk46.zip",
+            "hash": "6f575b1a553bb13ac3f3e29dc26e3381205d96031d3ab974ccfa40152be2866b"
         }
     },
     "shortcuts": [
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_czkawka_gui_46.zip"
+                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_czkawka_gui_gtk46.zip"
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Extras/issues/16104

- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application to version 10.0.0, delivering the latest upstream release.
  * 64-bit Windows installs now use the GTK 4.6 GUI build, matching current release artifacts.
  * Auto-update now tracks the GTK 4.6 64-bit build, providing consistent future updates.
  * Package integrity metadata refreshed to correspond with the new download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->