### PR TITLE
masscode: Update to version 4.2.0, fix autoupdate

### DIFF
--- a/bucket/masscode.json
+++ b/bucket/masscode.json
@@ -6,19 +6,21 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/massCodeIO/massCode/releases/download/v4.2.0/massCode-4.2.0-x64.exe#/dl.7z",
-            "hash": "7eefaac377008d1c4f8fbe6927625467ee2ae785f36d65833d5b2e6020794b11",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse"
-            ],
-            "shortcuts": [
-                [
-                    "massCode.exe",
-                    "massCode"
-                ]
-            ]
+            "hash": "7eefaac377008d1c4f8fbe6927625467ee2ae785f36d65833d5b2e6020794b11"
         }
     },
+    "installer": {
+        "script": [
+            "Get-Item \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse"
+        ]
+    },
+    "shortcuts": [
+        [
+            "massCode.exe",
+            "massCode"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds an application shortcut after 64-bit installation for quicker access.
  - Installer now expands and cleans up installation files automatically.

- Chores
  - Updated massCode to v4.2.0.
  - Refreshed 64-bit installer source and integrity checksum.
  - Improved auto-update URLs to match the new installer layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->