### PR TITLE
helium@0.5.7.1: Replaced dir variable with persist_dir

### DIFF
--- a/bucket/helium.json
+++ b/bucket/helium.json
@@ -1,7 +1,7 @@
 {
     "version": "0.5.7.1",
     "description": "Private, fast, and honest web browser based on Chromium",
-    "homepage": "https://helium.computer/",
+    "homepage": "https://helium.computer",
     "license": "BSD-3-Clause, GPL-3.0",
     "architecture": {
         "64bit": {
@@ -19,14 +19,14 @@
         [
             "chrome.exe",
             "helium",
-            "--user-data-dir=\"$dir\\User Data\""
+            "--user-data-dir=\"$persist_dir\\User Data\""
         ]
     ],
     "shortcuts": [
         [
             "chrome.exe",
             "Helium",
-            "--user-data-dir=\"$dir\\User Data\""
+            "--user-data-dir=\"$persist_dir\\User Data\""
         ]
     ],
     "persist": "User Data",


### PR DESCRIPTION
### Summary
This pull request replaces all instances of the `$dir` variable with `$persist_dir` to ensure consistency across the codebase. As outlined in the [Scoop wiki on persistent data](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data), `$persist_dir` is the recommended variable for handling persistent files and configurations.

### Motivation
- Aligns implementation with official Scoop best practices.  
- Enhances consistency and readability across manifests and scripts.  
- Improves maintainability by following standardized conventions for persistence management.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration for improved user data persistence
  * Adjusted homepage URL formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->