### PR TITLE
aimp@5.40.2696: Fix persist

### DIFF
--- a/bucket/aimp.json
+++ b/bucket/aimp.json
@@ -18,9 +18,9 @@
     },
     "extract_dir": "AIMP",
     "post_install": [
-        "'Icons.original', 'Skins.original', 'Plugins.original' | ForEach-Object {",
-        "    $source_dir = Join-Path $dir $_",
-        "    $destination_dir = Join-Path $dir $($_ -ireplace '\\.original', '')",
+        "'Icons', 'Skins', 'Plugins' | ForEach-Object {",
+        "    $source_dir = Join-Path $dir \"$_.original\"",
+        "    $destination_dir = Join-Path $dir $_",
         "    if (Test-Path \"$source_dir\") {",
         "        Copy-Item -Path \"$source_dir\\*\" -Destination $destination_dir -Force -Recurse",
         "        Remove-Item -Path $source_dir -Recurse -Force -ErrorAction SilentlyContinue",


### PR DESCRIPTION
This PR fixes plugin incompatibility issues caused by persistent directories.

Some tests are shown below:

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ aimp ≢]
└─>  scoop install .\aimp.json
Installing 'aimp' (5.40.2696) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\aimp.json'
Loading dl.zip from cache.
Checking hash of dl.zip ... ok.
Extracting dl.zip ... done.
Linking D:\Software\Scoop\Local\apps\aimp\current => D:\Software\Scoop\Local\apps\aimp\5.40.2696
Creating shim for 'AIMP'.
Making D:\Software\Scoop\Local\shims\aimp.exe a GUI binary.
Creating shim for 'AIMPac'.
Making D:\Software\Scoop\Local\shims\aimpac.exe a GUI binary.
Creating shim for 'AIMPate'.
Making D:\Software\Scoop\Local\shims\aimpate.exe a GUI binary.
Creating shortcut for AIMP (AIMP.exe)
Creating shortcut for AIMP Audio Converter (AIMPac.exe)
Creating shortcut for AIMP Advanced Tag Editor (AIMPate.exe)
Persisting Icons
Persisting Skins
Persisting Plugins
Persisting Profile
Running post_install script...done.
'aimp' (5.40.2696) was installed successfully!

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ aimp ≢]
└─>  scoop update aimp -f
aimp: 5.40.2696 -> 5.40.2696
Updating one outdated app:
Updating 'aimp' (5.40.2696 -> 5.40.2696)
Downloading new version
Loading dl.zip from cache.
Checking hash of dl.zip ... ok.
Uninstalling 'aimp' (5.40.2696)
Removing shim 'AIMP.shim'.
Removing shim 'AIMP.exe'.
Removing shim 'AIMPac.shim'.
Removing shim 'AIMPac.exe'.
Removing shim 'AIMPate.shim'.
Removing shim 'AIMPate.exe'.
Unlinking D:\Software\Scoop\Local\apps\aimp\current
Installing 'aimp' (5.40.2696) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\aimp.json'
Loading dl.zip from cache.
Extracting dl.zip ... done.
Linking D:\Software\Scoop\Local\apps\aimp\current => D:\Software\Scoop\Local\apps\aimp\5.40.2696
Creating shim for 'AIMP'.
Making D:\Software\Scoop\Local\shims\aimp.exe a GUI binary.                                                             
Creating shim for 'AIMPac'.
Making D:\Software\Scoop\Local\shims\aimpac.exe a GUI binary.
Creating shim for 'AIMPate'.
Making D:\Software\Scoop\Local\shims\aimpate.exe a GUI binary.
Creating shortcut for AIMP (AIMP.exe)
Creating shortcut for AIMP Audio Converter (AIMPac.exe)
Creating shortcut for AIMP Advanced Tag Editor (AIMPate.exe)
Persisting Icons
Persisting Skins
Persisting Plugins
Persisting Profile
Running post_install script...done.
'aimp' (5.40.2696) was installed successfully!
```

- Closes #12927 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automatic post-install step that organizes AIMP assets so Icons, Skins, and Plugins are placed correctly and preserves customizations across updates.
  * Expands persisted items to include Skins and reorders persistence so settings and assets are retained predictably.
* **Bug Fixes**
  * Cleans up leftover “.original” folders so assets are available immediately after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->