### PR TITLE
multidrive: Add version 1.2.0

### DIFF
--- a/bucket/multidrive.json
+++ b/bucket/multidrive.json
@@ -2,7 +2,10 @@
     "version": "1.2.0",
     "description": "Free disk backup, clone, and wipe utility with CLI support",
     "homepage": "https://multidrive.io",
-    "license": "Freeware",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://multidrive.io/terms"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/atola-technology/multidrive/releases/download/v1.2.0/MultiDrive_1.2.zip",
@@ -10,10 +13,7 @@
         }
     },
     "extract_dir": "MultiDrive",
-    "bin": [
-        "MultiDrive.exe",
-        "mdcli.exe"
-    ],
+    "bin": "mdcli.exe",
     "shortcuts": [
         [
             "MultiDrive.exe",


### PR DESCRIPTION
<!--
Closes #   (leave empty, since this is a new package)
-->

- [x] Use conventional PR title: `multidrive@1.2: Add MultiDrive (free disk clone & backup utility)`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

---

### Manifest summary

**App name:** MultiDrive  
**Version:** 1.2  
**Homepage:** [https://multidrive.io](https://multidrive.io)  
**License:** Freeware  
**Installer type:** Silent (`/s /D=$dir`)  
**Binaries:**  
- `MultiDrive.exe` – GUI  
- `mdcli.exe` – CLI  

### Verification

Tested locally on Windows 10 & 11:
- Silent installation works  
- Both GUI and CLI shims created (`multidrive`, `mdcli`)  
- Uninstall works  
- `checkver` detects version correctly from [changelog](https://multidrive.io/changelog)

### Autoupdate

Uses `https://dl.atola.com/multidrive/MultiDriveSetup_$version.exe`

### Package request

Closes #16536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows installer manifest for the multidrive utility: provides a 64-bit installer with integrity checks, silent install support, a mapped executable for easy launch, and a Start Menu shortcut.
  * Enables GitHub-based version checks and templated autoupdate support (initial version 1.2.0).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->