### PR TITLE
mc: Update to version 4.8.33.236, fix checkver & autoupdate

### DIFF
--- a/bucket/mc.json
+++ b/bucket/mc.json
@@ -1,10 +1,18 @@
 {
-    "version": "4.8.33",
+    "version": "4.8.33.236",
     "description": "Native GNU Midnight Commander for Win32",
     "homepage": "https://midnight-commander.org/",
     "license": "GPL-3.0-or-later",
-    "url": "https://downloads.sourceforge.net/project/mcwin32/mcwin32-build231-setup.exe",
-    "hash": "sha1:6f956f82f76d8dbd971d818cedef12c65d91d0c5",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/adamyg/mcwin32/releases/download/4.8.33.236/mcwin32-build236-setup.exe",
+            "hash": "023fa2f8f4cad2d9d793d0abca208f2957b03db8b0651a1af355b4b4ecb936e4"
+        },
+        "64bit": {
+            "url": "https://github.com/adamyg/mcwin32/releases/download/4.8.33.236/mcwin32-build236-x64-setup.exe",
+            "hash": "c7edf10402542d334df7e6ff802e2213d384eafa949a6fa88d3813bd87a8ee04"
+        }
+    },
     "innosetup": true,
     "bin": "mc.exe",
     "shortcuts": [
@@ -14,10 +22,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://sourceforge.net/projects/mcwin32/files/",
-        "regex": "Latest Build\\s+([\\d.]+)\\s+(?<build>[\\d]+)"
+        "github": "https://github.com/adamyg/mcwin32"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/mcwin32/mcwin32-build$matchBuild-setup.exe"
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/adamyg/mcwin32/releases/download/$version/mcwin32-build$buildVersion-setup.exe"
+            },
+            "64bit": {
+                "url": "https://github.com/adamyg/mcwin32/releases/download/$version/mcwin32-build$buildVersion-x64-setup.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed checkver using GitHub instead of SourceForge.

Changes:

* Changed checkver and downloads to use GitHub.
* Added 32bit and 64bit versions.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated to version 4.8.33.236
* Added dedicated 32-bit and 64-bit download packages
* Improved update detection and delivery mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->