### PR TITLE
everythingtoolbar: Update to version 2.0.4, fix url & autoupdate, add suggest

### DIFF
--- a/bucket/everythingtoolbar.json
+++ b/bucket/everythingtoolbar.json
@@ -1,17 +1,19 @@
 {
-    "version": "1.5.5",
+    "version": "2.0.4",
     "description": "Everything integration for the Windows taskbar.",
     "homepage": "https://github.com/srwi/EverythingToolbar",
     "license": "MIT",
-    "depends": "everything",
+    "suggest": {
+        "everything": "extras/everything",
+        ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/srwi/EverythingToolbar/releases/download/1.5.5/EverythingToolbar-1.5.5.msi",
-            "hash": "ca617b34a6ca89b4410613112265eeabd5726c62291601836003bbb2f2078803",
-            "extract_dir": "PFiles64\\EverythingToolbar"
+            "url": "https://github.com/srwi/EverythingToolbar/releases/download/2.0.4/EverythingToolbar-2.0.4-x64.exe",
+            "hash": "6353b2b4313718d4875f921d88c3de3f15191f7e9bcbfbc9bf52a02ac214fc55"
         }
     },
-    "post_install": "Start-Process \"$dir\\EverythingToolbar.Launcher.exe\"",
+    "innosetup": true,
     "shortcuts": [
         [
             "EverythingToolbar.Launcher.exe",
@@ -22,11 +24,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/srwi/EverythingToolbar/releases/download/$version/EverythingToolbar-$version.msi"
+                "url": "https://github.com/srwi/EverythingToolbar/releases/download/$version/EverythingToolbar-$version-x64.exe"
             }
         },
         "hash": {
-            "url": "$baseurl/EverythingToolbar-$version.sha256"
+            "url": "$baseurl/EverythingToolbar-$version-x64.sha256"
         }
     }
 }


### PR DESCRIPTION
This PR includes the following content:

- Update to version 2.0.4
- Switch installer from MSI to InnoSetup
- Drop `depends` and `post_install`
- Fix URL and autoupdate
- Add `suggest` field for `everything` and `.NET Desktop Runtime`
---

<p align="center">
It requires the .NET Desktop Runtime 8.0 to function properly.
<img width="678" height="358" alt="屏幕截图 2025-09-18 003644" src="https://github.com/user-attachments/assets/08b3832c-9402-46d5-8fee-68a11a0daeec" />
</p>

---

Some tests are as follows:

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ]
└─>  .\checkver.ps1 -App "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\everythingtoolbar.json" -f
everythingtoolbar: 2.0.4 (scoop version is 2.0.4)
Forcing autoupdate!
Autoupdating everythingtoolbar
DEBUG[1758127071] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758127071] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758127071] $substitutions.$patchVersion                  4
DEBUG[1758127071] $substitutions.$buildVersion
DEBUG[1758127071] $substitutions.$basenameNoExt                 EverythingToolbar-2.0.4-x64
DEBUG[1758127071] $substitutions.$minorVersion                  0
DEBUG[1758127071] $substitutions.$version                       2.0.4
DEBUG[1758127071] $substitutions.$dotVersion                    2.0.4
DEBUG[1758127071] $substitutions.$matchHead                     2.0.4
DEBUG[1758127071] $substitutions.$cleanVersion                  204
DEBUG[1758127071] $substitutions.$baseurl                       https://github.com/srwi/EverythingToolbar/releases/download/2.0.4
DEBUG[1758127071] $substitutions.$urlNoExt                      https://github.com/srwi/EverythingToolbar/releases/download/2.0.4/EverythingToolbar-2.0.4-x64
DEBUG[1758127071] $substitutions.$majorVersion                  2
DEBUG[1758127071] $substitutions.$preReleaseVersion             2.0.4
DEBUG[1758127071] $substitutions.$dashVersion                   2-0-4
DEBUG[1758127071] $substitutions.$underscoreVersion             2_0_4
DEBUG[1758127071] $substitutions.$url                           https://github.com/srwi/EverythingToolbar/releases/download/2.0.4/EverythingToolbar-2.0.4-x64.exe
DEBUG[1758127071] $substitutions.$basename                      EverythingToolbar-2.0.4-x64.exe
DEBUG[1758127071] $substitutions.$matchTail
DEBUG[1758127071] $substitutions.$match1                        2.0.4
DEBUG[1758127071] $hashfile_url = https://github.com/srwi/EverythingToolbar/releases/download/2.0.4/EverythingToolbar-2.0.4-x64.sha256 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for EverythingToolbar-2.0.4-x64.exe in https://github.com/srwi/EverythingToolbar/releases/download/2.0.4/EverythingToolbar-2.0.4-x64.sha256
DEBUG[1758127072] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*EverythingToolbar-2\.0\.4-x64\.exe(?:\s|$)|EverythingToolbar-2\.0\.4-x64\.exe[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:99:13
Found: 6353b2b4313718d4875f921d88c3de3f15191f7e9bcbfbc9bf52a02ac214fc55 using Extract Mode
Writing updated everythingtoolbar manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ everythingtoolbar.json ]
└─> scoop install .\everythingtoolbar.json
Installing 'everythingtoolbar' (2.0.4) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\everythingtoolbar.json'
Loading EverythingToolbar-2.0.4-x64.exe from cache.
Checking hash of EverythingToolbar-2.0.4-x64.exe ... ok.
Extracting EverythingToolbar-2.0.4-x64.exe ... done.                                                                    
Linking D:\Software\Scoop\Local\apps\everythingtoolbar\current => D:\Software\Scoop\Local\apps\everythingtoolbar\2.0.4
Creating shortcut for EverythingToolbar (EverythingToolbar.Launcher.exe)
'everythingtoolbar' (2.0.4) was installed successfully!
'everythingtoolbar' suggests installing 'extras/windowsdesktop-runtime-lts'.
```

Closes #16158 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds optional suggestions to install Everything and .NET Desktop Runtime for a better experience.

* **Chores**
  * Upgrades EverythingToolbar to v2.0.4.
  * Switches to a new 64-bit installer (Inno Setup) for smoother setup.
  * Streamlines installation by removing unnecessary extraction steps.
  * Updates auto-update targeting to the x64 installer with refreshed checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->