### PR TITLE
beyondcompare@5.1.5.31310: Add BCSessions.xml to persist

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -49,27 +49,31 @@
         ]
     ],
     "pre_install": [
-        "# Create a default BCPreferences.xml that will skip update checks.",
-        "$contents = @{'BCPreferences.xml' = '<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>'}",
-        "$files = $manifest.persist | Where-Object { ([IO.Path]::HasExtension($_)) -and (-not (Test-Path \"$persist_dir\\$_\")) }",
-        "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value $content[$_] }"
+        "$contents = @{",
+        "    # Create a default BCPreferences.xml that will skip update checks.",
+        "    'BCPreferences.xml' = '<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>'",
+        "}",
+        "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
+        "# Please keep the file list the same in both pre_install and post_install scripts.",
+        "'BC5Key.txt', 'BCColors.xml', 'BCCommands.xml', 'BCFileFormats.xml', 'BCPreferences.xml', 'BCState.xml', 'BCSessions.xml' | ForEach-Object {",
+        "    if (Test-Path \"$persist_dir\\$_\") {",
+        "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
+        "    } else {",
+        "        Set-Content -Path \"$dir\\$_\" -Value $contents[$_]",
+        "    }",
+        "}"
     ],
-    "post_install": "dir \"$dir\\*.original\" -File | ? Length -not | rm",
     "persist": [
         "Helpers",
-        "Packers",
-        "BC5Key.txt",
-        "BCColors.xml",
-        "BCCommands.xml",
-        "BCFileFormats.xml",
-        "BCPreferences.xml",
-        "BCState.xml",
-        "BCSessions.xml"
+        "Packers"
     ],
     "pre_uninstall": [
-        "$files = $manifest.persist | Where-Object { [IO.Path]::HasExtension($_) }",
-        "$files | ForEach-Object {",
-        "   Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force -ErrorAction 'Ignore'",
+        "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
+        "# Please keep the file list the same in both pre_install and post_install scripts.",
+        "'BC5Key.txt', 'BCColors.xml', 'BCCommands.xml', 'BCFileFormats.xml', 'BCPreferences.xml', 'BCState.xml', 'BCSessions.xml' | ForEach-Object {",
+        "    if (Test-Path \"$dir\\$_\") {",
+        "        Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
+        "    }",
         "}"
     ],
     "checkver": {

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -55,7 +55,8 @@
         "   Set-Content \"$dir\\$file\" $CONT -Encoding Ascii",
         "}",
         "Set-Content -Path \"$dir\\BC5Key.txt\" -Value ''",
-        "$manifest._files_to_persist | ForEach-Object {",
+        "$files = $manifest.persist | Where-Object { $_ -match '\\.' }",
+        "$files | ForEach-Object {",
         "    # If we have the file, rename, then copy from 'persist'",
         "    if ((Test-Path \"$dir\\$_\") -and (Test-Path \"$persist_dir\\$_\")) {",
         "       Move-Item \"$dir\\$_\" \"$dir\\$_.original\" -Force",
@@ -63,24 +64,21 @@
         "    Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force -ErrorAction 'Ignore'",
         "}"
     ],
-    "_files_to_persist": [
+    "persist": [
+        "Helpers",
+        "Packers",
+        "BC5Key.txt",
         "BCColors.xml",
         "BCCommands.xml",
         "BCFileFormats.xml",
         "BCPreferences.xml",
         "BCState.xml",
         "BCSessions.xml"
-    ],
-    "persist": [
-        "Helpers",
-        "Packers",
-        "BC5Key.txt"
      ],
     "pre_uninstall": [
-        "$manifest._files_to_persist | ForEach-Object {",
-        "   if (Test-Path \"$dir\\$_\") {",
-        "       Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
-        "   }",
+        "$files = $manifest.persist | Where-Object { $_ -match '\\.' }",
+        "$files | ForEach-Object {",
+        "   Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force -ErrorAction 'Ignore'",
         "}"
     ],
     "checkver": {

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -54,26 +54,32 @@
         "   $CONT = @('<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>')",
         "   Set-Content \"$dir\\$file\" $CONT -Encoding Ascii",
         "}",
-        "'BCColors.xml', 'BCCommands.xml', 'BCFileFormats.xml', 'BC5Key.txt' | ForEach-Object {",
-        "   if (!(Test-Path \"$persist_dir\\$_\")) {",
-        "      New-Item \"$dir\\$_\" -ItemType File | Out-Null",
-        "   }",
+        "Set-Content -Path \"$dir\\BC5Key.txt\" -Value ''",
+        "$manifest._files_to_persist | ForEach-Object {",
+        "    # If we have the file, rename, then copy from 'persist'",
+        "    if ((Test-Path \"$dir\\$_\") -and (Test-Path \"$persist_dir\\$_\")) {",
+        "       Move-Item \"$dir\\$_\" \"$dir\\$_.original\" -Force",
+        "    }",
+        "    Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force -ErrorAction 'Ignore'",
         "}"
     ],
-    "persist": [
-        "Helpers",
-        "Packers",
+    "_files_to_persist": [
         "BCColors.xml",
         "BCCommands.xml",
         "BCFileFormats.xml",
         "BCPreferences.xml",
         "BCState.xml",
-        "BC5Key.txt"
+        "BCSessions.xml"
     ],
+    "persist": [
+        "Helpers",
+        "Packers",
+        "BC5Key.txt"
+     ],
     "pre_uninstall": [
-        "'BCColors.xml', 'BCCommands.xml', 'BCFileFormats.xml', 'BCPreferences.xml', 'BCState.xml', 'BC5Key.txt' | ForEach-Object {",
+        "$manifest._files_to_persist | ForEach-Object {",
         "   if (Test-Path \"$dir\\$_\") {",
-        "       Move-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
+        "       Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
         "   }",
         "}"
     ],

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -54,8 +54,8 @@
         "   $CONT = @('<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>')",
         "   Set-Content \"$dir\\$file\" $CONT -Encoding Ascii",
         "}",
-        "$files = $manifest.persist | Where-Object { [IO.Path]::HasExtension($_) }",
-        "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value '' }"
+        "$files = $manifest.persist | Where-Object { ([IO.Path]::HasExtension($_)) -and (-not (Test-Path \"$dir\\$_\")) }",
+        "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value $null }"
     ],
     "persist": [
         "Helpers",
@@ -67,7 +67,7 @@
         "BCPreferences.xml",
         "BCState.xml",
         "BCSessions.xml"
-     ],
+    ],
     "pre_uninstall": [
         "$files = $manifest.persist | Where-Object { [IO.Path]::HasExtension($_) }",
         "$files | ForEach-Object {",

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -49,13 +49,10 @@
         ]
     ],
     "pre_install": [
-        "$file = 'BCPreferences.xml'",
-        "if (!(Test-Path \"$persist_dir\\$file\")) {",
-        "   $CONT = @('<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>')",
-        "   Set-Content \"$dir\\$file\" $CONT -Encoding Ascii",
-        "}",
+        "# Create a default BCPreferences.xml that will skip update checks.",
+        "$contents = @{'BCPreferences.xml' = '<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>'}",
         "$files = $manifest.persist | Where-Object { ([IO.Path]::HasExtension($_)) -and (-not (Test-Path \"$persist_dir\\$_\")) }",
-        "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value $null }"
+        "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value $content[$_] }"
     ],
     "persist": [
         "Helpers",

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -54,15 +54,8 @@
         "   $CONT = @('<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>')",
         "   Set-Content \"$dir\\$file\" $CONT -Encoding Ascii",
         "}",
-        "Set-Content -Path \"$dir\\BC5Key.txt\" -Value ''",
-        "$files = $manifest.persist | Where-Object { $_ -match '\\.' }",
-        "$files | ForEach-Object {",
-        "    # If we have the file, rename, then copy from 'persist'",
-        "    if ((Test-Path \"$dir\\$_\") -and (Test-Path \"$persist_dir\\$_\")) {",
-        "       Move-Item \"$dir\\$_\" \"$dir\\$_.original\" -Force",
-        "    }",
-        "    Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force -ErrorAction 'Ignore'",
-        "}"
+        "$files = $manifest.persist | Where-Object { [IO.Path]::HasExtension($_) }",
+        "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value '' }"
     ],
     "persist": [
         "Helpers",
@@ -76,7 +69,7 @@
         "BCSessions.xml"
      ],
     "pre_uninstall": [
-        "$files = $manifest.persist | Where-Object { $_ -match '\\.' }",
+        "$files = $manifest.persist | Where-Object { [IO.Path]::HasExtension($_) }",
         "$files | ForEach-Object {",
         "   Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force -ErrorAction 'Ignore'",
         "}"

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -54,6 +54,7 @@
         "$files = $manifest.persist | Where-Object { ([IO.Path]::HasExtension($_)) -and (-not (Test-Path \"$persist_dir\\$_\")) }",
         "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value $content[$_] }"
     ],
+    "post_install": "dir \"$dir\\*.original\" -File | ? Length -not | rm",
     "persist": [
         "Helpers",
         "Packers",

--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -54,7 +54,7 @@
         "   $CONT = @('<BCPreferences Version=\"2\" MinVersion=\"2\"><TBcPrefs><CheckForUpdatesDayAmt Value=\"0\"/></TBcPrefs></BCPreferences>')",
         "   Set-Content \"$dir\\$file\" $CONT -Encoding Ascii",
         "}",
-        "$files = $manifest.persist | Where-Object { ([IO.Path]::HasExtension($_)) -and (-not (Test-Path \"$dir\\$_\")) }",
+        "$files = $manifest.persist | Where-Object { ([IO.Path]::HasExtension($_)) -and (-not (Test-Path \"$persist_dir\\$_\")) }",
         "$files | ForEach-Object { Set-Content -Path \"$dir\\$_\" -Value $null }"
     ],
     "persist": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix persistence issue descried in referenced issue:

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #16124

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preferences now initialize from a dynamic contents map for more flexible setup.

* **Bug Fixes / Reliability**
  * Persistence refined to retain only essential packager files, reducing unnecessary restores.
  * Install/uninstall now use manifest-driven copy/restore for more reliable file handling.

* **Chores**
  * Install/uninstall flows simplified to dynamic manifest handling for safer preservation of user data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->