### PR TITLE
chore: Fix url and autoupdate in the PowerShell module manifests

### DIFF
--- a/bucket/dockercompletion.json
+++ b/bucket/dockercompletion.json
@@ -3,7 +3,7 @@
     "description": "Docker command completion for PowerShell",
     "homepage": "https://github.com/matt9ucci/DockerCompletion",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/dockercompletion.1.2801.0.250503.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/dockercompletion.1.2801.0.250503.nupkg",
     "hash": "e7e87e03b19c8ce1d89059708b73d040e87eb72f0a9f02dba7c5a0e3f85b5350",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/dockercompletion.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/dockercompletion.$version.nupkg"
     }
 }

--- a/bucket/git-aliases.json
+++ b/bucket/git-aliases.json
@@ -13,7 +13,7 @@
             "git-with-openssh"
         ]
     },
-    "url": "https://psg-prod-eastus.azureedge.net/packages/git-aliases.0.3.8.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/git-aliases.0.3.8.nupkg",
     "hash": "9463cfe2d4c4c1cf8e3e73a687fed5bd34da6a9f736fd8a8cf071430f30c3f07",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -24,6 +24,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/git-aliases.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/git-aliases.$version.nupkg"
     }
 }

--- a/bucket/pseps.json
+++ b/bucket/pseps.json
@@ -3,7 +3,7 @@
     "description": "Templating tool for PowerShell",
     "homepage": "https://straightdave.github.io/eps/",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/eps.1.0.0.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/eps.1.0.0.nupkg",
     "hash": "ddf192dcb6ae8eefd60e5b440c2d4fbd1bccd4bc49b59624357e831168463440",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/eps.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/eps.$version.nupkg"
     }
 }

--- a/bucket/psfzf.json
+++ b/bucket/psfzf.json
@@ -6,7 +6,7 @@
     "suggest": {
         "fzf": "fzf"
     },
-    "url": "https://psg-prod-eastus.azureedge.net/packages/psfzf.2.6.14.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/psfzf.2.6.14.nupkg",
     "hash": "08e74ae07bb61ac83cdee2e1fb29eec68a89428fb5e477e11eea3cd42b641630",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -17,6 +17,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/psfzf.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/psfzf.$version.nupkg"
     }
 }

--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -3,7 +3,7 @@
     "description": "kubectl auto-completion for PowerShell",
     "homepage": "https://github.com/mziyabo/PSKubectlCompletion",
     "license": "Apache-2.0",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/pskubectlcompletion.1.0.4.nupkg",
     "hash": "497d7c0724b5946176d8a6a250e074d1bf3848e9e75adaf2d73d623f57d1716e",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/pskubectlcompletion.$version.nupkg"
     }
 }

--- a/bucket/psreadline.json
+++ b/bucket/psreadline.json
@@ -3,7 +3,7 @@
     "description": "A bash inspired readline implementation for PowerShell",
     "homepage": "https://github.com/PowerShell/PSReadLine",
     "license": "BSD-2-Clause",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/psreadline.2.3.6.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/psreadline.2.3.6.nupkg",
     "hash": "b05dcd2e85569f0f941be028e5acaf715824b8ce0ced2a25aa8b2bd775247683",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/psreadline.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/psreadline.$version.nupkg"
     }
 }

--- a/bucket/terminal-icons.json
+++ b/bucket/terminal-icons.json
@@ -8,7 +8,7 @@
         "Add it to your $PROFILE to make it permanent",
         "A Nerd Font is required for this module to work"
     ],
-    "url": "https://psg-prod-eastus.azureedge.net/packages/terminal-icons.0.11.0.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/terminal-icons.0.11.0.nupkg",
     "hash": "0d5086fbd48b4b12d5c00b1e226393b326b38c3e06dbf8825f522188e9dfe4dd",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -19,6 +19,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/terminal-icons.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/terminal-icons.$version.nupkg"
     }
 }

--- a/bucket/z.json
+++ b/bucket/z.json
@@ -3,7 +3,7 @@
     "description": "z lets you quickly navigate the file system in PowerShell based on your cd command history.",
     "homepage": "https://github.com/badmotorfinger/z",
     "license": "Unknown",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/z.1.1.14.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/z.1.1.14.nupkg",
     "hash": "c3f808b1f63fe2ed8252126a82d882c6250f97ae9d07f7126c90c013f21f51ce",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,7 +14,7 @@
         "regex": "Downloads of\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/z.$version.nupkg",
+        "url": "https://cdn.powershellgallery.com/packages/z.$version.nupkg",
         "extract_dir": "z-$version"
     }
 }

--- a/bucket/zlocation.json
+++ b/bucket/zlocation.json
@@ -7,7 +7,7 @@
         "Use the module by running: 'Import-Module ZLocation'",
         "Add that command to your $PROFILE to make it permanent"
     ],
-    "url": "https://psg-prod-eastus.azureedge.net/packages/zlocation.1.4.3.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/zlocation.1.4.3.nupkg",
     "hash": "027f219447d0f02b364700c4a284a946389a946850eacf47efff5c300854aa46",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -18,7 +18,7 @@
         "regex": "Downloads of\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/zlocation.$version.nupkg",
+        "url": "https://cdn.powershellgallery.com/packages/zlocation.$version.nupkg",
         "extract_dir": "ZLocation-$version\\ZLocation"
     }
 }


### PR DESCRIPTION
The CDN domain for the PowerShell Gallery has been changed to `cdn.powershellgallery.com`. The certificate for the original domain has expired.

#16148 fixed url and autoupdate in the `posh-git` manifest, while this PR fixes url and autoupdate in the manifest for the remaining PowerShell modules in `ScoopInstaller/Extras`.

All modifications in this PR are identical across all files—replacing `psg-prod-eastus.azureedge.net` with `cdn.powershellgallery.com`. Therefore, only the result of `.\checkver.ps1 -App z` is listed.

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App z -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -u -f
z: 1.1.14 (scoop version is 1.1.14)
Forcing autoupdate!
Autoupdating z
DEBUG[1758037431] [$updatedProperties] = [url extract_dir hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758037431] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758037431] $substitutions.$basenameNoExt                 z.1.1.14
DEBUG[1758037431] $substitutions.$matchTail
DEBUG[1758037431] $substitutions.$majorVersion                  1
DEBUG[1758037431] $substitutions.$baseurl                       https://cdn.powershellgallery.com/packages
DEBUG[1758037431] $substitutions.$dashVersion                   1-1-14
DEBUG[1758037431] $substitutions.$matchHead                     1.1.14
DEBUG[1758037431] $substitutions.$basename                      z.1.1.14.nupkg
DEBUG[1758037431] $substitutions.$match1                        1.1.14
DEBUG[1758037431] $substitutions.$cleanVersion                  1114
DEBUG[1758037431] $substitutions.$url                           https://cdn.powershellgallery.com/packages/z.1.1.14.nupkg
DEBUG[1758037431] $substitutions.$preReleaseVersion             1.1.14
DEBUG[1758037431] $substitutions.$minorVersion                  1
DEBUG[1758037431] $substitutions.$version                       1.1.14
DEBUG[1758037431] $substitutions.$buildVersion
DEBUG[1758037431] $substitutions.$urlNoExt                      https://cdn.powershellgallery.com/packages/z.1.1.14
DEBUG[1758037431] $substitutions.$underscoreVersion             1_1_14
DEBUG[1758037431] $substitutions.$dotVersion                    1.1.14
DEBUG[1758037431] $substitutions.$patchVersion                  14
DEBUG[1758037431] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading z.1.1.14.nupkg to compute hashes!
Loading z.1.1.14.nupkg from cache
Computed hash: c3f808b1f63fe2ed8252126a82d882c6250f97ae9d07f7126c90c013f21f51ce
Writing updated z manifest
```

Closes #16128 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read.
