### PR TITLE
pycharm: Update to version 2025.3-253.28294.336, switch to unified version

### DIFF
--- a/bucket/pycharm-professional.json
+++ b/bucket/pycharm-professional.json
@@ -9,7 +9,8 @@
     "notes": [
         "PyCharm Community Edition and Professional Edition have now been merged into a unified product.",
         "See: https://blog.jetbrains.com/pycharm/2025/04/unified-pycharm/",
-        "`pycharm-professional` is scheduled for deprecation in the coming months. Please use `extras/pycharm` instead."
+        "`pycharm-professional` is scheduled for deprecation on June 1, 2026.",
+        "The unified `extras/pycharm` manifest now replaces all PyCharm variants. Please use `extras/pycharm` instead."
     ],
     "suggest": {
         "PyCharm": "extras/pycharm"

--- a/bucket/pycharm.json
+++ b/bucket/pycharm.json
@@ -1,13 +1,18 @@
 {
-    "version": "2025.2.5-252.28238.29",
-    "description": "Cross-Platform IDE for Python by JetBrains (Community edition).",
+    "version": "2025.3-253.28294.336",
+    "description": "Cross-Platform IDE for Python by JetBrains.",
     "homepage": "https://www.jetbrains.com/pycharm/",
     "license": {
-        "identifier": "Apache-2.0",
-        "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.5.win.zip",
-    "hash": "35eaa7a1b94090512124459e8f34a4e5fbcd695e59e988f0edd376a58b98e492",
+    "notes": [
+        "PyCharm Community Edition and Professional Edition have now been merged into a unified product.",
+        "PyCharm Community 2025.2 is the last standalone version available to existing users only.",
+        "For more information, see: https://blog.jetbrains.com/pycharm/2025/04/unified-pycharm/"
+    ],
+    "url": "https://download.jetbrains.com/python/pycharm-2025.3.win.zip",
+    "hash": "de773126d6e0f4f4c788091a075d833509ee9c34bf8894c46e006825ceec4431",
     "extract_to": "IDE",
     "installer": {
         "script": [
@@ -45,17 +50,16 @@
     },
     "persist": [
         "IDE\\bin\\idea.properties",
-        "IDE\\bin\\pycharm.exe.vmoptions",
         "IDE\\bin\\pycharm64.exe.vmoptions",
         "profile"
     ],
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&platform=zip&type=release",
+        "url": "https://data.services.jetbrains.com/products/releases?code=PC&latest=true&platform=zip&type=release",
         "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/python/pycharm-community-$matchVer.win.zip",
+        "url": "https://download.jetbrains.com/python/pycharm-$matchVer.win.zip",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
https://blog.jetbrains.com/pycharm/2025/04/unified-pycharm/

> PyCharm is now one unified product!
All users now automatically start with a free one-month Pro trial. After that, you can subscribe to Pro or keep using the core features for free – now with Jupyter support included.
PyCharm Professional users are unaffected and will continue to enjoy full access to all Pro features in the unified product.

> PyCharm Community 2025.2 is the last standalone version available to existing users only. If you’re currently using PyCharm Community, you can upgrade to the 2025.2 version using the Toolbox App or via the in-product upgrade notification. New users can download unified PyCharm 2025.2 with all the Community features and Jupyter notebooks included for free.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
- Relates to https://github.com/ScoopInstaller/Extras/commit/c2321303684086ebfcedc9d3808b1409ee9a9fc0

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the PyCharm Professional package from the bucket. Existing installations remain, but new installs and updates from this bucket are no longer available.

* **Documentation**
  * Updated the PyCharm package description to a generic title, removing the “Community edition” label to align with upstream naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->