### PR TITLE
weblogic-remote-console: Add version 2.4.18

### DIFF
--- a/bucket/weblogic-remote-console.json
+++ b/bucket/weblogic-remote-console.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.4.18",
+    "description": "A WebLogic Console that connects remotely using the WebLogic Management REST API",
+    "homepage": "https://oracle.github.io/weblogic-remote-console/",
+    "license": "UPL-1.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/oracle/weblogic-remote-console/releases/download/v2.4.18/WebLogic-Remote-Console-2.4.18-win.zip",
+            "hash": "77d76616aa2e2eda29a1fb154b1804c976cd5fe8a7ab53d920f82474f1b0377b"
+        }
+    },
+    "shortcuts": [
+        [
+            "WebLogic Remote Console.exe",
+            "WebLogic Remote Console"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/oracle/weblogic-remote-console"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/oracle/weblogic-remote-console/releases/download/v$version/WebLogic-Remote-Console-$version-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://oracle.github.io/weblogic-remote-console/

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * WebLogic Remote Console version 2.4.18 is now available through Scoop package manager with automatic update support and version checking via GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->