### PR TITLE
vapoursyntheditor@19: Fix checkver

### DIFF
--- a/bucket/vapoursyntheditor.json
+++ b/bucket/vapoursyntheditor.json
@@ -16,8 +16,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://bitbucket.org/mystery_keeper/vapoursynth-editor/downloads/?tab=tags",
-        "regex": "<td class=\"name\">r(\\d+)<\\/td>"
+        "url": "https://api.bitbucket.org/2.0/repositories/mystery_keeper/vapoursynth-editor/refs/tags?sort=-target.date&pagelen=1",
+        "jsonpath": "$.values[0].name",
+        "regex": "r(\\d+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Fixed checkver by using Bitbucket API:

<https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-tags-get>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version checking mechanism to use a more reliable API-based retrieval method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->