### PR TITLE
servy: Update to version 1.9, fix autoupdate

### DIFF
--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.8",
+    "version": "1.9",
     "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
     "homepage": "https://servy-win.github.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aelassas/servy/releases/download/v1.8/servy-1.8-net8.0-x64-installer.exe",
-            "hash": "8cdcec1320a16cba243b84096f68e8a377975b2b521a3fa2e33c759972ee1f34"
+            "url": "https://github.com/aelassas/servy/releases/download/v1.9/servy-1.9-x64-installer.exe",
+            "hash": "efc5f6abba42fea790b19fc28e3b10352ffe7c6c4c40bf0478dbfa53cb1ec3ae"
         }
     },
     "innosetup": true,
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-net8.0-x64-installer.exe"
+                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-x64-installer.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

### What changed

Starting with Servy v1.9, the installer uses a **generic filename**:
```
servy-$version-x64-installer.exe
```

instead of the previous version-specific name:
```
servy-$version-net8.0-x64-installer.exe
```

This PR updates the Scoop `autoupdate` URL in the manifest to reflect the **new pattern**:
```
https://github.com/aelassas/servy/releases/download/v$version/servy-$version-x64-installer.exe
```

instead of the old pattern:
```
https://github.com/aelassas/servy/releases/download/v$version/servy-$version-net8.0-x64-installer.exe
```


This ensures that future releases are automatically detected and updated without requiring changes for each new .NET runtime.

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bumped application version to 1.9.
  - Updated 64-bit installer link to the latest format for this release.
  - Refreshed installer checksum to match the new binary.
  - Adjusted auto-update URLs to align with the new installer naming, improving update reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->