### PR TITLE
tageditor: Update to version 3.9.7, drop 32bit support, add arm64 support

### DIFF
--- a/bucket/tageditor.json
+++ b/bucket/tageditor.json
@@ -1,20 +1,19 @@
 {
-    "version": "3.9.0",
+    "version": "3.9.7",
     "description": "A tag editor utility supporting MP4/M4A/AAC (iTunes), ID3, Vorbis, Opus, FLAC and Matroska.",
     "homepage": "https://github.com/Martchus/tageditor",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Martchus/tageditor/releases/download/v3.9.0/tageditor-3.9.0-x86_64-w64-mingw32.exe.zip",
-            "hash": "1c5f27c8dc6b6bb733f2b8b02d805862c6ac7be6143ada4b97111f98714a44b2"
+            "url": "https://github.com/Martchus/tageditor/releases/download/v3.9.7/tageditor-3.9.7-x86_64-w64-mingw32.exe.zip",
+            "hash": "2446c725a2b037e3cdf39b57c63f1f2fe77f73dd340ecf27ffbe9a3d95c90bde"
         },
-        "32bit": {
-            "url": "https://github.com/Martchus/tageditor/releases/download/v3.9.0/tageditor-3.9.0-i686-w64-mingw32.exe.zip",
-            "hash": "f581972f457cefabbaa0bc90610d6332a64cb40d912ad3c23417fe9242b799f6"
+        "arm64": {
+            "url": "https://github.com/Martchus/tageditor/releases/download/v3.9.7/tageditor-3.9.7-aarch64-w64-mingw32.exe.zip",
+            "hash": "bb60b0bdacf004803f03aad4ebfff5bcacc5ba4cca5c8c4a9501c00bd7cdedc3"
         }
     },
-    "pre_install": "Rename-Item \"$dir\\$($fname -replace '\\.zip')\" 'tageditor.exe'",
-    "bin": "tageditor.exe",
+    "bin": "tageditor-cli.exe",
     "shortcuts": [
         [
             "tageditor.exe",
@@ -27,8 +26,8 @@
             "64bit": {
                 "url": "https://github.com/Martchus/tageditor/releases/download/v$version/tageditor-$version-x86_64-w64-mingw32.exe.zip"
             },
-            "32bit": {
-                "url": "https://github.com/Martchus/tageditor/releases/download/v$version/tageditor-$version-i686-w64-mingw32.exe.zip"
+            "arm64": {
+                "url": "https://github.com/Martchus/tageditor/releases/download/v$version/tageditor-$version-aarch64-w64-mingw32.exe.zip"
             }
         }
     }


### PR DESCRIPTION
Changes:

* Updated to 3.9.7
* Sorted architectures alphabetically
* Fixed `checkver`.
* Fixed `bin`: CLI tool is now named "tageditor-cli".
* Removed `pre-install`: No longer needed.
* Removed 32bit, added ARM64

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ARM64 architecture.

* **Chores**
  * Updated version to 3.9.7.
  * Dropped support for 32-bit systems.
  * Updated installation resources and binary executable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->