### PR TITLE
zed-opengl: Update checkver

### DIFF
--- a/bucket/zed-opengl.json
+++ b/bucket/zed-opengl.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.204.5",
+    "version": "0.205.5",
     "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
     "homepage": "https://zed.dev/",
     "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/v0.204.5/zed-opengl.zip",
-            "hash": "ebcf529d535883530a14b0c82ed9fc203f7eca677adbac1cccb8c89e7cd42d60"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/v0.205.5/zed-opengl.zip",
+            "hash": "21b9eb8d62f5bbfda62ed2f9fbce752b8d148aa830187ed6f088266bc6503382"
         }
     },
     "bin": [
@@ -22,7 +22,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/deevus/zed-windows-builds"
+        "url": "https://github.com/deevus/zed-windows-builds/releases",
+        "regex": "v(\\d+\\.\\d+\\.\\d+)"
     },
     "autoupdate": {
         "url": "https://github.com/deevus/zed-windows-builds/releases/download/v$version/zed-opengl.zip",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated zed-opengl to v0.205.5.
  - Refreshed 64-bit download URL and checksum to match the latest release.
- Bug Fixes
  - Improved version detection by switching to the releases page with a precise version pattern, enhancing reliability of update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->