### PR TITLE
Outfieldr@1.1.1 : A TLDR Client Written in Zig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,1 @@
-# Since Scoop is a Windows-only tool, we can safely use CRLF line endings for all text files.
-# If Git decides that the content is text, its line endings will be normalized to CRLF in the working tree on checkout.
-# In the Git index/repository the files will always be stored with LF line endings. This is fine.
-* text=auto eol=crlf
+bucket/*.json text eol=lf

--- a/bucket/outfieldr.json
+++ b/bucket/outfieldr.json
@@ -1,13 +1,14 @@
 {
   "version": "1.1.1",
-  "description": "A TLDR Client Written in zig",
+  "description": "TLDR client written in Zig - provides concise command examples and man-page alternatives from the TLDR pages project. Outfieldr is a lightweight, cross-platform implementation that fetches and displays simplified documentation for thousands of CLI tools and commands.",
   "homepage": "https://github.com/MANICX100/outfieldr",
   "license": "MIT",
   "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
   "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38",
   "bin": "tldr.exe",
   "checkver": {
-    "github": "MANICX100/outfieldr"
+    "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/latest",
+    "jp": "$.tag_name"
   },
   "autoupdate": {
     "url": "https://github.com/MANICX100/outfieldr/releases/download/$version/tldr.exe"

--- a/bucket/outfieldr.json
+++ b/bucket/outfieldr.json
@@ -1,0 +1,15 @@
+{
+  "version": "latest",
+  "description": "TLDR Client Written in Zig",
+  "homepage": "https://github.com/MANICX100/outfieldr",
+  "license": "MIT",
+  "url": "https://github.com/MANICX100/outfieldr/releases/latest/download/tldr.exe",
+  "bin": "tldr.exe",
+  "checkver": {
+    "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/latest",
+    "jp": "$.tag_name"
+  },
+  "autoupdate": {
+    "url": "https://github.com/MANICX100/outfieldr/releases/latest/download/tldr.exe"
+  }
+}

--- a/bucket/outfieldr.json
+++ b/bucket/outfieldr.json
@@ -7,14 +7,9 @@
   "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38",
   "bin": "tldr.exe",
   "checkver": {
-    "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/tags/1.1.1",
-    "jp": "$.tag_name"
+    "github": "MANICX100/outfieldr"
   },
   "autoupdate": {
-    "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
-    "hash": {
-      "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/assets/1.1.1",
-      "jsonpath": "$.[0].hash"
-    }
+    "url": "https://github.com/MANICX100/outfieldr/releases/download/$version/tldr.exe"
   }
 }

--- a/bucket/outfieldr.json
+++ b/bucket/outfieldr.json
@@ -1,16 +1,25 @@
 {
-  "version": "1.1.1",
-  "description": "TLDR client written in Zig - provides concise command examples and man-page alternatives from the TLDR pages project. Outfieldr is a lightweight, cross-platform implementation that fetches and displays simplified documentation for thousands of CLI tools and commands.",
-  "homepage": "https://github.com/MANICX100/outfieldr",
-  "license": "MIT",
-  "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
-  "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38",
-  "bin": "tldr.exe",
-  "checkver": {
-    "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/latest",
-    "jp": "$.tag_name"
-  },
-  "autoupdate": {
-    "url": "https://github.com/MANICX100/outfieldr/releases/download/$version/tldr.exe"
-  }
+    "version": "1.1.1",
+    "description": "TLDR client written in Zig - provides concise command examples and man-page alternatives from the TLDR pages project. Outfieldr is a lightweight, cross-platform implementation that fetches and displays simplified documentation for thousands of CLI tools and commands.",
+    "homepage": "https://github.com/MANICX100/outfieldr",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
+            "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38"
+        }
+    },
+    "bin": "tldr.exe",
+    "checkver": {
+        "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/latest",
+        "jsonpath": "$.assets[*].browser_download_url",
+        "regex": "(?:/)?(?<version>(\\d+\\.?)+)/tldr\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/MANICX100/outfieldr/releases/download/$version/tldr.exe"
+            }
+        }
+    }
 }

--- a/bucket/outfieldr.json
+++ b/bucket/outfieldr.json
@@ -3,23 +3,14 @@
     "description": "TLDR client written in Zig - provides concise command examples and man-page alternatives from the TLDR pages project. Outfieldr is a lightweight, cross-platform implementation that fetches and displays simplified documentation for thousands of CLI tools and commands.",
     "homepage": "https://github.com/MANICX100/outfieldr",
     "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
-            "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38"
-        }
-    },
+    "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
+    "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38",
     "bin": "tldr.exe",
     "checkver": {
         "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/latest",
-        "jsonpath": "$.assets[*].browser_download_url",
-        "regex": "(?:/)?(?<version>(\\d+\\.?)+)/tldr\\.exe"
+        "jp": "$.tag_name"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/MANICX100/outfieldr/releases/download/$version/tldr.exe"
-            }
-        }
+        "url": "https://github.com/MANICX100/outfieldr/releases/download/$version/tldr.exe"
     }
 }

--- a/bucket/outfieldr.json
+++ b/bucket/outfieldr.json
@@ -1,15 +1,20 @@
 {
-  "version": "latest",
-  "description": "TLDR Client Written in Zig",
+  "version": "1.1.1",
+  "description": "A TLDR Client Written in zig",
   "homepage": "https://github.com/MANICX100/outfieldr",
   "license": "MIT",
-  "url": "https://github.com/MANICX100/outfieldr/releases/latest/download/tldr.exe",
+  "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
+  "hash": "0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38",
   "bin": "tldr.exe",
   "checkver": {
-    "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/latest",
+    "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/tags/1.1.1",
     "jp": "$.tag_name"
   },
   "autoupdate": {
-    "url": "https://github.com/MANICX100/outfieldr/releases/latest/download/tldr.exe"
+    "url": "https://github.com/MANICX100/outfieldr/releases/download/1.1.1/tldr.exe",
+    "hash": {
+      "url": "https://api.github.com/repos/MANICX100/outfieldr/releases/assets/1.1.1",
+      "jsonpath": "$.[0].hash"
+    }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- New manifest: bucket/outfieldr.json

- Version: 1.1.1

- Download: Direct GitHub release asset (tldr.exe from MANICX100/outfieldr/releases/download/1.1.1/)

- Hash: SHA256 0ae1a915666f040e002968108f4a72a11b053fb790ea47679229c092414e2b38 for integrity verification

- autoupdate: Uses checkver: {"github": "MANICX100/outfieldr"} and $version token for automatic updates

Closes #16241

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a package manifest enabling installation of the Outfieldr TLDR client (v1.1.1).
  * Automatic version detection from GitHub releases for easier updates.
  * Autoupdate support with verified binary downloads via checksum validation.
  * Includes metadata (description, homepage, license) for clearer package info.

* **Chores**
  * Distribution config updated to ensure consistent LF line endings for package manifests; no application code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->