### PR TITLE
rclone-ui: Add version 2.6.3

### DIFF
--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.6.1",
+    "version": "2.6.3",
     "description": "GUI for rclone & S3",
     "homepage": "https://rcloneui.com",
     "license": "Apache-2.0",
@@ -9,12 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe#/dl.7z",
-            "hash": "5d3e7918847ca072e3309ee8d77f5f7f7d22e92c5d72dc44d390c43497631314"
+            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.3/Rclone.UI_x64.exe#/dl.7z",
+            "hash": "189693012e60ed9c3f9195406c87d36d6f1d3ebcf0240a55eeb068586c29aa71"
         },
         "arm64": {
-            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe#/dl.7z",
-            "hash": "ad481aa5531bf78b0a379947feb662c27c52ad55a1a9c368e9cc5606e22f0bd4"
+            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.3/Rclone.UI_arm64.exe#/dl.7z",
+            "hash": "317478d56de257121e0e48ff335fc4bac5ba76768a0253869c4cd0381b8d9c54"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Force -Recurse",

--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -3,6 +3,10 @@
     "description": "GUI for rclone & S3",
     "homepage": "https://github.com/rclone-ui/rclone-ui",
     "license": "Apache-2.0",
+    "notes": [
+        "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
+        "If missing, install the Evergreen Runtime from Microsoft."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe",
@@ -19,10 +23,6 @@
             "/D=$dir"
         ]
     },
-    "uninstaller": {
-        "file": "Uninstall.exe",
-        "args": "/S"
-    },
     "bin": [
         [
             "Rclone UI.exe",
@@ -35,11 +35,13 @@
             "Rclone UI"
         ]
     ],
-    "notes": [
-        "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
-        "If missing, install the Evergreen Runtime from Microsoft."
-    ],
-    "checkver": "github",
+    "uninstaller": {
+        "file": "Uninstall.exe",
+        "args": "/S"
+    },
+    "checkver": {
+        "github": "rclone-ui/rclone-ui"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -1,47 +1,53 @@
 {
-  "version": "2.6.1",
-  "description": "GUI for rclone & S3",
-  "homepage": "https://github.com/rclone-ui/rclone-ui",
-  "license": "Apache-2.0",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe",
-      "hash": "5d3e7918847ca072e3309ee8d77f5f7f7d22e92c5d72dc44d390c43497631314"
-    },
-    "arm64": {
-      "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe",
-      "hash": "ad481aa5531bf78b0a379947feb662c27c52ad55a1a9c368e9cc5606e22f0bd4"
-    }
-  },
-  "installer": {
-    "args": [
-      "/S",
-      "/D=$dir"
-    ]
-  },
-  "uninstaller": {
-    "file": "Uninstall.exe",
-    "args": "/S"
-  },
-  "bin": [
-    ["Rclone UI.exe", "rclone-ui"]
-  ],
-  "shortcuts": [
-    ["Rclone UI.exe", "Rclone UI"]
-  ],
-  "notes": [
-    "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
-    "If missing, install the Evergreen Runtime from Microsoft."
-  ],
-  "checkver": { "github": "rclone-ui/rclone-ui" },
-  "autoupdate": {
+    "version": "2.6.1",
+    "description": "GUI for rclone & S3",
+    "homepage": "https://github.com/rclone-ui/rclone-ui",
+    "license": "Apache-2.0",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_x64.exe"
-      },
-      "arm64": {
-        "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_arm64.exe"
-      }
+        "64bit": {
+            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe",
+            "hash": "5d3e7918847ca072e3309ee8d77f5f7f7d22e92c5d72dc44d390c43497631314"
+        },
+        "arm64": {
+            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe",
+            "hash": "ad481aa5531bf78b0a379947feb662c27c52ad55a1a9c368e9cc5606e22f0bd4"
+        }
+    },
+    "installer": {
+        "args": [
+            "/S",
+            "/D=$dir"
+        ]
+    },
+    "uninstaller": {
+        "file": "Uninstall.exe",
+        "args": "/S"
+    },
+    "bin": [
+        [
+            "Rclone UI.exe",
+            "rclone-ui"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Rclone UI.exe",
+            "Rclone UI"
+        ]
+    ],
+    "notes": [
+        "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
+        "If missing, install the Evergreen Runtime from Microsoft."
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_x64.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_arm64.exe"
+            }
+        }
     }
-  }
 }

--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -1,0 +1,47 @@
+{
+  "version": "2.6.1",
+  "description": "GUI for rclone & S3",
+  "homepage": "https://github.com/rclone-ui/rclone-ui",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe",
+      "hash": "5d3e7918847ca072e3309ee8d77f5f7f7d22e92c5d72dc44d390c43497631314"
+    },
+    "arm64": {
+      "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe",
+      "hash": "ad481aa5531bf78b0a379947feb662c27c52ad55a1a9c368e9cc5606e22f0bd4"
+    }
+  },
+  "installer": {
+    "args": [
+      "/S",
+      "/D=$dir"
+    ]
+  },
+  "uninstaller": {
+    "file": "Uninstall.exe",
+    "args": "/S"
+  },
+  "bin": [
+    ["Rclone UI.exe", "rclone-ui"]
+  ],
+  "shortcuts": [
+    ["Rclone UI.exe", "Rclone UI"]
+  ],
+  "notes": [
+    "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
+    "If missing, install the Evergreen Runtime from Microsoft."
+  ],
+  "checkver": { "github": "rclone-ui/rclone-ui" },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_x64.exe"
+      },
+      "arm64": {
+        "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_arm64.exe"
+      }
+    }
+  }
+}

--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -1,7 +1,7 @@
 {
     "version": "2.6.1",
     "description": "GUI for rclone & S3",
-    "homepage": "https://github.com/rclone-ui/rclone-ui",
+    "homepage": "https://rcloneui.com",
     "license": "Apache-2.0",
     "notes": [
         "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
@@ -9,20 +9,15 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe",
+            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe#/dl.7z",
             "hash": "5d3e7918847ca072e3309ee8d77f5f7f7d22e92c5d72dc44d390c43497631314"
         },
         "arm64": {
-            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe",
+            "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe#/dl.7z",
             "hash": "ad481aa5531bf78b0a379947feb662c27c52ad55a1a9c368e9cc5606e22f0bd4"
         }
     },
-    "installer": {
-        "args": [
-            "/S",
-            "/D=$dir"
-        ]
-    },
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Force -Recurse",
     "bin": [
         [
             "Rclone UI.exe",
@@ -35,20 +30,16 @@
             "Rclone UI"
         ]
     ],
-    "uninstaller": {
-        "file": "Uninstall.exe",
-        "args": "/S"
-    },
     "checkver": {
-        "github": "rclone-ui/rclone-ui"
+        "github": "https://github.com/rclone-ui/rclone-ui"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_x64.exe"
+                "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_x64.exe#/dl.7z"
             },
             "arm64": {
-                "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_arm64.exe"
+                "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_arm64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rclone UI (v2.6.3) to the app catalog with Windows installer support.
  * Provides x64 and ARM64 builds with verified downloads and architecture-specific autoupdate URLs.
  * Supports silent install/uninstall, pre-install cleanup, and creates desktop/start menu shortcuts.
  * Notes Microsoft Edge WebView2 runtime requirement and guidance for Evergreen Runtime; autoupdate checks use GitHub releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->