### PR TITLE
yasb@1.8.4: Update URLs

### DIFF
--- a/bucket/yasb.json
+++ b/bucket/yasb.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/amnweb/yasb/releases/download/v1.8.4/yasb-1.8.4-win64.msi",
+            "url": "https://github.com/amnweb/yasb/releases/download/v1.8.4/yasb-1.8.4-x64.msi",
             "hash": "e43b2f34e6036abcabd8b4af81247728d948ded64ebcdaed6de52eb64e4512bd"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/amnweb/yasb/releases/download/v$version/yasb-$version-win64.msi"
+                "url": "https://github.com/amnweb/yasb/releases/download/v$version/yasb-$version-x64.msi"
             }
         },
         "hash": {


### PR DESCRIPTION
Updated the 64bit installer URL to `…-x64.msi` so the manifest aligns with the naming used for upcoming multi-architecture releases.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 64-bit Windows installer download URL naming conventions across both primary and auto-update configurations to ensure consistency and standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->