### PR TITLE
supermium: Update to version 132.0.6834.226-r5-02, switch to github releases

### DIFF
--- a/bucket/supermium.json
+++ b/bucket/supermium.json
@@ -41,11 +41,8 @@
     "persist": "User Data",
     "checkver": {
         "url": "https://api.github.com/repositories/638089306/releases/latest",
-        "script": [
-            "$release = ConvertFrom-Json $page -ErrorAction Stop",
-            "$release.tag_name + ', ' + $release.name"
-        ],
-        "regex": "(?i)(?<tag>v?[\\d]+(?<suffix>-.+)?),.+?(?<prefix>[\\d.]+)",
+        "jsonpath": "$..['tag_name', 'name']",
+        "regex": "(?i)\"(?<tag>v?[\\d]+(?<suffix>-[^\"]+)?)\",\"[^\"]+?(?<prefix>[\\d.]+)",
         "replace": "${prefix}${suffix}"
     },
     "autoupdate": {


### PR DESCRIPTION
### Summary
This PR updates Supermium to version **132.0.6834.226-r5-02** and migrates the download source to **GitHub Releases**. The version format was adjusted to include the `-r5-02` suffix to ensure proper upgrade behavior.

> [!NOTE]
> In the official repository, the versions related to **132.0.6834.226** include `132.0.6834.226 R5.02`, `132.0.6834.226 R5.01`, and `132.0.6834.226 R5`, all of which are stable releases.  
> 
> Due to the behavior defined in [scoop-update.ps1#L282-L287](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/libexec/scoop-update.ps1#L282-L287), without using an additional suffix such as `r5-02`, when `$old_version -eq $version`, the absence of the `-force` parameter would prevent users with older installations from upgrading to the latest release.
> 
> Therefore, using the suffix is necessary.

### Changes
- Update `version` from `132.0.6834.226` → `132.0.6834.226-r5-02`
- Migrate download source from `win32subsystem.live` to `GitHub Releases`
- Replace single-line `license` field with object including `url`
- Enhance `post_install`:
  - Removes redundant local data to ensure portable behavior
- Update `checkver` to use GitHub API (`/releases/latest`)
- Improve `regex` and `replace` to handle combined tag and name parsing
- Update `autoupdate` URLs to match new GitHub release structure

### Testing
1. `.\checkver.ps1 -App supermium` & `scoop install supermium`

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App supermium -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f            
supermium: 132.0.6834.226-r5-02 (scoop version is 132.0.6834.226-r5-02)
Forcing autoupdate!
Autoupdating supermium
DEBUG[1760288681] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1760288681] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760288681] $substitutions.$matchPrefix                   132.0.6834.226
DEBUG[1760288681] $substitutions.$url                           https://github.com/win32ss/supermium/releases/download/v132-r5-02/supermium_132_32_nonsetup.zip
DEBUG[1760288681] $substitutions.$preReleaseVersion             02
DEBUG[1760288681] $substitutions.$basenameNoExt                 supermium_132_32_nonsetup
DEBUG[1760288681] $substitutions.$version                       132.0.6834.226-r5-02
DEBUG[1760288681] $substitutions.$matchTag                      v132-r5-02
DEBUG[1760288681] $substitutions.$urlNoExt                      https://github.com/win32ss/supermium/releases/download/v132-r5-02/supermium_132_32_nonsetup
DEBUG[1760288681] $substitutions.$underscoreVersion             132_0_6834_226_r5_02
DEBUG[1760288681] $substitutions.$minorVersion                  0
DEBUG[1760288681] $substitutions.$buildVersion                  226
DEBUG[1760288681] $substitutions.$matchTail                     .226-r5-02
DEBUG[1760288681] $substitutions.$cleanVersion                  13206834226r502
DEBUG[1760288681] $substitutions.$basename                      supermium_132_32_nonsetup.zip
DEBUG[1760288681] $substitutions.$dotVersion                    132.0.6834.226.r5.02
DEBUG[1760288681] $substitutions.$matchSuffix                   -r5-02
DEBUG[1760288681] $substitutions.$baseurl                       https://github.com/win32ss/supermium/releases/download/v132-r5-02
DEBUG[1760288681] $substitutions.$majorVersion                  132
DEBUG[1760288681] $substitutions.$matchHead                     132.0.6834
DEBUG[1760288681] $substitutions.$dashVersion                   132-0-6834-226-r5-02
DEBUG[1760288681] $substitutions.$patchVersion                  6834
DEBUG[1760288681] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1760288682] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/win32ss/supermium/releases/download/v132-r5-02/supermium_132_32_nonsetup.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 3e181d50818fc95769f123012ad4cc0ffefe882f2fa4606620d2c031638a5912 using Github Mode
... ...
Writing updated supermium manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ supermium ≢]
└─> scoop install .\supermium.json
Installing 'supermium' (132.0.6834.226-r5-02) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\supermium.json'
Loading supermium_132_64_nonsetup.zip from cache.
Checking hash of supermium_132_64_nonsetup.zip ... ok.
Extracting supermium_132_64_nonsetup.zip ... done.                                                                      
Linking D:\Software\Scoop\Local\apps\supermium\current => D:\Software\Scoop\Local\apps\supermium\132.0.6834.226-r5-02
Creating shim for 'supermium'.
Making D:\Software\Scoop\Local\shims\supermium.exe a GUI binary.                                                        
Creating shortcut for Supermium (chrome.exe)
Persisting User Data
Running post_install script...done.
'supermium' (132.0.6834.226-r5-02) was installed successfully!
```

2. The regex can correctly extract the relevant information 

- Use [regex101](https://regex101.com/) as the testing site for verifying the regular expression. Select the following examples as test inputs — these samples are derived from different versions of the official repository releases, with slight modifications to validate various cases.

```
v138-r2, Version 138.0.7260.260 R2

V132-r5-02, Supermium 132.0.6834.226 R5.02

v126-r3, Supermium 126.0.6478.249 R3 (XP x64 Hotfix)

126, Supermium 126.0.6478.249
```

- The test results are as follows:

<img width="1857" height="1018" alt="2025-10-13 001403" src="https://github.com/user-attachments/assets/8e98e31e-97e4-4b6b-b3f4-62a86be52de2" />

---

- Relates to #16322 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portable Mode now auto-copies existing user data during installation for a smoother migration.

* **Chores**
  * Updated to version 132.0.6834.226-r5-02.
  * Downloads and update checks now use GitHub Releases for more reliable installs and automatic version tracking.
  * Set an explicit extraction directory to ensure consistent install layout.
  * Enhanced license information with a direct link to the license text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->