### PR TITLE
bandiview@7.23: add bandiview to scoop extras

### DIFF
--- a/bucket/bandiview.json
+++ b/bucket/bandiview.json
@@ -39,8 +39,8 @@
                 "Remove-Item -Path \"$dir\\data\\coupang.exe\" -Force -ErrorAction SilentlyContinue",
                 "Remove-Item -Path \"$dir\\data\\local.html\" -Force -ErrorAction SilentlyContinue",
                 "Remove-Item -Path \"$dir\\data\\meta.html\" -Force -ErrorAction SilentlyContinue",
-                "Remove-Item -Path \"$dir\\data\\RegDLL.x64.exe\" -Force -ErrorAction SilentlyContinue",
-                "Remove-Item -Path \"$dir\\data\\WebView2.x64.dll\" -Force -ErrorAction SilentlyContinue",
+                "Remove-Item -Path \"$dir\\data\\RegDLL.a64.exe\" -Force -ErrorAction SilentlyContinue",
+                "Remove-Item -Path \"$dir\\data\\WebView2.a64.dll\" -Force -ErrorAction SilentlyContinue",
                 "# Remove 64bit binaries",
                 "Get-ChildItem \"$dir\" -Recurse | Where{$_.Name -Match \"\\.x64\\.....?$\"} | Remove-Item",
                 "Rename-Item -Path \"$dir\\Bandiview.a64.exe\" -NewName \"$dir\\Bandiview.exe\""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Add app `bandiview`, which is the latest version of deprecated `honeyview`.  
  
On [honeyview official homepage](https://en.bandisoft.com/honeyview/) says:
```
Discontinuance of Honeyview Updates
There will be no more updates for Honeyview.
Download BandiView to use the features of Honeyview including further improvements.
```


<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for installing and managing Bandiview (x64 and arm64).
  * Creates a desktop shortcut for easy launching.
  * Preserves user configuration across updates and supports portable-mode persistence.
  * Automatic update checks and autoupdate support to detect and apply new releases.
  * Installer performs architecture-specific pre-install steps and removes bundled ads and unneeded files for a cleaner install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->