### PR TITLE
pdfgear: Add version 2.1.12

### DIFF
--- a/bucket/pdfgear.json
+++ b/bucket/pdfgear.json
@@ -2,7 +2,10 @@
     "version": "2.1.12",
     "description": "Read, edit, convert, merge, and sign PDFs across devices for free, no registration required.",
     "homepage": "https://www.pdfgear.com",
-    "license": "Freeware",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.pdfgear.com/end-user-license-agreement/"
+    },
     "architecture": {
         "64bit": {
             "url": "https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.12.exe",
@@ -18,7 +21,7 @@
     ],
     "checkver": {
         "url": "https://www.pdfgear.com/pdfgear-for-windows",
-        "regex": "pdfgear_setup_v([\\d.]+).exe"
+        "regex": "pdfgear_setup_v([\\d.]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Added a manifest for [pdfgear](https://www.pdfgear.com) version 2.1.12.

Some tests are shown below:

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App pdfgear -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f          
pdfgear: 2.1.12 (scoop version is 2.1.12)
Forcing autoupdate!
Autoupdating pdfgear
DEBUG[1760620741] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1760620741] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760620741] $substitutions.$cleanVersion                  2112
DEBUG[1760620741] $substitutions.$dotVersion                    2.1.12
DEBUG[1760620741] $substitutions.$minorVersion                  1
DEBUG[1760620741] $substitutions.$basenameNoExt                 pdfgear_setup_v2.1.12
DEBUG[1760620741] $substitutions.$underscoreVersion             2_1_12
DEBUG[1760620741] $substitutions.$basename                      pdfgear_setup_v2.1.12.exe
DEBUG[1760620741] $substitutions.$urlNoExt                      https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.12
DEBUG[1760620741] $substitutions.$matchHead                     2.1.12
DEBUG[1760620741] $substitutions.$patchVersion                  12
DEBUG[1760620741] $substitutions.$baseurl                       https://downloadfiles.pdfgear.com/releases/windows
DEBUG[1760620741] $substitutions.$dashVersion                   2-1-12
DEBUG[1760620741] $substitutions.$preReleaseVersion             2.1.12
DEBUG[1760620741] $substitutions.$match1                        2.1.12
DEBUG[1760620741] $substitutions.$matchTail
DEBUG[1760620741] $substitutions.$buildVersion
DEBUG[1760620741] $substitutions.$majorVersion                  2
DEBUG[1760620741] $substitutions.$version                       2.1.12
DEBUG[1760620741] $substitutions.$url                           https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.12.exe
DEBUG[1760620741] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading pdfgear_setup_v2.1.12.exe to compute hashes!
Loading pdfgear_setup_v2.1.12.exe from cache
Computed hash: c8a19a4a06fb8d28812916ff1735cd4dc0f82bf16fbc5100bbeb71a44f32ccf9
Writing updated pdfgear manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ pdfgear ≢]
└─> scoop install .\pdfgear.json
Installing 'pdfgear' (2.1.12) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\pdfgear.json'
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: fdf86e|OK  |   8.8MiB/s|100|D:/Software/Scoop/Local/cache/pdfgear#2.1.12#58d8232.exe
Download: Status Legend:
Download: (OK):download completed.
Checking hash of pdfgear_setup_v2.1.12.exe ... ok.
Extracting pdfgear_setup_v2.1.12.exe ... done.
Linking D:\Software\Scoop\Local\apps\pdfgear\current => D:\Software\Scoop\Local\apps\pdfgear\2.1.12
Creating shortcut for PDFgear (PDFLauncher.exe)
'pdfgear' (2.1.12) was installed successfully!

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ pdfgear ≢]
└─> scoop uninstall pdfgear
Uninstalling 'pdfgear' (2.1.12).
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\PDFgear.lnk
Unlinking D:\Software\Scoop\Local\apps\pdfgear\current
'pdfgear' was uninstalled.
```

- Closes #11834 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDFgear (v2.1.12) is now available for download and installation.
  * 64-bit Windows installer provided with desktop shortcuts for easy access.
  * Automatic update detection and autoupdate support enabled for seamless future upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->