### PR TITLE
sts: Update to version 4.32.1, fix checkver & autoupdate, update homepage

### DIFF
--- a/bucket/sts.json
+++ b/bucket/sts.json
@@ -1,7 +1,7 @@
 {
     "version": "4.32.1",
     "description": "Spring Tools for Eclipse",
-    "homepage": "https://spring.io/tools/sts",
+    "homepage": "https://spring.io/tools",
     "license": "EPL-1.0",
     "depends": "7zip19.00-helper",
     "notes": "For Windows 32bit, please use \"sts396\" in versions bucket.",


### PR DESCRIPTION
Related: #16379

- Update base URL from https://download.springsource.com to https://cdn.spring.io/spring-tools
- Update checkver regex to use new STS full name: `spring-tools-for-eclipse`
- Update autoupdate hash to use sha256

---
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated to version 4.32.1.
  * Homepage shortened to main tools page.
  * Downloads moved to the cdn.spring.io CDN with updated package naming and paths.
  * Autoupdate templates adjusted; integrity checks strengthened by switching to SHA-256.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->