### PR TITLE
openark@1.5.2: Fix checkver & autoupdate URLs, update homepage & description

### DIFF
--- a/bucket/openark.json
+++ b/bucket/openark.json
@@ -1,16 +1,16 @@
 {
     "version": "1.5.2",
-    "description": "An anti-rookit(ARK) tool",
-    "homepage": "https://openark.blackint3.com",
+    "description": "The Next Generation Anti-Rootkit (ARK) tool for Windows.",
+    "homepage": "http://openark.blackint3.com:88",
     "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BlackINT3/OpenArk/releases/download/v1.5.2/OpenArk64.exe#/OpenArk.exe",
-            "hash": "206c3f8a66dc9db5791921945002cfb09d2c51f1b563f1b10739eecd67a88562"
+            "url": "http://file.blackint3.com:88/openark/files/openark/OpenArk-v1.5.2/OpenArk64.exe#/OpenArk.exe",
+            "hash": "sha1:71c22841385bcd3a547621163af7361aec43d519"
         },
         "32bit": {
-            "url": "https://github.com/BlackINT3/OpenArk/releases/download/v1.5.2/OpenArk32.exe#/OpenArk.exe",
-            "hash": "1a9fa9b265cc1ee3690e29c8a4461565a72feefdab9a3459903f695c63b26c77"
+            "url": "http://file.blackint3.com:88/openark/files/openark/OpenArk-v1.5.2/OpenArk32.exe#/OpenArk.exe",
+            "hash": "sha1:0f76966e55087a1ba4bdd567a44e6eca1f385d63"
         }
     },
     "shortcuts": [
@@ -20,16 +20,21 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/BlackINT3/OpenArk"
+        "url": "http://openark.blackint3.com:88/release/",
+        "regex": "(?i)>OpenArk\\s*v([\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/BlackINT3/OpenArk/releases/download/v$version/OpenArk64.exe#/OpenArk.exe"
+                "url": "http://file.blackint3.com:88/openark/files/openark/OpenArk-v$version/OpenArk64.exe#/OpenArk.exe"
             },
             "32bit": {
-                "url": "https://github.com/BlackINT3/OpenArk/releases/download/v$version/OpenArk32.exe#/OpenArk.exe"
+                "url": "http://file.blackint3.com:88/openark/files/openark/OpenArk-v$version/OpenArk32.exe#/OpenArk.exe"
             }
+        },
+        "hash": {
+            "url": "http://openark.blackint3.com:88/release/openark-v$cleanVersion",
+            "regex": ">$basename</a>\\s*$sha1\\s*\\(SHA1\\)"
         }
     }
 }


### PR DESCRIPTION
### Summary

Switch download sources to the official OpenArk server, uses SHA1 hashes instead of SHA256, and modifies the homepage and version checking method accordingly.

### Related Issue

- Relates to #16379 

### Changes

- Update homepage URL  
- Change download source to `file.blackint3.com:88`
- Replace SHA256 with SHA1 hashes (per upstream)

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App openark -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
openark: 1.5.2 (scoop version is 1.5.2)
Forcing autoupdate!
Autoupdating openark
DEBUG[1761225938] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1761225938] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1761225938] $substitutions.$majorVersion                  1
DEBUG[1761225938] $substitutions.$matchHead                     1.5.2
DEBUG[1761225938] $substitutions.$minorVersion                  5
DEBUG[1761225938] $substitutions.$matchTail
DEBUG[1761225938] $substitutions.$preReleaseVersion             1.5.2
DEBUG[1761225938] $substitutions.$urlNoExt                      http://file.blackint3.com:88/openark/files/openark/OpenArk-v1.5.2/OpenArk32
DEBUG[1761225938] $substitutions.$baseurl                       http://file.blackint3.com:88/openark/files/openark/OpenArk-v1.5.2
DEBUG[1761225938] $substitutions.$dashVersion                   1-5-2
DEBUG[1761225938] $substitutions.$buildVersion
DEBUG[1761225938] $substitutions.$underscoreVersion             1_5_2
DEBUG[1761225938] $substitutions.$basenameNoExt                 OpenArk32
DEBUG[1761225938] $substitutions.$basename                      OpenArk32.exe
DEBUG[1761225938] $substitutions.$url                           http://file.blackint3.com:88/openark/files/openark/OpenArk-v1.5.2/OpenArk32.exe
DEBUG[1761225938] $substitutions.$cleanVersion                  152
DEBUG[1761225938] $substitutions.$match1                        1.5.2
DEBUG[1761225938] $substitutions.$patchVersion                  2
DEBUG[1761225938] $substitutions.$dotVersion                    1.5.2
DEBUG[1761225938] $substitutions.$version                       1.5.2
DEBUG[1761225938] $hashfile_url = http://openark.blackint3.com:88/release/openark-v152 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for OpenArk32.exe in http://openark.blackint3.com:88/release/openark-v152
DEBUG[1761225939] $regex = >OpenArk32\.exe</a>\s*([a-fA-F0-9]{40})\s*\(SHA1\) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha1:0f76966e55087a1ba4bdd567a44e6eca1f385d63 using Extract Mode
... ...
Writing updated openark manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][  openark ≢  ~1]
└─> scoop install .\openark.json
Installing 'openark' (1.5.2) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\openark.json'
Loading OpenArk64.exe from cache.
Checking hash of OpenArk64.exe ... ok.
Linking D:\Software\Scoop\Local\apps\openark\current => D:\Software\Scoop\Local\apps\openark\1.5.2
Creating shortcut for OpenArk (OpenArk.exe)
'openark' (1.5.2) was installed successfully!
```
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenArk download endpoints and verification mechanisms for improved reliability and security of binary distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->