### PR TITLE
foxit(-pdf)-reader: Update to version 2025.2.1, split 32/64-bit, fix installation

### DIFF
--- a/bucket/foxit-pdf-reader.json
+++ b/bucket/foxit-pdf-reader.json
@@ -1,6 +1,6 @@
 {
     "##": "Using cdn78.foxitsoftware.com for better speed worldwide. Please keep foxit-reader and foxit-pdf-reader in sync.",
-    "version": "2025.2.0",
+    "version": "2025.2.1",
     "description": "Fast and feature rich PDF reader that offers a delightful reading experience.",
     "homepage": "https://www.foxit.com/pdf-reader/",
     "license": {
@@ -9,16 +9,25 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2025.2.0/FoxitPDFReader20252_L10N_Setup_Prom_x64.exe",
-            "hash": "31db3256b8f5ec55ec9bc5a278a03c938802ed17a61fe6394e196e5fa4fed1bd"
+            "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2025.2.1/FoxitPDFReader202521_L10N_Setup_Prom_x64.exe",
+            "hash": "f72daae81be3e848ebaf0c0bf70e4030e4a266ea0f6f232f08f30324971cbc6c"
+        },
+        "32bit": {
+            "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2025.2.1/FoxitPDFReader202521_L10N_Setup_Prom_x86.exe",
+            "hash": "a0bfc28ca7bfcb93bf1a9ef92e497ec6b93f0e2614cdf7dafa5106bb2be7de59"
         }
     },
     "installer": {
         "script": [
-            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\extracted\" -Removal",
-            "Expand-MsiArchive \"$dir\\extracted\\AttachedContainer\\FoxitSetup.msi\" \"$dir\\extracted\\msi\"",
-            "Move-Item \"$dir\\extracted\\msi\\Foxit Software\\Foxit PDF Reader\\*\" \"$dir\"",
-            "Remove-Item \"$dir\\extracted\" -Force -Recurse"
+            "# Lessmsi cannot handle .msp patches correctly in this case. So we use msiexec to extract the files.",
+            "Expand-7zipArchive \"$dir\\$fname\" \"$dir\\msi\" -ExtractDir '.rsrc\\1033\\PAYLOAD' -Removal",
+            "$succ = Invoke-ExternalCommand msiexec -ArgumentList @('/a', \"$dir\\msi\\500\", '/p', \"$dir\\msi\\700\", '/qn', \"TARGETDIR=$dir\\extracted\") -LogPath \"$dir\\install.log\"",
+            "if(-not $succ) {",
+            "    error \"Failed to extract files from `\"$dir\\msi`\".`nLog file:`n  $(friendly_path `\"$dir\\install.log`\")`n$(new_issue_msg $app $bucket 'decompress error')\"",
+            "    break",
+            "}",
+            "Move-Item \"$dir\\extracted\\Foxit Software\\Foxit PDF Reader\\*\" \"$dir\"",
+            "Remove-Item \"$dir\\msi\", \"$dir\\extracted\", \"$dir\\install.log\" -Force -Recurse"
         ]
     },
     "bin": "FoxitPDFReader.exe",
@@ -30,20 +39,28 @@
     ],
     "checkver": {
         "script": [
-            "$url = 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&language=ML'",
-            "if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
-            "    $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue",
-            "} else {",
-            "    $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck",
+            "$output = @()",
+            "'64', '32' | ForEach-Object {",
+            "    $req = $null",
+            "    $url = \"https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&operating_type=$_&package_type=exe&language=ML\"",
+            "    if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
+            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue",
+            "    } else {",
+            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck",
+            "    }",
+            "    $output += [string]($req.Headers.Location)",
             "}",
-            "Write-Output $req.Headers.Location"
+            "Write-Output ($output -join ', ')"
         ],
-        "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
+        "regex": "/win/(?<version>[\\d.]+)/(?<fname64>FoxitPDFReader.*\\.exe), .*/win/\\k<version>/(?<fname32>FoxitPDFReader.*\\.exe)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname"
+                "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname64"
+            },
+            "32bit": {
+                "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname32"
             }
         }
     }

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -1,6 +1,6 @@
 {
     "##": "Using cdn78.foxitsoftware.com for better speed worldwide. Please keep foxit-reader and foxit-pdf-reader in sync.",
-    "version": "2025.2.0",
+    "version": "2025.2.1",
     "description": "Fast and feature rich PDF reader that offers a delightful reading experience.",
     "homepage": "https://www.foxit.com/pdf-reader/",
     "license": {
@@ -9,16 +9,25 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2025.2.0/FoxitPDFReader20252_L10N_Setup_Prom_x64.exe",
-            "hash": "31db3256b8f5ec55ec9bc5a278a03c938802ed17a61fe6394e196e5fa4fed1bd"
+            "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2025.2.1/FoxitPDFReader202521_L10N_Setup_Prom_x64.exe",
+            "hash": "f72daae81be3e848ebaf0c0bf70e4030e4a266ea0f6f232f08f30324971cbc6c"
+        },
+        "32bit": {
+            "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/2025.2.1/FoxitPDFReader202521_L10N_Setup_Prom_x86.exe",
+            "hash": "a0bfc28ca7bfcb93bf1a9ef92e497ec6b93f0e2614cdf7dafa5106bb2be7de59"
         }
     },
     "installer": {
         "script": [
-            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\extracted\" -Removal",
-            "Expand-MsiArchive \"$dir\\extracted\\AttachedContainer\\FoxitSetup.msi\" \"$dir\\extracted\\msi\"",
-            "Move-Item \"$dir\\extracted\\msi\\Foxit Software\\Foxit PDF Reader\\*\" \"$dir\"",
-            "Remove-Item \"$dir\\extracted\" -Force -Recurse"
+            "# Lessmsi cannot handle .msp patches correctly in this case. So we use msiexec to extract the files.",
+            "Expand-7zipArchive \"$dir\\$fname\" \"$dir\\msi\" -ExtractDir '.rsrc\\1033\\PAYLOAD' -Removal",
+            "$succ = Invoke-ExternalCommand msiexec -ArgumentList @('/a', \"$dir\\msi\\500\", '/p', \"$dir\\msi\\700\", '/qn', \"TARGETDIR=$dir\\extracted\") -LogPath \"$dir\\install.log\"",
+            "if(-not $succ) {",
+            "    error \"Failed to extract files from `\"$dir\\msi`\".`nLog file:`n  $(friendly_path `\"$dir\\install.log`\")`n$(new_issue_msg $app $bucket 'decompress error')\"",
+            "    break",
+            "}",
+            "Move-Item \"$dir\\extracted\\Foxit Software\\Foxit PDF Reader\\*\" \"$dir\"",
+            "Remove-Item \"$dir\\msi\", \"$dir\\extracted\", \"$dir\\install.log\" -Force -Recurse"
         ]
     },
     "bin": "FoxitPDFReader.exe",
@@ -30,20 +39,28 @@
     ],
     "checkver": {
         "script": [
-            "$url = 'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&language=ML'",
-            "if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
-            "    $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue",
-            "} else {",
-            "    $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck",
+            "$output = @()",
+            "'64', '32' | ForEach-Object {",
+            "    $req = $null",
+            "    $url = \"https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&operating_type=$_&package_type=exe&language=ML\"",
+            "    if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
+            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue",
+            "    } else {",
+            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck",
+            "    }",
+            "    $output += [string]($req.Headers.Location)",
             "}",
-            "Write-Output $req.Headers.Location"
+            "Write-Output ($output -join ', ')"
         ],
-        "regex": "/win/(?<version>[\\d.]+)/(?<fname>FoxitPDFReader.*exe)$"
+        "regex": "/win/(?<version>[\\d.]+)/(?<fname64>FoxitPDFReader.*\\.exe), .*/win/\\k<version>/(?<fname32>FoxitPDFReader.*\\.exe)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname"
+                "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname64"
+            },
+            "32bit": {
+                "url": "https://cdn78.foxitsoftware.com/product/reader/desktop/win/$version/$matchFname32"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

## Changes
- Update to version 2025.2.1, split 32/64-bit.
- Fix installation/extraction.
<!--
Closes #XXXX
or
Relates to #16118
-->
Closes #16118

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 64‑bit and 32‑bit architecture-specific installers and a scripted installer flow for cleaner setup and cleanup.

* **Bug Fixes**
  * More reliable update checks with improved language selection and error handling across architectures.

* **Refactor**
  * Packaging migrated to architecture-based metadata; removed legacy installer flag; autoupdate now uses per-architecture URLs.

* **Chores**
  * Bumped Foxit Reader to version 2025.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->