### PR TITLE
archi: Update to version 5.7.0, enable checkver, fix autoupdate

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -1,12 +1,12 @@
 {
-    "version": "5.6.0",
+    "version": "5.7.0",
     "description": "A tool and editor to create ArchiMate models",
     "homepage": "https://www.archimatetool.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/archi/5.6.0/Archi-Win64-5.6.0.zip",
-            "hash": "sha1:5c1047c741c5cef0657debd8179f0c79f5db64c2"
+            "url": "https://github.com/archimatetool/archi.io/releases/download/570/Archi-Win64-5.7.0.zip",
+            "hash": "sha1:e0cdcc339deccbb2493f46bef1d339e23951394e"
         }
     },
     "extract_dir": "Archi",
@@ -17,10 +17,15 @@
             "Archi"
         ]
     ],
+    "checkver": {
+        "url": "https://api.github.com/repos/archimatetool/archi.io/releases/latest",
+        "jsonpath": "$.name",
+        "regex": "([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.archimatetool.com/downloads/archi/$matchShort/Archi-Win64-$version.zip"
+                "url": "https://github.com/archimatetool/archi.io/releases/download/$cleanVersion/Archi-Win64-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `archi`: Update to version 5.7.0, enable checkver, fix autoupdate.

### Related Issues/PRs/Commits
-  Closes #16274

<!-- where the first check box is documented, in case you don't read. -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [[Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)