### PR TITLE
engauge-digitizer@12.1: Removed checkver, autoupdate and 32bit, found 64bit on Internet Archive

### DIFF
--- a/bucket/engauge-digitizer.json
+++ b/bucket/engauge-digitizer.json
@@ -1,16 +1,17 @@
 {
+    "##": [
+        "Deprecated, both homepage and GitHub repo have been removed.",
+        "Project been forked and maintained, but no Windows binaries are provided: <https://github.com/akhuettel/engauge-digitizer>.",
+        "Found the x64 Windows release on Wayback Machine / Internet Archive, but not the x86 one."
+    ],
     "version": "12.1",
     "description": "Extracts data points from images of graphs.",
     "homepage": "https://markummitchell.github.io/engauge-digitizer/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/markummitchell/engauge-digitizer/releases/download/v12.1/digit-exe-windows10-64-bit-without-installer-file-12.1.zip",
+            "url": "https://web.archive.org/web/20231013022903if_/https://objects.githubusercontent.com/github-production-release-asset-2e65be/26443394/e6b48100-12f8-11ea-9bca-a0a325940698?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231013%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231013T022903Z&X-Amz-Expires=300&X-Amz-Signature=fe28443e7659753b3b1a44306de1187c617a9417d23910d2d6ae0bcc7fa11c06&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=26443394&response-content-disposition=attachment%3B%20filename%3Ddigit-exe-windows10-64-bit-without-installer-file-12.1.zip&response-content-type=application%2Foctet-stream#/digit-exe-windows10-64-bit-without-installer-file-12.1.zip",
             "hash": "4265618c3979a239032be4c2e60555677e5039ef0fb80e03397c1bc8963a8218"
-        },
-        "32bit": {
-            "url": "https://github.com/markummitchell/engauge-digitizer/releases/download/v12.1/digit-exe-windows10-32-bit-without-installer-file-12.1.zip",
-            "hash": "309015c943dded56744695f829bb8422bd0c02e4b32d9143129b96e870710b8f"
         }
     },
     "extract_dir": "Engauge Digitizer",
@@ -19,18 +20,5 @@
             "engauge.exe",
             "Engauge Digitizer"
         ]
-    ],
-    "checkver": {
-        "github": "https://github.com/markummitchell/engauge-digitizer"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/markummitchell/engauge-digitizer/releases/download/v$version/digit-exe-windows10-64-bit-without-installer-file-$version.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/markummitchell/engauge-digitizer/releases/download/v$version/digit-exe-windows10-32-bit-without-installer-file-$version.zip"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
Changes:

* Removed checkver and autoupdate
* Removed 32bit
* Changed 64bit download URL to Wayback Machine

Because:

* Both homepage and GitHub repo is gone, removed, nuked
* Did not manage to find the 32bit download

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
