### PR TITLE
rtss@7.3.7: Fix url & checkver

### DIFF
--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -7,7 +7,7 @@
         "vcredist": "extras/vcredist2022",
         "MSI Afterburner": "extras/msiafterburner"
     },
-    "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/[Guru3D]-RTSSSetup737Build28314.zip",
+    "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D%5D-RTSSSetup737Build28314.zip",
     "hash": "9b084a8cb3e53ec1a673894d0b66e22b16c9fd8785636b020b2d422f3f2a820e",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\*RTSSSetup*.exe\" -Removal",
@@ -53,9 +53,10 @@
             "} else {",
             "    Invoke-WebRequest -Uri $Matches.redirect_url -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck",
             "}",
-            "$version + ' ' + $response.Headers.Location"
+            "[string]($response.Headers.Location) -match 'https://ftp\\.nluug\\.nl/pub/games/PC/guru3d/(?<file_path>[^/]+?)/(?<file_name>.+)'",
+            "Write-Output \"$version $($Matches.file_path)/$([System.Net.WebUtility]::UrlEncode($Matches.file_name))\""
         ],
-        "regex": "(?<version>[\\d.]+) https://ftp\\.nluug\\.nl/pub/games/PC/guru3d/(?<file>.*)"
+        "regex": "(?<version>[\\d.]+) (?<file>.+)"
     },
     "autoupdate": {
         "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/$matchFile"


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `rtss@7.3.7`: Fix url & checkver. Encode filename to pass CI and fix installation.

```
Checking hash of [Guru3D]-RTSSSetup737Build28314.zip ... InvalidOperation: D:\Scoop\apps\scoop\current\lib\download.ps1:734
Line |
 734 |      $actual = (Get-FileHash -Path $file -Algorithm $algorithm).Hash.T …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
ERROR Hash check failed!
App:         extras/rtss
URL:         https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/[Guru3D]-RTSSSetup737Build28314.zip
Expected:    9b084a8cb3e53ec1a673894d0b66e22b16c9fd8785636b020b2d422f3f2a820e
Actual:

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/ScoopInstaller/Extras/issues/new?title=rtss%407.3.7%3a+hash+check+failed
```

### Related Issues/PRs/Commits
- https://github.com/ScoopInstaller/Extras/commit/1a901f369e677d265eee143c03a4d9b49b053c0c
-  #16256

<!-- where the first check box is documented, in case you don't read. -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [[Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed URL encoding for installer downloads so filenames containing brackets are handled correctly.

- Refactor
  - Improved update-check parsing to extract version and file path from redirects more reliably while keeping the final download URL unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->