### PR TITLE
texteditoranywhere@2.01: Add discontinuation note, remove checkver & autoupdate

### DIFF
--- a/bucket/texteditoranywhere.json
+++ b/bucket/texteditoranywhere.json
@@ -3,6 +3,7 @@
     "description": "Text Editor Anywhere allows you to use your favourite text editor anywhere you can enter text.",
     "homepage": "https://www.listary.com/text-editor-anywhere",
     "license": "Unknown",
+    "notes": "TEA has been discontinued and is no longer actively maintained. See: https://discussion.listary.com/t/tea-not-working-on-windows-10/5407/1",
     "url": "https://www.listary.com/download/TEAPortable.zip",
     "hash": "18122737baed04bcd13e1d00f1ee8124420b02a312803209b695248a26320fae",
     "extract_dir": "TextEditorAnywhere",


### PR DESCRIPTION
Text Editor Anywhere is deprecated:

* <https://discussion.listary.com/t/tea-not-working-on-windows-10/5407>

Checkver fails because the webpage redirects to home now: <https://www.listary.com/text-editor-anywhere>

Thus I removed checkver (broken) and autoupdate (download URL does not allow to specify version).

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a discontinuation notice for the app to clarify its status and future availability.

* **Chores**
  * Removed version-checking and automatic update configuration from the app's manifest.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->