### PR TITLE
stellarium@25.3: Remove autoupdate hash extraction

### DIFF
--- a/bucket/stellarium.json
+++ b/bucket/stellarium.json
@@ -33,10 +33,6 @@
             "arm64": {
                 "url": "https://github.com/Stellarium/stellarium/releases/download/v$version/stellarium-$matchLong-qt6-arm64.exe"
             }
-        },
-        "hash": {
-            "url": "https://github.com/Stellarium/stellarium/releases/tag/v$version",
-            "regex": "(?sm)$basename</.*?SHA256</strong>:\\s+$sha256"
         }
     }
 }


### PR DESCRIPTION
stellarium@25.3: Hash logic no longer works, use GitHub assets digest instead

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hash verification metadata from the autoupdate configuration. Autoupdate functionality for 64-bit and ARM64 platforms remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->