### PR TITLE
nettracex@0.1.5: Add Scoop manifest for NetTraceX TUI

### DIFF
--- a/bucket/nettracex.json
+++ b/bucket/nettracex.json
@@ -1,7 +1,7 @@
 {
     "version": "0.1.5",
     "description": "NetTraceX TUI - A comprehensive network diagnostic toolkit",
-    "homepage": "https://nettracex.net",
+    "homepage": "https://github.com/nettracex/nettracex-tui",
     "license": "MIT",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added release metadata for NetTraceX v0.1.5 including version, description, homepage, license, and author.
  * Added 64-bit Windows distribution details: download URL, integrity hash, and installed binary name to enable deployment and installation verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->