### PR TITLE
completionpredictor: Add version 0.1.1

### DIFF
--- a/bucket/completionpredictor.json
+++ b/bucket/completionpredictor.json
@@ -15,7 +15,7 @@
     "hash": "51dc843aead6b2d7af9622a42507f6634c81fdd1f51d36bc74519720400f40e0",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Force -Recurse",
     "psmodule": {
-        "name": "completionpredictor"
+        "name": "CompletionPredictor"
     },
     "checkver": {
         "url": "https://www.powershellgallery.com/packages/completionpredictor",


### PR DESCRIPTION
Added a manifest for [completionpredictor](https://github.com/PowerShell/CompletionPredictor) version 0.1.1.

Some tests are shown below:

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App completionpredictor -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
completionpredictor: 0.1.1 (scoop version is 0.1.1)
Forcing autoupdate!
Autoupdating completionpredictor
DEBUG[1758622253] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758622253] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758622253] $substitutions.$urlNoExt                      https://cdn.powershellgallery.com/packages/completionpredictor.0.1.1
DEBUG[1758622253] $substitutions.$underscoreVersion             0_1_1
DEBUG[1758622253] $substitutions.$matchTail
DEBUG[1758622253] $substitutions.$match1                        0.1.1
DEBUG[1758622253] $substitutions.$minorVersion                  1
DEBUG[1758622253] $substitutions.$url                           https://cdn.powershellgallery.com/packages/completionpredictor.0.1.1.nupkg
DEBUG[1758622253] $substitutions.$preReleaseVersion             0.1.1
DEBUG[1758622253] $substitutions.$basename                      completionpredictor.0.1.1.nupkg
DEBUG[1758622253] $substitutions.$baseurl                       https://cdn.powershellgallery.com/packages
DEBUG[1758622253] $substitutions.$patchVersion                  1
DEBUG[1758622253] $substitutions.$dotVersion                    0.1.1
DEBUG[1758622253] $substitutions.$matchHead                     0.1.1
DEBUG[1758622253] $substitutions.$buildVersion
DEBUG[1758622253] $substitutions.$cleanVersion                  011
DEBUG[1758622253] $substitutions.$version                       0.1.1
DEBUG[1758622253] $substitutions.$dashVersion                   0-1-1
DEBUG[1758622253] $substitutions.$basenameNoExt                 completionpredictor.0.1.1
DEBUG[1758622253] $substitutions.$majorVersion                  0
DEBUG[1758622253] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading completionpredictor.0.1.1.nupkg to compute hashes!
completionpredictor.0.1.1.nupkg (38.9 KB) [=======================================================================================================] 100%
Computed hash: 51dc843aead6b2d7af9622a42507f6634c81fdd1f51d36bc74519720400f40e0
Writing updated completionpredictor manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ completionpredictor ≢  +1]
└─> scoop install .\completionpredictor.json
Installing 'completionpredictor' (0.1.1) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\completionpredictor.json'
Loading completionpredictor.0.1.1.nupkg from cache.
Checking hash of completionpredictor.0.1.1.nupkg ... ok.
Extracting completionpredictor.0.1.1.nupkg ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\completionpredictor\current => D:\Software\Scoop\Local\apps\completionpredictor\0.1.1
Installing PowerShell module 'completionpredictor'
Linking D:\Software\Scoop\Local\modules\completionpredictor => D:\Software\Scoop\Local\apps\completionpredictor\current
'completionpredictor' (0.1.1) was installed successfully!
Notes
-----
This module requires PowerShell 7.2 with PSReadLine 2.2.2 or higher.
To enable the predictor, add the following to your $PROFILE:
- Import-Module CompletionPredictor
- Set-PSReadLineOption -PredictionSource HistoryAndPlugin
Switch between the Inline and List prediction views, by pressing F2
For more information, see: https://github.com/PowerShell/CompletionPredictor
```

---

In #9777, the statement `Some Indication of Popularity/Repute` is now outdated. The GitHub repository currently has 173 stars, and as of now, the latest version has been downloaded 188,552 times. It fully meets the criteria for inclusion in the `Extras` bucket.  

(Download count source: https://www.powershellgallery.com/packages/completionpredictor)

---

- Closes #9777 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an installable package for the CompletionPredictor PowerShell module (v0.1.1) with versioning and automatic update support.
* **Documentation**
  * Included installation and usage notes for enabling the predictor in PSReadLine and switching prediction views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->