### PR TITLE
handy: Add version 0.5.4

### DIFF
--- a/bucket/handy.json
+++ b/bucket/handy.json
@@ -1,21 +1,16 @@
 {
     "version": "0.5.4",
-    "description": "A free, open source, and extensible speech-to-text application that works completely offline",
+    "description": "A free, open source, and extensible speech-to-text application that works completely offline.",
     "homepage": "https://handy.computer/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cjpais/Handy/releases/download/v0.5.4/Handy_0.5.4_x64-setup.exe",
+            "url": "https://github.com/cjpais/Handy/releases/download/v0.5.4/Handy_0.5.4_x64-setup.exe#/dl.7z",
             "hash": "f03e056abae530cb290562c0fefb97d0ab9850402493eaa823759ad13fde309f"
         }
     },
     "installer": {
-        "script": [
-            "# Extract NSIS payload using 7z",
-            "7z x \"$dir\\Handy_0.5.4_x64-setup.exe\" -o\"$dir\" -y",
-            "# Remove installer",
-            "Remove-Item \"$dir\\Handy_0.5.4_x64-setup.exe\" -Force"
-        ]
+        "script": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*.exe\" -Force -Recurse"
     },
     "shortcuts": [
         [
@@ -29,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cjpais/Handy/releases/download/v$version/Handy_$version_x64-setup.exe"
+                "url": "https://github.com/cjpais/Handy/releases/download/v$version/Handy_$version_x64-setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
# handy: Add version 0.5.4

Adds a new package `handy` to the `Extras` repository. Handy is a free, open source, and extensible speech-to-text application that works completely offline.

Closes #16414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manifest for the Handy tool (v0.5.4). Includes license and platform/architecture details, download URL and SHA-256 integrity, NSIS installer behavior with payload extraction and cleanup, desktop shortcut mapping, GitHub-based version checking, and an autoupdate URL template for automated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->