### PR TITLE
debugviewpp: Update to version 1.9.0.28, drop 32bit support, fix checkver & autoupdate

### DIFF
--- a/bucket/debugviewpp.json
+++ b/bucket/debugviewpp.json
@@ -1,53 +1,31 @@
 {
-    "version": "1.8.0.103",
+    "version": "1.9.0.28",
     "description": "Collect, view and filter application logs.",
     "homepage": "https://github.com/CobaltFusion/DebugViewPP",
     "license": "BSL-1.0",
-    "notes": "The 'OutputForwarderVSIX.vsix' is located at '$dir'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/1.8.0.103-x64/DebugView%2B%2B.zip",
-            "hash": "35fe7bf1713e5ffc0d89fb00e58deae414165fe4e8e0326a09a63cb040818c7e"
-        },
-        "32bit": {
-            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.95/DebugView%2B%2B.zip",
-            "hash": "98d2c858271b69f8577c6225905413b0c13139f6edc55d4ac92c7c92e6de22e6"
+            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.9.0.28/debugviewpp-1.9.0.28-win64.zip",
+            "hash": "9581b77db285bfaaa2516e1d5fc2fb865ffb880e1d35dd07204dde88d0ccb8f8",
+            "extract_dir": "debugviewpp-1.9.0.28-win64/bin"
         }
     },
     "bin": [
-        "DebugView++.exe",
-        [
-            "DebugView++.exe",
-            "DebugView"
-        ],
+        "Debugviewpp.exe",
         "DebugViewConsole.exe"
     ],
     "shortcuts": [
         [
-            "DebugView++.exe",
-            "DebugView++"
+            "Debugviewpp.exe",
+            "Debugview++"
         ]
     ],
-    "checkver": {
-        "script": [
-            "try {",
-            "    foreach ($tag in (Invoke-RestMethod https://api.github.com/repositories/14376430/releases).tag_name) {",
-            "        if ($64 -and $32) { break }",
-            "        if ($_ -clike '*-x64') { $64 = $tag } else { $32 = $tag }",
-            "    }",
-            "    $64, $32 -join ' '",
-            "}",
-            "catch { '' }"
-        ],
-        "regex": "\\A(?<prefix64>v?)([\\d.]+)-x64 (?<prefix32>v?)(?<ver32>[\\d.]+)\\Z"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix64$version-x64/DebugView%2B%2B.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchPrefix32$matchVer32/DebugView%2B%2B.zip"
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$version/debugviewpp-$version-win64.zip",
+                "extract_dir": "debugviewpp-$version-win64/bin"
             }
         }
     }


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Version bumped to 1.9.0.28
  * Removed 32-bit support; 64-bit version only
  * Updated executable naming for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->