### PR TITLE
ausweisapp2@2.4.0: Fix extract_dir, add architecture field to support 64-bit only

### DIFF
--- a/bucket/ausweisapp2.json
+++ b/bucket/ausweisapp2.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Governikus/AusweisApp/releases/download/2.4.0/AusweisApp-2.4.0.msi",
-            "hash": "de3b364f7a7b957a0721439892216eec6f5fedabc9331484f21510b71d1bd5f5"
+            "hash": "de3b364f7a7b957a0721439892216eec6f5fedabc9331484f21510b71d1bd5f5",
+            "extract_dir": "PFiles64\\AusweisApp"
         }
     },
-    "extract_dir": "PFiles64/AusweisApp",
     "shortcuts": [
         [
             "AusweisApp.exe",
@@ -20,9 +20,13 @@
         "github": "https://github.com/Governikus/AusweisApp"
     },
     "autoupdate": {
-        "url": "https://github.com/Governikus/AusweisApp/releases/download/$version/AusweisApp-$version.msi",
-        "hash": {
-            "url": "$url.sha256"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Governikus/AusweisApp/releases/download/$version/AusweisApp-$version.msi",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #16504

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer/update now explicitly targets 64‑bit installations.
  * Application files will be extracted to the 64‑bit program path (PFiles64/AusweisApp).
  * Package download URL and checksum moved into the 64‑bit architecture configuration.
  * Autoupdate settings preserved and applied under the 64‑bit configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->