### PR TITLE
vrcx: Update to version 2025.10.11, fix autoupdate

### DIFF
--- a/bucket/vrcx.json
+++ b/bucket/vrcx.json
@@ -1,12 +1,12 @@
 {
-    "version": "2025.09.10",
+    "version": "2025.10.11",
     "description": "Friendship management tool for VRChat",
     "homepage": "https://github.com/vrcx-team/VRCX",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vrcx-team/VRCX/releases/download/v2025.09.10/VRCX_20250910.zip",
-            "hash": "69eb13656432c33d36c36e0f9b9e5949c1af289a70a0314d9eee71b8cbd54cbe"
+            "url": "https://github.com/vrcx-team/VRCX/releases/download/v2025.10.11/VRCX_2025.10.11.zip",
+            "hash": "72dd313d32ad382c13ed48a743628d5058edb1b41f9349dff5cd48fc6fcc1f95"
         }
     },
     "shortcuts": [
@@ -21,7 +21,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vrcx-team/VRCX/releases/download/v$version/VRCX_$cleanVersion.zip"
+                "url": "https://github.com/vrcx-team/VRCX/releases/download/v$version/VRCX_$version.zip"
             }
         }
     }


### PR DESCRIPTION

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted 64-bit auto-update URL pattern to match release naming, preventing failed updates and ensuring consistent downloads.
  * Improved reliability of update checks for 64-bit installations.

* **Chores**
  * Bumped version to 2025.10.11.
  * Updated 64-bit download link to the latest release.
  * Refreshed checksum to verify the integrity of the new package, ensuring users receive the correct build during installation or update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->