### PR TITLE
biblioteq@2025.05.17: Checkver exclude versions with no build artifacts

### DIFF
--- a/bucket/biblioteq.json
+++ b/bucket/biblioteq.json
@@ -1,4 +1,5 @@
 {
+    "##": "Not all releases include build artifacts, hence the checkver.jsonpath. See: https://github.com/textbrowser/biblioteq/issues/300.",
     "version": "2025.05.17",
     "description": "Professional archiving, cataloging, and library management suite providing connectivity to PostgreSQL and SQLite.",
     "homepage": "https://textbrowser.github.io/biblioteq/",


### PR DESCRIPTION
Very few new versions of biblioteq actually have build artifacts added. Seems it's a manually process to build and attach those:

* <https://github.com/textbrowser/biblioteq/issues/300>

Thus, the manifest should only look for new versions with at least one build artifact added to it, to avoid errors on each run of Excavator.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified version-checking behavior and noted that some releases may lack build artifacts.

* **Chores**
  * Switched version checks to use the GitHub Releases API and refined release-tag detection for more accurate update info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->