### PR TITLE
helium@0.5.8.1: Add data migration

### DIFF
--- a/bucket/helium.json
+++ b/bucket/helium.json
@@ -56,7 +56,8 @@
     ],
     "post_uninstall": [
         "$appdata = \"$env:LOCALAPPDATA\\imput\\Helium\\User Data\"",
-        "if ((Get-Item $appdata -ErrorAction SilentlyContinue)?.LinkType -eq 'Junction') {",
+        "$item = Get-Item $appdata -ErrorAction SilentlyContinue",
+        "if ($item -and $item.LinkType -eq 'Junction') {",
         "    Remove-Item $appdata -Force",
         "}"
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
### Summary
- Migrate userdata from previous non scoop installation.
- Create a junction link to userdata in localappdata, so that if the browser is started from its exe it don't create new userdata folder.
- Removes the junction link when browser is uninstalled.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated user-data migration during installation to preserve existing settings and files by relocating data to the app’s persistent directory, ensuring continuity after upgrade and handling migration errors gracefully.
  * Automatic cleanup during uninstallation to remove legacy filesystem links and reduce residual artifacts, resulting in a cleaner system state after removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->