### PR TITLE
scopy: Update to version 2.1.0, fix checkver & autoupdate

### DIFF
--- a/bucket/scopy.json
+++ b/bucket/scopy.json
@@ -3,10 +3,19 @@
     "description": "A software oscilloscope and signal analysis toolset",
     "homepage": "https://wiki.analog.com/university/tools/m2k/scopy",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/analogdevicesinc/scopy/releases/download/v2.1.0/Scopy-v2.1.0-Windows-portable.zip",
-    "hash": "747fcc82988bb1d4b9a866b34b30cc53ff42657f6d9c007d2c6de3e31d852d6e",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/analogdevicesinc/scopy/releases/download/v2.1.0/Scopy-v2.1.0-Windows-portable.zip",
+            "hash": "747fcc82988bb1d4b9a866b34b30cc53ff42657f6d9c007d2c6de3e31d852d6e"
+        }
+    },
     "extract_dir": "Scopy-v2.1.0-Windows-portable",
-    "bin": "Scopy.exe",
+    "bin": [
+        [
+            "Scopy-console.exe",
+            "Scopy"
+        ]
+    ],
     "shortcuts": [
         [
             "Scopy.exe",
@@ -17,7 +26,11 @@
         "github": "https://github.com/analogdevicesinc/scopy"
     },
     "autoupdate": {
-        "extract_dir": "Scopy-v$version-Windows-portable",
-        "url": "https://github.com/analogdevicesinc/scopy/releases/download/v$version/Scopy-v$version-Windows-portable.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/analogdevicesinc/scopy/releases/download/v$version/Scopy-v$version-Windows-portable.zip"
+            }
+        },
+        "extract_dir": "Scopy-v$version-Windows-portable"
     }
 }


### PR DESCRIPTION
Changes:

* Update to v2.1.0
* Fix checkver, autoupdate.
* Update install logic, is not distributed as portable ZIP

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version 2.1.0 released.
  * Windows distribution now provided as a portable ZIP (no installer required).
* **Changes**
  * Portable package includes a dedicated extract directory and updated executable mapping for launching the app.
  * Shortcuts preserved and adjusted for the portable layout.
  * Update checks simplified to use the project release source and point to the portable artifact.
* **Removals**
  * Installer-based distribution and prior environment configuration removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->