### PR TITLE
http-downloader@1.0.6.5: Update checkver & pre_install

### DIFF
--- a/bucket/http-downloader.json
+++ b/bucket/http-downloader.json
@@ -14,8 +14,9 @@
         }
     },
     "pre_install": [
-        "'portable', 'download_history', 'http_downloader_settings' | ForEach-Object {",
-        "    if (-not (Test-Path \"$persist_dir\\$_\")) {",
+        "New-Item \"$dir\\portable\" -Force | Out-Null",
+        "'download_history', 'http_downloader_settings' | ForEach-Object {",
+        "    if (-not (Test-Path -Path \"$persist_dir\\$_\")) {",
         "        New-Item -Path \"$dir\\$_\" -ItemType File -Force | Out-Null",
         "    }",
         "}"


### PR DESCRIPTION
### Summary

Refactors the `http-downloader` manifest to enhance maintainability and updates the `checkver` logic to exclude pre-releases from version detection.

### Related issues or pull requests

- Relates to #16379

### Changes

- Rewrote `pre_install` script using `ForEach-Object` for cleaner and more maintainable logic  
- Adjusted `persist` entries ordering for better readability  
- Updated regex pattern to match only official releases (excluding pre-releases and non-tag references)  

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App http-downloader -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
http-downloader: 1.0.6.5 (scoop version is 1.0.6.5)
Forcing autoupdate!
Autoupdating http-downloader
DEBUG[1761408038] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1761408038] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1761408038] $substitutions.$minorVersion                  0
DEBUG[1761408038] $substitutions.$urlNoExt                      https://github.com/erickutcher/httpdownloader/releases/download/v1.0.6.5/HTTP_Downloader_32
DEBUG[1761408038] $substitutions.$matchTail                     .5
DEBUG[1761408038] $substitutions.$preReleaseVersion             1.0.6.5
DEBUG[1761408038] $substitutions.$match1                        1.0.6.5
DEBUG[1761408038] $substitutions.$patchVersion                  6
DEBUG[1761408038] $substitutions.$majorVersion                  1
DEBUG[1761408038] $substitutions.$basenameNoExt                 HTTP_Downloader_32
DEBUG[1761408038] $substitutions.$url                           https://github.com/erickutcher/httpdownloader/releases/download/v1.0.6.5/HTTP_Downloader_32.zip
DEBUG[1761408038] $substitutions.$cleanVersion                  1065
DEBUG[1761408038] $substitutions.$dotVersion                    1.0.6.5
DEBUG[1761408038] $substitutions.$basename                      HTTP_Downloader_32.zip
DEBUG[1761408038] $substitutions.$underscoreVersion             1_0_6_5
DEBUG[1761408038] $substitutions.$buildVersion                  5
DEBUG[1761408038] $substitutions.$version                       1.0.6.5
DEBUG[1761408038] $substitutions.$baseurl                       https://github.com/erickutcher/httpdownloader/releases/download/v1.0.6.5
DEBUG[1761408038] $substitutions.$matchHead                     1.0.6
DEBUG[1761408038] $substitutions.$dashVersion                   1-0-6-5
DEBUG[1761408038] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1761408039] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/erickutcher/httpdownloader/releases/download/v1.0.6.5/HTTP_Downloader_32.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/erickutcher/httpdownloader/releases
Downloading HTTP_Downloader_32.zip to compute hashes!
Loading HTTP_Downloader_32.zip from cache
Computed hash: 2a13f933e6fb1db525a42519a56f8466f21df4c61c37401b95c0f014e3cf0807
... ...
Writing updated http-downloader manifest

┏[  D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket][   http-downloader ≢  ~1]
└─>  scoop install .\http-downloader.json
Installing 'http-downloader' (1.0.6.5) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\http-downloader.json'
Loading HTTP_Downloader_64.zip from cache.
Checking hash of HTTP_Downloader_64.zip ... ok.
Extracting HTTP_Downloader_64.zip ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\http-downloader\current => D:\Software\Scoop\Local\apps\http-downloader\1.0.6.5
Creating shim for 'HTTP_Downloader'.
Making D:\Software\Scoop\Local\shims\http_downloader.exe a GUI binary.
Creating shortcut for HTTP Downloader (HTTP_Downloader.exe)
Persisting incomplete
Persisting download_history
Persisting http_downloader_settings
'http-downloader' (1.0.6.5) was installed successfully!
```
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now ensures two configuration files (settings and download history) are created during setup.
  * The persistence order for settings and history has been adjusted.
  * Version checking now sources releases/tags from the project's GitHub repository for more accurate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->