### PR TITLE
betaflight-blackbox-explorer@3.6.0: Remove checkver & autoupdate

### DIFF
--- a/bucket/betaflight-blackbox-explorer.json
+++ b/bucket/betaflight-blackbox-explorer.json
@@ -1,4 +1,5 @@
 {
+    "##": "Online only since 2024-05-04: <https://github.com/betaflight/blackbox-log-viewer/releases/tag/3.7.0>",
     "version": "3.6.0",
     "description": "Interactive log viewer for flight logs recorded with blackbox",
     "homepage": "https://betaflight.com",
@@ -17,15 +18,5 @@
             "betaflight-blackbox-explorer.exe",
             "Betaflight Blackbox Explorer"
         ]
-    ],
-    "checkver": {
-        "github": "https://github.com/betaflight/blackbox-log-viewer"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/betaflight/blackbox-log-viewer/releases/download/$version/betaflight-blackbox-explorer_$version_win64-installer.exe"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
Changes:

* No new desktop versions going forward ( <https://github.com/betaflight/blackbox-log-viewer/releases/tag/3.7.0> ), thus removed checkver and autoupdate.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
