### PR TITLE
wpsoffice: Update to version 12.2.0.21179, remove checkver

### DIFF
--- a/bucket/wpsoffice.json
+++ b/bucket/wpsoffice.json
@@ -20,5 +20,8 @@
             "wpsoffice.exe",
             "WPS Office"
         ]
-    ]
+    ],
+    "autoupdate": {
+        "url": "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/$version/500.1001/WPSOffice_$version.exe"
+    }
 }


### PR DESCRIPTION
- Closes #16565

This was the latest version i was able to adjust to without much hassle, in 23155 they've changed and seemingly obfuscated where the binaries are kept, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated WPS Office to version 12.2.0.21179 and refreshed the installer package.
  * Package metadata and integrity information updated to match the new release.
  * App description, homepage, license, pre-install steps, installed shortcuts and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->