### PR TITLE
pvetui: Add version 1.0.7

### DIFF
--- a/bucket/pvetui.json
+++ b/bucket/pvetui.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.0.7",
+  "architecture": {
+    "32bit": {
+      "url": "https://github.com/devnullvoid/pvetui/releases/download/v1.0.7/pvetui_1.0.7_windows_386.zip",
+      "bin": [
+        "pvetui.exe"
+      ],
+      "hash": "f00f0ac99418fe752df091ed9f63fdac09c0307991589f227affa9f47e76e9cd"
+    },
+    "64bit": {
+      "url": "https://github.com/devnullvoid/pvetui/releases/download/v1.0.7/pvetui_1.0.7_windows_amd64.zip",
+      "bin": [
+        "pvetui.exe"
+      ],
+      "hash": "a5af7d91ebd4e2bd5b80247fab69ac22b62e5c8ef79bc91b50ba6e82fb43f2fc"
+    },
+    "arm64": {
+      "url": "https://github.com/devnullvoid/pvetui/releases/download/v1.0.7/pvetui_1.0.7_windows_arm64.zip",
+      "bin": [
+        "pvetui.exe"
+      ],
+      "hash": "53305a45e923c89b00e7e01388a600b08330f93d56279a4cd9def71b61b68b0b"
+    }
+  },
+  "homepage": "https://github.com/devnullvoid/pvetui",
+  "license": "MIT",
+  "description": "A terminal user interface (TUI) for Proxmox VE"
+}


### PR DESCRIPTION
Adds pvetui, a terminal user interface for managing Proxmox VE clusters. Provides interactive management of VMs, containers, and nodes from the terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release metadata for v1.0.7 with support for multiple architectures (32-bit, 64-bit, ARM64) including download information and security checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->