### PR TITLE
ultravnc@1.6.4.0: Fix errors (decompress & post_install)

### DIFF
--- a/bucket/ultravnc.json
+++ b/bucket/ultravnc.json
@@ -7,17 +7,17 @@
     "hash": "910ab4df4441c4f415c59007501e23ea2db331aa5dfa6ecbd5e583f34362d975",
     "architecture": {
         "64bit": {
-            "extract_dir": "64"
+            "extract_dir": "x64"
         },
         "32bit": {
-            "extract_dir": "32"
+            "extract_dir": "x86"
         }
     },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\UltraVnc.ini\")) { New-Item \"$dir\\UltraVnc.ini\" | Out-Null }",
         "if (!(Test-Path \"$persist_dir\\options.vnc\")) { New-Item \"$dir\\options.vnc\" | Out-Null }"
     ],
-    "post_install": "if (!(Test-Path \"$persist_dir\\SecureVNCPlugin64.dsm\")) { Copy-Item \"$persist_dir\\SecureVNCPlugin64.dsm\" \"$dir\\SecureVNCPlugin64.dsm\" | Out-Null }",
+    "post_install": "if (!(Test-Path \"$persist_dir\\SecureVNCPlugin64.dsm\")) { Copy-Item \"$dir\\SecureVNCPlugin64.dsm\" \"$persist_dir\\SecureVNCPlugin64.dsm\"  | Out-Null }",
     "bin": [
         "vncviewer.exe",
         "winvnc.exe"


### PR DESCRIPTION
- Fixed extraction directories from `64` and `32` to `x64` and `x86`

- Fixed the post_install script, the two paths of `Copy-Item` were reversed

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #16201 
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
