### PR TITLE
jarkViewer: Add version 1.28

### DIFF
--- a/bucket/jarkviewer.json
+++ b/bucket/jarkviewer.json
@@ -20,13 +20,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jark006/jarkViewer/releases/download/v$version/jarkViewer.exe"
+                "url": "https://github.com/jark006/JarkViewer/releases/download/v$version/jarkViewer.exe"
             }
-        },
-        "hash": {
-            "url": "https://api.github.com/repos/jark006/jarkViewer/releases/latest",
-            "jp": "$.assets[0].digest",
-            "find": "sha256:$sha256"
         }
     }
 }


### PR DESCRIPTION
Closes #16308 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JarkViewer v1.28 to the catalog for Windows 64-bit.
  * Provides a verified installer download with SHA-256 for secure installation.
  * Installs a desktop shortcut for quick access.
  * Enables automatic version checks against GitHub releases.
  * Supports autoupdates for 64-bit installs with templated update URLs and streamlined update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->