### PR TITLE
winutil: Add version 25.10.06

### DIFF
--- a/bucket/winutil.json
+++ b/bucket/winutil.json
@@ -1,9 +1,9 @@
 {
     "version": "25.10.06",
-    "description": "Chris Titus Tech's Windows Utility - Install Programs, Tweaks, Fixes, and Updates",
+    "description": "Chris Titus Tech's Windows Utility - Install Programs, Tweaks, Fixes, and Updates.",
     "homepage": "https://github.com/ChrisTitusTech/winutil",
     "license": "MIT",
-    "notes": "Open from CMD or PowerShell with `gsudo winutil`",
+    "notes": "Open from CMD or PowerShell with `gsudo winutil`.",
     "suggest": {
         "gsudo": "main/gsudo"
     },
@@ -17,7 +17,7 @@
         "    )",
         "    $Directories.ForEach{",
         "        if ([System.IO.Directory]::Exists($_)) {",
-        "            $null = [System.IO.Directory]::Delete($_,$true)",
+        "            $null = [System.IO.Directory]::Delete($_, $true)",
         "        }",
         "    }",
         "}"


### PR DESCRIPTION
Closes #16327

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manifest to make a Windows utility available for easy installation.
  * Includes versioned release info with description, homepage, license, and notes.
  * Supports automatic update checks and autoupdate from releases.
  * Improves uninstallation by optionally removing leftover local app data when purged.
  * Recommends elevated execution for smoother operations where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->