### PR TITLE
servy: Add version 1.7

### DIFF
--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -12,6 +12,16 @@
     },
     "innosetup": true,
     "bin": "servy-cli.exe",
+    "shortcuts": [
+        [
+            "Servy.exe", 
+            "Servy"
+        ],
+        [
+            "Servy.Manager.exe", 
+            "Servy Manager"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/aelassas/servy"
     },

--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,7 +1,6 @@
 ﻿{
     "version": "1.6",
     "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
-    "notes": "servy-cli is available in PATH after installation. For Servy and Servy Manager, you need to open them from Start Menu. For more info, visit https://servy-win.github.io",
     "homepage": "https://servy-win.github.io",
     "license": "MIT",
     "architecture": {

--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "version": "1.6",
     "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
     "homepage": "https://servy-win.github.io",

--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -14,11 +14,11 @@
     "bin": "servy-cli.exe",
     "shortcuts": [
         [
-            "Servy.exe", 
+            "Servy.exe",
             "Servy"
         ],
         [
-            "Servy.Manager.exe", 
+            "Servy.Manager.exe",
             "Servy Manager"
         ]
     ],

--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,13 +1,13 @@
 ﻿{
-    "version": "1.5",
+    "version": "1.6",
     "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
-    "notes": "sercy-cli is available in PATH after installation. For Servy and Servy Manager, you need to open them from Start Menu. For more info, visit https://servy-win.github.io",
+    "notes": "servy-cli is available in PATH after installation. For Servy and Servy Manager, you need to open them from Start Menu. For more info, visit https://servy-win.github.io",
     "homepage": "https://servy-win.github.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aelassas/servy/releases/download/v1.5/servy-1.5-net8.0-x64-installer.exe",
-            "hash": "5aadee0290115cd98134e8c3ff09c45e86173d41fe431f2537eee4448ff27b74"
+            "url": "https://github.com/aelassas/servy/releases/download/v1.6/servy-1.6-net8.0-x64-installer.exe",
+            "hash": "8a79845742a7d739309735eddae46e650d3a4237cb8a3a3f8faf26ae0826de0f"
         }
     },
     "innosetup": true,

--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,0 +1,25 @@
+﻿{
+    "version": "1.5",
+    "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
+    "notes": "sercy-cli is available in PATH after installation. For Servy and Servy Manager, you need to open them from Start Menu. For more info, visit https://servy-win.github.io",
+    "homepage": "https://servy-win.github.io",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/aelassas/servy/releases/download/v1.5/servy-1.5-net8.0-x64-installer.exe",
+            "hash": "5aadee0290115cd98134e8c3ff09c45e86173d41fe431f2537eee4448ff27b74"
+        }
+    },
+    "innosetup": true,
+    "bin": "servy-cli.exe",
+    "checkver": {
+        "github": "https://github.com/aelassas/servy"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-net8.0-x64-installer.exe"
+            }
+        }
+    }
+}

--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.6",
+    "version": "1.7",
     "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
     "homepage": "https://servy-win.github.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aelassas/servy/releases/download/v1.6/servy-1.6-net8.0-x64-installer.exe",
-            "hash": "8a79845742a7d739309735eddae46e650d3a4237cb8a3a3f8faf26ae0826de0f"
+            "url": "https://github.com/aelassas/servy/releases/download/v1.7/servy-1.7-net8.0-x64-installer.exe",
+            "hash": "250fda5e528e1c31744ae5eda633962a1c62f386bd345227c50df6c1d69afe82"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
Add Servy version 1.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Windows installer manifest for Servy with versioned downloads and SHA256 integrity checks.
  * Installs desktop and Start Menu shortcuts for Servy and Servy Manager.
  * Enables automatic update checks and streamlined autoupdates for 64‑bit installations.
  * Supports Inno Setup–based installation and maps the command-line tool for immediate use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->