### PR TITLE
mqttx: Update to version 1.12.1, temporarily remove ARM64 support

### DIFF
--- a/bucket/mqttx.json
+++ b/bucket/mqttx.json
@@ -1,26 +1,30 @@
 {
-    "version": "1.11.1",
+    "version": "1.12.1",
     "description": "MQTT 5.0 Desktop Client",
     "homepage": "https://mqttx.app",
-    "license": "Apache-2.0",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://github.com/emqx/MQTTX/blob/main/LICENSE"
+    },
+    "notes": [
+        "ARM64 architecture has been temporarily removed from the manifest due to compatibility issues observed on Windows 11 ARM devices.",
+        "For more details, see the upstream discussion: https://github.com/emqx/MQTTX/issues/1803#issuecomment-2962059492",
+        "Once the upstream provides a stable ARM64 version, support for this architecture will be re-added to the manifest."
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/emqx/MQTTX/releases/download/v1.11.1/MQTTX-Setup-1.11.1-x64.exe#/dl.7z",
-            "hash": "sha512:d2af8839ad6e9ce5c1bb382ecbbd171e08041f369b29413049e768a220f86df88ac3393a02b09e42fb6fa5abbf751e786b2a489c14f5933f6e2f903429ed38b4"
+            "url": "https://github.com/emqx/MQTTX/releases/download/v1.12.1/MQTTX-Setup-1.12.1-x64.exe#/dl.7z",
+            "hash": "sha512:321e57f500fc85309ffb7d45d34fbc9cfd560623cbe8593a4474ca81baf95d4bbe80eb5b3adaecd6eb1d99b98757a9844f6f197e40d2cf875087441a3148919d"
         },
         "32bit": {
-            "url": "https://github.com/emqx/MQTTX/releases/download/v1.11.1/MQTTX-Setup-1.11.1-ia32.exe#/dl.7z",
-            "hash": "sha512:63330193e443ccd47444aeebfda335c129ec5359bdc8d7f57abdd34cdc711ae621b4817aca5a7382ff99afdf098580d597991e3965dccf484a0328bb403d5f1f"
-        },
-        "arm64": {
-            "url": "https://github.com/emqx/MQTTX/releases/download/v1.11.1/MQTTX-Setup-1.11.1-arm64.exe#/dl.7z",
-            "hash": "sha512:a634b5e379440c628fac41d1dfff3e083367d51a98746239c26853494a202a2c09028e4c4ba9f6b3e3bcc33a8c96400aa1f5f272e4cea44bcb911da34b571500"
+            "url": "https://github.com/emqx/MQTTX/releases/download/v1.12.1/MQTTX-Setup-1.12.1-ia32.exe#/dl.7z",
+            "hash": "sha512:f109e1fc77b224ce21cc7dedc84a2d756eb8353b3f68083d83409110d23c78a30ed3caaa3ee88a26d2a7ef1e977bc7c62269fe7c835345a2398ac013613b3cd9"
         }
     },
     "pre_install": [
-        "Get-ChildItem \"$dir\\`$PLUGINSDIR\\app*.7z\" | Rename-Item -NewName 'app.7z'",
-        "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app.7z\" \"$dir\"",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse"
+        "Get-ChildItem -Path \"$dir\\`$PLUGINSDIR\\app*.7z\" | Rename-Item -NewName 'app.7z'",
+        "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app.7z\" -DestinationPath  \"$dir\"",
+        "Remove-Item -Path \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse -Force -ErrorAction SilentlyContinue"
     ],
     "shortcuts": [
         [
@@ -45,13 +49,6 @@
                 "hash": {
                     "url": "$baseurl/latest.yml",
                     "regex": "(?sm)ia32.*?sha512:\\s+$base64"
-                }
-            },
-            "arm64": {
-                "url": "https://github.com/emqx/MQTTX/releases/download/v$version/MQTTX-Setup-$version-arm64.exe#/dl.7z",
-                "hash": {
-                    "url": "$baseurl/latest.yml",
-                    "regex": "(?sm)arm64.*?sha512:\\s+$base64"
                 }
             }
         }


### PR DESCRIPTION
### Summary

This PR updates MQTTX to version 1.12.1 and temporarily removes ARM64 architecture from the manifest.

### Related Issue

- Relates to #16379
- Relates to https://github.com/emqx/MQTTX/issues/1803#issuecomment-2962059492
<img width="949" height="266" alt="image" src="https://github.com/user-attachments/assets/0ae97ad3-9565-4319-b3b7-0048e1d25ccb" />

### Changes

- Converted license to object format with `identifier` and `url`
- Updated x64 and ia32 URLs and SHA512 hashes for version 1.12.1
- Removed ARM64 architecture due to observed compatibility issues on Windows 11 ARM devices
- Added notes explaining temporary ARM64 removal and link to upstream discussion

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App mqttx -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
mqttx: 1.12.1 (scoop version is 1.12.1)
Forcing autoupdate!
Autoupdating mqttx
DEBUG[1760985731] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1760985732] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760985732] $substitutions.$matchHead                     1.12.1
DEBUG[1760985732] $substitutions.$dashVersion                   1-12-1
DEBUG[1760985732] $substitutions.$minorVersion                  12
DEBUG[1760985732] $substitutions.$urlNoExt                      https://github.com/emqx/MQTTX/releases/download/v1.12.1/MQTTX-Setup-1.12.1-ia32
DEBUG[1760985732] $substitutions.$basename                      MQTTX-Setup-1.12.1-ia32.exe
DEBUG[1760985732] $substitutions.$preReleaseVersion             1.12.1
DEBUG[1760985732] $substitutions.$majorVersion                  1
DEBUG[1760985732] $substitutions.$match1                        1.12.1
DEBUG[1760985732] $substitutions.$baseurl                       https://github.com/emqx/MQTTX/releases/download/v1.12.1
DEBUG[1760985732] $substitutions.$dotVersion                    1.12.1
DEBUG[1760985732] $substitutions.$matchTail
DEBUG[1760985732] $substitutions.$version                       1.12.1
DEBUG[1760985732] $substitutions.$buildVersion
DEBUG[1760985732] $substitutions.$underscoreVersion             1_12_1
DEBUG[1760985732] $substitutions.$patchVersion                  1
DEBUG[1760985732] $substitutions.$cleanVersion                  1121
DEBUG[1760985732] $substitutions.$basenameNoExt                 MQTTX-Setup-1.12.1-ia32
DEBUG[1760985732] $substitutions.$url                           https://github.com/emqx/MQTTX/releases/download/v1.12.1/MQTTX-Setup-1.12.1-ia32.exe
DEBUG[1760985732] $hashfile_url = https://github.com/emqx/MQTTX/releases/download/v1.12.1/latest.yml -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for MQTTX-Setup-1.12.1-ia32.exe in https://github.com/emqx/MQTTX/releases/download/v1.12.1/latest.yml
DEBUG[1760985733] $regex = (?sm)ia32.*?sha512:\s+([a-zA-Z0-9+\/=]{24,88}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha512:f109e1fc77b224ce21cc7dedc84a2d756eb8353b3f68083d83409110d23c78a30ed3caaa3ee88a26d2a7ef1e977bc7c62269fe7c835345a2398ac013613b3cd9 using Extract Mode
DEBUG[1760985733] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1760985733] $substitutions.$matchHead                     1.12.1
DEBUG[1760985733] $substitutions.$dashVersion                   1-12-1
DEBUG[1760985733] $substitutions.$minorVersion                  12
DEBUG[1760985733] $substitutions.$urlNoExt                      https://github.com/emqx/MQTTX/releases/download/v1.12.1/MQTTX-Setup-1.12.1-x64
DEBUG[1760985733] $substitutions.$basename                      MQTTX-Setup-1.12.1-x64.exe
DEBUG[1760985733] $substitutions.$preReleaseVersion             1.12.1
DEBUG[1760985733] $substitutions.$majorVersion                  1
DEBUG[1760985733] $substitutions.$match1                        1.12.1
DEBUG[1760985733] $substitutions.$baseurl                       https://github.com/emqx/MQTTX/releases/download/v1.12.1
DEBUG[1760985733] $substitutions.$dotVersion                    1.12.1
DEBUG[1760985733] $substitutions.$matchTail
DEBUG[1760985733] $substitutions.$version                       1.12.1
DEBUG[1760985733] $substitutions.$buildVersion
DEBUG[1760985733] $substitutions.$underscoreVersion             1_12_1
DEBUG[1760985733] $substitutions.$patchVersion                  1
DEBUG[1760985733] $substitutions.$cleanVersion                  1121
DEBUG[1760985733] $substitutions.$basenameNoExt                 MQTTX-Setup-1.12.1-x64
DEBUG[1760985733] $substitutions.$url                           https://github.com/emqx/MQTTX/releases/download/v1.12.1/MQTTX-Setup-1.12.1-x64.exe
DEBUG[1760985733] $hashfile_url = https://github.com/emqx/MQTTX/releases/download/v1.12.1/latest.yml -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for MQTTX-Setup-1.12.1-x64.exe in https://github.com/emqx/MQTTX/releases/download/v1.12.1/latest.yml
DEBUG[1760985734] $regex = (?sm)x64.*?sha512:\s+([a-zA-Z0-9+\/=]{24,88}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha512:321e57f500fc85309ffb7d45d34fbc9cfd560623cbe8593a4474ca81baf95d4bbe80eb5b3adaecd6eb1d99b98757a9844f6f197e40d2cf875087441a3148919d using Extract Mode
Writing updated mqttx manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ mqttx ≢  ~1]
└─> scoop install .\mqttx.json
Installing 'mqttx' (1.12.1) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\mqttx.json'
Loading MQTTX-Setup-1.12.1-x64.exe from cache.
Checking hash of MQTTX-Setup-1.12.1-x64.exe ... ok.
Extracting MQTTX-Setup-1.12.1-x64.exe ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\mqttx\current => D:\Software\Scoop\Local\apps\mqttx\1.12.1                         
Creating shortcut for MQTT X (MQTTX.exe)
'mqttx' (1.12.1) was installed successfully!
Notes
-----
ARM64 architecture has been temporarily removed from the manifest due to compatibility issues observed on Windows 11 ARM devices.
For more details, see the upstream discussion: https://github.com/emqx/MQTTX/issues/1803#issuecomment-2962059492
Once the upstream provides a stable ARM64 version, support for this architecture will be re-added to the manifest.
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.12.1 with updated package checksums for 64-bit and 32-bit architectures.
  * ARM64 architecture support temporarily removed; see release notes for details.
  * License information updated with enhanced metadata.

* **Bug Fixes**
  * Installation script improved with better error handling, explicit path specifications, and enhanced cleanup capabilities for more reliable deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->