### PR TITLE
android-studio@2025.1.4.8: Remove invalid persist entry

### DIFF
--- a/bucket/android-studio.json
+++ b/bucket/android-studio.json
@@ -1,13 +1,13 @@
 {
     "version": "2025.1.4.8",
     "description": "The official IDE for Android development, which includes everything you need to build Android apps.",
-    "homepage": "https://developer.android.com/studio/",
+    "homepage": "https://developer.android.com/studio",
     "license": {
         "identifier": "Freeware",
         "url": "https://developer.android.com/studio/terms.html"
     },
     "suggest": {
-        "Android SDK": "android-clt"
+        "Android SDK": "main/android-clt"
     },
     "architecture": {
         "64bit": {
@@ -22,14 +22,13 @@
         }
     },
     "extract_dir": "android-studio",
-    "persist": "plugins",
     "checkver": "android-studio-([\\d.]+)-windows\\.zip",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$version/android-studio-$version-windows.zip",
                 "hash": {
-                    "url": "https://developer.android.com/studio/",
+                    "url": "https://developer.android.com/studio",
                     "regex": "(?sm)$basename.*?$sha256"
                 }
             }


### PR DESCRIPTION
### Summary
This update removes the invalid `persist` entry from the `android-studio` manifest and makes minor adjustments for accuracy and consistency.

### Changes
- **Removed** the `persist` field (`plugins`):
  - Android Studio does **not** store user-installed plugins or settings under `$dir\plugins`.
  - Instead, user data — including settings, cache, and manually installed plugins — is stored in  
    `$env:APPDATA\Google\AndroidStudio<version>`.
- **Updated** the `homepage` URL to remove the trailing slash for consistency.
- **Corrected** the `Android SDK` suggestion to `main/android-clt`.
<br>

- Closes #12123 
- Closes #15020 
- Relates to #8116
- Relates to #8120
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Android SDK suggestion path to prevent install/mapping issues.
  * Normalized auto-update URL to improve update checks.

* **Refactor**
  * Removed plugin persistence for Android Studio; plugins will not carry over between updates. You may need to reinstall desired plugins after updating.

* **Chores**
  * Standardized homepage URL formatting (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->