### PR TITLE
winsetupfromusb: Change download URL to Wayback Machine, remove checkver and autoupdate

### DIFF
--- a/bucket/winsetupfromusb.json
+++ b/bucket/winsetupfromusb.json
@@ -1,4 +1,8 @@
 {
+    "##": [
+        "Webpage is down, project dead? Thus using Wayback Machine for the download URL.",
+        "https://winsetupfromusb.org/ is an UNOFFICIAL webpage that looks like the original one."
+    ],
     "version": "1.10",
     "description": "Create multi-boot USB for Windows/Linux installations.",
     "homepage": "http://www.winsetupfromusb.com/",
@@ -6,7 +10,7 @@
         "identifier": "Freeware",
         "url": "http://www.winsetupfromusb.com/faq/"
     },
-    "url": "http://downloads.winsetupfromusb.com/WinSetupFromUSB-1-10.exe#/dl.7z",
+    "url": "https://web.archive.org/web/20241215195946if_/http://downloads.winsetupfromusb.com/WinSetupFromUSB-1-10.exe#/dl.7z",
     "hash": "f1f2db8cc6e02a8c7abd3e91a7aad23d1f3730eb16763b9041e73a55b817a7eb",
     "extract_dir": "WinSetupFromUSB-1-10",
     "pre_install": [
@@ -27,13 +31,5 @@
             "WinSetupFromUSB.exe",
             "WinSetupFromUSB"
         ]
-    ],
-    "checkver": {
-        "url": "http://www.winsetupfromusb.com/downloads/",
-        "regex": "WinSetupFromUSB\\s([\\d.]+)\\.exe"
-    },
-    "autoupdate": {
-        "url": "http://downloads.winsetupfromusb.com/WinSetupFromUSB-$dashVersion.exe#/dl.7z",
-        "extract_dir": "WinSetupFromUSB-$dashVersion"
-    }
+    ]
 }


### PR DESCRIPTION
Changes

* Change download URL to Wayback Machine
* Remove checkver and autoupdate

Because

* Homepage is down
  * <https://winsetupfromusb.org/> is an UNOFFICIAL webpage that looks like the original one.
* Autoupdate for manually installing other versions won't work, as wayback machine did not cache all versions on the same date
* Project seems dead?
  * <https://msfn.org/board/topic/120444-how-to-install-windows-from-usb-winsetupfromusb-with-gui/page/145/>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Download source updated to use Web Archive
  * Automatic version checking and update features have been disabled
  * Added advisory notice regarding webpage status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->