### PR TITLE
ente-photos: Add version 1.7.14

### DIFF
--- a/bucket/ente-photos.json
+++ b/bucket/ente-photos.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.7.14",
+    "description": "The private, secure photo storage app with end-to-end encryption",
+    "homepage": "https://ente.io",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ente-io/photos-desktop/releases/download/v1.7.14/ente-1.7.14-x64.exe#/dl.7z",
+            "hash": "4f8ca620a06b1dcb48d53bbb2671e507bc017769094d82afe9017d93e7e798dd",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        },
+        "arm64": {
+            "url": "https://github.com/ente-io/photos-desktop/releases/download/v1.7.14/ente-1.7.14-arm64.exe#/dl.7z",
+            "hash": "9bd858ac5288db59a73eb1658ac340aab702a4430907b2f1f5558639f896cb4b",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\""
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\resources\\app-update.yml\" -Force -Recurse",
+    "shortcuts": [
+        [
+            "ente.exe",
+            "Ente Photos"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ente-io/photos-desktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ente-io/photos-desktop/releases/download/v$version/ente-$version-x64.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/ente-io/photos-desktop/releases/download/v$version/ente-$version-arm64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Closes #15955

```powershell
scoop bucket add zeldrisho https://github.com/zeldrisho/scoop-bucket
scoop install zeldrisho/ente-photos
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to install Ente Photos Desktop v1.7.14 with architecture-specific builds (64-bit and ARM64).
  - Automatically creates desktop and Start Menu shortcuts for quick access.
  - Enables seamless autoupdate using versioned downloads.
  - Streamlined install process with automatic archive extraction and post-install cleanup for a cleaner footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->