### PR TITLE
dismplusplus: Update pre_install and persist

### DIFF
--- a/bucket/dismplusplus.json
+++ b/bucket/dismplusplus.json
@@ -7,8 +7,7 @@
     "hash": "5bbab96d60704854efd8246a7d9371688b9102261544827fc8884126d70bcb3b",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\Config\\Config.ini\")) {",
-        "    ensure \"$dir\\Config\" | Out-Null",
-        "    New-Item \"$dir\\Config\\Config.ini\" | Out-Null",
+        "    New-Item -Path \"$dir\\Config\\Config.ini\" -ItemType \"File\" -Force | Out-Null",
         "}"
     ],
     "architecture": {
@@ -58,7 +57,10 @@
             ]
         }
     },
-    "persist": "Config\\Config.ini",
+    "persist": [
+        "ActiveBackup",
+        "Config\\Config.ini"
+    ],
     "checkver": {
         "url": "https://api.github.com/repositories/74809720/releases/latest",
         "jsonpath": "$.assets[0].browser_download_url",


### PR DESCRIPTION
- persist: added `ActiveBackup` folder to persist user backups along with config.
- pre_install: removed unnecessary checks and directly created `Config.ini` using `New-Item -Force`.

Closes #15670

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
