### PR TITLE
playnite: Update to version 10.41, fix checkver & autoupdate

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -45,9 +45,11 @@
         "Themes"
     ],
     "checkver": {
-        "github": "https://github.com/JosefNemec/Playnite"
+        "url": "https://api.github.com/repos/JosefNemec/Playnite/releases/latest",
+        "jsonpath": "$..assets[?(@.browser_download_url =~ /download\\/[\\d.]+\\/.*?\\.(?:7z|zip)/)].browser_download_url",
+        "regex": "download/(?<version>[\\d.]+)/(?<file>.*?\\.(?:7z|zip))"
     },
     "autoupdate": {
-        "url": "https://github.com/JosefNemec/Playnite/releases/download/$version/$version.7z"
+        "url": "https://github.com/JosefNemec/Playnite/releases/download/$version/$matchFile"
     }
 }

--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -1,10 +1,10 @@
 {
-    "version": "10.40",
+    "version": "10.41",
     "description": "Video game library manager and launcher with support for 3rd party libraries like Steam, GOG, Origin, Battle.net, ...",
     "homepage": "https://playnite.link",
     "license": "MIT",
-    "url": "https://github.com/JosefNemec/Playnite/releases/download/10.40/Playnite1040.7z",
-    "hash": "94d36a3f1cadb50114bf93d837c100408c0372adde45a02d6bb21174c61f0e4a",
+    "url": "https://github.com/JosefNemec/Playnite/releases/download/10.41/10.41.7z",
+    "hash": "c567ddfeff1834198d68f27a1013f6fab94f6baf67d41858711039a77b4a1dc8",
     "pre_install": [
         "Copy-Item \"$persist_dir\\config.json\" \"$dir\" -ErrorAction 'SilentlyContinue'",
         "if (Test-Path \"$persist_dir\\Themes\") {",
@@ -48,6 +48,6 @@
         "github": "https://github.com/JosefNemec/Playnite"
     },
     "autoupdate": {
-        "url": "https://github.com/JosefNemec/Playnite/releases/download/$version/Playnite$cleanVersion.7z"
+        "url": "https://github.com/JosefNemec/Playnite/releases/download/$version/$version.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- Relates to #16254

> playnite: 10.41 (scoop version is 10.40) autoupdate available
Autoupdating playnite
Could not find hash in https://api.github.com/repos/JosefNemec/Playnite/releases
Downloading Playnite1041.7z to compute hashes!
The remote server returned an error: (404) Not Found.
URL https://github.com/JosefNemec/Playnite/releases/download/10.41/Playnite1041.7z is not valid
ERROR Could not update playnite, hash for Playnite1041.7z failed!
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

---
The upstream developer decided to change the file naming convention again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Playnite to version 10.41.
  * Refreshed download URL and updated checksum to match the new release artifact.
  * Switched release detection to use the upstream release API for more reliable latest-release discovery.
  * Modified autoupdate behavior to use the actual release asset filename dynamically for more accurate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->