### PR TITLE
dbeaver@25.2.3: Replace dbeaver-cli.exe with dbeaverc.exe

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -19,7 +19,7 @@
     "extract_dir": "dbeaver",
     "bin": [
         "dbeaver.exe",
-        "dbeaver-cli.exe"
+        "dbeaverc.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
> ### [Windows](https://dbeaver.com/docs/dbeaver/Command-Line/#windows)
> You can use the `dbeaverc.exe [parameters]` executable. This version doesn't spawn a new window, so you can see output messages in the same terminal.

Replace dbeaver-cli.exe with dbeaverc.exe to fix update/install failed after 25.2.3

- Closes #16401 

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DBeaver executable reference in configuration file from "dbeaver-cli.exe" to "dbeaverc.exe".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->