### PR TITLE
apifox: Update to version 2.7.36, fix checkver

### DIFF
--- a/bucket/apifox.json
+++ b/bucket/apifox.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.7.1",
+    "version": "2.7.36",
     "description": "All-in-one collaboration platform for API documentation, API debugging, API Mock and API test automation.",
     "homepage": "https://apifox.com",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://file-assets.apifox.com/download/2.7.1/Apifox-2.7.1.exe#/dl.7z",
-            "hash": "sha512:0c335d74d584fa58f6eabe8008aa08dfe2070710058198497c922d0a1e42ce28c21494f42d5bbab672bdc1407ff8b18aae2ebe62dd0fa20b40ce7dfc1b612c03"
+            "url": "https://file-assets.apifox.com/download/2.7.36/Apifox-2.7.36.exe#/dl.7z",
+            "hash": "sha512:69c663765541d5cee5ba46ea2a4e896ec2ebfdd1528c0d9e6a3eceded8098b95d4342de65b5e03baca9f6ddd248a3d34734e1b074214deae15a784eec4791271"
         }
     },
     "pre_install": [
@@ -26,8 +26,8 @@
         "Wait-Process -Name 'ApifoxAppAgent' -ErrorAction SilentlyContinue -Timeout 30"
     ],
     "checkver": {
-        "url": "https://apifox.com/help/app/changelog",
-        "regex": ">([\\d.]+)<"
+        "url": "https://docs.apifox.com/changelog",
+        "regex": ">([\\d.]+)<a"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This PR upgrades `apifox` to the latest stable version (2.7.36) and fixes `checkver`.

Some tests are shown below:

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App apifox -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
apifox: 2.7.36 (scoop version is 2.7.36)
Forcing autoupdate!
Autoupdating apifox
DEBUG[1758738138] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758738138] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758738138] $substitutions.$url                           https://file-assets.apifox.com/download/2.7.36/Apifox-2.7.36.exe
DEBUG[1758738138] $substitutions.$preReleaseVersion             2.7.36
DEBUG[1758738138] $substitutions.$patchVersion                  36
DEBUG[1758738138] $substitutions.$matchHead                     2.7.36
DEBUG[1758738138] $substitutions.$match1                        2.7.36
DEBUG[1758738138] $substitutions.$version                       2.7.36
DEBUG[1758738138] $substitutions.$minorVersion                  7
DEBUG[1758738138] $substitutions.$basenameNoExt                 Apifox-2.7.36
DEBUG[1758738138] $substitutions.$buildVersion
DEBUG[1758738138] $substitutions.$baseurl                       https://file-assets.apifox.com/download/2.7.36
DEBUG[1758738138] $substitutions.$matchTail
DEBUG[1758738138] $substitutions.$basename                      Apifox-2.7.36.exe
DEBUG[1758738138] $substitutions.$dashVersion                   2-7-36
DEBUG[1758738138] $substitutions.$cleanVersion                  2736
DEBUG[1758738138] $substitutions.$underscoreVersion             2_7_36
DEBUG[1758738138] $substitutions.$majorVersion                  2
DEBUG[1758738138] $substitutions.$dotVersion                    2.7.36
DEBUG[1758738138] $substitutions.$urlNoExt                      https://file-assets.apifox.com/download/2.7.36/Apifox-2.7.36
DEBUG[1758738139] $hashfile_url = https://file-assets.apifox.com/download/2.7.36/latest.yml -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Apifox-2.7.36.exe in https://file-assets.apifox.com/download/2.7.36/latest.yml
DEBUG[1758738139] $regex = sha512: ([a-zA-Z0-9+\/=]{24,88}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha512:69c663765541d5cee5ba46ea2a4e896ec2ebfdd1528c0d9e6a3eceded8098b95d4342de65b5e03baca9f6ddd248a3d34734e1b074214deae15a784eec4791271 using Extract Mode
Writing updated apifox manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop download "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\apifox.json"
INFO  Downloading 'apifox' [64bit]
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 536f58|OK  |   5.6MiB/s|100|D:/Software/Scoop/Local/cache/apifox#2.7.36#3a20470.7z
Download: Status Legend:
Download: (OK):download completed.
Checking hash of Apifox-2.7.36.exe ... ok.
'apifox' (2.7.36) was downloaded successfully!
```

- Closes #16222
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Ensures the installer fetches the correct 2.7.36 binary and verifies integrity to prevent install/update failures.
- Chores
  - Upgraded Apifox to version 2.7.36 to align with the latest upstream release. No functional changes expected for users beyond the version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->