### PR TITLE
debugtron@0.5.0: Fix checkver to exclude preprelease versions

### DIFF
--- a/bucket/debugtron.json
+++ b/bucket/debugtron.json
@@ -16,12 +16,9 @@
         ]
     ],
     "checkver": {
-        "script": [
-            "(Invoke-RestMethod -Method 'Get' -Uri 'https://api.github.com/repos/pd4d10/debugtron/releases').'tag_name'.Where{",
-            "    $_ -match '(^v[\\d.]+[\\d]$)'",
-            "}[0]"
-        ],
-        "regex": "([\\d.]+)"
+        "url": "https://api.github.com/repos/pd4d10/debugtron/releases",
+        "jsonpath": "$..tag_name",
+        "regex": "v([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Fixed checkver: GitHub releases that are prereleases are not marked as prereleases, thus have to be filtered out.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version detection configuration to enhance autoupdate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->