### PR TITLE
sonic-visualiser: Update to version 5.2.1, drop 32bit support

### DIFF
--- a/bucket/sonic-visualiser.json
+++ b/bucket/sonic-visualiser.json
@@ -1,18 +1,13 @@
 {
-    "version": "4.5.2",
-    "homepage": "https://www.sonicvisualiser.org",
+    "version": "5.2.1",
     "description": "Visualisation, analysis, and annotation of music audio recordings.",
+    "homepage": "https://www.sonicvisualiser.org",
     "license": "GPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v4.5.2/sonic-visualiser-4.5.2-win64.msi",
-            "hash": "fc6bd67628b982a7e3e80faaea25e3ddfe991dec167f0b86002b6545a43d8770",
+            "url": "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v5.2.1/sonic-visualiser-5.2.1-win64.msi",
+            "hash": "fb421363db474de2161ef5e73d5a5a1f548d2df0624d811ad0713e76bdae43b1",
             "extract_dir": "PFiles64\\Sonic Visualiser"
-        },
-        "32bit": {
-            "url": "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v4.5.2/sonic-visualiser-4.5.2-win32.msi",
-            "hash": "79845c404523990dd6baabdc7ac9ba25156b34d73a565d7ebdcb6f3aae8ec02f",
-            "extract_dir": "PFiles\\Sonic Visualiser"
         }
     },
     "shortcuts": [
@@ -20,6 +15,18 @@
             "Sonic Visualiser.exe",
             "Sonic Visualiser"
         ]
+    ],
+    "post_uninstall": [
+        "if ($purge) {",
+        "    $Directories = [string[]](",
+        "        [System.IO.Path]::Combine($env:APPDATA, 'sonic-visualiser')",
+        "    )",
+        "    $Directories.ForEach{",
+        "        if ([System.IO.Directory]::Exists($_)) {",
+        "            $null = [System.IO.Directory]::Delete($_,$true)",
+        "        }",
+        "    }",
+        "}"
     ],
     "checkver": {
         "github": "https://github.com/sonic-visualiser/sonic-visualiser",
@@ -29,9 +36,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v$version/sonic-visualiser-$version-win64.msi"
-            },
-            "32bit": {
-                "url": "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v$version/sonic-visualiser-$version-win32.msi"
             }
         }
     }


### PR DESCRIPTION
Changes:

* Remove 32bit
* Update to 5.2.1
* Add purge logic to remove leftovers

Because:

* 32bit is not included anymore

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Version upgraded from 4.5.2 to 5.2.1
  * 64-bit installation updated with new binary files and validation checksums
  * 32-bit platform support removed

* **New Features**
  * Automatic cleanup of application data directory upon uninstallation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->