### PR TITLE
ddu@18.1.3.5: Fix persist and extraction

### DIFF
--- a/bucket/ddu.json
+++ b/bucket/ddu.json
@@ -9,17 +9,18 @@
     "url": "https://ftp.nluug.nl/pub/games/PC/guru3d/ddu/%5BGuru3D%5D-DDU.zip",
     "hash": "1813bdfe0123d6b1c75a3b3971c715e602163669707618dac823f76aedc67bd3",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\*DDU*.exe\" -DestinationPath \"$dir\" -Removal",
-        "Remove-Item \"$dir\\`$*\", \"$dir/*Guru3D*\" -Recurse",
-        "if (!(Test-Path \"$persist_dir/Settings/Settings.xml\")) { New-Item \"$dir/Settings/Settings.xml\" | Out-Null }"
+        "Expand-7zipArchive \"$dir\\*DDU*.exe\" -DestinationPath \"$dir\" -ExtractDir \"DDU v$version\" -Removal",
+        "Remove-Item \"$dir\\*Guru3D*\" -Recurse",
+        "ensure \"$persist_dir\\settings\" | Out-Null",
+        "Copy-Item \"$persist_dir\\settings\\Settings.xml\" \"$dir\\settings\" -ErrorAction 'SilentlyContinue'"
     ],
-    "persist": "Settings\\Settings.xml",
     "shortcuts": [
         [
             "Display Driver Uninstaller.exe",
             "DDU - Display Driver Uninstaller"
         ]
     ],
+    "pre_uninstall": "Copy-Item \"$dir\\settings\\Settings.xml\" \"$persist_dir\\settings\" -ErrorAction SilentlyContinue",
     "checkver": {
         "url": "https://www.guru3d.com/download/display-driver-uninstaller-download/",
         "regex": "<title>Display Driver Uninstaller \\(DDU\\) download version ([\\d.]+)</title>"

--- a/bucket/ddu.json
+++ b/bucket/ddu.json
@@ -11,7 +11,6 @@
     "pre_install": [
         "Expand-7zipArchive \"$dir\\*DDU*.exe\" -DestinationPath \"$dir\" -ExtractDir \"DDU v$version\" -Removal",
         "Remove-Item \"$dir\\*Guru3D*\" -Recurse",
-        "ensure \"$persist_dir\\settings\" | Out-Null",
         "Copy-Item \"$persist_dir\\settings\\Settings.xml\" \"$dir\\settings\" -ErrorAction SilentlyContinue"
     ],
     "shortcuts": [
@@ -20,7 +19,11 @@
             "DDU - Display Driver Uninstaller"
         ]
     ],
-    "pre_uninstall": "Copy-Item \"$dir\\settings\\Settings.xml\" \"$persist_dir\\settings\" -ErrorAction SilentlyContinue",
+    "pre_uninstall": [
+        "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
+        "ensure \"$persist_dir\\settings\" | Out-Null",
+        "Copy-Item \"$dir\\settings\\Settings.xml\" \"$persist_dir\\settings\" -ErrorAction SilentlyContinue"
+    ],
     "checkver": {
         "url": "https://www.guru3d.com/download/display-driver-uninstaller-download/",
         "regex": "<title>Display Driver Uninstaller \\(DDU\\) download version ([\\d.]+)</title>"

--- a/bucket/ddu.json
+++ b/bucket/ddu.json
@@ -12,7 +12,7 @@
         "Expand-7zipArchive \"$dir\\*DDU*.exe\" -DestinationPath \"$dir\" -ExtractDir \"DDU v$version\" -Removal",
         "Remove-Item \"$dir\\*Guru3D*\" -Recurse",
         "ensure \"$persist_dir\\settings\" | Out-Null",
-        "Copy-Item \"$persist_dir\\settings\\Settings.xml\" \"$dir\\settings\" -ErrorAction 'SilentlyContinue'"
+        "Copy-Item \"$persist_dir\\settings\\Settings.xml\" \"$dir\\settings\" -ErrorAction SilentlyContinue"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
- Relates to https://github.com/ScoopInstaller/Extras/commit/2913d04129eb6a0451b730772c3f58d5184a65f0
- Closes #16280
- Relates to #16276


<!-- where the first check box is documented, in case you don't read. -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Settings are now automatically preserved across updates and reinstalls via a persistent settings directory; settings are copied to/from that directory during install/uninstall.

- Bug Fixes
  - Installation cleanup is now more targeted to avoid removing unrelated files.
  - Extraction directory naming made more predictable to prevent conflicts.

- Chores
  - Install/uninstall workflow updated: settings directory ensured, Settings.xml copy steps added, and manifest persist property removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->