### PR TITLE
flix-cli: Add version 1.7.10.8

### DIFF
--- a/bucket/flix-cli.json
+++ b/bucket/flix-cli.json
@@ -6,8 +6,8 @@
     "depends": ["python"],
     "suggest": {
         "ffmpeg": [
-          "ffmpeg",
-          "ffmpeg-shared"
+            "ffmpeg",
+            "ffmpeg-shared"
         ],
         "mpv": "extras/mpv",
         "fzf": "fzf"
@@ -26,3 +26,4 @@
         "jsonpath": "$.info.version"
     }
 }
+


### PR DESCRIPTION
flix-cli : A cli to browse and watch movies and TV shows. This tool scrapes the site flixhq.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package manifest for flix-cli containing metadata (version, description, homepage, license), installer and uninstaller scripts, an executable mapping for the CLI, checksum and download info, and a PyPI-based automatic version check to support distribution and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->