### PR TITLE
runcat@2.0: Remove checkver & autoupdate, add arm64 support, fix suggest

### DIFF
--- a/bucket/runcat.json
+++ b/bucket/runcat.json
@@ -1,11 +1,11 @@
 {
     "##": "Newer versions are only available through Microsoft Store: <https://apps.microsoft.com/detail/9nw5lpnvwfwj>.",
     "version": "2.0",
-    "description": "A cute running cat animation on your windows taskbar (based on CPU load)",
+    "description": "A cute running cat animation on your windows taskbar (based on CPU load).",
     "homepage": "https://github.com/Kyome22/RunCat365",
     "license": "Apache-2.0",
     "suggest": {
-        ".NET Desktop Runtime v6": "versions/windowsdesktop-runtime-6.0"
+        ".NET Desktop Runtime 6.0": "versions/windowsdesktop-runtime-6.0"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Changes:

* Removed checkver and autoupdate
* Changed to new GitHub repo name, kept the application name
* Added ARM64
* Changed `suggest` to `versions/windowsdesktop-runtime-6.0` bucket, since Dotnet v6 is EOL
  * <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core>

Because:

* Repo name changed.
* **Newer versions are only available through Microsoft Store.**
  * <https://apps.microsoft.com/detail/9nw5lpnvwfwj>
  * https://github.com/Kyome22/RunCat365/pull/115#issuecomment-3430927769
  > For the time being, we plan to distribute only via the Microsoft Store. Because an app without a code-signing certificate may be flagged as a trojan, a certificate is required; however, obtaining and maintaining a code-signing certificate for distribution outside the Microsoft Store is quite costly.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native ARM64 support for the application.

* **Updates**
  * Updated .NET runtime requirement to .NET Desktop Runtime 6.0.
  * Updated application homepage/name and refreshed download sources/URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->