### PR TITLE
smplayer@25.6.0.0: Fix persist

### DIFF
--- a/bucket/smplayer.json
+++ b/bucket/smplayer.json
@@ -22,7 +22,7 @@
         "$cfg_dir = Join-Path -Path $persist_dir -ChildPath 'config\\smplayer.ini'",
         "if (-not (Test-Path -Path $cfg_dir)) {",
         "    info \"File $cfg_dir does not exist. Creating...\"",
-        "    ensure (Split-Path -Path $cfg_dir -Parent) | Out-Null",
+        "    New-Item -Path $cfg_dir -ItemType File -Force | Out-Null",
         "    $cfg = @(",
         "        '[update_checker]', 'enabled=false',",
         "        '[%General]', 'screenshot_folder={screenshots_dir}'",


### PR DESCRIPTION
### Summary

This PR fixes the incorrect `persist` configuration for SMPlayer and improves how the configuration file is initialized.

- Closes #14712 
- Closes #13157

### Changes

- **Improved `license` field**  
  Structured the `license` entry with an explicit identifier and URL.
- **Removed unnecessary persisted files**  
  Only `config` and `screenshots` directories are now persisted for better clarity.
- **Enhanced configuration initialization**
  - Disabled automatic update checking.
  - Added proper handling for the `screenshot_folder` setting using dynamic paths.
  - Ensured compatibility with `no_junction` setups.

### Testing

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ smplayer ≢  ~1]
└─> scoop install .\smplayer.json -u
Installing 'smplayer' (24.5.0.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\smplayer.json'
Loading smplayer-portable-24.5.0.0-x64.7z from cache.
Checking hash of smplayer-portable-24.5.0.0-x64.7z ... ok.
Extracting smplayer-portable-24.5.0.0-x64.7z ... done.
Running pre_install script...INFO  File D:\Software\Scoop\Local\persist\smplayer\config\smplayer.ini does not exist. Creating...
done.
Linking D:\Software\Scoop\Local\apps\smplayer\current => D:\Software\Scoop\Local\apps\smplayer\24.5.0.0
Creating shortcut for SMPlayer (smplayer.exe)
Persisting config
Persisting screenshots
'smplayer' (24.5.0.0) was installed successfully!

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ smplayer ≢  ~1]
└─> Get-Content -Path "$(scoop prefix smplayer)\config\smplayer.ini" | Where-Object { $_ -match 'screenshot_folder=.+' }
screenshot_folder=D:\\Software\\Scoop\\Local\\persist\\smplayer\\screenshots
```

<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated installation setup to initialize and preserve user configuration and screenshot location automatically.
  * Reduced persisted items to only essential user data (configuration and screenshots).
  * Removed explicit uninstall cleanup steps in favor of the streamlined persistence model.
  * Enhanced license metadata to include a structured identifier and URL for clearer attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->