### PR TITLE
fbflipper@0.239.0: Remove checkver

### DIFF
--- a/bucket/fbflipper.json
+++ b/bucket/fbflipper.json
@@ -1,5 +1,5 @@
 {
-    "##": "Deprecated since 2025-09-26, no Windows artifact added to new releases since v0.239.0 released 2023-11-30",
+    "##": "Archived since 2025-09-26, no Windows artifact added to new releases since v0.239.0 released 2023-11-30",
     "version": "0.239.0",
     "description": "A desktop debugging platform for mobile developers",
     "homepage": "https://fbflipper.com",
@@ -20,5 +20,12 @@
             "Flipper.exe",
             "Facebook Flipper"
         ]
-    ]
+    ],
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/facebook/flipper/releases/download/v$version/Flipper-win.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Changes:

* Removed checkver and autoupdate

Because:

* Deprecated since 2025-09-26 ( <https://github.com/facebook/flipper> )
* No Windows artifact added to new releases since v0.239.0 released 2023-11-30

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a top-level deprecation notice for the Windows artifact.

* **Chores**
  * Removed the automatic version-checking/update metadata that pointed to the previous repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->