### PR TITLE
clementine: Update to version 1.4.1-58-gbae968a2f, fix checkver

### DIFF
--- a/bucket/clementine.json
+++ b/bucket/clementine.json
@@ -14,8 +14,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/clementine-player/Clementine/releases/latest",
-        "jsonpath": "$.tag_name",
-        "regex": "([\\d.]+-[a-z0-9-]+)"
+        "jsonpath": "$.tag_name"
     },
     "autoupdate": {
         "url": "https://github.com/clementine-player/Clementine/releases/download/$version/ClementineSetup-$version.exe#/dl.7z"


### PR DESCRIPTION
Changes:

* Fixed checkver
* Updated to 1.4.1-58-gbae968a2f

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated version to 1.4.1-58-gbae968a2f with improved version detection mechanism.

* **Chores**
  * Modified update system to use API-based version checking for more reliable release tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->