### PR TITLE
folding-at-home: Update to version 8.4.9, fix checkver & autoupdate

### DIFF
--- a/bucket/folding-at-home.json
+++ b/bucket/folding-at-home.json
@@ -1,33 +1,29 @@
 {
-    "version": "7.6.21",
+    "version": "8.4.9",
     "description": "Distributed computing project focused on disease research",
     "homepage": "https://foldingathome.org",
     "license": {
         "identifier": "Freeware,GPL-3.0-only",
         "url": "https://foldingathome.org/support/faq/opensource"
     },
-    "url": "https://download.foldingathome.org/releases/public/release/fah-installer/windows-10-32bit/v7.6/fah-installer_7.6.21_x86.exe#/dl.7z",
-    "hash": "5fa372861d3219f71e836d37a78174e27ad4f54ce75c13aad548b5d6a92154b0",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.foldingathome.org/releases/public/fah-client/windows-10-64bit/release/fah-client_8.4.9_AMD64.exe#/dl.7z",
+            "hash": "9664979343247bddf709538e0af5dea7363d835474ff202aa96c5a40b9718a99"
+        }
+    },
     "pre_install": [
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse | Out-Null",
-        "'log.txt', 'GPUs.txt' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\") ) { New-Item \"$dir\\$_\" | Out-Null }",
+        "$null = Remove-Item -Path \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse",
+        "'log.txt', 'GPUs.txt' | ForEach-Object -Process {",
+        "    if (-not (Test-Path -Path \"$persist_dir\\$_\") ) { $null = New-Item -Path \"$dir\\$_\" }",
         "}",
-        "if (!(Test-Path \"$persist_dir\\config.xml\") ) { Set-Content \"$dir\\config.xml\" '<config></config>' -Encoding Ascii }"
+        "if (-not (Test-Path \"$persist_dir\\config.xml\") ) { Set-Content -Path \"$dir\\config.xml\" -Value '<config></config>' -Encoding Ascii }"
     ],
     "bin": "FAHClient.exe",
     "shortcuts": [
         [
             "FAHClient.exe",
             "Folding@home"
-        ],
-        [
-            "FAHControl.exe",
-            "FAHControl"
-        ],
-        [
-            "FAHViewer.exe",
-            "FAHViewer"
         ]
     ],
     "persist": [
@@ -40,36 +36,15 @@
         "config.xml"
     ],
     "checkver": {
-        "script": [
-            "$url1 = 'https://download.foldingathome.org/releases/public/release/fah-installer/windows-10-32bit'",
-            "$links = $(Invoke-WebRequest($url1)).Links",
-            "$major_version = 0",
-            "$minor_version = 0",
-            "$links | ForEach-Object {",
-            "    # not using [\\d.] here because '.' and '..' will be matched",
-            "    if(!($_.outerHTML -match '(\\d+)\\.(\\d+)')) { return }",
-            "    # Convert to int because '9' is greater than '10' in Powershell's string comparison",
-            "    $m1 = [int]$matches[1]",
-            "    $m2 = [int]$matches[2]",
-            "    if ( ($m1 -gt $major_version) -or ($m1 -eq $major_version -and $m2 -gt $minor_version) ) {",
-            "        $major_version = $m1",
-            "        $minor_version = $m2",
-            "    }",
-            "}",
-            "",
-            "$url2 = \"$url1/v$major_version.$minor_version\"",
-            "$links = $(Invoke-WebRequest($url2)).Links",
-            "$patch_version = 0",
-            "$links | ForEach-Object {",
-            "    if(!($_.outerHTML -match 'fah-installer_(\\d+)\\.(\\d+)\\.(\\d+)_x86\\.exe')) { return }",
-            "    $m3 = [int]$matches[3]",
-            "    if ($m3 -gt $patch_version) { $patch_version = $m3 }",
-            "}",
-            "Write-Output \"$major_version.$minor_version.$patch_version\""
-        ],
-        "regex": "(.*)"
+        "url": "https://download.foldingathome.org/releases/public/fah-client/windows-10-64bit/release/",
+        "regex": "_([\\d.]+)_",
+        "reverse": true
     },
     "autoupdate": {
-        "url": "https://download.foldingathome.org/releases/public/release/fah-installer/windows-10-32bit/v$majorVersion.$minorVersion/fah-installer_$version_x86.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://download.foldingathome.org/releases/public/fah-client/windows-10-64bit/release/fah-client_$version_AMD64.exe#/dl.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
Changes:

* Update to v8.4.9
* Change to x64, as download specifically says amd64
* Fix checkver
* PowerShell cleanup
  * Specify parameter names
  * Use `$null =` instead of `| Out-Null`
  * Use `-not` instead of `!`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native 64-bit architecture support.

* **Changes**
  * Updated to version 8.4.9.
  * Streamlined installation shortcuts—FAHClient.exe shortcut is now the primary entry point, with FAHControl and FAHViewer shortcuts removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->