### PR TITLE
fontforge: Update to version 20251009, fix checkver & autoupdate, drop 32bit support

### DIFF
--- a/bucket/fontforge.json
+++ b/bucket/fontforge.json
@@ -27,7 +27,7 @@
     "checkver": {
         "url": "https://api.github.com/repositories/5390156/releases/latest",
         "jsonpath": "$..browser_download_url",
-        "regex": "(\\d{8})/(?<fname>FontForge-\\d{4}-\\d{2}-\\d{2}-Windows(?<arch>-(?:x86|x64))?(?<release>[-r\\d]*?)?.exe)"
+        "regex": "(\\d{8})/(?<fname>FontForge-\\d{4}-\\d{2}-\\d{2}-Windows(?<arch>-x64)?(?<release>[-r\\d]*?)?.exe)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Change `checkver` to use JSONPath, and update the regex to account for the `-x64` in the filename of the latest release.
- Change `autoupdate` to use the new named captured variable in `checkver`.
- Add `architecture` field to support 64-bit only. Move URL & hash under architecture.64bit.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #16342 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated FontForge to the 20251009 release.
  * Switched to the Windows x64 installer and refreshed its checksum.
  * Reorganized release metadata to target 64-bit architecture.
  * Improved auto-update detection by switching to the GitHub releases API and using browser-download matching for more reliable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->