### PR TITLE
vivaldi@7.6.3797.63: Add arm64 support, add autoupdate hash extraction

### DIFF
--- a/bucket/vivaldi.json
+++ b/bucket/vivaldi.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://downloads.vivaldi.com/stable/Vivaldi.7.6.3797.63.exe#/dl.7z",
             "hash": "99ed2982a324985df7bc0aade8b902cb7e0e4fbbfe89458ee4c254694a26e501"
+        },
+        "arm64": {
+            "url": "https://downloads.vivaldi.com/stable/Vivaldi.7.6.3797.63.arm64.exe#/dl.7z",
+            "hash": "7328c6ca0741514302b65ff0d66a1536bdb4c33de9cd03ab43b043cd6c659e6b"
         }
     },
     "installer": {
@@ -39,7 +43,14 @@
             },
             "32bit": {
                 "url": "https://downloads.vivaldi.com/stable/Vivaldi.$version.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://downloads.vivaldi.com/stable/Vivaldi.$version.arm64.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "https://vivaldi.com/download/archive/?platform=win",
+            "find": "$basename.+?data-sha256=\"$sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 architecture, enabling downloads and automatic updates for ARM64-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->