### PR TITLE
youtrack@2025.1.82518: Removed checkver

### DIFF
--- a/bucket/youtrack.json
+++ b/bucket/youtrack.json
@@ -28,5 +28,12 @@
         "conf",
         "data",
         "logs"
-    ]
+    ],
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/charisma/youtrack-$version.zip",
+        "hash": {
+            "url": "$url.sha256"
+        },
+        "extract_dir": "youtrack-$version"
+    }
 }


### PR DESCRIPTION
Changes:

- Removed checkver and autoupdate

Because:

- ZIP releases are no longer created for new versions, now only Docker is supported.
     - https://www.jetbrains.com/help/youtrack/server/youtrack-zip.html
     - https://www.jetbrains.com/youtrack/download/previous.html

Relates to #16379


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated distribution config so ZIP packages are no longer generated for new releases.
  * Disabled automatic remote version check and related update extraction logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->