### PR TITLE
anki: fix autoupdate and add programfiles persist

### DIFF
--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -1,23 +1,23 @@
 {
-    "version": "25.02.7",
+    "version": "25.09",
     "description": "Powerful and intelligent flash cards",
     "homepage": "https://apps.ankiweb.net",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ankitects/anki/releases/download/25.02.7/anki-25.02.7-windows-qt6.exe#/dl.7z",
-            "hash": "1e8d1f3291bd5e473b36766f2dec2a931658cf788499a85125458ac9f3237a57"
+            "url": "https://github.com/ankitects/anki/releases/download/25.09/anki-launcher-25.09-windows.exe#/dl.7z",
+            "hash": "398f690a8208bd381dc2d4220720a82f6d2249c1fd1b38f46a90db356cb7c69e"
         }
     },
     "pre_install": [
         "@(",
-        "    '@echo off'",
-        "    'SET _allParams=\"%*\"'",
-        "    'IF /i %_allParams:-b =%==%_allParams% ('",
-        "    \"    start `\"anki`\" /D `\"%~dp0`\" `\"%~dp0anki.exe`\" -b `\"$persist_dir\\data`\" %*\"",
-        "    ') ELSE ('",
-        "    '    start \"anki\" /D \"%~dp0\" \"%~dp0anki.exe\" %*'",
-        "    ')'",
+        "   '@echo off'",
+        "   'echo Starting Anki...'",
+        "   'set USB_ROOT=%~dp0'",
+        "   'set ANKI_LAUNCHER_VENV_ROOT=%USB_ROOT%\\programfiles'",
+        "   'set ANKI_LAUNCHER=%USB_ROOT%\\anki'",
+        "   'set ANKI_BASE=%USB_ROOT%\\data'",
+        "   'start /b %ANKI_LAUNCHER%'",
         ") | Set-Content \"$dir\\anki.cmd\" -Encoding ASCII",
         "Remove-Item \"$dir\\`$*\" -Recurse"
     ],
@@ -30,14 +30,17 @@
             "anki.exe"
         ]
     ],
-    "persist": "data",
+    "persist": [
+        "data",
+        "programfiles"
+    ],
     "checkver": {
         "github": "https://github.com/ankitects/anki"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows-qt6.exe#/dl.7z"
+                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-launcher-$version-windows.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixes autoupdate. The latest releases act as an launcher that downloads and , this PR also changes the script to have the installer
download its files to scoop's folder instead of the user's AppData folder. I've tested things to the best of my ability but I'm inexperienced so maybe expect mistakes.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
