### PR TITLE
sqldeveloper: Add version 24.3.1.347.1826

### DIFF
--- a/bucket/sqldeveloper.json
+++ b/bucket/sqldeveloper.json
@@ -10,7 +10,7 @@
         "JDK17": "java/openjdk17"
     },
     "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-no-jre.zip",
-    "hash": "sha1:38cab3650bcc67cd8af4f7ca54a6a5413bbba61c",
+    "hash": "3390ef58972f1f255077c49e66b171b8664773bb16e37570a7ca16acc5afb8cb",
     "extract_dir": "sqldeveloper",
     "shortcuts": [
         [
@@ -24,10 +24,6 @@
         "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
     },
     "autoupdate": {
-        "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-$version-no-jre.zip",
-        "hash": {
-            "url": "https://www.oracle.com/database/sqldeveloper/technologies/download/",
-            "find": "(?is)$basename.*?SHA1:\\s*$sha1"
-        }
+        "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-$version-no-jre.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

A graphical tool for working with SQL in Oracle databases

Closes https://github.com/ScoopInstaller/Scoop/issues/2892

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing Oracle SQL Developer via the package manager.
  * Includes versioned manifests, automatic version checking, and autoupdate rules targeting no‑JRE distributions.
  * Manifest provides metadata (version, description, homepage, license), integrity verification, extraction details, and a desktop shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->