### PR TITLE
clash-party: Rename from `mihomo-party`

### DIFF
--- a/bucket/clash-party.json
+++ b/bucket/clash-party.json
@@ -1,0 +1,46 @@
+{
+    "version": "1.8.7",
+    "description": "Another Mihomo GUI.",
+    "homepage": "https://clashparty.org/",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mihomo-party-org/clash-party/releases/download/v1.8.7/clash-party-windows-1.8.7-x64-portable.7z",
+            "hash": "385687c0b2635d236ded5084ca25e221be1e861d5dcaefe4d43a1e229ea7f930"
+        },
+        "32bit": {
+            "url": "https://github.com/mihomo-party-org/clash-party/releases/download/v1.8.7/clash-party-windows-1.8.7-ia32-portable.7z",
+            "hash": "f6304ede3039297cef4619c61add819d00842390f7af81005c14c77bd34aeedd"
+        },
+        "arm64": {
+            "url": "https://github.com/mihomo-party-org/clash-party/releases/download/v1.8.7/clash-party-windows-1.8.7-arm64-portable.7z",
+            "hash": "9e31dd951de11ae3a5d3527a7380e3128e1c3cd5024a99e5e12e7bd131e3b8a7"
+        }
+    },
+    "persist": "data",
+    "shortcuts": [
+        [
+            "Clash Party.exe",
+            "Clash Party"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/mihomo-party-org/clash-party"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mihomo-party-org/clash-party/releases/download/v$version/clash-party-windows-$version-x64-portable.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/mihomo-party-org/clash-party/releases/download/v$version/clash-party-windows-$version-ia32-portable.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/mihomo-party-org/clash-party/releases/download/v$version/clash-party-windows-$version-arm64-portable.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/mihomo-party.json
+++ b/bucket/mihomo-party.json
@@ -1,8 +1,10 @@
 {
+    "##": "Deprecated the manifest after 2026-01-01",
     "version": "1.8.7",
     "description": "Another Mihomo GUI.",
     "homepage": "https://mihomo.party",
     "license": "GPL-3.0",
+    "notes": "As of version 1.8.6, mihomo-party has been renamed to 'clash-party', please install 'extras/clash-party' instead.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/mihomo-party-org/mihomo-party/releases/download/v1.8.7/mihomo-party-windows-1.8.7-x64-portable.7z",


### PR DESCRIPTION
Reflecting the project's name change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Clash Party Windows portable package (64-bit, 32-bit, ARM64) with verified checksums, persistent data storage, a Start Menu shortcut, and automatic update checks against the upstream repository.

* **Chores**
  * Marked Mihomo Party manifest deprecated effective 2026-01-01 and noted the rename to Clash Party (no distribution changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->