### PR TITLE
backrest: Remove 'backrest-windows-tray.exe'

### DIFF
--- a/bucket/backrest.json
+++ b/bucket/backrest.json
@@ -13,10 +13,7 @@
             "hash": "d5b9a1045d35ae7c87e737b4e4415c0a941175062c62c1b44f14b76b51e32666"
         }
     },
-    "bin": [
-        "backrest.exe",
-        "backrest-windows-tray.exe"
-    ],
+    "bin": "backrest.exe",
     "shortcuts": [
         [
             "backrest.exe",


### PR DESCRIPTION
Since version 1.10, backrest-windows-tray.exe is merged into backrest.exe (https://github.com/garethgeorge/backrest/pull/903).

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the separate Windows tray executable from the distribution; the package now references only the main Windows executable.
  * Installer/distribution metadata updated to reflect a single Windows executable, simplifying Windows-specific installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->