### PR TITLE
dreamset@2.4.13: Moved downloads to Wayback Machine

### DIFF
--- a/bucket/dreamset.json
+++ b/bucket/dreamset.json
@@ -19,19 +19,5 @@
             "dreamset.exe",
             "Dreamset"
         ]
-    ],
-    "checkver": {
-        "url": "https://www.dreamset-editor.com/dreamset-history",
-        "regex": "-\\s+ver\\s+([\\d.]+)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://www.dreamset-editor.com/files/dreamset$cleanVersionx64.zip"
-            },
-            "32bit": {
-                "url": "https://www.dreamset-editor.com/files/dreamset$cleanVersion.zip"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
Changes:

* Remove checkver and autoupdate
* Use Wyback Machine / Inernet Archive for downloads

Because:

* Downloads and checkver is blocked by Cloudflare.
* No new version in years.
* Could not easily find contact info on homepage about whitelisting Scoop from Cloudflare.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated download sources to use Internet Archive archives for improved availability and reliability.
  * Removed automatic update and version checking features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->