### PR TITLE
helium@0.5.8.1: Update checkver to detect pre-release

### DIFF
--- a/bucket/helium.json
+++ b/bucket/helium.json
@@ -1,18 +1,18 @@
 {
-    "version": "0.5.7.1",
+    "version": "0.5.8.1",
     "description": "Private, fast, and honest web browser based on Chromium",
     "homepage": "https://helium.computer",
     "license": "BSD-3-Clause, GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/imputnet/helium-windows/releases/download/0.5.7.1/helium_0.5.7.1_x64-windows.zip",
-            "hash": "1867e8936d99d287ce68e03c3eee0568837a557b27a8905dd9f52d6a1ee0489e",
-            "extract_dir": "helium_0.5.7.1_x64-windows"
+            "url": "https://github.com/imputnet/helium-windows/releases/download/0.5.8.1/helium_0.5.8.1_x64-windows.zip",
+            "hash": "55d3e063686fdabc958ad08f91aa22cb914506fe434ad721d3cc57f8b3de7850",
+            "extract_dir": "helium_0.5.8.1_x64-windows"
         },
         "arm64": {
-            "url": "https://github.com/imputnet/helium-windows/releases/download/0.5.7.1/helium_0.5.7.1_arm64-windows.zip",
-            "hash": "658f6b06044205982b9ce42950cbedf4805c5519423d646d6feb379692e3c985",
-            "extract_dir": "helium_0.5.7.1_arm64-windows"
+            "url": "https://github.com/imputnet/helium-windows/releases/download/0.5.8.1/helium_0.5.8.1_arm64-windows.zip",
+            "hash": "802fe602bb7faf26d9d14968cae72c58b1d3d343ebd670804614ac22c9b03390",
+            "extract_dir": "helium_0.5.8.1_arm64-windows"
         }
     },
     "bin": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
### Summary
This PR updates the `checkver` mechanism to include pre-releases. Helium marks new updates as pre-releases in its [GitHub releases](https://github.com/imputnet/helium-windows/releases), which delays updates for Scoop users. Including pre-release versions ensures users stay up to date, particularly with Chromium updates, which are important for security.

### Code Changes
```json
"checkver": {
    "url": "https://api.github.com/repos/imputnet/helium-windows/releases",
    "jsonpath": "$.[0].tag_name"
}
```
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched version detection to programmatic release data retrieval for more accurate update checks.
  * Updated packaged release to v0.5.8.1 for both 64-bit and ARM64 architectures, including refreshed download artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->