### PR TITLE
googlechrome@141.0.7390.77: Add arm64, use enterprise edition

### DIFF
--- a/bucket/googlechrome.json
+++ b/bucket/googlechrome.json
@@ -1,22 +1,39 @@
 {
     "version": "141.0.7390.77",
-    "description": "Fast, secure, and free web browser, built for the modern web.",
-    "homepage": "https://www.google.com/chrome/",
+    "description": "The Fast & Secure Web Browser Built to be Yours",
+    "homepage": "https://google.com/chrome",
     "license": {
         "identifier": "Freeware",
-        "url": "https://www.google.com/chrome/terms/"
+        "url": "https://google.com/chrome/terms"
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/otaa3qtz2vrbvruea2x2bt2x6u_141.0.7390.77/141.0.7390.77_chrome_installer_uncompressed.exe#/dl.7z",
-            "hash": "a46e4e9dd0343c9cbe32f62bff6c9c62480d347d81beb6b63eea9b3fb907bb3e"
+            "url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi#/dl.7z",
+            "hash": "5927b34062aaf5594a2b873cf7ae7d0df1f6515dad78967d05711c1125ef1c95"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/acxkfbuwzb7eb5gqtipcabrgslnq_141.0.7390.77/141.0.7390.77_chrome_installer_uncompressed.exe#/dl.7z",
-            "hash": "29ae6aeeb40fbcf40c2116763ec22edef9388b79cbde79053df142d037a20297"
+            "url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi#/dl.7z",
+            "hash": "54ae40d221bcf7c8a68cefcb5251d025eebf7ac8c72e134bae5828a64bb27933"
+        },
+        "arm64": {
+            "url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise_arm64.msi#/dl.7z",
+            "hash": "1d8a590f3f1395aa233d69dbe2bfb6f45ffe608c5ce71263bea1e352921bf328"
         }
     },
-    "extract_dir": "Chrome-bin",
+    "extract_to": "tmp",
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\tmp\\Binary.GoogleChromeInstaller\" \"$dir\\tmp\"",
+        "Expand-7zipArchive \"$dir\\tmp\\updater.7z\" \"$dir\\tmp\"",
+        "$inst = Get-ChildItem \"$dir\\tmp\" -Filter '*_chrome_installer.exe' -File -Recurse | Select-Object -First 1 -ExpandProperty FullName",
+        "Expand-7zipArchive \"$inst\" \"$dir\\tmp\"",
+        "Expand-7zipArchive \"$dir\\tmp\\chrome.7z\" -ExtractDir 'Chrome-bin' -DestinationPath \"$dir\""
+    ],
+    "post_install": [
+        "Remove-Item \"$dir\\tmp\" -Recurse -Force"
+    ],
+    "env_set": {
+        "CHROME_EXECUTABLE": "$dir\\chrome.exe"
+    },
     "bin": [
         [
             "chrome.exe",
@@ -29,28 +46,22 @@
             "Google Chrome"
         ]
     ],
-    "env_set": {
-        "CHROME_EXECUTABLE": "$dir\\chrome.exe"
-    },
     "checkver": {
-        "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
-        "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+        "url": "https://api.github.com/repositories/197275551/contents/manifests/g/Google/Chrome",
+        "jsonpath": "$..name",
+        "regex": "([\\d.]+)",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer_uncompressed.exe#/dl.7z",
-                "hash": {
-                    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
-                    "xpath": "/chromechecker/stable64[version='$version']/sha256"
-                }
+                "url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi#/dl.7z"
             },
             "32bit": {
-                "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer_uncompressed.exe#/dl.7z",
-                "hash": {
-                    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
-                    "xpath": "/chromechecker/stable32[version='$version']/sha256"
-                }
+                "url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise.msi#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise_arm64.msi#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
- Add arm64
- Uses enterprise edition for simpler download links (identical to regular edition for personal use)
- Alternative checkver

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ARM64 installation support for Google Chrome.
  - Sets CHROME_EXECUTABLE environment variable after install.

- Refactor
  - Switched to MSI-based installation with expanded extraction steps for more reliable setup.
  - Added pre- and post-install routines to handle multi-archive expansion and cleanup.

- Chores
  - Updated app metadata (description, homepage, license).
  - Improved version checking via a new source for more accurate updates.
  - Refreshed download URLs and hashes; enabled autoupdate for all architectures, including ARM64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->