### PR TITLE
jetbrains-hub@2025.1.82518: Remove checkver

### DIFF
--- a/bucket/jetbrains-hub.json
+++ b/bucket/jetbrains-hub.json
@@ -28,5 +28,12 @@
         "conf",
         "data",
         "logs"
-    ]
+    ],
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/hub/hub-$version.zip",
+        "hash": {
+            "url": "$url.sha256"
+        },
+        "extract_dir": "hub-$version"
+    }
 }


### PR DESCRIPTION
Changes:

* Removed checkver and autoupdate

Because:

* ZIP releases are no longer created for new versions, now only Docker is supported.
  * <https://www.jetbrains.com/help/hub/hub-zip.html>
  * <https://www.jetbrains.com/hub/download/previous.html>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated JetBrains Hub distribution: ZIP releases are no longer produced and automatic update checks via that mechanism have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->