### PR TITLE
netbird-ui@0.59.8: Add new manifest

### DIFF
--- a/bucket/netbird-ui.json
+++ b/bucket/netbird-ui.json
@@ -3,9 +3,7 @@
     "description": "Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.",
     "homepage": "https://netbird.io/",
     "license": "BSD-3-Clause",
-    "notes": [
-        "This app contains only a UI executable. If you need a CLI tool, install the \"netbird\" app."
-    ],
+    "notes": "This app contains only a UI executable. If you need a CLI tool, install the \"netbird\" app.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/netbirdio/netbird/releases/download/v0.59.8/netbird-ui-windows_0.59.8_windows_amd64.tar.gz",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Closes #16473

It's enough to have `netbird-ui.exe` to run it, so we don't need to download both archives.
I believe we can just keep the CLI and UI apps separated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows Scoop manifest to enable easy installation and automatic updates for NetBird UI (v0.59.8).
  * Manifest provides metadata, 64-bit and arm64 download support with checksums, executable and shortcut setup, and architecture-aware autoupdate configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->