### PR TITLE
duplicati@2.1.0.5_stable_2025-03-04: Fix checkver and order of manifest

### DIFF
--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -1,7 +1,7 @@
 {
     "version": "2.1.0.5_stable_2025-03-04",
-    "homepage": "https://www.duplicati.com/",
     "description": "A free, open source, backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers.",
+    "homepage": "https://www.duplicati.com/",
     "license": "MIT",
     "notes": [
         "If you want Dupilicati to run at the startup of your system, run: (requires administrator privileges)",
@@ -51,8 +51,9 @@
         "}"
     ],
     "checkver": {
-        "url": "https://github.com/duplicati/duplicati/tags",
-        "regex": "v(?<half>[\\d.]+)-([\\d.]+_stable_[\\d-]+)"
+        "url": "https://api.github.com/repos/duplicati/duplicati/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v(.*)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version detection configuration to use an alternative API endpoint and extraction method for improved version checking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->