### PR TITLE
UAD-NG: Add version 1.1.2

### DIFF
--- a/bucket/universal-android-debloater-next-generation.json
+++ b/bucket/universal-android-debloater-next-generation.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.1.2",
+    "description": "A GUI written in Rust using ADB to debloat non-rooted Android devices.",
+    "homepage": "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/releases/download/v1.1.2/uad-ng-windows.exe",
+            "hash": "eccdd8e05184388f2038e652afe3a77e1f6abc9d13e9fb21aad59cd6a924cb03"
+        }
+    },
+    "shortcuts": [
+        [
+            "uad-ng-windows.exe",
+            "Universal Android Debloater Next Generation"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/releases/download/v$version/uad-ng-windows.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- Closes #16230

This is a detached fork of the [UAD project](https://github.com/0x192/universal-android-debloater), which aims to improve privacy and battery performance by removing unnecessary and obscure system apps.

This project is under active development, while the [original project](https://github.com/0x192/universal-android-debloater) hasn't been updated for over two years.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Universal Android Debloater Next Generation (Windows 64-bit) to the app catalog, version 1.1.2.
  - Enables easy installation with a verified download and a desktop/start menu shortcut.
  - Supports automatic updates to future releases.

- Chores
  - Configured version checking to track upstream releases for smoother updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->