### PR TITLE
zed: Update to version 0.208.4, switch to official release

### DIFF
--- a/bucket/zed.json
+++ b/bucket/zed.json
@@ -11,7 +11,7 @@
     },
     "installer": {
         "script": [
-            "Expand-InnoArchive -Path \"$dir\\$fname\"",
+            "Expand-InnoArchive -Path \"$dir\\$fname\" -ExtractDir '{app}'",
             "Expand-InnoArchive -Path \"$dir\\$fname\" -ExtractDir '{code_GetInstallDir}' -Removal"
         ]
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

## Summary

Zed now have official [Windows build](https://zed.dev/windows). This PR migrates the Zed manifest from the unofficial Windows build to the new official one. 

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to #13996
- Relates to #15052

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated Zed to version 0.208.4.
  - Switched 64-bit download to the official executable release and updated its checksum.
  - Added installer extraction steps for the official installer to streamline setup.
  - Moved version checking and autoupdate to the official repository with a direct executable path.
  - Exposed both CLI and GUI executable entries for clearer launch options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->