### PR TITLE
uad-ng: Add version 1.1.2

### DIFF
--- a/bucket/uad-ng.json
+++ b/bucket/uad-ng.json
@@ -2,7 +2,7 @@
     "version": "1.1.2",
     "description": "A GUI written in Rust using ADB to debloat non-rooted Android devices.",
     "homepage": "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/releases/download/v1.1.2/uad-ng-windows.exe",
@@ -21,6 +21,9 @@
             "64bit": {
                 "url": "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/releases/download/v$version/uad-ng-windows.exe"
             }
+        },
+        "hash": {
+            "url": "$url-checksum.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
- Closes #16230
- Relates to #16024
<!--
Closes #XXXX
or
Relates to #XXXX
-->


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows manifest for Universal Android Debloater Next Generation (v1.1.2) for easy installation via the package manager.
  * Includes download metadata and SHA-256 checksum for the 64-bit build.
  * Adds a desktop/start menu shortcut for quick launch.
  * Enables automatic version checks and seamless updates via the project's release feed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->