### PR TITLE
fluidsynth: Update to version 2.5.1, fix checkver & autoupdate

### DIFF
--- a/bucket/fluidsynth.json
+++ b/bucket/fluidsynth.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "Software synthesizer based on the SoundFont 2 specifications.",
     "homepage": "https://www.fluidsynth.org",
     "license": {
@@ -8,14 +8,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.0/fluidsynth-v2.5.0-win10-x64-cpp11.zip",
-            "hash": "ae3135746ed81e968abf9820f8e39cd5b63caa5a0432da00aeb09f3bafcdfeeb",
-            "extract_dir": "fluidsynth-v2.5.0-win10-x64-cpp11"
+            "url": "https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.1/fluidsynth-v2.5.1-win10-x64-cpp11.zip",
+            "hash": "ed6fab7422deb3efd1a06eba4ca00a60a9bab7704d9847123236ba4b0982c5e2",
+            "extract_dir": "fluidsynth-v2.5.1-win10-x64-cpp11"
         },
         "32bit": {
-            "url": "https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.0/fluidsynth-v2.5.0-win10-x86-cpp11.zip",
-            "hash": "beeee8609f457ed64be834d48091fa41e025ec93f9b0a4aff2efd195f22c7038",
-            "extract_dir": "fluidsynth-v2.5.0-win10-x86-cpp11"
+            "url": "https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.1/fluidsynth-v2.5.1-win10-x86-cpp11.zip",
+            "hash": "262cf17be06a6767410ff1e8ef599e228f7e901393d109959b0505e06c41a4f6",
+            "extract_dir": "fluidsynth-v2.5.1-win10-x86-cpp11"
         }
     },
     "env_add_path": "bin",


### PR DESCRIPTION
### Summary

Updates `fluidsynth` to version **2.5.1** and restructures the manifest for better maintainability and accuracy.

### Related issues or pull requests

- Relates to #12056 
- Relates to #16379 

### Changes

- Updated version to **2.5.1**
- Added `32bit` architecture with explicit extract paths  
- Introduced `env_add_path` instead of manual PATH modification instructions  
- Improved `license` field with full SPDX and URL  
- Updated `checkver` to use the GitHub API with JSONPath and regex for dynamic asset detection  
- Reworked `autoupdate` logic to handle both x64 and x86 builds with flexible matching  
- Refined description and homepage fields for consistency with other manifests  

### Notes

- [**Support for GLib and libinstpatch is hereby deprecated.** They will be removed in 2.6.0. ](https://github.com/FluidSynth/fluidsynth/releases#:~:text=Support%20for%20GLib%20and%20libinstpatch%20is%20hereby%20deprecated.%20They%20will%20be%20removed%20in%202.6.0.)

- Starting from version 2.6.0, the related assets may revert to names like `fluidsynth-2.x.y-win10-x64.zip` and `fluidsynth-2.x.y-win10-x86.zip`. However, this change will not affect either the `checkver` or `autoupdate` functionality.

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App fluidsynth -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f                
fluidsynth: 2.5.1 (scoop version is 2.5.0) autoupdate available
Forcing autoupdate!
Autoupdating fluidsynth
DEBUG[1762422027] [$updatedProperties] = [url extract_dir hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1762422027] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1762422027] $substitutions.$buildVersion
DEBUG[1762422027] $substitutions.$url                           https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.1/fluidsynth-v2.5.1-win10-x86-cpp11.zip
DEBUG[1762422027] $substitutions.$minorVersion                  5
DEBUG[1762422027] $substitutions.$match1                        2.5.1
DEBUG[1762422027] $substitutions.$version                       2.5.1
DEBUG[1762422027] $substitutions.$basenameNoExt                 fluidsynth-v2.5.1-win10-x86-cpp11
DEBUG[1762422027] $substitutions.$patchVersion                  1
DEBUG[1762422027] $substitutions.$urlNoExt                      https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.1/fluidsynth-v2.5.1-win10-x86-cpp11
DEBUG[1762422027] $substitutions.$dashVersion                   2-5-1
DEBUG[1762422027] $substitutions.$matchSuffix                   -cpp11
DEBUG[1762422027] $substitutions.$matchPrefix                   fluidsynth-v2.5.1-win10
DEBUG[1762422027] $substitutions.$matchTag                      v2.5.1
DEBUG[1762422027] $substitutions.$matchHead                     2.5.1
DEBUG[1762422027] $substitutions.$majorVersion                  2
DEBUG[1762422027] $substitutions.$preReleaseVersion             2.5.1
DEBUG[1762422027] $substitutions.$matchTail
DEBUG[1762422027] $substitutions.$basename                      fluidsynth-v2.5.1-win10-x86-cpp11.zip
DEBUG[1762422027] $substitutions.$dotVersion                    2.5.1
DEBUG[1762422027] $substitutions.$baseurl                       https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.1
DEBUG[1762422027] $substitutions.$cleanVersion                  251
DEBUG[1762422027] $substitutions.$underscoreVersion             2_5_1
DEBUG[1762422027] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1762422028] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/FluidSynth/fluidsynth/releases/download/v2.5.1/fluidsynth-v2.5.1-win10-x86-cpp11.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 262cf17be06a6767410ff1e8ef599e228f7e901393d109959b0505e06c41a4f6 using Github Mode
... ...
Writing updated fluidsynth manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ fluidsynth ≢  ~1]
└─> scoop install .\fluidsynth.json
Installing 'fluidsynth' (2.5.1) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\fluidsynth.json'
Loading fluidsynth-v2.5.1-win10-x64-cpp11.zip from cache.
Checking hash of fluidsynth-v2.5.1-win10-x64-cpp11.zip ... ok.
Extracting fluidsynth-v2.5.1-win10-x64-cpp11.zip ... done.
Linking D:\Software\Scoop\Local\apps\fluidsynth\current => D:\Software\Scoop\Local\apps\fluidsynth\2.5.1
Adding D:\Software\Scoop\Local\apps\fluidsynth\current\bin to your path.
'fluidsynth' (2.5.1) was installed successfully!
```
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * FluidSynth upgraded to version 2.5.1 with refreshed SoundFont 2 synthesizer description
  * Installer packages updated for both 32‑ and 64‑bit (download URLs, integrity hashes, and extraction paths)
  * Automatic update checks improved with more robust version detection and per-architecture update handling
* **Documentation**
  * Homepage URL normalized; license metadata expanded for clearer attribution
* **Installation**
  * Binary path handling modernized (environment PATH updated)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->