### PR TITLE
dual-monitor-tools@2.12: Fix persist

### DIFF
--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -6,8 +6,19 @@
     "url": "https://downloads.sourceforge.net/project/dualmonitortool/dualmonitortool/2.12/DualMonitorTools-2.12.zip",
     "hash": "sha1:705cd7b8c56b4dfcef5f876ae88ca279bd4c7623",
     "pre_install": [
-        "if (-not (Test-Path \"$persist_dir\\DmtMagicWords.xml\")) { New-Item \"$dir\\DmtMagicWords.xml\" -ItemType File | Out-Null }",
-        "if (-not (Test-Path \"$persist_dir\\DmtSettings.xml\")) { New-Item \"$dir\\DmtSettings.xml\" -ItemType File | Out-Null }"
+        "# Hardlink is incompatible with app. Using copy workaround.",
+        "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
+        "    if (-not (Test-Path \"$persist_dir\"))",
+        "    {",
+        "        New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
+        "    }",
+        "    if (Test-Path \"$persist_dir\\$_\") {",
+        "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
+        "    }",
+        "    else {",
+        "        New-Item \"$persist_dir\\$_\" -ItemType File | Out-Null",
+        "    }",
+        "}"
     ],
     "bin": "DMT.exe",
     "shortcuts": [
@@ -15,10 +26,6 @@
             "DMT.exe",
             "Dual Monitor Tools"
         ]
-    ],
-    "persist": [
-        "DmtMagicWords.xml",
-        "DmtSettings.xml"
     ],
     "pre_uninstall": [
         "# Hardlink is incompatible with app. Using copy workaround.",

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -8,7 +8,7 @@
     "pre_install": [
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
-        "    if (-not (Test-Path \"$persist_dir\\$_\")) {",
+        "    if ((Test-Path \"$persist_dir\\$_\")) {",
         "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
         "    }",
         "}"
@@ -27,7 +27,7 @@
     "pre_uninstall": [
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
-        "    if (-not (Test-Path \"$dir\\$_\")) {",
+        "    if ((Test-Path \"$dir\\$_\")) {",
         "        Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
         "    }",
         "}"

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -20,10 +20,6 @@
             "Dual Monitor Tools"
         ]
     ],
-    "persist": [
-        "DmtMagicWords.xml",
-        "DmtSettings.xml"
-    ],
     "pre_uninstall": [
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -6,12 +6,8 @@
     "url": "https://downloads.sourceforge.net/project/dualmonitortool/dualmonitortool/2.12/DualMonitorTools-2.12.zip",
     "hash": "sha1:705cd7b8c56b4dfcef5f876ae88ca279bd4c7623",
     "pre_install": [
-        "# Hardlink is incompatible with app. Using copy workaround.",
-        "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
-        "    if (Test-Path \"$persist_dir\\$_\") {",
-        "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
-        "    }",
-        "}"
+        "if (-not (Test-Path \"$persist_dir\\DmtMagicWords.xml\")) { New-Item \"$dir\\DmtMagicWords.xml\" -ItemType File | Out-Null }",
+        "if (-not (Test-Path \"$persist_dir\\DmtSettings.xml\")) { New-Item \"$dir\\DmtSettings.xml\" -ItemType File | Out-Null }"
     ],
     "bin": "DMT.exe",
     "shortcuts": [
@@ -19,6 +15,10 @@
             "DMT.exe",
             "Dual Monitor Tools"
         ]
+    ],
+    "persist": [
+        "DmtMagicWords.xml",
+        "DmtSettings.xml"
     ],
     "pre_uninstall": [
         "# Hardlink is incompatible with app. Using copy workaround.",

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -30,7 +30,8 @@
         "    if (-not (Test-Path \"$dir\\$_\")) {",
         "        Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
         "    }",
-        "}"],
+        "}"
+    ],
     "checkver": {
         "url": "https://sourceforge.net/projects/dualmonitortool/files/",
         "regex": "dualmonitortool/([\\d.]+)/"

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -8,15 +8,10 @@
     "pre_install": [
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
-        "    if (-not (Test-Path \"$persist_dir\"))",
-        "    {",
-        "        New-Item \"$persist_dir\" -ItemType Directory | Out-Null",
-        "    }",
         "    if (Test-Path \"$persist_dir\\$_\") {",
         "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
-        "    }",
-        "    else {",
-        "        Set-Content -Path \"$persist_dir\\$_\" -Value '<?xml version=\"1.0\" encoding=\"utf-8\"?>' -Encoding UTF8",
+        "    } else {",
+        "        Set-Content -Path \"$dir\\$_\" -Value '<?xml version=\"1.0\" encoding=\"utf-8\"?>' -Encoding UTF8",
         "    }",
         "}"
     ],
@@ -31,6 +26,7 @@
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
         "    if (Test-Path \"$dir\\$_\") {",
+        "        ensure $persist_dir | Out-Null",
         "        Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
         "    }",
         "}"

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -16,7 +16,7 @@
         "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
         "    }",
         "    else {",
-        "        New-Item \"$persist_dir\\$_\" -ItemType File | Out-Null",
+        "        Set-Content -Path \"$persist_dir\\$_\" -Value '<?xml version=\"1.0\" encoding=\"utf-8\"?>' -Encoding UTF8",
         "    }",
         "}"
     ],

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -6,8 +6,12 @@
     "url": "https://downloads.sourceforge.net/project/dualmonitortool/dualmonitortool/2.12/DualMonitorTools-2.12.zip",
     "hash": "sha1:705cd7b8c56b4dfcef5f876ae88ca279bd4c7623",
     "pre_install": [
-        "if (-not (Test-Path \"$persist_dir\\DmtMagicWords.xml\")) { New-Item \"$dir\\DmtMagicWords.xml\" -ItemType File | Out-Null }",
-        "if (-not (Test-Path \"$persist_dir\\DmtSettings.xml\")) { New-Item \"$dir\\DmtSettings.xml\" -ItemType File | Out-Null }"
+        "# Hardlink is incompatible with app. Using copy workaround.",
+        "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
+        "    if (-not (Test-Path \"$persist_dir\\$_\")) {",
+        "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
+        "    }",
+        "}"
     ],
     "bin": "DMT.exe",
     "shortcuts": [
@@ -20,6 +24,13 @@
         "DmtMagicWords.xml",
         "DmtSettings.xml"
     ],
+    "pre_uninstall": [
+        "# Hardlink is incompatible with app. Using copy workaround.",
+        "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
+        "    if (-not (Test-Path \"$dir\\$_\")) {",
+        "        Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
+        "    }",
+        "}"],
     "checkver": {
         "url": "https://sourceforge.net/projects/dualmonitortool/files/",
         "regex": "dualmonitortool/([\\d.]+)/"

--- a/bucket/dual-monitor-tools.json
+++ b/bucket/dual-monitor-tools.json
@@ -8,7 +8,7 @@
     "pre_install": [
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
-        "    if ((Test-Path \"$persist_dir\\$_\")) {",
+        "    if (Test-Path \"$persist_dir\\$_\") {",
         "        Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
         "    }",
         "}"
@@ -27,7 +27,7 @@
     "pre_uninstall": [
         "# Hardlink is incompatible with app. Using copy workaround.",
         "'DmtMagicWords.xml', 'DmtSettings.xml' | ForEach-Object {",
-        "    if ((Test-Path \"$dir\\$_\")) {",
+        "    if (Test-Path \"$dir\\$_\") {",
         "        Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -Force",
         "    }",
         "}"


### PR DESCRIPTION
- Fixed file persistence (The app overwrites the file, thereby deleting the hard link.)
- Fixed the logic of `pre_install`, switching from creating a blank file to copying from `persist_dir`
- Added `pre_uninstall` to copy files to `persist_dir` in advance

- Closes #16463 

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #16463
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer/uninstaller now uses a safer copy-based method to preserve user configuration during uninstall.
  * Automatic restoration of configuration on uninstall prevents data loss and ensures settings are retained.

* **Chores**
  * Simplified persistent configuration handling by removing redundant manifest entries and consolidating install/uninstall workflows.
  * Added an uninstall-stage step to mirror installation safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->