### PR TITLE
msiafterburner: Update to version 4.6.6, fix checkver & autoupdate

### DIFF
--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -12,25 +12,24 @@
         "Profiles will be migrated automatically."
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2008",
+        "vcredist": "extras/vcredist2022",
         "RivaTuner Statistics Server": "extras/rtss",
         "MSI Kombustor": "extras/msikombustor",
         "FurMark": "extras/furmark"
     },
-    "url": "https://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip?__token__=exp=acl=/*~hmac=#/dl.zip",
-    "hash": "201d19005e71ba56fa432b3f555207e1ea190e05c279dfb4711f19520e66abf4",
+    "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip",
+    "hash": "348e9690a638d84e30e32e9c7c2dd7aad9fd82d71eced1942c04c4c5620b0e1e",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\MSIAfterburnerInstaller*.exe\" -DestinationPath \"$dir\\.exe.d\" -Removal",
-        "Expand-7zipArchive \"$dir\\.exe.d\\.text\" -DestinationPath \"$dir\\.text.d\" -Removal",
-        "Expand-7zipArchive \"$dir\\.text.d\\MSIAfterburnerSetup*.exe\" -DestinationPath \"$dir\" -Removal",
-        "Remove-Item \"$dir\\.exe.d\", \"$dir\\.text.d\" -Recurse",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\", \"$dir\\Redist\" -Recurse"
+        "Expand-7zipArchive \"$dir\\MSIAfterburnerSetup*.exe\" -DestinationPath \"$dir\" -Removal",
+        "'$*', 'Redist', 'Uninstall*', '*guru3d*.txt' | ForEach-Object {",
+        "    Remove-Item -Path \"$dir\\$_\" -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
     ],
     "post_install": [
         "if (Test-Path \"$persist_dir\\AB_Profiles\") {",
         "    warn 'Migrating Afterburner profiles...'",
-        "    Move-Item \"$persist_dir\\AB_Profiles\\*\" \"$persist_dir\\Profiles\\\"",
-        "    Remove-Item \"$persist_dir\\AB_Profiles\" -Recurse",
+        "    Copy-Item -Path \"$persist_dir\\AB_Profiles\\*\" -Destination \"$persist_dir\\Profiles\" -Force -Recurse",
+        "    Remove-Item -Path \"$persist_dir\\AB_Profiles\" -Force -Recurse -ErrorAction SilentlyContinue",
         "}"
     ],
     "bin": "MSIAfterburner.exe",
@@ -42,10 +41,24 @@
     ],
     "persist": "Profiles",
     "checkver": {
-        "url": "https://www.guru3d.com/files-details/msi-afterburner-beta-download.html",
-        "regex": "<title>MSI Afterburner ([\\d.]+) \\(final\\) Download</title>"
+        "url": "https://www.guru3d.com/download/msi-afterburner-beta-download",
+        "script": [
+            "$page -match 'aform.*?value=\"(?<aform>[0-9a-f]+)\".*?Download (?<version>[\\d.]+)'",
+            "$version = $Matches.version",
+            "$body = @{ aform = $Matches.aform }",
+            "$response = Invoke-WebRequest -Uri $url -Method Post -Body $body",
+            "$response.Content -match 'location=\"(?<redirect_url>https://www.guru3d.com/getdownload/[0-9a-f]+)\"'",
+            "$response = if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
+            "    Invoke-WebRequest -Uri $Matches.redirect_url -MaximumRedirection 0 -ErrorAction SilentlyContinue",
+            "} else {",
+            "    Invoke-WebRequest -Uri $Matches.redirect_url -MaximumRedirection 0 -ErrorAction SilentlyContinue -SkipHttpErrorCheck",
+            "}",
+            "[string]($response.Headers.Location) -match 'https://ftp\\.nluug\\.nl/pub/games/PC/guru3d/(?<file_path>[^/]+?)/(?<file_name>.+)'",
+            "Write-Output \"$version $($Matches.file_path)/$([System.Net.WebUtility]::UrlEncode($Matches.file_name))\""
+        ],
+        "regex": "(?<version>[\\d.]+) (?<file>.+)"
     },
     "autoupdate": {
-        "url": "https://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip?__token__=exp=acl=/*~hmac=#/dl.zip"
+        "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/$matchFile"
     }
 }

--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.6.5",
+    "version": "4.6.6",
     "description": "Overclocking utility for graphics cards. Main features include GPU/Shader/Memory clock adjustment, advanced fan speed and GPU voltage control.",
     "homepage": "https://www.msi.com/page/afterburner",
     "license": {
@@ -18,7 +18,7 @@
         "FurMark": "extras/furmark"
     },
     "url": "https://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip?__token__=exp=acl=/*~hmac=#/dl.zip",
-    "hash": "10de22e72500fdfbb533b4b048ed52aa88d2661d847eeba7cceec405490ca25a",
+    "hash": "201d19005e71ba56fa432b3f555207e1ea190e05c279dfb4711f19520e66abf4",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\MSIAfterburnerInstaller*.exe\" -DestinationPath \"$dir\\.exe.d\" -Removal",
         "Expand-7zipArchive \"$dir\\.exe.d\\.text\" -DestinationPath \"$dir\\.text.d\" -Removal",
@@ -43,8 +43,7 @@
     "persist": "Profiles",
     "checkver": {
         "url": "https://www.guru3d.com/files-details/msi-afterburner-beta-download.html",
-        "regex": ">\\s*Download\\s+([\\d.]+)\\s+Stable\\s+\\(Final\\)",
-        "reverse": true
+        "regex": "<title>MSI Afterburner ([\\d.]+) \\(final\\) Download</title>"
     },
     "autoupdate": {
         "url": "https://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip?__token__=exp=acl=/*~hmac=#/dl.zip"


### PR DESCRIPTION
### Summary

This PR fixes the recurring hash mismatch and autoupdate failures caused by MSI's dynamic download URLs. The manifest is now more stable, maintainable, and logically consistent.

### Changes

- **Download source**: Replaced MSI’s dynamic URL with a static mirror hosted by Guru3D to ensure stable hash verification.
- **checkver script**: Added a POST-based resolution flow to dynamically retrieve the final download URL and version.
- **autoupdate**: Now uses `$matchFile` extracted from `checkver` output for reliable URL updates.
- **Installation**: Simplified `pre_install` steps and improved cleanup logic.
- **Suggestions**: Updated recommended `vcredist` to 2022.

---

Some tests are shown below:

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App msiafterburner -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
msiafterburner: 4.6.6 (scoop version is 4.6.6)
Forcing autoupdate!
Autoupdating msiafterburner
DEBUG[1759683687] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1759683687] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1759683687] $substitutions.$baseurl                       https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner
DEBUG[1759683687] $substitutions.$buildVersion
DEBUG[1759683687] $substitutions.$preReleaseVersion             4.6.6
DEBUG[1759683687] $substitutions.$basenameNoExt                 [Guru3D]-MSIAfterburnerSetup466Build16757
DEBUG[1759683687] $substitutions.$urlNoExt                      https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D%5D-MSIAfterburnerSetup466Build16757
DEBUG[1759683687] $substitutions.$matchFile                     afterburner/%5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip
DEBUG[1759683687] $substitutions.$version                       4.6.6
DEBUG[1759683687] $substitutions.$cleanVersion                  466
DEBUG[1759683687] $substitutions.$matchTail
DEBUG[1759683687] $substitutions.$dashVersion                   4-6-6
DEBUG[1759683687] $substitutions.$minorVersion                  6
DEBUG[1759683687] $substitutions.$underscoreVersion             4_6_6
DEBUG[1759683687] $substitutions.$matchHead                     4.6.6
DEBUG[1759683687] $substitutions.$majorVersion                  4
DEBUG[1759683687] $substitutions.$patchVersion                  6
DEBUG[1759683687] $substitutions.$basename                      [Guru3D]-MSIAfterburnerSetup466Build16757.zip
DEBUG[1759683687] $substitutions.$dotVersion                    4.6.6
DEBUG[1759683687] $substitutions.$url                           https://ftp.nluug.nl/pub/games/PC/guru3d/afterburner/%5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip
DEBUG[1759683687] $substitutions.$matchVersion                  4.6.6
DEBUG[1759683687] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading [Guru3D]-MSIAfterburnerSetup466Build16757.zip to compute hashes!
%5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip (40.5 MB) [=====================================================================================] 100%
Computed hash: 348e9690a638d84e30e32e9c7c2dd7aad9fd82d71eced1942c04c4c5620b0e1e
Writing updated msiafterburner manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ msiafterburner ≢]
└─> scoop install .\msiafterburner.json
Installing 'msiafterburner' (4.6.6) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\msiafterburner.json'
Loading %5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip from cache.
Checking hash of %5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip ... ok.
Extracting %5BGuru3D%5D-MSIAfterburnerSetup466Build16757.zip ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\msiafterburner\current => D:\Software\Scoop\Local\apps\msiafterburner\4.6.6
Creating shim for 'MSIAfterburner'.
Making D:\Software\Scoop\Local\shims\msiafterburner.exe a GUI binary.
Creating shortcut for MSI Afterburner (MSIAfterburner.exe)
Persisting Profiles
Running post_install script...done.
'msiafterburner' (4.6.6) was installed successfully!
Notes
-----
The 'RivaTuner Statistics Server' has been moved to it's own manifest.
To install it run 'scoop install extras/rtss'.
Profiles will be migrated automatically.
'msiafterburner' suggests installing 'extras/furmark'.
'msiafterburner' suggests installing 'extras/msikombustor'.
'msiafterburner' suggests installing 'extras/rtss'.
'msiafterburner' suggests installing 'extras/vcredist2022'.
```

Closes #16267

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated MSI Afterburner to 4.6.6, with refreshed download source and integrity verification.
  * Updated recommended Visual C++ runtime to a newer distribution.
  * Improved update detection to reliably find new stable releases.

* Bug Fixes
  * Installer now preserves user profiles during post-install migration and improves pre-install cleanup for more reliable installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->