### PR TITLE
posh-git@1.1.0: Update download URL for posh-git

### DIFF
--- a/bucket/posh-git.json
+++ b/bucket/posh-git.json
@@ -3,7 +3,7 @@
     "description": "A PowerShell module which provides Git/PowerShell integration.",
     "homepage": "http://dahlbyk.github.io/posh-git/",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/posh-git.1.1.0.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/posh-git.1.1.0.nupkg",
     "hash": "87d9d37eb63d0d1b5f66622ab7ec16cd452a43cec45963ac0e596737750a00cc",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/posh-git.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/posh-git.$version.nupkg"
     }
 }


### PR DESCRIPTION
Powershell gallery CDN domain has been changed to `cdn.powershellgallery.com`. SSL Certificate expired for currently used `psg-prod-eastus.azureedge.net` that breaks posh-git installation.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
