### PR TITLE
retroshare: Update to version 0.6.7.2, fix checkver & autoupdate, add 32bit version

### DIFF
--- a/bucket/retroshare.json
+++ b/bucket/retroshare.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.6",
+    "version": "0.6.7.2",
     "description": "RetroShare is a Free and Open Source cross-platform, Friend-2-Friend and secure decentralised communication platform.",
     "homepage": "https://retroshare.cc/",
     "license": "GPL-2.0-only",
@@ -9,8 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/RetroShare/RetroShare/releases/download/v0.6.6/RetroShare-0.6.6-Windows-Portable-20210313-0-g751fffc30-Qt-5.15.2-x64.7z",
-            "hash": "870895241d8f43b63d90ed9a5f394b09533eb84951607f68fb75743372427527"
+            "url": "https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x64.7z",
+            "hash": "5a89a746115f34312ace09a3ec84c1929f31ab680eb6892d72c71406a15bb3fb"
+        },
+        "32bit": {
+            "url": "https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86.7z",
+            "hash": "23f2b5d31a495839ea8a511a72f71711bf260b80c6592c68f2f68a672fccd164"
         }
     },
     "bin": [
@@ -25,13 +29,17 @@
     ],
     "persist": "Data",
     "checkver": {
-        "url": "https://retroshare.cc/downloads.html",
-        "regex": "RetroShare-([\\d.]+)-Windows-Portable-(?<build>[\\w-.]+)-x64\\.7z\""
+        "url": "https://api.github.com/repositories/40011265/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /Windows-Portable/i)].browser_download_url",
+        "regex": "download/v([\\d.]+)/RetroShare-(?<commit>[^\"]+)-Windows-Portable-(?<build>[\\w.-]+?)(?<!-tor)(?=(?:-x64|-x86)?\\.7z)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/RetroShare/RetroShare/releases/download/v$version/RetroShare-$version-Windows-Portable-$matchBuild-x64.7z"
+                "url": "https://github.com/RetroShare/RetroShare/releases/download/v$version/RetroShare-$matchCommit-Windows-Portable-$matchBuild-x64.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/RetroShare/RetroShare/releases/download/v$version/RetroShare-$matchCommit-Windows-Portable-$matchBuild-x86.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
### Summary
This PR updates RetroShare to version 0.6.7.2 and adds the missing 32-bit architecture download.  
It also fixes the `checkver` and `autoupdate` fields to correctly handle the GitHub release URLs.

### Changes
- Update `version` from 0.6.6 → 0.6.7.2
- Add 32-bit architecture URLs and hashes
- Update `checkver` to use GitHub API latest release
- Improve regex to exclude `-tor` builds and handle `-x64`/`-x86` variations
- Update `autoupdate` to use `$matchCommit` instead of `$version` in filenames

### Testing
1. `.\checkver.ps1 -App retroshare` & `scoop install retroshare`

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App retroshare -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f 
retroshare: 0.6.7.2 (scoop version is 0.6.7.2)
Forcing autoupdate!
Autoupdating retroshare
DEBUG[1760021501] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1760021501] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760021501] $substitutions.$matchBuild                    20231126-Qt-5.15.2
DEBUG[1760021501] $substitutions.$majorVersion                  0
DEBUG[1760021501] $substitutions.$baseurl                       https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2
DEBUG[1760021501] $substitutions.$matchHead                     0.6.7
DEBUG[1760021501] $substitutions.$patchVersion                  7
DEBUG[1760021501] $substitutions.$basenameNoExt                 RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86
DEBUG[1760021501] $substitutions.$urlNoExt                      https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86
DEBUG[1760021501] $substitutions.$match1                        0.6.7.2
DEBUG[1760021501] $substitutions.$version                       0.6.7.2
DEBUG[1760021501] $substitutions.$basename                      RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86.7z
DEBUG[1760021501] $substitutions.$buildVersion                  2
DEBUG[1760021501] $substitutions.$matchCommit                   0.6.7a-4-ga1fdce2e5
DEBUG[1760021501] $substitutions.$matchTail                     .2
DEBUG[1760021501] $substitutions.$cleanVersion                  0672
DEBUG[1760021501] $substitutions.$underscoreVersion             0_6_7_2
DEBUG[1760021501] $substitutions.$preReleaseVersion             0.6.7.2
DEBUG[1760021501] $substitutions.$minorVersion                  6
DEBUG[1760021501] $substitutions.$dotVersion                    0.6.7.2
DEBUG[1760021501] $substitutions.$url                           https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86.7z
DEBUG[1760021501] $substitutions.$dashVersion                   0-6-7-2
DEBUG[1760021501] $hashfile_url = https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/chksums.txt -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86.7z in https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/chksums.txt      
DEBUG[1760021503] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*RetroShare-0\.6\.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5\.15\.2-x86\.7z(?:\s|$)|RetroShare-0\.6\.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5\.15\.2-x86\.7z[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:99:13
Found: 23f2b5d31a495839ea8a511a72f71711bf260b80c6592c68f2f68a672fccd164 using Extract Mode
... ...
Writing updated retroshare manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ retroshare ≢  ~1]
└─> scoop install .\retroshare.json
Installing 'retroshare' (0.6.7.2) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\retroshare.json'
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 77e644|OK  |    56KiB/s|100|D:/Software/Scoop/Local/cache/retroshare#0.6.7.2#2f6bd32.7z
Download: Status Legend:
Download: (OK):download completed.
Checking hash of RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x64.7z ... ok.
Extracting RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x64.7z ... done.
Linking D:\Software\Scoop\Local\apps\retroshare\current => D:\Software\Scoop\Local\apps\retroshare\0.6.7.2
Creating shim for 'retroshare'.
Making D:\Software\Scoop\Local\shims\retroshare.exe a GUI binary.                                                       
Creating shim for 'retroshare-service'.
Creating shortcut for RetroShare (retroshare.exe)
Persisting Data
'retroshare' (0.6.7.2) was installed successfully!
Notes
-----
'retroshare-nogui' is replaced by 'retroshare-service' since version 0.6.6
See https://retroshareteam.wordpress.com/2021/03/15/release-notes-for-v0-6-6/ for details and instructions
```
2. Regex correctly captures builds without `-tor` suffix

- Use [regex101](https://regex101.com/) as the test site for the regular expression. Select the following content as the test URLs, which come from official repository releases of different versions, ending with `"` to simulate the result extracted using `jsonpath`.

```
https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x64-tor.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x64.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.7.2/RetroShare-0.6.7a-4-ga1fdce2e5-Windows-Portable-20231126-Qt-5.15.2-x86.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.6/RetroShare-0.6.6-Windows-Portable-20210313-0-g751fffc30-Qt-5.15.2-x64.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.5/RetroShare-0.6.5-Windows-Portable-20190204-1-gfb005f041-Qt-5.12.0-tor.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.5/RetroShare-0.6.5-Windows-Portable-20190204-1-gfb005f041-Qt-5.12.0.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.4/RetroShare-0.6.4-Windows-Portable-20180312-91634ba6-Qt-4.8.7.7z"

https://github.com/RetroShare/RetroShare/releases/download/v0.6.4/RetroShare-0.6.4-Windows-Portable-20180312-91634ba6-Qt-5.9.1.7z"
```

- The test results are as follows:

<img width="1861" height="1017" alt="2025-10-09 230119" src="https://github.com/user-attachments/assets/3aa46c27-a802-4bb6-a409-07cc2a8eac36" /> <br>

Closes #14320

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added 32-bit Windows Portable package support.

- Chores
  - Updated RetroShare to version 0.6.7.2.
  - Switched update checks to use GitHub releases for more reliable detection.
  - Improved autoupdate to use commit-based identifiers for both 64-bit and 32-bit archives, aligning URLs with the latest release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->