### PR TITLE
wox@1.3.524: Fix checkver & autoupdate, update license

### DIFF
--- a/bucket/wox.json
+++ b/bucket/wox.json
@@ -2,13 +2,16 @@
     "version": "1.3.524",
     "description": "A full-featured launcher, access programs and web contents as you type.",
     "homepage": "http://www.wox.one",
-    "license": "MIT",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/Wox-launcher/Wox/blob/master/LICENSE"
+    },
     "suggest": {
-        "Python3": "python",
+        "Python3": "main/python",
         "Everything": "extras/everything"
     },
     "url": "https://github.com/Wox-launcher/Wox/releases/download/v1.3.524/Wox-1.3.524-full.nupkg",
-    "hash": "sha1:bfb73e46c3c054c00c24ab0f03ed441ab1308e07",
+    "hash": "b01a48a69a363d4995b05599bf8c39129313f79b3d4ab64b85b3e8564997faeb",
     "extract_dir": "lib\\net45",
     "bin": "Wox.exe",
     "shortcuts": [
@@ -18,12 +21,11 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/Wox-launcher/Wox"
+        "url": "https://api.github.com/repositories/15315789/releases",
+        "jsonpath": "$[?(@.prerelease == false)].html_url",
+        "regex": "(?i)tag/v([\\d.]+)(?=\")"
     },
     "autoupdate": {
-        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/Wox-$version-full.nupkg",
-        "hash": {
-            "url": "$baseurl/RELEASES"
-        }
+        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/Wox-$version-full.nupkg"
     }
 }


### PR DESCRIPTION
### Summary

Fixes incorrect license metadata and improves update logic for `wox`.

### Changes

- Corrected license from **MIT** to **GPL-3.0-or-later** based on upstream LICENSE file  
- Added `license.url` pointing to the official [LICENSE](https://github.com/Wox-launcher/Wox/blob/master/LICENSE)  
- Reworked `checkver` to fetch releases from GitHub API  
- Simplified `autoupdate` and ensured hash consistency  

### Note

The current manifest in this PR can automatically fetch the version number of stable releases.  

However, starting from the 2.x pre-release series, the upstream project has abandoned `nupkg` support. When a stable 2.x release is published, the manifest will fail to automatically update to that version.  

Simply updating the download and autoupdate URLs will resolve the issue.  

Other aspects of the manifest, such as the installation logic or related workflows, may also require adjustments to ensure compatibility with future releases.

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App wox -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
wox: 1.3.524 (scoop version is 1.3.524)
Forcing autoupdate!
Autoupdating wox
DEBUG[1760980014] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1760980014] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760980014] $substitutions.$minorVersion                  3
DEBUG[1760980014] $substitutions.$baseurl                       https://github.com/Wox-launcher/Wox/releases/download/v1.3.524
DEBUG[1760980014] $substitutions.$basenameNoExt                 Wox-1.3.524-full
DEBUG[1760980014] $substitutions.$version                       1.3.524
DEBUG[1760980014] $substitutions.$underscoreVersion             1_3_524
DEBUG[1760980014] $substitutions.$majorVersion                  1
DEBUG[1760980014] $substitutions.$buildVersion
DEBUG[1760980014] $substitutions.$preReleaseVersion             1.3.524
DEBUG[1760980014] $substitutions.$basename                      Wox-1.3.524-full.nupkg
DEBUG[1760980014] $substitutions.$matchHead                     1.3.524
DEBUG[1760980014] $substitutions.$url                           https://github.com/Wox-launcher/Wox/releases/download/v1.3.524/Wox-1.3.524-full.nupkg
DEBUG[1760980014] $substitutions.$patchVersion                  524
DEBUG[1760980014] $substitutions.$matchTail
DEBUG[1760980014] $substitutions.$dotVersion                    1.3.524
DEBUG[1760980014] $substitutions.$cleanVersion                  13524
DEBUG[1760980014] $substitutions.$urlNoExt                      https://github.com/Wox-launcher/Wox/releases/download/v1.3.524/Wox-1.3.524-full
DEBUG[1760980014] $substitutions.$dashVersion                   1-3-524
DEBUG[1760980014] $substitutions.$match1                        1.3.524
DEBUG[1760980014] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1760980015] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/Wox-launcher/Wox/releases/download/v1.3.524/Wox-1.3.524-full.nupkg')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/Wox-launcher/Wox/releases
Downloading Wox-1.3.524-full.nupkg to compute hashes!
Loading Wox-1.3.524-full.nupkg from cache
Computed hash: b01a48a69a363d4995b05599bf8c39129313f79b3d4ab64b85b3e8564997faeb
Writing updated wox manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ wox ≢  ~1]
└─> scoop install .\wox.json
Installing 'wox' (1.3.524) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\wox.json'
Loading Wox-1.3.524-full.nupkg from cache.
Checking hash of Wox-1.3.524-full.nupkg ... ok.
Extracting Wox-1.3.524-full.nupkg ... done.
Linking D:\Software\Scoop\Local\apps\wox\current => D:\Software\Scoop\Local\apps\wox\1.3.524
Creating shim for 'Wox'.
Making D:\Software\Scoop\Local\shims\wox.exe a GUI binary.
Creating shortcut for Wox (Wox.exe)
'wox' (1.3.524) was installed successfully!
```

Relates to #16379 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license metadata to GPL-3.0-or-later with official documentation
  * Enhanced version checking mechanism with structured configuration and improved pattern matching
  * Streamlined automatic update process with simplified configuration structure
  * Updated package integrity verification and hash validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->