### PR TITLE
ipscan@3.9.2: Switch to JRE self-contained installer, drop 32-bit support

### DIFF
--- a/bucket/ipscan.json
+++ b/bucket/ipscan.json
@@ -1,23 +1,23 @@
 {
     "version": "3.9.2",
-    "description": "Angry IP Scanner - fast and friendly network scanner",
+    "description": "Angry IP Scanner - fast and friendly network scanner.",
     "homepage": "https://angryip.org",
     "license": {
         "identifier": "GPL-2.0-or-later",
         "url": "https://github.com/angryip/ipscan/blob/master/LICENSE"
     },
     "notes": [
-        "To install a plugin, place the .jar file in \"$HOME\\.ipscan\" and restart the application.",
+        "To install a plugin, place the .jar file in \"$env:USERPROFILE\\.ipscan\" and restart the application.",
         "For more information, see: https://angryip.org/contribute/plugins",
         "For common issues and troubleshooting, visit: https://angryip.org/faq"
     ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/angryip/ipscan/releases/download/3.9.2/ipscan-3.9.2-setup.exe#/dl.7z",
-            "hash": "324c97b0e1c84382c3d059aaea39eb4dbc9cdeb9ee631a7d31c1129f983b867a",
-            "pre_install": "Remove-Item -Path \"$dir\\`$*\", \"$dir\\uninstall*\" -Force -Recurse -ErrorAction SilentlyContinue"
+            "hash": "324c97b0e1c84382c3d059aaea39eb4dbc9cdeb9ee631a7d31c1129f983b867a"
         }
     },
+    "pre_install": "Remove-Item -Path \"$dir\\`$*\", \"$dir\\uninstall*\" -Force -Recurse -ErrorAction Ignore",
     "bin": "ipscan.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
### Description

This PR updates the **ipscan** manifest to align with upstream changes and improve user experience.

### Changes

- **Removed** 32-bit architecture support  
  - Upstream discontinued 32-bit builds after version [`3.8.2`](https://github.com/angryip/ipscan/releases/tag/3.8.2).
- **Switched** the download source to the Windows installer (`ipscan-<version>-setup.exe`)  
- **Updated metadata**  
  - Revised description and homepage so that users can correctly find **Angry IP Scanner** on [scoop.sh](https://scoop.sh/#/apps).  
  - Added a proper `license` object with URL.  
  - Simplified `pre_install` cleanup logic.  
  - Replaced outdated `notes` with guidance on plugin installation and links to the official FAQ.

### Reasoning

The Windows installer is now the **officially recommended** distribution method by the upstream project, as it includes a bundled JRE and ensures the most reliable execution environment.  

Additionally, improving the manifest’s metadata allows users to locate **Angry IP Scanner** more easily on the Scoop website, reducing redundant package request issues.  

This update removes obsolete architecture handling and simplifies future maintenance.


### Testing

```
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ angry-ip-scanner ≢]
└─>  scoop install .\ipscan.json
Installing 'ipscan' (3.9.2) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\ipscan.json'
Loading ipscan-3.9.2-setup.exe from cache.
Checking hash of ipscan-3.9.2-setup.exe ... ok.
Extracting ipscan-3.9.2-setup.exe ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\ipscan\current => D:\Software\Scoop\Local\apps\ipscan\3.9.2
Creating shim for 'ipscan'.
Making D:\Software\Scoop\Local\shims\ipscan.exe a GUI binary.
Creating shortcut for Angry IP Scanner (ipscan.exe)
'ipscan' (3.9.2) was installed successfully!
Notes
-----
To install a plugin, place the .jar file in "$HOME\.ipscan" and restart the application.
For more information, see: https://angryip.org/contribute/plugins
For common issues and troubleshooting, visit: https://angryip.org/faq

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ angry-ip-scanner ≢]
└─> Get-ChildItem -Path "D:\Software\Scoop\Local\apps\ipscan\current" 

        Directory: D:\Software\Scoop\Local\apps\ipscan\current


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d----        2025/10/16     19:06                  jre
-a---         2025/8/19      5:09         114517   icon.ico
-a---        2025/10/16     19:06            161   install.json
-a---         2025/8/19      5:09        2917973 󰣆  ipscan.exe
-a---         2025/8/19      5:09          18344 󰈙  license.txt
-a---        2025/10/16     19:06           1410   manifest.json

```

- Closes #16348 
- Relates to https://github.com/ScoopInstaller/Extras/commit/6ad59e5eae7f7072ec41787dedd0cab20a1c1972
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product name and homepage to HTTPS; installation notes revised and plugin installation guidance added; license now includes a reference link.
* **Changes**
  * 64-bit distribution removed; 32-bit distribution retained.
  * Installer now removes prior installation files during setup.
  * Runtime recommendation removed and replaced by plugin guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->