### PR TITLE
madvr@0.92.17: Fix checkver, update homepage, improve scripts

### DIFF
--- a/bucket/madvr.json
+++ b/bucket/madvr.json
@@ -1,26 +1,29 @@
 {
     "version": "0.92.17",
     "description": "High quality DirectShow video renderer",
-    "homepage": "http://madvr.com",
+    "homepage": "https://madshi.net",
     "license": "Freeware",
-    "depends": "gsudo",
     "url": "https://www.videohelp.com/download/madVR09217.zip",
     "hash": "87e088f7b5de20d0a9065c73015d7fb7c225870380dd3169c70171b77e74bb97",
     "pre_install": [
-        "if (-not (Test-Path \"$persist_dir\\settings.bin\")) { New-Item \"$dir\\settings.bin\" | Out-Null }",
-        "(Get-Content \"$dir\\install.bat\") -replace '@pause >nul' | Out-File \"$dir\\install.bat\" -Encoding Ascii -Force",
-        "(Get-Content \"$dir\\uninstall.bat\") -replace '@pause >nul' | Out-File \"$dir\\uninstall.bat\" -Encoding Ascii -Force"
+        "if (-not (Test-Path \"$persist_dir\\settings.bin\")) {",
+        "    New-Item -Path \"$dir\\settings.bin\" -ItemType File -Force | Out-Null",
+        "}",
+        "'install', 'uninstall' | ForEach-Object {",
+        "    $content = Get-Content -Path \"$dir\\$_.bat\" -Encoding Ascii",
+        "    $content -replace '@pause >nul' | Set-Content -Path \"$dir\\$_.bat\" -Encoding Ascii -Force",
+        "}"
     ],
     "installer": {
         "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-            "sudo \"$dir\\install.bat\""
+            "if (-not (is_admin)) { abort \"$app requires admin rights to $cmd\" }",
+            "Start-Process -FilePath \"$dir\\install.bat\" -NoNewWindow -Wait"
         ]
     },
     "uninstaller": {
         "script": [
-            "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-            "sudo \"$dir\\uninstall.bat\""
+            "if (-not (is_admin)) { abort \"$app requires admin rights to $cmd\" }",
+            "Start-Process -FilePath \"$dir\\uninstall.bat\" -NoNewWindow -Wait"
         ]
     },
     "shortcuts": [
@@ -38,7 +41,10 @@
         ]
     ],
     "persist": "settings.bin",
-    "checkver": "latest release v([\\d.]+):",
+    "checkver": {
+        "url": "https://forum.doom9.org/showthread.php?t=146228",
+        "regex": ">madVR v([\\d.]+)"
+    },
     "autoupdate": {
         "url": "https://www.videohelp.com/download/madVR$cleanVersion.zip"
     }


### PR DESCRIPTION
### Summary

This PR improves the madVR manifest for better maintainability and compatibility.

### Related Issue

- Relates to #16379

### Changes
- Updated homepage to `https://madshi.net`.
- Removed unnecessary dependency on `gsudo`.
- Improved `pre_install` script structure for readability and safety.
- Replaced `sudo` calls with `Invoke-Expression` to ensure better compatibility.
- Enhanced `checkver` to fetch version info directly from the official Doom9 forum thread.

### Testing

```powershell
# The manifest can be automatically updated as normal
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App madvr -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f        
madvr: 0.92.17 (scoop version is 0.92.17)
Forcing autoupdate!
Autoupdating madvr
DEBUG[1760971339] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1760971340] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760971340] $substitutions.$cleanVersion                  09217
DEBUG[1760971340] $substitutions.$matchHead                     0.92.17
DEBUG[1760971340] $substitutions.$preReleaseVersion             0.92.17
DEBUG[1760971340] $substitutions.$patchVersion                  17
DEBUG[1760971340] $substitutions.$minorVersion                  92
DEBUG[1760971340] $substitutions.$match1                        0.92.17
DEBUG[1760971340] $substitutions.$dotVersion                    0.92.17
DEBUG[1760971340] $substitutions.$dashVersion                   0-92-17
DEBUG[1760971340] $substitutions.$baseurl                       https://www.videohelp.com/download
DEBUG[1760971340] $substitutions.$urlNoExt                      https://www.videohelp.com/download/madVR09217
DEBUG[1760971340] $substitutions.$underscoreVersion             0_92_17
DEBUG[1760971340] $substitutions.$buildVersion
DEBUG[1760971340] $substitutions.$basename                      madVR09217.zip
DEBUG[1760971340] $substitutions.$matchTail
DEBUG[1760971340] $substitutions.$basenameNoExt                 madVR09217
DEBUG[1760971340] $substitutions.$version                       0.92.17
DEBUG[1760971340] $substitutions.$url                           https://www.videohelp.com/download/madVR09217.zip
DEBUG[1760971340] $substitutions.$majorVersion                  0
DEBUG[1760971340] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading madVR09217.zip to compute hashes!
Loading madVR09217.zip from cache
Computed hash: 87e088f7b5de20d0a9065c73015d7fb7c225870380dd3169c70171b77e74bb97
Writing updated madvr manifest

# Install madVR without administrator privileges
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ madvr ≢]
└─>  scoop install .\madvr.json
Installing 'madvr' (0.92.17) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\madvr.json'
Loading madVR09217.zip from cache.
Checking hash of madVR09217.zip ... ok.
Extracting madVR09217.zip ... done.
Running pre_install script...done.
Running installer script...ERROR madvr requires admin rights to install

# Install madVR with administrator privileges
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ madvr ≢]
└─> scoop install .\madvr.json
Installing 'madvr' (0.92.17) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\madvr.json'
Loading madVR09217.zip from cache.
Checking hash of madVR09217.zip ... ok.
Extracting madVR09217.zip ... done.
Running pre_install script...done.
Running installer script...

   Installation succeeded.

   Please do not delete the madVR folder.
   The installer has not copied the files anywhere.

done.
Linking D:\Software\Scoop\Local\apps\madvr\current => D:\Software\Scoop\Local\apps\madvr\0.92.17
Creating shortcut for madTPG (madTPG.exe)
Creating shortcut for NVidia & Intel RGB Levels Tweaker (madLevelsTweaker.exe)
Creating shortcut for mad Home Cinema Control (madHcCtrl.exe)
Persisting settings.bin
'madvr' (0.92.17) was installed successfully!

# Update madVR with administrator privileges
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ madvr ≢]
└─> scoop update madvr -f
madvr: 0.92.17 -> 0.92.17
Updating one outdated app:
Updating 'madvr' (0.92.17 -> 0.92.17)
Downloading new version
Loading madVR09217.zip from cache.
Checking hash of madVR09217.zip ... ok.
Uninstalling 'madvr' (0.92.17)
Running uninstaller script...

   Uninstallation succeeded.

done.
Unlinking D:\Software\Scoop\Local\apps\madvr\current
Installing 'madvr' (0.92.17) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\madvr.json'
Loading madVR09217.zip from cache.
Extracting madVR09217.zip ... done.
Running pre_install script...done.
Running installer script...

   Installation succeeded.

   Please do not delete the madVR folder.
   The installer has not copied the files anywhere.

done.
Linking D:\Software\Scoop\Local\apps\madvr\current => D:\Software\Scoop\Local\apps\madvr\0.92.17
Creating shortcut for madTPG (madTPG.exe)
Creating shortcut for NVidia & Intel RGB Levels Tweaker (madLevelsTweaker.exe)
Creating shortcut for mad Home Cinema Control (madHcCtrl.exe)
Persisting settings.bin
'madvr' (0.92.17) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable install/uninstall flow: installer/uninstaller now abort if not run with admin rights, ensures required settings file exists, and normalizes bundled scripts for consistent execution.

* **Chores**
  * Updated homepage URL to current site.
  * Removed an unnecessary dependency.
  * Improved version-checking to use a structured source and pattern for updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->