### PR TITLE
proton-drive: Add version 1.12.9

### DIFF
--- a/bucket/proton-drive.json
+++ b/bucket/proton-drive.json
@@ -1,33 +1,33 @@
 {
-    "version": "1.11.4",
-    "description": "Free end-to-end encrypted cloud storage made by Proton AG",
+    "version": "1.12.9",
+    "description": "Free end-to-end encrypted cloud storage made by Proton.",
     "homepage": "https://proton.me/drive",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://proton.me/download/drive/windows/1.11.4/x64/Proton%20Drive%20Setup%201.11.4.exe",
-            "hash": "e00c0668839cf3c1d8d1ac508526275fc55557aa197cf3690fa4db6e9dec8961"
+            "url": "https://proton.me/download/drive/windows/1.12.9/x64/Proton%20Drive%20Setup%201.12.9.exe",
+            "hash": "cd27f1c47123b181683e0f03b5fea1a6b0c98160bc9502d38148e4fa5cbb1e37"
         },
         "arm64": {
-            "url": "https://proton.me/download/drive/windows/1.11.4/arm64/Proton%20Drive%20Setup%201.11.4.exe",
-            "hash": "37e1a00375a809599a32d2f63aa8872648fbed2273b273824ca10e1026c20bb3"
+            "url": "https://proton.me/download/drive/windows/1.12.9/arm64/Proton%20Drive%20Setup%201.12.9.exe",
+            "hash": "c791640fb7a0c42832cf850f8ad8ac2c3df78f34d849684e41c73a113bc7a74f"
         }
     },
     "pre_install": [
-        "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\tmp\" -Removal",
-        "$msi = Get-ChildItem \"$dir\\tmp\\AttachedContainer\\*.msi\" | Select-Object -First 1",
-        "Expand-MsiArchive $msi -ExtractDir 'PFiles64\\Proton\\Drive' -DestinationPath \"$dir\""
+        "Expand-DarkArchive -Path \"$dir\\$fname\" -DestinationPath \"$dir\\tmp\" -Removal",
+        "$msi = Get-ChildItem \"$dir\\tmp\\AttachedContainer\\*.msi\" | Select-Object -First 1 -ExpandProperty FullName",
+        "Expand-MsiArchive $msi -ExtractDir 'PFiles64\\Proton\\Drive' -DestinationPath \"$dir\"",
+        "Remove-Item \"$dir\\tmp\" -Recurse -Force"
     ],
-    "post_install": "Remove-Item \"$dir\\tmp\" -Recurse -Force",
     "shortcuts": [
         [
             "ProtonDrive.exe",
-            "Proton Drive"
+            "Proton\\Proton Drive"
         ]
     ],
     "checkver": {
         "url": "https://proton.me/download/drive/windows/version.json",
-        "jsonpath": "$.Releases[0].Version"
+        "jsonpath": "$.Releases[?(@.CategoryName == 'Stable')].Version"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Closes #11582

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Proton Drive (v1.12.9) as an installable app for Windows via the package manager.
  - Supports both 64-bit and ARM64 systems with verified downloads.
  - Automatic version checking and parameterized update URLs for streamlined updates.
  - Installer extracts archives, runs the MSI installer, performs cleanup, and creates a Start Menu shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->