### PR TITLE
final2x: Add version 3.0.0

### DIFF
--- a/bucket/final2x.json
+++ b/bucket/final2x.json
@@ -1,6 +1,6 @@
 {
     "version": "3.0.0",
-    "description": "a cross-platform image super-resolution tool.",
+    "description": "A cross-platform image super-resolution tool.",
     "homepage": "https://github.com/EutropicAI/Final2x",
     "license": {
         "identifier": "BSD-3-Clause",

--- a/bucket/final2x.json
+++ b/bucket/final2x.json
@@ -1,5 +1,5 @@
 {
-    "version": "2025-08-16",
+    "version": "3.0.0",
     "description": "a cross-platform image super-resolution tool.",
     "homepage": "https://github.com/EutropicAI/Final2x",
     "license": {
@@ -24,16 +24,19 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/655489856/releases/latest",
-        "jsonpath": "$.assets[?(@.name =~ /windows.+(?:7z|zip)$/i)].browser_download_url",
-        "regex": "download/([\\d-]+)/(?<archarm64>[^\"/]+arm64[^\"/]+).+?(?<archx64>[^\"/]+x64[^\"/]+)"
+        "script": [
+            "$release = ConvertFrom-Json $page -ErrorAction Stop",
+            "$release.tag_name, $release.name"
+        ],
+        "regex": "(?<tag>[\\d-]+) v(?<version>[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/EutropicAI/Final2x/releases/download/$version/$matchArchx64"
+                "url": "https://github.com/EutropicAI/Final2x/releases/download/$matchTag/Final2x-windows-x64-unpacked.7z"
             },
             "arm64": {
-                "url": "https://github.com/EutropicAI/Final2x/releases/download/$version/$matchArcharm64"
+                "url": "https://github.com/EutropicAI/Final2x/releases/download/$matchTag/Final2x-windows-arm64-unpacked.7z"
             }
         }
     }

--- a/bucket/final2x.json
+++ b/bucket/final2x.json
@@ -1,0 +1,40 @@
+{
+    "version": "2025-08-16",
+    "description": "a cross-platform image super-resolution tool.",
+    "homepage": "https://github.com/EutropicAI/Final2x",
+    "license": {
+        "identifier": "BSD-3-Clause",
+        "url": "https://github.com/EutropicAI/Final2x/blob/main/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-x64-unpacked.7z",
+            "hash": "0374359223b852a5632740fda11a1838d7c8741e55a622f4919d2dce476ec933"
+        },
+        "arm64": {
+            "url": "https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-arm64-unpacked.7z",
+            "hash": "2798fd680e74cb5d724304181dc7cd2292d4799ba03cfaf40eca38048d95a552"
+        }
+    },
+    "shortcuts": [
+        [
+            "Final2x.exe",
+            "Final2x"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repositories/655489856/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /windows.+(?:7z|zip)$/i)].browser_download_url",
+        "regex": "download/([\\d-]+)/(?<archarm64>[^\"/]+arm64[^\"/]+).+?(?<archx64>[^\"/]+x64[^\"/]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/EutropicAI/Final2x/releases/download/$version/$matchArchx64"
+            },
+            "arm64": {
+                "url": "https://github.com/EutropicAI/Final2x/releases/download/$version/$matchArcharm64"
+            }
+        }
+    }
+}

--- a/bucket/final2x.json
+++ b/bucket/final2x.json
@@ -26,7 +26,7 @@
         "url": "https://api.github.com/repositories/655489856/releases/latest",
         "script": [
             "$release = ConvertFrom-Json $page -ErrorAction Stop",
-            "$release.tag_name, $release.name"
+            "$release.tag_name + ' ' + $release.name"
         ],
         "regex": "(?<tag>[\\d-]+) v(?<version>[\\d.]+)"
     },


### PR DESCRIPTION
Added a manifest for [final2x](https://github.com/EutropicAI/Final2x) version 3.0.0.

Some tests are shown below:

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ]
└─> .\checkver.ps1 -App "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\final2x.json" -f
final2x: 2025-08-16 (scoop version is 2025-08-16)
Forcing autoupdate!
Autoupdating final2x
DEBUG[1758461488] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758461488] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758461488] $substitutions.$buildVersion
DEBUG[1758461488] $substitutions.$dashVersion                   2025-08-16
DEBUG[1758461488] $substitutions.$majorVersion                  2025
DEBUG[1758461488] $substitutions.$basenameNoExt                 Final2x-windows-x64-unpacked
DEBUG[1758461488] $substitutions.$version                       2025-08-16
DEBUG[1758461488] $substitutions.$baseurl                       https://github.com/EutropicAI/Final2x/releases/download/2025-08-16
DEBUG[1758461488] $substitutions.$urlNoExt                      https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-x64-unpacked
DEBUG[1758461488] $substitutions.$url                           https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-x64-unpacked.7z
DEBUG[1758461488] $substitutions.$cleanVersion                  20250816
DEBUG[1758461488] $substitutions.$matchArcharm64                Final2x-windows-arm64-unpacked.7z
DEBUG[1758461488] $substitutions.$matchArchx64                  Final2x-windows-x64-unpacked.7z
DEBUG[1758461488] $substitutions.$underscoreVersion             2025_08_16
DEBUG[1758461488] $substitutions.$preReleaseVersion             16
DEBUG[1758461488] $substitutions.$dotVersion                    2025.08.16
DEBUG[1758461488] $substitutions.$match1                        2025-08-16
DEBUG[1758461488] $substitutions.$patchVersion
DEBUG[1758461488] $substitutions.$basename                      Final2x-windows-x64-unpacked.7z
DEBUG[1758461488] $substitutions.$minorVersion
DEBUG[1758461488] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1758461489] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-x64-unpacked.7z')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 0374359223b852a5632740fda11a1838d7c8741e55a622f4919d2dce476ec933 using Github Mode
DEBUG[1758461489] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758461489] $substitutions.$buildVersion
DEBUG[1758461489] $substitutions.$dashVersion                   2025-08-16
DEBUG[1758461489] $substitutions.$majorVersion                  2025
DEBUG[1758461489] $substitutions.$basenameNoExt                 Final2x-windows-arm64-unpacked
DEBUG[1758461489] $substitutions.$version                       2025-08-16
DEBUG[1758461489] $substitutions.$baseurl                       https://github.com/EutropicAI/Final2x/releases/download/2025-08-16
DEBUG[1758461489] $substitutions.$urlNoExt                      https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-arm64-unpacked
DEBUG[1758461489] $substitutions.$url                           https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-arm64-unpacked.7z
DEBUG[1758461489] $substitutions.$cleanVersion                  20250816
DEBUG[1758461489] $substitutions.$matchArcharm64                Final2x-windows-arm64-unpacked.7z
DEBUG[1758461489] $substitutions.$matchArchx64                  Final2x-windows-x64-unpacked.7z
DEBUG[1758461489] $substitutions.$underscoreVersion             2025_08_16
DEBUG[1758461489] $substitutions.$preReleaseVersion             16
DEBUG[1758461489] $substitutions.$dotVersion                    2025.08.16
DEBUG[1758461489] $substitutions.$match1                        2025-08-16
DEBUG[1758461489] $substitutions.$patchVersion
DEBUG[1758461489] $substitutions.$basename                      Final2x-windows-arm64-unpacked.7z
DEBUG[1758461489] $substitutions.$minorVersion
DEBUG[1758461489] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1758461489] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/EutropicAI/Final2x/releases/download/2025-08-16/Final2x-windows-arm64-unpacked.7z')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 2798fd680e74cb5d724304181dc7cd2292d4799ba03cfaf40eca38048d95a552 using Github Mode
Writing updated final2x manifest

┏[D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ final2x ]
└─>  scoop install .\final2x.json
Installing 'final2x' (2025-08-16) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\final2x.json'
Loading Final2x-windows-x64-unpacked.7z from cache.
Checking hash of Final2x-windows-x64-unpacked.7z ... ok.
Extracting Final2x-windows-x64-unpacked.7z ... done.
Linking D:\Software\Scoop\Local\apps\final2x\current => D:\Software\Scoop\Local\apps\final2x\2025-08-16
Creating shortcut for Final2x (Final2x.exe)
'final2x' (2025-08-16) was installed successfully!
```

Closes #16193

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Final2x image super‑resolution app with 64‑bit and ARM64 builds.
  * Secure downloads with SHA‑256 verification and architecture‑specific links.
  * Includes a Start Menu shortcut (“Final2x”) for quick access.
  * Automatic update support with version checking against GitHub Releases.
  * Package metadata provided: version, description, homepage, and BSD‑3‑Clause license.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->