### PR TITLE
koodo-reader: Update to version 2.1.7, switch to stable NSIS installer

### DIFF
--- a/bucket/koodo-reader.json
+++ b/bucket/koodo-reader.json
@@ -31,7 +31,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/koodo-reader/koodo-reader"
+        "url": "https://koodoreader.com/en/download",
+        "regex": "Stable Version.*?(?<version>[\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/koodo-reader.json
+++ b/bucket/koodo-reader.json
@@ -1,21 +1,28 @@
 {
-    "version": "2.1.0",
+    "version": "2.1.6",
     "homepage": "https://www.koodoreader.com",
     "description": "All-in-one ebook reader.",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.0/Koodo-Reader-2.1.0-x64-Win.zip",
-            "hash": "466564becc49ad332698bd05cabfc622b988470210eea8344c93464f17fb4111"
+            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.6/Koodo-Reader-2.1.6-x64.exe#/dl.7z",
+            "hash": "9c63490935b6debe2926b095ce3b1703c7dffe67c5f1cbbebd56f47cb26fe19b"
         },
         "32bit": {
-            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.0/Koodo-Reader-2.1.0-ia32-Win.zip",
-            "hash": "580bcdb550cf097f373a3ba66dd0198d3793daf103b8c8f652dbe80e626e244e"
+            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.6/Koodo-Reader-2.1.6-ia32.exe#/dl.7z",
+            "hash": "c226d5fc6c5ad7ddd0c7231b056fddf8151d8832aa2830f7729333a2addb18dd"
         },
         "arm64": {
-            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.0/Koodo-Reader-2.1.0-arm64-Win.zip",
-            "hash": "20e635cb07cddab135240bd31fbbf3ff0fa48241e3d8edc71a67149a9b1ec433"
+            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.6/Koodo-Reader-2.1.6-arm64.exe#/dl.7z",
+            "hash": "022570102aa51e3528d0e518e1bc79209aeb55092234151f6d13869e1c99c553"
         }
+    },
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\resources\" -Recurse -Force -ErrorAction SilentlyContinue",
+            "Get-Item \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item \"$dir\\`$*\" -Force -Recurse"
+        ]
     },
     "shortcuts": [
         [
@@ -29,13 +36,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-x64-Win.zip"
+                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-x64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-ia32-Win.zip"
+                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-ia32.exe#/dl.7z"
             },
             "arm64": {
-                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-arm64-Win.zip"
+                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-arm64.exe#/dl.7z"
             }
         }
     }

--- a/bucket/koodo-reader.json
+++ b/bucket/koodo-reader.json
@@ -5,15 +5,15 @@
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.6/Koodo-Reader-2.1.6-x64.exe#/dl.7z",
+            "url": "https://dl.koodoreader.com/v2.1.6/Koodo-Reader-2.1.6-x64.exe#/dl.7z",
             "hash": "9c63490935b6debe2926b095ce3b1703c7dffe67c5f1cbbebd56f47cb26fe19b"
         },
         "32bit": {
-            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.6/Koodo-Reader-2.1.6-ia32.exe#/dl.7z",
+            "url": "https://dl.koodoreader.com/v2.1.6/Koodo-Reader-2.1.6-ia32.exe#/dl.7z",
             "hash": "c226d5fc6c5ad7ddd0c7231b056fddf8151d8832aa2830f7729333a2addb18dd"
         },
         "arm64": {
-            "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v2.1.6/Koodo-Reader-2.1.6-arm64.exe#/dl.7z",
+            "url": "https://dl.koodoreader.com/v2.1.6/Koodo-Reader-2.1.6-arm64.exe#/dl.7z",
             "hash": "022570102aa51e3528d0e518e1bc79209aeb55092234151f6d13869e1c99c553"
         }
     },
@@ -37,13 +37,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-x64.exe#/dl.7z"
+                "url": "https://dl.koodoreader.com/v$version/Koodo-Reader-$version-x64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-ia32.exe#/dl.7z"
+                "url": "https://dl.koodoreader.com/v$version/Koodo-Reader-$version-ia32.exe#/dl.7z"
             },
             "arm64": {
-                "url": "https://github.com/koodo-reader/koodo-reader/releases/download/v$version/Koodo-Reader-$version-arm64.exe#/dl.7z"
+                "url": "https://dl.koodoreader.com/v$version/Koodo-Reader-$version-arm64.exe#/dl.7z"
             }
         }
     }

--- a/bucket/koodo-reader.json
+++ b/bucket/koodo-reader.json
@@ -1,20 +1,20 @@
 {
-    "version": "2.1.6",
+    "version": "2.1.7",
     "homepage": "https://www.koodoreader.com",
     "description": "All-in-one ebook reader.",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://dl.koodoreader.com/v2.1.6/Koodo-Reader-2.1.6-x64.exe#/dl.7z",
-            "hash": "9c63490935b6debe2926b095ce3b1703c7dffe67c5f1cbbebd56f47cb26fe19b"
+            "url": "https://dl.koodoreader.com/v2.1.7/Koodo-Reader-2.1.7-x64.exe#/dl.7z",
+            "hash": "sha512:98e75a3ea103e7731b8648829791875181fad8f5defd7391ed90f7794d738f67af4fb4fa7b9efc532b45a9cb69821284d9bfdfa334fb5631f0a64437bf27be9b"
         },
         "32bit": {
-            "url": "https://dl.koodoreader.com/v2.1.6/Koodo-Reader-2.1.6-ia32.exe#/dl.7z",
-            "hash": "c226d5fc6c5ad7ddd0c7231b056fddf8151d8832aa2830f7729333a2addb18dd"
+            "url": "https://dl.koodoreader.com/v2.1.7/Koodo-Reader-2.1.7-ia32.exe#/dl.7z",
+            "hash": "sha512:f8a37a5b6c0245b19c1dcb73c475509cee731db419fd82a1a257fc980b2a23d07cb50b7826694f24215ca92dc2938f7546fb2ec32e5bcfa2d516eef9b74dfd08"
         },
         "arm64": {
-            "url": "https://dl.koodoreader.com/v2.1.6/Koodo-Reader-2.1.6-arm64.exe#/dl.7z",
-            "hash": "022570102aa51e3528d0e518e1bc79209aeb55092234151f6d13869e1c99c553"
+            "url": "https://dl.koodoreader.com/v2.1.7/Koodo-Reader-2.1.7-arm64.exe#/dl.7z",
+            "hash": "sha512:d1a2286fdacf2dadbc7cdf557b0b81010e183f3d40eb407d1b082d98ad8af137d13cdee72455b8c189dc19596537297a26dfcd8b396d3f898d32ca43fd5f1eb2"
         }
     },
     "installer": {
@@ -45,6 +45,10 @@
             "arm64": {
                 "url": "https://dl.koodoreader.com/v$version/Koodo-Reader-$version-arm64.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "regex": "(?sm)$basename.*?sha512:\\s+$base64"
         }
     }
 }


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `koodo-reader`: Update to version 2.1.7, switch to stable NSIS installer.

### Related Issues/PRs
-  #16168
- Closes #16245

<!-- where the first check box is documented, in case you don't read. -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [[Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved installer with automated resource removal, archive extraction, and cleanup.

* **Chores**
  * Bumped application to v2.1.7.
  * Switched download targets to new executable packages for 64-bit, 32-bit, and ARM64 with updated SHA512 integrity checks.
  * Updated auto-update configuration to use new download targets and added a top-level hash lookup from the release metadata.
  * Revised version-check source and extraction method for more reliable release detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->