### PR TITLE
ccleaner: Unregister scheduled task on uninstall

### DIFF
--- a/bucket/ccleaner.json
+++ b/bucket/ccleaner.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.39.11548",
+    "version": "6.39",
     "description": "Number-one tool for cleaning PC",
     "homepage": "https://www.ccleaner.com/ccleaner",
     "license": "Freeware",
@@ -39,9 +39,13 @@
     ],
     "checkver": {
         "url": "https://www.ccleaner.com/ccleaner/builds",
-        "regex": "CCleaner Free \\(v([\\d.]+)\\) - Latest official release"
+        "regex": "download.ccleaner.com/portable/ccsetup(\\d)(\\d+).zip",
+        "replace": "$1.$2"
     },
     "autoupdate": {
-        "url": "https://download.ccleaner.com/portable/ccsetup$majorVersion$minorVersion.zip"
+        "url": "https://download.ccleaner.com/portable/ccsetup$majorVersion$minorVersion.zip",
+        "hash": {
+            "url": ""
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

1. Add an elevated call to `Unregister-ScheduledTask` to "post_uninstall"
2. add dependency on **gsudo**

CCleaner (a.k.a. crap-cleaner) is now registering an admin privileged scheduled task that persist `scoop uninstall`, a.k.a. crap.
Ironic


<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #16501
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new system dependency requirement for installation.
  * Updated the packaged version string.
  * Improved update metadata to better support automatic updates.
  * Enhanced the uninstallation process to remove leftover shortcuts and unregister a related scheduled background task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->