### PR TITLE
flclash: Update to version 0.8.90, drop arm64 support, add hash extraction

### DIFF
--- a/bucket/flclash.json
+++ b/bucket/flclash.json
@@ -15,14 +15,15 @@
             "FlClash"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/chen08209/FlClash"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/chen08209/FlClash/releases/download/v$version/FlClash-$version-windows-amd64.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
The automatic update process was failing because the upstream repository has stopped compiling arm64 packages, but our update script still included arm64 architecture detection. This caused the update to fail when attempting to fetch non-existent arm64 binaries.

This commit removes the arm64 architecture check from the auto-update process to restore functionality.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded to version 0.8.90.
  * Updated 64‑bit x86 download link and checksum to match the new release.
  * Simplified version check behavior and adjusted auto-update to rely on the downloaded file checksum URL.
  * Removed ARM64 entries from releases and auto-update; ARM64 users should use an alternative distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->