### PR TITLE
cookiecutter: Update to version 2.6.0, fix autoupdate

### DIFF
--- a/bucket/cookiecutter.json
+++ b/bucket/cookiecutter.json
@@ -1,11 +1,11 @@
 {
-    "version": "2.1.1",
+    "version": "2.6.0",
     "description": "A command-line utility that creates projects from project templates.",
     "homepage": "https://github.com/cookiecutter/cookiecutter",
     "license": "BSD-3-Clause",
     "depends": "python",
-    "url": "https://files.pythonhosted.org/packages/py2.py3/c/cookiecutter/cookiecutter-2.1.1-py2.py3-none-any.whl",
-    "hash": "9f3ab027cec4f70916e28f03470bdb41e637a3ad354b4d65c765d93aad160022",
+    "url": "https://files.pythonhosted.org/packages/py3/c/cookiecutter/cookiecutter-2.6.0-py3-none-any.whl",
+    "hash": "a54a8e37995e4ed963b3e82831072d1ad4b005af736bb17b99c2cbd9d41b6e2d",
     "installer": {
         "script": [
             "Push-Location \"$dir\"",
@@ -24,6 +24,6 @@
     "bin": "cookiecutter\\Scripts\\cookiecutter.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://files.pythonhosted.org/packages/py2.py3/c/cookiecutter/cookiecutter-$version-py2.py3-none-any.whl"
+        "url": "https://files.pythonhosted.org/packages/py3/c/cookiecutter/cookiecutter-$version-py3-none-any.whl"
     }
 }


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
