### PR TITLE
plantuml@1.2025.7: Fix relative path resolution and add UTF-8 encoding support

### DIFF
--- a/bucket/plantuml.json
+++ b/bucket/plantuml.json
@@ -11,8 +11,16 @@
     },
     "url": "https://github.com/plantuml/plantuml/releases/download/v1.2025.7/plantuml-1.2025.7.jar#/plantuml.jar",
     "hash": "4edcdda164a4be2f8f954f82868795500ebd49f42306236bf88eac41f7e217a8",
-    "pre_install": "Set-Content \"$dir\\plantuml.bat\" \"@javaw.exe -jar \"\"%~dp0plantuml.jar\"\"\" -Encoding Ascii",
-    "bin": "plantuml.jar",
+    "pre_install": [
+        "$batContent = '@java.exe -jar \"%~dp0plantuml.jar\" -charset UTF-8 %*'",
+        "Set-Content \"$dir\\plantuml.bat\" $batContent -Encoding Ascii"
+    ],
+    "bin": [
+        [
+            "plantuml.bat",
+            "plantuml"
+        ]
+    ],
     "shortcuts": [
         [
             "plantuml.bat",


### PR DESCRIPTION
- Fix relative path resolution by changing binary reference from jar to bat file (#16165 )
- Add UTF-8 encoding support with -charset UTF-8 parameter (#13114)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes scoop-installed PlantUML's inability to resolve relative paths correctly. The current manifest causes Scoop to generate shims that change the working directory to the PlantUML installation folder, breaking relative path resolution for user files.

**Changes made:**
- Changed `"bin": "plantuml.jar"` to `"bin": [["plantuml.bat", "plantuml"]]` to prevent directory changes in shims
- Updated bat file creation to include `-charset UTF-8` parameter for proper Unicode support
- Changed from `javaw.exe` to `java.exe` for proper console output
- Ensured all arguments are passed with `%*`

**Testing:**
- ✅ Relative paths now resolve from user's working directory instead of PlantUML installation directory
- ✅ UTF-8 characters render correctly in diagrams
- ✅ All existing functionality preserved

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->