### PR TITLE
meshroom: Update to version 2025.1.0, fix checkver & autoupdate

### DIFF
--- a/bucket/meshroom.json
+++ b/bucket/meshroom.json
@@ -23,15 +23,15 @@
     "checkver": {
         "url": "https://api.github.com/repositories/34405381/releases/latest",
         "jsonpath": "$.body",
-        "regex": "(?i)\\[[^[]+-([\\d.]+)[^[]+Windows\\]\\([^)]+records/(?<doi>[\\d]+)/files/(?<name>[^]]+)\\)"
+        "regex": "(?i)\\[[^[]+-([\\d.]+)[^[]+Windows\\]\\(.+records/(?<doi>[\\d]+)/files/(?<name>[^]]+)\\)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://zenodo.org/records/$matchDoi/files/$matchName",
                 "hash": {
-                    "url": "https://zenodo.org/records/$matchDoi",
-                    "regex": "(?msi)>$basename</a>.+?>md5:$md5"
+                    "url": "https://zenodo.org/api/records/$matchDoi",
+                    "regex": "(?msi)\"$basename\".+?\"md5:$md5\""
                 },
                 "extract_dir": "Meshroom-$version"
             }


### PR DESCRIPTION
### Summary

Updates `meshroom` to version **2025.1.0** and switches the download source from FossHub to **Zenodo**, which now hosts the official release archives. Also improves license metadata and adjusts extraction paths accordingly.

### Related issues or pull requests

- Relates to #16379  
- Relates to #16460 

### Changes

- Updated version to **2025.1.0**  
- Changed download source from `www.fosshub.com` to `zenodo.org`  
- Updated `hash` to MD5 checksum (as provided by Zenodo)  
- Added explicit `extract_dir` for the new archive structure  
- Improved `license` field with SPDX identifier and URL  
- Updated `autoupdate` to reference the new Zenodo record page and regex-based hash detection  

### Notes

- `www.fosshub.com` links are no longer valid for direct downloads and now return HTML pages instead of the actual archives.  
- Zenodo is now the official host for Meshroom releases and provides stable, checksum-verified downloads.  
- Since the installer is approximately **9.3 GB** in size, the **MD5 checksum** is still used even though it is not cryptographically secure, because it is directly obtainable from the download URL.  
- Additionally, the **download**, **hash verification**, and **installation** stages require a significant amount of time to complete.

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App meshroom -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
meshroom: 2025.1.0 (scoop version is 2025.1.0)
Forcing autoupdate!
Autoupdating meshroom
DEBUG[1761384494] [$updatedProperties] = [url hash extract_dir] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1761384494] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1761384494] $substitutions.$patchVersion                  0
DEBUG[1761384494] $substitutions.$matchHead                     2025.1.0
DEBUG[1761384494] $substitutions.$majorVersion                  2025
DEBUG[1761384494] $substitutions.$match1                        2025.1.0
DEBUG[1761384494] $substitutions.$basenameNoExt                 Meshroom-2025.1.0-Windows
DEBUG[1761384494] $substitutions.$cleanVersion                  202510
DEBUG[1761384494] $substitutions.$underscoreVersion             2025_1_0
DEBUG[1761384494] $substitutions.$url                           https://zenodo.org/records/16887472/files/Meshroom-2025.1.0-Windows.zip
DEBUG[1761384494] $substitutions.$buildVersion
DEBUG[1761384494] $substitutions.$preReleaseVersion             2025.1.0
DEBUG[1761384494] $substitutions.$urlNoExt                      https://zenodo.org/records/16887472/files/Meshroom-2025.1.0-Windows
DEBUG[1761384494] $substitutions.$dashVersion                   2025-1-0
DEBUG[1761384494] $substitutions.$dotVersion                    2025.1.0
DEBUG[1761384494] $substitutions.$minorVersion                  1
DEBUG[1761384494] $substitutions.$basename                      Meshroom-2025.1.0-Windows.zip
DEBUG[1761384494] $substitutions.$baseurl                       https://zenodo.org/records/16887472/files
DEBUG[1761384494] $substitutions.$matchTail
DEBUG[1761384494] $substitutions.$matchDoi                      16887472
DEBUG[1761384494] $substitutions.$version                       2025.1.0
DEBUG[1761384494] $substitutions.$matchName                     Meshroom-2025.1.0-Windows.zip
DEBUG[1761384494] $hashfile_url = https://zenodo.org/api/records/16887472 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Meshroom-2025.1.0-Windows.zip in https://zenodo.org/api/records/16887472
DEBUG[1761384495] $regex = (?msi)"Meshroom-2025\.1\.0-Windows\.zip".+?"md5:([a-fA-F0-9]{32})" -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: md5:6af3282e0b6e739a36a2607d8e86fa82 using Extract Mode
Writing updated meshroom manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][ meshroom ≢  ~1]
└─> scoop install .\meshroom.json
Installing 'meshroom' (2025.1.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\meshroom.json'
Loading Meshroom-2025.1.0-Windows.zip from cache.
Checking hash of Meshroom-2025.1.0-Windows.zip ... ok.
Extracting Meshroom-2025.1.0-Windows.zip ... done.
Linking D:\Software\Scoop\Local\apps\meshroom\current => D:\Software\Scoop\Local\apps\meshroom\2025.1.0
Creating shim for 'meshroom'.
Creating shortcut for Meshroom (meshroom.exe)
'meshroom' (2025.1.0) was installed successfully!
```
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version updated to 2025.1.0
  * License information converted to structured format (identifier + URL)
  * Homepage URL normalized (trailing slash removed)
  * Download source refreshed (moved to archived distribution host) and integrity hashes updated
  * Release-check and auto-update fetching/parsing refreshed to use direct release API and new response parsing

* **New Features**
  * Added a desktop shortcut entry for Meshroom executable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->