### PR TITLE
easytier-gui: Add version 2.4.5

### DIFF
--- a/bucket/easytier-gui.json
+++ b/bucket/easytier-gui.json
@@ -5,15 +5,15 @@
     "license": "LGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/EasyTier/EasyTier/releases/download/v2.4.5/easytier-gui_2.4.5_x64-setup.exe#dl.7z",
+            "url": "https://github.com/EasyTier/EasyTier/releases/download/v2.4.5/easytier-gui_2.4.5_x64-setup.exe#/dl.7z",
             "hash": "57727f955a01c9d2ac4566b9320cf383a3e446ebc5f882e7995aa5195a4ef1f0"
         },
         "32bit": {
-            "url": "https://github.com/EasyTier/EasyTier/releases/download/v2.4.5/easytier-gui_2.4.5_x86-setup.exe#dl.7z",
+            "url": "https://github.com/EasyTier/EasyTier/releases/download/v2.4.5/easytier-gui_2.4.5_x86-setup.exe#/dl.7z",
             "hash": "eb5b146431ab75a35f3a500ed162887a082d925ddb3c888ceabea96ce0e66510"
         },
         "arm64": {
-            "url": "https://github.com/EasyTier/EasyTier/releases/download/v2.4.5/easytier-gui_2.4.5_arm64-setup.exe#dl.7z",
+            "url": "https://github.com/EasyTier/EasyTier/releases/download/v2.4.5/easytier-gui_2.4.5_arm64-setup.exe#/dl.7z",
             "hash": "52bdd7b52ba11036636673e28b71e14637fd915b3a4189eea20f81d833ac77bf"
         }
     },
@@ -28,13 +28,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/EasyTier/EasyTier/releases/download/v$version/easytier-gui_$version_x64-setup.exe#dl.7z"
+                "url": "https://github.com/EasyTier/EasyTier/releases/download/v$version/easytier-gui_$version_x64-setup.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/EasyTier/EasyTier/releases/download/v$version/easytier-gui_$version_x86-setup.exe#dl.7z"
+                "url": "https://github.com/EasyTier/EasyTier/releases/download/v$version/easytier-gui_$version_x86-setup.exe#/dl.7z"
             },
             "arm64": {
-                "url": "https://github.com/EasyTier/EasyTier/releases/download/v$version/easytier-gui_$version_arm64-setup.exe#dl.7z"
+                "url": "https://github.com/EasyTier/EasyTier/releases/download/v$version/easytier-gui_$version_arm64-setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #14582
- Relates to #14583
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EasyTier GUI manifest supporting 64-bit, 32-bit, and arm64 installers.
  * Included per-architecture download metadata with integrity hashes.
  * Added pre-install script support.
  * Added desktop shortcut creation.
  * Added automatic version check and autoupdate configuration tied to releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->