### PR TITLE
eclipse-parallel@2023-09: Remove checkver

### DIFF
--- a/bucket/eclipse-parallel.json
+++ b/bucket/eclipse-parallel.json
@@ -1,5 +1,4 @@
 {
-    "##": "Deprecated, cannot find newer versions",
     "version": "2023-09",
     "description": "Eclipse for Parallel Application Developers",
     "homepage": "https://www.eclipse.org",
@@ -16,5 +15,15 @@
             "eclipse.exe",
             "Eclipse for Parallel Application Developers"
         ]
-    ]
+    ],
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/R/eclipse-parallel-$version-R-win32-x86_64.zip",
+                "hash": {
+                    "url": "$url.sha512"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Changes:

* Removed checkver and autoupdate

Because:

* Checkver failed.
* Cannot find newer versions manually either.

This may relate to:
- https://github.com/eclipse-packaging/packages/issues/85
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3986

<!-- -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified version checking mechanism by removing explicit remote version source configuration, relying instead on the version token within the URL for autoupdate functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->