### PR TITLE
autohotkey@2.0.19: Switch checkver to github

### DIFF
--- a/bucket/autohotkey.json
+++ b/bucket/autohotkey.json
@@ -75,8 +75,7 @@
         "script": "Start-Process \"$dir\\UX\\AutoHotkeyUX.exe\" -ArgumentList @('/script', \"`\"$dir\\UX\\install.ahk`\"\", '/uninstall', '/silent') -Wait"
     },
     "checkver": {
-        "url": "https://www.autohotkey.com/download/2.0/version.txt",
-        "regex": "([\\d.]+)"
+        "github": "https://github.com/AutoHotkey/AutoHotkey"
     },
     "autoupdate": {
         "url": "https://github.com/AutoHotkey/AutoHotkey/releases/download/v$version/AutoHotkey_$version.zip",


### PR DESCRIPTION
Changes:

* Fixed checkver, use GitHub releases instead. Previous URL got blocked by Cloudflare.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
