### PR TITLE
aider-desk@0.35.0: Add AIDER_DESK_DATA_DIR env variable to persist user data

### DIFF
--- a/bucket/aider-desk.json
+++ b/bucket/aider-desk.json
@@ -15,7 +15,7 @@
     },
     "post_uninstall": "Remove-Item \"$env:APPDATA\\aider-desk\" -Recurse -Force",
     "env_set": {
-        "AIDER_DESK_DATA_DIR": "$persist_dir/appdata"
+        "AIDER_DESK_DATA_DIR": "$persist_dir\\appdata"
     },
     "shortcuts": [
         [


### PR DESCRIPTION

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App data is now stored in a persistent directory to preserve data across updates and reinstalls.
  * Environment variable AIDER_DESK_DATA_DIR is set to point to the app’s persistent data path.

* **Chores**
  * Installer manifest updated to declare the environment variable for consistent data storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->