### PR TITLE
obs-studio@32.0.1: Persist data folder

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -35,9 +35,9 @@
         "}"
     ],
     "post_install": [
-        "'data.original', 'obs-plugins.original' | ForEach-Object {",
-        "    $source_dir = Join-Path $dir $_",
-        "    $destination_dir = Join-Path $dir $($_ -ireplace '\\.original', '')",
+        "'data', 'obs-plugins' | ForEach-Object {",
+        "    $source_dir = Join-Path $dir \"$_.original\"",
+        "    $destination_dir = Join-Path $dir $_",
         "    if (Test-Path \"$source_dir\") {",
         "        Copy-Item -Path \"$source_dir\\*\" -Destination $destination_dir -Force -Recurse",
         "        Remove-Item -Path $source_dir -Recurse -Force -ErrorAction SilentlyContinue",


### PR DESCRIPTION
### Summary
This PR refactors the `obs-studio` manifest to improve persistence handling, enhance post-install behavior, and align field ordering with Contributing Guide.

### Changes
- **Field order**
  - Reordered manifest fields to comply with Contributing Guide.
- **post_install**
  - Unified handling of both `data.original` and `obs-plugins.original`.
  - Automatically restores, copies, and cleans up both directories.
- **persist**
  - Added missing `data` directory.
  - Apart from `obs-plugins`, the `data` folder may also contain user-customized content in `obs-scripting` and `obs-studio\themes`. Considering the file size and clarity of the manifest, this approach from the list has been chosen.

### Testing

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ obs-studio ≢  ~1]
└─> scoop install .\obs-studio.json
Installing 'obs-studio' (32.0.1) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\obs-studio.json'
Loading OBS-Studio-32.0.1-Windows-x64.zip from cache.
Checking hash of OBS-Studio-32.0.1-Windows-x64.zip ... ok.
Extracting OBS-Studio-32.0.1-Windows-x64.zip ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\obs-studio\current => D:\Software\Scoop\Local\apps\obs-studio\32.0.1
Creating shortcut for OBS Studio (obs64.exe)
Persisting data
Persisting config
Persisting obs-plugins
Persisting portable_mode.txt
Running post_install script...done.
'obs-studio' (32.0.1) was installed successfully!
Notes
-----
Add Virtual Camera module by running: "D:\Software\Scoop\Local\apps\obs-studio\current\data\obs-plugins\win-dshow\virtualcam-install.bat"
Remove it by running: "D:\Software\Scoop\Local\apps\obs-studio\current\data\obs-plugins\win-dshow\virtualcam-uninstall.bat"

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ obs-studio ≢  ~1]
└─> scoop update obs-studio -f
obs-studio: 32.0.1 -> 32.0.1
Updating one outdated app:
Updating 'obs-studio' (32.0.1 -> 32.0.1)
Downloading new version
Loading OBS-Studio-32.0.1-Windows-x64.zip from cache.
Checking hash of OBS-Studio-32.0.1-Windows-x64.zip ... ok.
Uninstalling 'obs-studio' (32.0.1)
Unlinking D:\Software\Scoop\Local\apps\obs-studio\current
Installing 'obs-studio' (32.0.1) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\obs-studio.json'
Loading OBS-Studio-32.0.1-Windows-x64.zip from cache.
Extracting OBS-Studio-32.0.1-Windows-x64.zip ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\obs-studio\current => D:\Software\Scoop\Local\apps\obs-studio\32.0.1
Creating shortcut for OBS Studio (obs64.exe)
Persisting data
Persisting config
Persisting obs-plugins
Persisting portable_mode.txt
Running post_install script...done.
'obs-studio' (32.0.1) was installed successfully!
Notes
-----
Add Virtual Camera module by running: "D:\Software\Scoop\Local\apps\obs-studio\current\data\obs-plugins\win-dshow\virtualcam-install.bat"
Remove it by running: "D:\Software\Scoop\Local\apps\obs-studio\current\data\obs-plugins\win-dshow\virtualcam-uninstall.bat"

┏[ D:\Software\Scoop\Local\apps\obs-studio\current]
└─> Get-ChildItem -Path .\ -Directory -Depth 2

        Directory: D:\Software\Scoop\Local\apps\obs-studio\current


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d----         2025/9/27      5:46                  bin
l-r--        2025/10/10     23:41                  config 󰁕 D:\Software\Scoop\Local\persist\obs-studio\config
l-r--        2025/10/10     23:41                  data 󰁕 D:\Software\Scoop\Local\persist\obs-studio\data
l-r--        2025/10/10     23:41                  obs-plugins 󰁕 D:\Software\Scoop\Local\persist\obs-studio\obs-plugins

        Directory: D:\Software\Scoop\Local\apps\obs-studio\current\bin


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d----         2025/9/27      5:46                  64bit

        Directory: D:\Software\Scoop\Local\apps\obs-studio\current\bin\64bit


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d----         2025/9/27      5:46                  iconengines
d----         2025/9/27      5:46                  imageformats
d----         2025/9/27      5:46                  platforms
d----         2025/9/27      5:46                  styles
```

- Closes #14506 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures portable mode is correctly enabled during installation.
  * Preserves data, configuration, and plugins across updates for more reliable persistence.
  * Fixes directory handling to prevent missing or duplicated files after install.

* **Chores**
  * Improved installation and post-install processes for more reliable setup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->