### PR TITLE
anypoint-studio: Add version 7.23.0

### DIFF
--- a/bucket/anypoint-studio.json
+++ b/bucket/anypoint-studio.json
@@ -1,15 +1,20 @@
 {
     "version": "7.23.0",
-    "description": "Anypoint Studio is MuleSoft's Eclipse-based integration development environment for designing and testing Mule applications",
+    "description": "MuleSoft's Eclipse-based IDE for designing and testing Mule applications.",
     "homepage": "https://www.mulesoft.com/platform/studio",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.mulesoft.com/legal/terms"
     },
+    "notes": [
+        "Anypoint Studio requires Java Development Kit (JDK) 8 or 11.",
+        "Your workspace and configuration will be persisted across updates.",
+        "For more information, visit: https://docs.mulesoft.com/studio/"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://mule-studio.s3.amazonaws.com/7.23.0-GA/AnypointStudio-7.23.0-win64.zip",
-            "hash": "D7041974EDA8C243F43CEED36063D7CC5A1B6C1A0E238CA39AFF9A3D8DB350A8"
+            "hash": "d7041974eda8c243f43ceed36063d7cc5a1b6c1a0e238ca39aff9a3d8db350a8"
         }
     },
     "extract_dir": "AnypointStudio",
@@ -34,11 +39,5 @@
                 "url": "https://mule-studio.s3.amazonaws.com/$version-GA/AnypointStudio-$version-win64.zip"
             }
         }
-    },
-    "notes": [
-        "Anypoint Studio requires Java Development Kit (JDK) 8 or 11.",
-        "Your workspace and configuration will be persisted across updates.",
-        "For more information, visit: https://docs.mulesoft.com/studio/"
-    ]
+    }
 }
-


### PR DESCRIPTION
Adds Anypoint Studio 7.23.0, MuleSoft's Eclipse-based integration development environment.

- Homepage: https://www.mulesoft.com/platform/studio
- License: Proprietary (free to use)
- Binary provided by: MuleSoft, Inc.

Notes:
- Requires Java JDK 8 or 11
- ~2GB download
- Includes workspace and configuration persistence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installer support for Anypoint Studio 7.23.0. The new configuration includes version information, 64-bit architecture downloads with SHA-256 integrity verification, installation paths, executable binary locations, system shortcut mappings, directory persistence settings, version checking capabilities, and automatic update URL templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->