### PR TITLE
discord@1.0.9210: switch to official version

### DIFF
--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,39 +1,42 @@
 {
-    "version": "1.0.9208-23",
-    "description": "Free Voice and Text Chat",
-    "homepage": "https://discord.com/",
+    "version": "1.0.9210",
+    "description": "Group Chat That's All Fun & Games",
+    "homepage": "https://discord.com",
     "license": {
         "identifier": "Freeware",
         "url": "https://discord.com/terms"
     },
+    "notes": "If it doesn't autostart, re-enable app startup setting",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/portapps/discord-portable/releases/download/1.0.9208-23/discord-portable-win64-1.0.9208-23.7z",
-            "hash": "3f865d535bccfbf437904211f9532eee0c3d5c5fa766cdf5447aa9ac9d2e361d"
+            "url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9210/DiscordSetup.exe#/dl.7z",
+            "hash": "97d9ed582ec7efe45a0eb76765b41972483012ebf526708568d5e3d4701ba083"
         }
     },
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\Discord-$version-full.nupkg\" -ExtractDir 'lib\\net45' -DestinationPath \"$dir\\app-$version\" -Removal",
+        "Move-Item \"$dir\\app-$version\\installer.db\" \"$dir\"",
+        "Move-Item \"$dir\\app-$version\\app.ico\" \"$dir\"",
+        "New-Item \"$dir\\packages\" -ItemType Directory | Out-Null",
+        "Move-Item \"$dir\\RELEASES\" \"$dir\\packages\""
+    ],
     "shortcuts": [
         [
-            "discord-portable.exe",
-            "Discord"
+            "Update.exe",
+            "Discord",
+            "--processStart Discord.exe",
+            "app.ico"
         ]
     ],
-    "persist": [
-        "data",
-        "log"
-    ],
     "checkver": {
-        "url": "https://github.com/portapps/discord-portable",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+        "url": "https://updates.discord.com/distributions/app/manifests/latest?channel=stable&platform=win&arch=x64",
+        "regex": "x64/(\\d+\\.\\d+\\.\\d+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/portapps/discord-portable/releases/download/$version/discord-portable-win64-$version.7z"
+                "url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/$version/DiscordSetup.exe#/dl.7z"
             }
-        },
-        "hash": {
-            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Closes #8383

Closes portapps/discord-portable/issues/91

This version deals with the issues of portapps version (autostart, universal linking), it can autoupdate at "current" folder

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
