### PR TITLE
pulseview@0.4.2: Remove checkver & change download URL to Wayback Machine

### DIFF
--- a/bucket/pulseview.json
+++ b/bucket/pulseview.json
@@ -1,16 +1,17 @@
 {
+    "##": "Deprecated? Homepage is dead, had to move downloads to Wayback Machine.",
     "version": "0.4.2",
     "description": "A logic analyzer GUI for sigrok",
     "homepage": "https://sigrok.org/wiki/PulseView",
     "license": "GPL-3.0-or-later",
     "architecture": {
-        "64bit": {
-            "url": "https://sigrok.org/download/binary/pulseview/pulseview-0.4.2-64bit-static-release-installer.exe#/dl.7z",
-            "hash": "63e9ba060bec76bca7e87bc7e06fd5f7405bc6c74aa0afd76e9e9b7b1c9fab41"
-        },
         "32bit": {
-            "url": "https://sigrok.org/download/binary/pulseview/pulseview-0.4.2-32bit-static-release-installer.exe#/dl.7z",
+            "url": "https://web.archive.org/web/20250726225815if_/https://sigrok.org/download/binary/pulseview/pulseview-0.4.2-32bit-static-release-installer.exe#/dl.7z",
             "hash": "cb8bda4f0edc1878c371fd2757433da1803be4b3cb1dbb0d412460c9db6cd0bb"
+        },
+        "64bit": {
+            "url": "https://web.archive.org/web/20250726225815if_/https://sigrok.org/download/binary/pulseview/pulseview-0.4.2-64bit-static-release-installer.exe#/dl.7z",
+            "hash": "63e9ba060bec76bca7e87bc7e06fd5f7405bc6c74aa0afd76e9e9b7b1c9fab41"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse",
@@ -21,10 +22,6 @@
             "PulseView"
         ]
     ],
-    "checkver": {
-        "url": "https://sigrok.org/download/binary/pulseview/?C=M;O=D",
-        "regex": "pulseview-([\\d.]+)-64bit-static-release-installer\\.exe"
-    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Changes:

* Remove checkver
* Change download URL to Wayback Machine

Because:

* Homepage seems dead.

Edit: Found this:

* <https://hackaday.com/2025/04/25/sigrok-website-down-after-hosting-data-loss/>
* <https://sourceforge.net/p/sigrok/mailman/message/59249346/>
* <https://github.com/sigrokproject/pulseview>
  * <https://github.com/sigrokproject/pulseview/issues/96>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation and migration information.

* **Chores**
  * Updated download source URLs to archived versions for platform support.
  * Removed automatic version checking mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->