### PR TITLE
classic-volume-mixer: Update to version 24.09.1, fix autoupdate

### DIFF
--- a/bucket/classic-volume-mixer.json
+++ b/bucket/classic-volume-mixer.json
@@ -1,18 +1,31 @@
 {
-    "version": "2.4",
+    "version": "24.09.1",
     "description": "In Windows 11 the old volume mixer was \"removed\" and instead a new mixer was added to the settings app.",
     "homepage": "https://github.com/popeen/Classic-Volume-Mixer",
     "license": "MIT",
-    "url": "https://github.com/popeen/Classic-Volume-Mixer/releases/download/v2.4/ClassicVolumeMixer.exe",
-    "hash": "a2b2c8bbd8e28556b64a627b5732fc191439229b079737d7e841d13f93f5c7f6",
+    "url": "https://github.com/popeen/Classic-Volume-Mixer/releases/download/24.09.1/setup.exe",
+    "hash": "27c09ecc64aefb7d4a0ff0ecbd6b224a9deab3d5f29dc56e5f66a374fa5e0f46",
+    "innosetup": true,
     "shortcuts": [
         [
             "ClassicVolumeMixer.exe",
             "ClassicVolumeMixer"
         ]
     ],
+    "post_uninstall": [
+        "if ($purge) {",
+        "    $Files = [string[]](",
+        "        ('{0}\\ClassicVolumeMixerSettings.json' -f $env:APPDATA)",
+        "    )",
+        "    $Files.ForEach{",
+        "       if ([System.IO.File]::Exists($_)) {",
+        "           $null = [System.IO.File]::Delete($_)",
+        "       }",
+        "    }",
+        "}"
+    ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/popeen/Classic-Volume-Mixer/releases/download/v$version/ClassicVolumeMixer.exe"
+        "url": "https://github.com/popeen/Classic-Volume-Mixer/releases/download/$version/setup.exe"
     }
 }


### PR DESCRIPTION
Changes:

* Fixed checkver
* Updated to 24.09.1
* Added purge logic

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
