### PR TITLE
foxit(-pdf)-reader@2025.2.1: Fix checkver

### DIFF
--- a/bucket/foxit-pdf-reader.json
+++ b/bucket/foxit-pdf-reader.json
@@ -39,18 +39,10 @@
     ],
     "checkver": {
         "script": [
-            "$output = @()",
-            "'64', '32' | ForEach-Object {",
-            "    $req = $null",
-            "    $url = \"https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&operating_type=$_&package_type=exe&language=ML\"",
-            "    if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
-            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 1 -ErrorAction Ignore",
-            "    } else {",
-            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 1 -ErrorAction Ignore -SkipHttpErrorCheck",
-            "    }",
-            "    $output += [string]($req.Headers.Location)",
-            "}",
-            "Write-Output ($output -join ', ')"
+            "$Uri = [System.Net.HttpWebRequest]::Create(",
+            "    'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&operating_type=64&package_type=exe&language=ML'",
+            ").GetResponse().ResponseUri.AbsoluteUri",
+            "$Uri, $Uri.Replace('x64', 'x86') -join ', '"
         ],
         "regex": "/win/(?<version>[\\d.]+)/(?<fname64>FoxitPDFReader.*\\.exe), .*/win/\\k<version>/(?<fname32>FoxitPDFReader.*\\.exe)"
     },

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -39,18 +39,10 @@
     ],
     "checkver": {
         "script": [
-            "$output = @()",
-            "'64', '32' | ForEach-Object {",
-            "    $req = $null",
-            "    $url = \"https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&operating_type=$_&package_type=exe&language=ML\"",
-            "    if ($PSVersionTable.PSVersion.Major -lt 7.0) {",
-            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 1 -ErrorAction Ignore",
-            "    } else {",
-            "        $req = Invoke-WebRequest -Uri $url -MaximumRedirection 1 -ErrorAction Ignore -SkipHttpErrorCheck",
-            "    }",
-            "    $output += [string]($req.Headers.Location)",
-            "}",
-            "Write-Output ($output -join ', ')"
+            "$Uri = [System.Net.HttpWebRequest]::Create(",
+            "    'https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Windows&operating_type=64&package_type=exe&language=ML'",
+            ").GetResponse().ResponseUri.AbsoluteUri",
+            "$Uri, $Uri.Replace('x64', 'x86') -join ', '"
         ],
         "regex": "/win/(?<version>[\\d.]+)/(?<fname64>FoxitPDFReader.*\\.exe), .*/win/\\k<version>/(?<fname32>FoxitPDFReader.*\\.exe)"
     },


### PR DESCRIPTION
Closes #16337

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Foxit Reader and Foxit PDF Reader downloads by following a single final redirect and producing both 64‑bit and 32‑bit download URLs.
  * Reduced failed installs/updates related to redirect handling while preserving update behavior.

* **Refactor**
  * Simplified download-check logic to reduce complexity and improve robustness without changing end-user flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->