### PR TITLE
tern-subtitle-file-translator: Update to version 5.3.7, fix checkver & autoupdate, improve notes

### DIFF
--- a/bucket/tern-subtitle-file-translator.json
+++ b/bucket/tern-subtitle-file-translator.json
@@ -17,7 +17,7 @@
             "hash": "78ae47eaa1669579613def311f74600d66bac8835b2103570f545ccbbc5daf1b"
         }
     },
-    "pre_install": "Get-ChildItem -Path $dir -Include '*.exe' -Recurse | Rename-Item -NewName 'Tern-Subtitle File Translator.exe'",
+    "pre_install": "Get-ChildItem -Path \"$dir\\*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'Tern-Subtitle File Translator.exe'",
     "shortcuts": [
         [
             "Tern-Subtitle File Translator.exe",


### PR DESCRIPTION
### Summary

Updates `tern-subtitle-file-translator` to version **5.3.7**, improves metadata clarity, and enhances autoupdate reliability.

### Changes

- Updated to version **5.3.7**
- Rewrote `notes` section for clearer explanation of free usage vs. paid translation services
- Switched to 64-bit GitHub release asset `Windows-win32-x64-5.3.7.zip`
- Updated `hash` to match the new release
- Renamed shortcut executable to `字幕机翻.exe`
- Updated `autoupdate` URL to match new release naming format

### Note

Since the upstream `$.tag_name` and `$.assets.name` have changed before, to avoid unnecessary maintenance in the future, this PR uses a `regex` to capture them.

### Testing

```
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App tern-subtitle-file-translator -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
tern-subtitle-file-translator: 5.3.7 (scoop version is 5.3.7)
Forcing autoupdate!
Autoupdating tern-subtitle-file-translator
DEBUG[1761059659] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1761059659] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1761059659] $substitutions.$version                       5.3.7
DEBUG[1761059659] $substitutions.$matchHead                     5.3.7
DEBUG[1761059659] $substitutions.$urlNoExt                      https://github.com/1c7/Translate-Subtitle-File/releases/download/v5.3.7/Windows-win32-x64-5.3.7
DEBUG[1761059659] $substitutions.$basename                      Windows-win32-x64-5.3.7.zip
DEBUG[1761059659] $substitutions.$dotVersion                    5.3.7
DEBUG[1761059659] $substitutions.$basenameNoExt                 Windows-win32-x64-5.3.7
DEBUG[1761059659] $substitutions.$matchTag                      v5.3.7
DEBUG[1761059659] $substitutions.$matchTail
DEBUG[1761059659] $substitutions.$match1                        5.3.7
DEBUG[1761059659] $substitutions.$preReleaseVersion             5.3.7
DEBUG[1761059659] $substitutions.$url                           https://github.com/1c7/Translate-Subtitle-File/releases/download/v5.3.7/Windows-win32-x64-5.3.7.zip
DEBUG[1761059659] $substitutions.$patchVersion                  7
DEBUG[1761059659] $substitutions.$buildVersion
DEBUG[1761059659] $substitutions.$minorVersion                  3
DEBUG[1761059659] $substitutions.$underscoreVersion             5_3_7
DEBUG[1761059659] $substitutions.$majorVersion                  5
DEBUG[1761059659] $substitutions.$cleanVersion                  537
DEBUG[1761059659] $substitutions.$baseurl                       https://github.com/1c7/Translate-Subtitle-File/releases/download/v5.3.7
DEBUG[1761059659] $substitutions.$matchName                     Windows-win32-x64-5.3.7.zip
DEBUG[1761059659] $substitutions.$dashVersion                   5-3-7
DEBUG[1761059659] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1761059660] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/1c7/Translate-Subtitle-File/releases/download/v5.3.7/Windows-win32-x64-5.3.7.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 78ae47eaa1669579613def311f74600d66bac8835b2103570f545ccbbc5daf1b using Github Mode
Writing updated tern-subtitle-file-translator manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ tern-subtitle-file-translator ≢  ~1]
└─> scoop install .\tern-subtitle-file-translator.json
Installing 'tern-subtitle-file-translator' (5.3.7) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\tern-subtitle-file-translator.json'
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 421eb8|OK  |   4.2MiB/s|100|D:/Software/Scoop/Local/cache/tern-subtitle-file-translator#5.3.7#22267b6.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of Windows-win32-x64-5.3.7.zip ... ok.
Extracting Windows-win32-x64-5.3.7.zip ... done.                                                                        
Linking D:\Software\Scoop\Local\apps\tern-subtitle-file-translator\current => D:\Software\Scoop\Local\apps\tern-subtitle-file-translator\5.3.7
Creating shortcut for Tern-Subtitle File Translator (字幕机翻.exe)
'tern-subtitle-file-translator' (5.3.7) was installed successfully!
Notes
-----
The application itself is free to use forever.
However, translation services are billed separately and charged based on actual usage.
For more details on translator service pricing and available plans, please refer to https://doc.tern.1c7.me/folder/pricing.
```

- Relates to #16379 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Application version bumped to 5.3.7.
  * Windows 64‑bit download and checksum updated.
  * Improved update detection and auto-update using dynamic release metadata.
  * Release notes expanded to include pricing, usage and licensing details.
  * Installer now renames the executable to "Tern-Subtitle File Translator.exe" during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->