### PR TITLE
umi-ocr(-paddle)@2.1.5: Add bin, persist user data

### DIFF
--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -11,7 +11,7 @@
         }
     },
     "pre_install": [
-        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
         "'.settings', '.pre_settings' | ForEach-Object {",
         "    if (Test-Path \"$persist_dir\\data\\$_\") {",
         "        Copy-Item \"$persist_dir\\data\\$_\" \"$dir\\UmiOCR-data\\$_\" -Force",
@@ -48,10 +48,9 @@
         ]
     ],
     "pre_uninstall": [
-        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
         "'.settings', '.pre_settings' | ForEach-Object {",
         "    if (Test-Path \"$dir\\UmiOCR-data\\$_\") {",
-        "        ensure $persist_dir\\data",
         "        Copy-Item \"$dir\\UmiOCR-data\\$_\" \"$persist_dir\\data\\$_\" -Force",
         "    }",
         "}"

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -11,21 +11,23 @@
         }
     },
     "pre_install": [
-        "$data_dir = Join-Path $dir 'UmiOCR-data'",
-        "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "if ($cmd -eq 'install' -and -not (Test-Path \"$persist_data_dir\")) { return }",
-        "ensure $persist_data_dir | Out-Null",
-        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
+        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "'.settings', '.pre_settings' | ForEach-Object {",
+        "    if (Test-Path \"$persist_dir\\data\\$_\") {",
+        "        Copy-Item \"$persist_dir\\data\\$_\" \"$dir\\UmiOCR-data\\$_\" -Force",
+        "    }",
+        "}"
     ],
     "post_install": [
-        "$plugins_dir = Join-Path $dir 'UmiOCR-data/plugins'",
-        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data/plugins.original'",
+        "$plugins_dir = Join-Path $dir 'UmiOCR-data\\plugins'",
+        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data\\plugins.original'",
         "if (Test-Path \"$original_plugins_dir\") {",
         "    Write-Host \"`nINFO  Removing old bundled plugins from $plugins_dir...\" -ForegroundColor darkgray",
         "    $paddlePlugins = Get-ChildItem -Path \"$plugins_dir\" -Directory -Filter '*Paddle*'",
         "    $paddlePlugins | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue",
         "    Write-Host \"INFO  Updating bundled plugins to $plugins_dir...\" -ForegroundColor darkgray",
         "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
+        "    Remove-Item \"$original_plugins_dir\" -Force -Recurse | Out-Null",
         "}"
     ],
     "bin": "Umi-OCR.exe",
@@ -46,10 +48,13 @@
         ]
     ],
     "pre_uninstall": [
-        "if ($cmd -eq 'uninstall' -and $purge) { return }",
-        "$data_dir = Join-Path $dir 'UmiOCR-data'",
-        "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "Get-ChildItem -Path \"$data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
+        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "'.settings', '.pre_settings' | ForEach-Object {",
+        "    if (Test-Path \"$dir\\UmiOCR-data\\$_\") {",
+        "        ensure $persist_dir\\data",
+        "        Copy-Item \"$dir\\UmiOCR-data\\$_\" \"$persist_dir\\data\\$_\" -Force",
+        "    }",
+        "}"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -17,8 +17,8 @@
         "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
     ],
     "post_install": [
-        "$plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins'",
-        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins.original'",
+        "$plugins_dir = Join-Path $dir 'UmiOCR-data/plugins'",
+        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data/plugins.original'",
         "if (Test-Path \"$original_plugins_dir\") {",
         "    Write-Host \"`nINFO  Removing old bundled plugins from $plugins_dir...\" -ForegroundColor darkgray",
         "    $paddlePlugins = Get-ChildItem -Path \"$plugins_dir\" -Directory -Filter '*Paddle*'",

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -13,13 +13,17 @@
     "pre_install": [
         "$data_dir = Join-Path $dir 'UmiOCR-data'",
         "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "if ($cmd -eq 'install' -and -not (Test-Path \"$data_dir\")) { return }",
-        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Filter '*settings' | Copy-Item -Destination \"$data_dir\" -Force"
+        "if ($cmd -eq 'install' -and -not (Test-Path \"$persist_data_dir\")) { return }",
+        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
     ],
     "post_install": [
         "$plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins'",
         "$original_plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins.original'",
         "if (Test-Path \"$original_plugins_dir\") {",
+        "    Write-Host \"`nINFO  Removing old bundled plugins from $plugins_dir...\" -ForegroundColor darkgray",
+        "    $paddlePlugins = Get-ChildItem -Path \"$plugins_dir\" -Directory -Filter '*Paddle*'",
+        "    $paddlePlugins | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue",
+        "    Write-Host \"INFO  Updating bundled plugins to $plugins_dir...\" -ForegroundColor darkgray",
         "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
         "}"
     ],
@@ -44,7 +48,7 @@
         "if ($cmd -eq 'uninstall' -and $purge) { return }",
         "$data_dir = Join-Path $dir 'UmiOCR-data'",
         "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "Get-ChildItem -Path \"$data_dir\" -File -Filter '*settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
+        "Get-ChildItem -Path \"$data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -10,11 +10,41 @@
             "extract_dir": "Umi-OCR_Paddle_v2.1.5"
         }
     },
+    "pre_install": [
+        "$data_dir = Join-Path $dir 'UmiOCR-data'",
+        "$persist_data_dir = Join-Path $persist_dir 'data'",
+        "if ($cmd -eq 'install' -and -not (Test-Path \"$data_dir\")) { return }",
+        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Filter '*settings' | Copy-Item -Destination \"$data_dir\" -Force"
+    ],
+    "post_install": [
+        "$plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins'",
+        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins.original'",
+        "if (Test-Path \"$original_plugins_dir\") {",
+        "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
+        "}"
+    ],
+    "bin": "Umi-OCR.exe",
     "shortcuts": [
         [
             "Umi-OCR.exe",
             "Umi-OCR"
         ]
+    ],
+    "persist": [
+        [
+            "UmiOCR-data\\logs",
+            "data\\logs"
+        ],
+        [
+            "UmiOCR-data\\plugins",
+            "data\\plugins"
+        ]
+    ],
+    "pre_uninstall": [
+        "if ($cmd -eq 'uninstall' -and $purge) { return }",
+        "$data_dir = Join-Path $dir 'UmiOCR-data'",
+        "$persist_data_dir = Join-Path $persist_dir 'data'",
+        "Get-ChildItem -Path \"$data_dir\" -File -Filter '*settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/umi-ocr-paddle.json
+++ b/bucket/umi-ocr-paddle.json
@@ -14,6 +14,7 @@
         "$data_dir = Join-Path $dir 'UmiOCR-data'",
         "$persist_data_dir = Join-Path $persist_dir 'data'",
         "if ($cmd -eq 'install' -and -not (Test-Path \"$persist_data_dir\")) { return }",
+        "ensure $persist_data_dir | Out-Null",
         "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
     ],
     "post_install": [

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -11,7 +11,7 @@
         }
     },
     "pre_install": [
-        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
         "'.settings', '.pre_settings' | ForEach-Object {",
         "    if (Test-Path \"$persist_dir\\data\\$_\") {",
         "        Copy-Item \"$persist_dir\\data\\$_\" \"$dir\\UmiOCR-data\\$_\" -Force",
@@ -48,10 +48,9 @@
         ]
     ],
     "pre_uninstall": [
-        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
         "'.settings', '.pre_settings' | ForEach-Object {",
         "    if (Test-Path \"$dir\\UmiOCR-data\\$_\") {",
-        "        ensure $persist_dir\\data",
         "        Copy-Item \"$dir\\UmiOCR-data\\$_\" \"$persist_dir\\data\\$_\" -Force",
         "    }",
         "}"

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -10,11 +10,41 @@
             "extract_dir": "Umi-OCR_Rapid_v2.1.5"
         }
     },
+    "pre_install": [
+        "$data_dir = Join-Path $dir 'UmiOCR-data'",
+        "$persist_data_dir = Join-Path $persist_dir 'data'",
+        "if ($cmd -eq 'install' -and -not (Test-Path \"$data_dir\")) { return }",
+        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Filter '*settings' | Copy-Item -Destination \"$data_dir\" -Force"
+    ],
+    "post_install": [
+        "$plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins'",
+        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins.original'",
+        "if (Test-Path \"$original_plugins_dir\") {",
+        "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
+        "}"
+    ],
+    "bin": "Umi-OCR.exe",
     "shortcuts": [
         [
             "Umi-OCR.exe",
             "Umi-OCR"
         ]
+    ],
+    "persist": [
+        [
+            "UmiOCR-data\\logs",
+            "data\\logs"
+        ],
+        [
+            "UmiOCR-data\\plugins",
+            "data\\plugins"
+        ]
+    ],
+    "pre_uninstall": [
+        "if ($cmd -eq 'uninstall' -and $purge) { return }",
+        "$data_dir = Join-Path $dir 'UmiOCR-data'",
+        "$persist_data_dir = Join-Path $persist_dir 'data'",
+        "Get-ChildItem -Path \"$data_dir\" -File -Filter '*settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -13,14 +13,18 @@
     "pre_install": [
         "$data_dir = Join-Path $dir 'UmiOCR-data'",
         "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "if ($cmd -eq 'install' -and -not (Test-Path \"$data_dir\")) { return }",
-        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Filter '*settings' | Copy-Item -Destination \"$data_dir\" -Force"
+        "if ($cmd -eq 'install' -and -not (Test-Path \"$persist_data_dir\")) { return }",
+        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
     ],
     "post_install": [
         "$plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins'",
         "$original_plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins.original'",
         "if (Test-Path \"$original_plugins_dir\") {",
+        "    Write-Host \"`nINFO  Removing old bundled plugins from $plugins_dir...\" -ForegroundColor darkgray",
+        "    $paddlePlugins = Get-ChildItem -Path \"$plugins_dir\" -Directory -Filter '*Rapid*'",
+        "    $paddlePlugins | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue",
         "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
+        "    Write-Host \"INFO  Updating bundled plugins to $plugins_dir...\" -ForegroundColor darkgray",
         "}"
     ],
     "bin": "Umi-OCR.exe",
@@ -44,7 +48,7 @@
         "if ($cmd -eq 'uninstall' -and $purge) { return }",
         "$data_dir = Join-Path $dir 'UmiOCR-data'",
         "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "Get-ChildItem -Path \"$data_dir\" -File -Filter '*settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
+        "Get-ChildItem -Path \"$data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -17,8 +17,8 @@
         "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
     ],
     "post_install": [
-        "$plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins'",
-        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data' 'plugins.original'",
+        "$plugins_dir = Join-Path $dir 'UmiOCR-data/plugins'",
+        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data/plugins.original'",
         "if (Test-Path \"$original_plugins_dir\") {",
         "    Write-Host \"`nINFO  Removing old bundled plugins from $plugins_dir...\" -ForegroundColor darkgray",
         "    $paddlePlugins = Get-ChildItem -Path \"$plugins_dir\" -Directory -Filter '*Rapid*'",

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -11,21 +11,23 @@
         }
     },
     "pre_install": [
-        "$data_dir = Join-Path $dir 'UmiOCR-data'",
-        "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "if ($cmd -eq 'install' -and -not (Test-Path \"$persist_data_dir\")) { return }",
-        "ensure $persist_data_dir | Out-Null",
-        "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
+        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "'.settings', '.pre_settings' | ForEach-Object {",
+        "    if (Test-Path \"$persist_dir\\data\\$_\") {",
+        "        Copy-Item \"$persist_dir\\data\\$_\" \"$dir\\UmiOCR-data\\$_\" -Force",
+        "    }",
+        "}"
     ],
     "post_install": [
-        "$plugins_dir = Join-Path $dir 'UmiOCR-data/plugins'",
-        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data/plugins.original'",
+        "$plugins_dir = Join-Path $dir 'UmiOCR-data\\plugins'",
+        "$original_plugins_dir = Join-Path $dir 'UmiOCR-data\\plugins.original'",
         "if (Test-Path \"$original_plugins_dir\") {",
         "    Write-Host \"`nINFO  Removing old bundled plugins from $plugins_dir...\" -ForegroundColor darkgray",
         "    $paddlePlugins = Get-ChildItem -Path \"$plugins_dir\" -Directory -Filter '*Rapid*'",
         "    $paddlePlugins | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue",
-        "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
         "    Write-Host \"INFO  Updating bundled plugins to $plugins_dir...\" -ForegroundColor darkgray",
+        "    Copy-Item -Path \"$original_plugins_dir\\*\" -Destination \"$plugins_dir\" -Force -Recurse",
+        "    Remove-Item \"$original_plugins_dir\" -Force -Recurse | Out-Null",
         "}"
     ],
     "bin": "Umi-OCR.exe",
@@ -46,10 +48,13 @@
         ]
     ],
     "pre_uninstall": [
-        "if ($cmd -eq 'uninstall' -and $purge) { return }",
-        "$data_dir = Join-Path $dir 'UmiOCR-data'",
-        "$persist_data_dir = Join-Path $persist_dir 'data'",
-        "Get-ChildItem -Path \"$data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$persist_data_dir\" -Force"
+        "# Hardlinks cannot work properly here, as Umi-OCR would create a new file instead of writing directly.",
+        "'.settings', '.pre_settings' | ForEach-Object {",
+        "    if (Test-Path \"$dir\\UmiOCR-data\\$_\") {",
+        "        ensure $persist_dir\\data",
+        "        Copy-Item \"$dir\\UmiOCR-data\\$_\" \"$persist_dir\\data\\$_\" -Force",
+        "    }",
+        "}"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/umi-ocr.json
+++ b/bucket/umi-ocr.json
@@ -14,6 +14,7 @@
         "$data_dir = Join-Path $dir 'UmiOCR-data'",
         "$persist_data_dir = Join-Path $persist_dir 'data'",
         "if ($cmd -eq 'install' -and -not (Test-Path \"$persist_data_dir\")) { return }",
+        "ensure $persist_data_dir | Out-Null",
         "Get-ChildItem -Path \"$persist_data_dir\\*\" -File -Include '.settings', '.pre_settings' | Copy-Item -Destination \"$data_dir\" -Force"
     ],
     "post_install": [


### PR DESCRIPTION
This PR improves both `umi-ocr` and `umi-ocr-paddle` manifests.

Changes:
- Add `bin` entry for `Umi-OCR.exe`
- Add `pre_install` to restore user settings
- Add `post_install` to copy plugins from `plugins.original`
- Add `persist` entries for `logs` and `plugins`
- Add `pre_uninstall` to back up settings before uninstall
---

## Description

### Persist
- The software always deletes the original configuration files and recreates them when saving user settings. 
  - Therefore, `.settings` and `.pre_settings` are not added to `persist`.  
  - Instead, persistence is implemented by adding scripts to `pre_install` and `pre_uninstall`.

```powershell
┏[ D:\Software\Scoop\Local\apps\umi-ocr-paddle\current\UmiOCR-data]
└─> @(".settings", ".pre_settings") | ForEach-Object {
     if (-not (Test-Path $_)) {
         New-Item -Path $_ -ItemType File -Force | Out-Null
     }
 }

┏[ D:\Software\Scoop\Local\apps\umi-ocr-paddle\current\UmiOCR-data]
└─> Get-ChildItem -Path .\* -File -Include ".pre_settings", ".settings" | Select-Object -First 5 -Property Name, LastWriteTime, CreationTime

Name          LastWriteTime      CreationTime
----          -------------      ------------
.pre_settings 2025/9/14 23:32:48 2025/9/14 23:32:48
.settings     2025/9/14 23:32:48 2025/9/14 23:32:48

┏[D:\Software\Scoop\Local\apps\umi-ocr-paddle\current\UmiOCR-data]
└─> Get-ChildItem -Path .\* -File -Include ".pre_settings", ".settings" | Select-Object -First 5 -Property Name, LastWriteTime, CreationTime

Name          LastWriteTime      CreationTime
----          -------------      ------------
.pre_settings 2025/9/14 23:38:09 2025/9/14 23:32:48
.settings     2025/9/14 23:38:46 2025/9/14 23:38:46
```

- When installing `umi-ocr` or `umi-ocr-paddle` via Scoop, the official recommendation is to additionally import plugins to meet different usage needs. Thus, the `plugins` folder needs to be persisted., and `post_install` is used to update the built-in plugins.

### Bin
Both `umi-ocr` and `umi-ocr-paddle` support command-line usage.

```batch
╭─ 15 Sep, Monday |   in  D:      apps  Umi-OCR-Paddle  current
╰─❯  Umi-OCR.exe --help

 usage: Umi-OCR [-h] [--show] [--hide] [--quit] [--screenshot] [--clipboard]
               [--path] [--qrcode_create] [--qrcode_read] [--reload]
               [--all_pages] [--add_page ADD_PAGE] [--del_page DEL_PAGE]
               [--all_modules] [--call_py CALL_PY] [--call_qml CALL_QML]
               [--func FUNC] [--thread] [--clip] [--output OUTPUT]
               [--output_append OUTPUT_APPEND] [--> >] [-->> >>]
               [paras [paras ...]]

positional arguments:
  paras                 parameters of [--func].

optional arguments:
  -h, --help            show this help message and exit
  --show                Make the app appear in the foreground.
  --hide                Hide app in the background.
  --quit                Quit app.
  --screenshot          Screenshot OCR and output the result.
  --clipboard           Clipboard OCR and output the result.
  --path                OCR the image in path and output the result.
  --qrcode_create       Create a QR code from the text. Use --qrcode_create
                        "text" "save_image.jpg"
  --qrcode_read         Read the QR code. Use --qrcode_read
                        "image_to_recognize.jpg"
  --reload              Reload settings from the configuration file
                        ".settings"
  --all_pages           Output all template and page information.
  --add_page ADD_PAGE   usage: Umi-OCR --all_pages
  --del_page DEL_PAGE   usage: Umi-OCR --all_pages
  --all_modules         Output all module names that can be called.
  --call_py CALL_PY     Calling a function on a Python module.
  --call_qml CALL_QML   Calling a function on a Qml module.
  --func FUNC           The name of the function to be called.
  --thread              The function will be called on the child thread and
                        return the result, but it may be unstable or cause QML
                        to crash.
  --clip                Copy the results to the clipboard.
  --output OUTPUT       The path to the file where results will be saved.
                        (overwrite)
  --output_append OUTPUT_APPEND
                        The path to the file where results will be saved.
                        (append)
  --> >                 "-->" equivalent to "--output"
  -->> >>               "-->>" equivalent to "--output_append"
```
---

The test is as follows:

- After installation, launch the program, change some settings, and exit.

```powershell
┏[ ~]
└─> scoop install "D:\Temporary\Software\Microsoft\Windows Sandbox\Umi-OCR.json"
Installing 'Umi-OCR' (2.1.5) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Umi-OCR.json'
Loading Umi-OCR_Rapid_v2.1.5.7z.exe from cache.
Checking hash of Umi-OCR_Rapid_v2.1.5.7z.exe ... ok.
Extracting Umi-OCR_Rapid_v2.1.5.7z.exe ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\Umi-OCR\current => D:\Software\Scoop\Local\apps\Umi-OCR\2.1.5
Creating shim for 'Umi-OCR'.
Making D:\Software\Scoop\Local\shims\umi-ocr.exe a GUI binary.
Creating shortcut for Umi-OCR (Umi-OCR.exe)
Persisting UmiOCR-data\logs
Persisting UmiOCR-data\plugins
Running post_install script...done.
'Umi-OCR' (2.1.5) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\Umi-OCR\current\UmiOCR-data]
└─> Get-Item -Path ".\.pre_settings", ".\.settings" | Select-Object -Property Name, LastWriteTime, CreationTime

Name          LastWriteTime      CreationTime
----          -------------      ------------
.pre_settings 2025/9/15 19:08:42 2025/9/15 19:08:21
.settings     2025/9/15 19:08:41 2025/9/15 19:08:41

┏[ D:\Software\Scoop\Local\apps\Umi-OCR\current\UmiOCR-data]
└─> Get-ChildItem -Path ".\Plugins" -Directory | Select-Object -First 9 -Property Name, LastWriteTime, CreationTime

Name                       LastWriteTime      CreationTime
----                       -------------      ------------
win7_x64_RapidOCR-json     2025/9/15 19:08:25 2025/9/15 19:07:29
win7_x64_TesseractOCR_best 2024/3/21 16:57:26 2025/9/15 19:08:58

```

- Perform a forced update and verify that the configuration files are successfully restored to the installation directory and that the `plugins` folder contains the bundled plugins.

```powershell
┏[ ~]
└─> scoop update umi-ocr -f
umi-ocr: 2.1.5 -> 2.1.5
Updating one outdated app:
Updating 'umi-ocr' (2.1.5 -> 2.1.5)
Downloading new version
Loading Umi-OCR_Rapid_v2.1.5.7z.exe from cache.
Checking hash of Umi-OCR_Rapid_v2.1.5.7z.exe ... ok.
Running pre_uninstall script...done.
Uninstalling 'umi-ocr' (2.1.5)
Removing shim 'Umi-OCR.shim.umi-ocr'.
Unlinking D:\Software\Scoop\Local\apps\umi-ocr\current
Installing 'Umi-OCR' (2.1.5) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Umi-OCR.json'
Loading Umi-OCR_Rapid_v2.1.5.7z.exe from cache.
Extracting Umi-OCR_Rapid_v2.1.5.7z.exe ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\Umi-OCR\current => D:\Software\Scoop\Local\apps\Umi-OCR\2.1.5
Creating shim for 'Umi-OCR'.
Making D:\Software\Scoop\Local\shims\umi-ocr.exe a GUI binary.
Creating shortcut for Umi-OCR (Umi-OCR.exe)
Persisting UmiOCR-data\logs
Persisting UmiOCR-data\plugins
Running post_install script...
INFO  Removing old bundled plugins from D:\Software\Scoop\Local\apps\Umi-OCR\current\UmiOCR-data\plugins...
INFO  Updating bundled plugins to D:\Software\Scoop\Local\apps\Umi-OCR\current\UmiOCR-data\plugins...
done.
'Umi-OCR' (2.1.5) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\Umi-OCR\current\UmiOCR-data]
└─> Get-Item -Path ".\.pre_settings", ".\.settings" | Select-Object -Property Name, LastWriteTime, CreationTime

Name          LastWriteTime      CreationTime
----          -------------      ------------
.pre_settings 2025/9/15 19:08:42 2025/9/15 19:14:42
.settings     2025/9/15 19:08:41 2025/9/15 19:14:42

┏[ D:\Software\Scoop\Local\apps\Umi-OCR\current\UmiOCR-data]
└─> Get-ChildItem -Path ".\Plugins" -Directory | Select-Object -First 9 -Property Name, LastWriteTime, CreationTime

Name                       LastWriteTime      CreationTime
----                       -------------      ------------
win7_x64_RapidOCR-json     2025/9/15 19:14:42 2025/9/15 19:14:42
win7_x64_TesseractOCR_best 2024/3/21 16:57:26 2025/9/15 19:08:5

```

Closes #13707 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings, logs, and plugins now persist across installs/uninstalls for fewer repeated setups.
  * Bundled plugins are refreshed on install to restore a consistent plugin state.
  * Application executable entry point defined as Umi-OCR.exe for easier launching.

* **Chores**
  * Install/uninstall lifecycle and persistence steps added to improve reliability; no changes to update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->