### PR TITLE
teraterm@5.5.0: Split into 32-bit and 64-bit versions

### DIFF
--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -14,6 +14,11 @@
             "url": "https://github.com/TeraTermProject/teraterm/releases/download/v5.5.0/teraterm-5.5.0-x86.zip",
             "hash": "c354287e54e61c01014a1bfad7e936881af5c75c0e88571f6449592f6f84e5d0",
             "extract_dir": "teraterm-5.5.0-x86"
+        },
+        "arm64": {
+            "url": "https://github.com/TeraTermProject/teraterm/releases/download/v5.5.0/teraterm-5.5.0-arm64.zip",
+            "hash": "cb993ead5d50aa823feaa9485556f3d47ae07daafda4f95f50f324872277a200",
+            "extract_dir": "teraterm-5.5.0-arm64"
         }
     },
     "bin": "ttermpro.exe",
@@ -42,6 +47,10 @@
             "32bit": {
                 "url": "https://github.com/TeraTermProject/teraterm/releases/download/v$version/teraterm-$version-x86.zip",
                 "extract_dir": "teraterm-$version-x86"
+            },
+            "arm64": {
+                "url": "https://github.com/TeraTermProject/teraterm/releases/download/v$version/teraterm-$version-arm64.zip",
+                "extract_dir": "teraterm-$version-arm64"
             }
         }
     }


### PR DESCRIPTION
Tera Term 5.5.0 provides 32-bit and 64-bit.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added explicit arm64 support alongside 64-bit and 32-bit, improving platform coverage.
- Refactor
  - Reworked update metadata to a per-architecture structure for clearer, more reliable downloads and updates.
- Chores
  - Updated Teraterm to version 5.5.0.
  - Updated release download links, hashes, and extraction paths to match the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->