### PR TITLE
NetSpeedTray: Lightweight network monitor for Windows taskbar

### DIFF
--- a/bucket/netspeedtray.json
+++ b/bucket/netspeedtray.json
@@ -9,15 +9,10 @@
             "url": "https://github.com/erez-c137/NetSpeedTray/releases/download/v1.1.7/NetSpeedTray-1.1.7-Setup.exe",
             "hash": "7ef7fc985d1198ca3eca22e1d7a981515b8c4e77a67c19d3f8736e609bf0732c",
             "installer": {
-                "args": [
-                    "/S"
-                ]
+                "args": "/S"
             },
             "uninstaller": {
-                "file": "C:\\Program Files\\NetSpeedTray\\unins000.exe",
-                "args": [
-                    "/SILENT"
-                ]
+                "script": "\"$env:ProgramFiles\\NetSpeedTray\\unins000.exe\" /SILENT"
             }
         }
     },


### PR DESCRIPTION
Add NetSpeedTray: Lightweight network monitor for Windows taskbar

- [x] Use conventional PR title: `netspeedtray: Add lightweight network monitor for taskbar`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Package Details
- **Name**: NetSpeedTray
- **Description**: A lightweight, open-source network monitor for Windows that displays live upload/download speeds directly on the Taskbar
- **Homepage**: https://github.com/erez-c137/NetSpeedTray
- **License**: GPL-3.0-only

## Testing
- [x] Tested installation
- [x] Tested application functionality  
- [x] Tested uninstallation
- [x] Verified hash matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package-manager manifest to enable installation of NetSpeedTray v1.1.7 via Scoop. Includes 64‑bit distribution, integrity verification (SHA‑256), silent install and uninstall support, automatic version checks via GitHub, and an autoupdate template to simplify future upgrades and streamline deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->