### PR TITLE
fvim: Update to version 0.3.549, fix checkver & autoupdate

### DIFF
--- a/bucket/fvim.json
+++ b/bucket/fvim.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.549+ee4316c",
+    "version": "0.3.549",
     "description": "Neovim front-end UI",
     "homepage": "https://github.com/yatli/fvim",
     "license": "MIT",
@@ -31,13 +31,14 @@
             "    )",
             ")",
             "[string]::Format(",
-            "    '{0}|{1}|{2}',",
+            "    '{0}|{1}|{2}|{3}',",
             "    $LatestRelease.'tag_name'.TrimStart('v'),",
+            "    $LatestRelease.'tag_name'.TrimStart('v').Split('+')[0],",
             "    ($LatestRelease.'assets'.Where{$_.'name'.StartsWith('fvim-win-x64-')}.'browser_download_url'.Split('/')[-2, -1] -join '/'),",
             "    ($LatestRelease.'assets'.Where{$_.'name'.StartsWith('fvim-win-arm64-')}.'browser_download_url'.Split('/')[-2, -1] -join '/')",
             ")"
         ],
-        "regex": "(?<version>.+)\\|(?<urlx64>.+)\\|(?<urlarm64>.+)"
+        "regex": "(?<tagname>.+)\\|(?<version>.+)\\|(?<urlx64>.+)\\|(?<urlarm64>.+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Changes:

* Scripted custom checkver logic because author does a lot non-standard stuff with versioning, tag name of releases, and naming release artifacts.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Version bumped to 0.3.549+ee4316c with updated 64‑bit and arm64 assets and checksums.
* **Updates**
  * Improved update detection and delivery to reliably fetch the latest release and provide the correct 64‑bit and arm64 downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->