### PR TITLE
gperf: Add version 3.1-6

### DIFF
--- a/bucket/gperf.json
+++ b/bucket/gperf.json
@@ -15,18 +15,18 @@
     },
     "bin": "gperf.exe",
     "checkver": {
-      "url": "https://raw.githubusercontent.com/msys2/MSYS2-packages/master/gperf/PKGBUILD",
-      "regex": "pkgver\\s*=\\s*([\\d.]+)[\\s\\S]*?pkgrel\\s*=\\s*([0-9]+)",
-      "replace": "$1-$2"
+        "url": "https://raw.githubusercontent.com/msys2/MSYS2-packages/master/gperf/PKGBUILD",
+        "regex": "pkgver\\s*=\\s*([\\d.]+)[\\s\\S]*?pkgrel\\s*=\\s*([0-9]+)",
+        "replace": "$1-$2"
     },
     "autoupdate": {
-      "architecture": {
-        "64bit": {
-          "url": "https://repo.msys2.org/msys/x86_64/gperf-$version-x86_64.pkg.tar.zst"
-        },
-        "32bit": {
-          "url": "https://repo.msys2.org/msys/i686/gperf-$version-i686.pkg.tar.zst"
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.msys2.org/msys/x86_64/gperf-$version-x86_64.pkg.tar.zst"
+            },
+            "32bit": {
+                "url": "https://repo.msys2.org/msys/i686/gperf-$version-i686.pkg.tar.zst"
+            }
         }
-      }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
- Closes #16425
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gperf package support with multi-architecture downloads for 64-bit and 32-bit.
  * Enabled automated version detection and templated updates to simplify package maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->