### PR TITLE
gitextensions@6.0.1.18231: Use latest URL for checkver

### DIFF
--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -1,12 +1,12 @@
 {
-    "version": "6.0.1.18231",
+    "version": "5.2.1.18061",
     "description": "A graphical user interface for Git that allows you to control Git without using the commandline.",
     "homepage": "https://gitextensions.github.io/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/gitextensions/gitextensions/releases/download/v6.0.1/GitExtensions-Portable-x64-6.0.1.18231-d1a20a6e8.zip",
-            "hash": "c8219e319ffb1d9f517c91e0324707cf7c2694c12beaf740d279ae18b6f685d5"
+            "url": "https://github.com/gitextensions/gitextensions/releases/download/v5.2.1/GitExtensions-Portable-x64-5.2.1.18061-0d74cfdc3.zip",
+            "hash": "f57d76851b9b7f313a0f3425602e458520019905bb98e8314b3e7f0840221ef8"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\GitExtensions.settings\")) { New-Item \"$dir\\GitExtensions.settings\" | Out-Null }",
@@ -25,7 +25,7 @@
     ],
     "persist": "GitExtensions.settings",
     "checkver": {
-        "url": "https://api.github.com/repositories/85953/releases",
+        "url": "https://api.github.com/repositories/85953/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "/v(?<tag>[\\d.]+)/GitExtensions-Portable-(?:x[\\d.]+)-(?<version>[\\d.]+)-(?<commit>[\\w]+).zip"
     },


### PR DESCRIPTION
The previous checkver URL was pulling all releases, including pre-releases.  To force only stable versions, `/latest` was appended to the checkver URL.

Closes #16169 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)