### PR TITLE
freecommander@2025.921: Fix download & autoupdate URLs

### DIFF
--- a/bucket/freecommander.json
+++ b/bucket/freecommander.json
@@ -6,8 +6,8 @@
         "identifier": "Freeware",
         "url": "https://freecommander.com/en/license/"
     },
-    "url": "https://freecommander.com/downloads/FreeCommanderXE-32-public_portable.zip",
-    "hash": "4fe89e30e791f3e3cb1f77eedc2fe72ea3143003b92ef95cd385144498f32bef",
+    "url": "https://freecommander.com/downloads/FreeCommanderXE-32-public_portable921.zip",
+    "hash": "6016d4bdec6c582ac24c5cb7ca283669894903c0c468b2751c317d1c01f2b82b",
     "pre_install": [
         "if(!(Test-Path \"$persist_dir\\fcStart.ini\")) {",
         "    Set-Content \"$dir\\fcStart.ini\" @('[Start]', 'freeCommanderIniDir=%FcSrcPath%') -Encoding ASCII",
@@ -30,10 +30,10 @@
         "replace": "${1}.${2}"
     },
     "autoupdate": {
-        "url": "https://freecommander.com/downloads/FreeCommanderXE-32-public_portable.zip",
+        "url": "https://freecommander.com/downloads/FreeCommanderXE-32-public_portable$minorVersion.zip",
         "hash": {
             "url": "https://freecommander.com/en/downloads-portable/",
-            "regex": "$basename.*?SHA1:\\s+$sha1"
+            "regex": "$basename.*?SHA256:\\s+$sha256"
         }
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `freecommander@2025.921`: Fix download & autoupdate urls.

Related issues:
-  Closes #16107

<!-- where the first check box is documented, in case you don't read. -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Improved auto-update to correctly handle minor-versioned portable builds, reducing update failures.
- Chores
  - Updated FreeCommander package to the latest portable release.
- Security
  - Enhanced download integrity by switching verification to SHA-256.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->