### PR TITLE
beyondcompare: Remove obsolete copying of Helpers/Packers

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -71,12 +71,6 @@
         "BC5Key.txt"
     ],
     "pre_uninstall": [
-        "'Helpers', 'Packers' | ForEach-Object {",
-        "    if ((Test-Path \"$dir\\$_\") -And !((Get-Item -Path \"$dir\\$_\" -Force).LinkType -eq \"Junction\")) {",
-        "        New-Item \"$dir\\$_\" -ItemType Directory -ErrorAction Ignore | Out-Null",
-        "        Get-ChildItem -Path \"$dir\\$_\" -Recurse | Move-Item -Destination \"$persist_dir\\$_\" -Force",
-        "    }",
-        "}",
         "'BCColors.xml', 'BCCommands.xml', 'BCFileFormats.xml', 'BCPreferences.xml', 'BCState.xml', 'BC5Key.txt' | ForEach-Object {",
         "   if (Test-Path \"$dir\\$_\") {",
         "       Move-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",


### PR DESCRIPTION
Relates to:
- #15598 
- #16125

Removes manual copying of files to persist, hoping to prevent data loss caused by the manifest before I got involved. However, since it seems that when updating the (pre)uninstall procedures of the `manifest.json` inside the app/beyondcompare/current directory, which is then still the old one, are used instead of the one in the updated bucket. Personally, I think this is a design mistake, because it won't allow anyone to fix mistakes with an updated manifest before updating.

Personally, I think this is a design mistake, because it won't allow anyone to fix mistakes with an updated manifest before updating.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Extras/pull/15598#pullrequestreview-3277291974

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Simplified uninstall data handling to preserve only core Beyond Compare settings in the persistent folder.
  - Helper and packer directories are no longer moved during uninstall; if you rely on custom tools or extensions, consider backing them up manually before removal.
  - No changes to installation or day-to-day app usage; only the uninstall preservation behavior is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->