### PR TITLE
cider@1.6.3: Deprecate manifest

### DIFF
--- a/deprecated/cider.json
+++ b/deprecated/cider.json
@@ -1,5 +1,8 @@
 {
-    "##": "Deprecated since 2024-12-10 in favor of a paid version, v1.6.3 was last free version",
+    "##": [
+        "Deprecated since 2024-12-10 in favor of a paid version, v1.6.3 was last free version.",
+        "Cider-Setup-1.6.3.exe was taken down, both from GitHub releases and the SourceForge mirror."
+    ],
     "version": "1.6.3",
     "description": "Cross-platform Apple Music client",
     "license": "AGPL-3.0-or-later",
@@ -21,5 +24,19 @@
             "Cider.exe",
             "Cider"
         ]
-    ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ciderapp/Cider"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ciderapp/Cider/releases/download/v$version/Cider-Setup-$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512:\\s+$base64"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Deprecated 2024-12-10 in favor of a paid version. v1.6.3 was the last free version.

Old v1:

* <https://github.com/ciderapp/Cider>

New v2:

* <https://cider.sh>
* <https://github.com/ciderapp/Cider-2>

Changes:

* Deprecated, author removed installer from GitHub releases and SourceForge mirror ( <https://sourceforge.net/projects/cider-app.mirror/> ).
* Can't find installer on Web Archive either, or any other place.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation status field to package metadata.
  * Removed automatic version checking functionality.
  * Removed automatic update functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->