### PR TITLE
compactgui@3.8.0: Fix checkver & autoupdate, add suggest, add architecture field to support 64-bit only

### DIFF
--- a/bucket/compactgui.json
+++ b/bucket/compactgui.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/ImminentFate/CompactGUI/releases/download/v3.8.0/CompactGUI.exe",
-            "hash": "f21963a68c25b72d59a8431af2e0e98b4a701e87c4f4a47ec4363238d7d384d2",
+            "hash": "f21963a68c25b72d59a8431af2e0e98b4a701e87c4f4a47ec4363238d7d384d2"
         }
     },
     "bin": "CompactGUI.exe",


### PR DESCRIPTION
## Fixed checkver

Non-stable releases are not marked as prerelease in GitHub releases. Thus checkver logic should filter out non-stable releases.

* <https://github.com/IridiumIO/CompactGUI/issues/581>

## Removed autoupdate hash

Newer releases don't have checksum in the release notes anymore, but checksum is listed in GitHub assets digest.

## Add suggest

Requires .NET desktop runtime **9.0** to function properly.

## Add architecture field to support 64-bit only

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release/version detection to use GitHub releases for more reliable updates.
  * Reorganized automatic update metadata to an architecture-aware structure, focusing on 64-bit builds.
  * Cleaned up top-level update fields and preserved existing executables and shortcuts.

* **New Features**
  * Added an installation suggestion for the .NET Desktop Runtime to improve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->