### PR TITLE
sozi: Update to version 23.7.25, fix checkver & autoupdate

### DIFF
--- a/bucket/sozi.json
+++ b/bucket/sozi.json
@@ -23,23 +23,19 @@
         ]
     ],
     "post_uninstall": [
-        "if ($purge -and -not $global) {",
-        "    $LeftoverDirectories = [string[]](",
-        "        [System.IO.Path]::Combine($env:APPDATA, 'sozi') | Where-Object -FilterScript {[System.IO.Directory]::Exists($_)}",
+        "if ($purge) {",
+        "    $Directories = [string[]](",
+        "        [System.IO.Path]::Combine($env:APPDATA, 'sozi')",
         "    )",
-        "    if ($LeftoverDirectories.Count -gt 0) {",
-        "        $Message = [string] [System.Environment]::NewLine",
-        "        $Message += 'Found following leftover directories outside Scoop''s control:'",
-        "        $LeftoverDirectories.ForEach{",
-        "            $Message += [System.Environment]::NewLine",
-        "            $Message += '* {0}' -f $_",
+        "    $Directories.ForEach{",
+        "        if ([System.IO.Directory]::Exists($_)) {",
+        "            $null = [System.IO.Directory]::Delete($_,$true)",
         "        }",
-        "        info $Message",
         "    }",
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/sozi-projects/Sozi/releases",
+        "url": "https://api.github.com/repositories/940219/releases",
         "jsonpath": "$[?(@.prerelease == false)]",
         "regex": "/v(?<tag>[\\d.]+)/Sozi.Setup.([\\d.]+)-(?<build>[\\d]+).exe"
     },


### PR DESCRIPTION
Changes:

* Update to latest stable version.
* Fix checkver, autoupdate and install logix to handle new installer
* Inform of leftover directory `%APPDATA%\sozi` if `uninstall --purge`

Because:

* There is no longer a ZIP included, only an Electron installer.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated to version 23.7.25.
  * Switched to a new 64-bit installer format with updated checksum for streamlined installation.
  * Improved auto-update and release detection by pointing to the official releases endpoint for more reliable updates.

* **New Features**
  * Added post-uninstall cleanup to remove leftover directories when performing a purge.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->