### PR TITLE
autoclicker: Update to version 4.1.0.0, add architecture (64bit only) field, fixed shortcut name

### DIFF
--- a/bucket/autoclicker.json
+++ b/bucket/autoclicker.json
@@ -3,13 +3,17 @@
     "description": "A full-fledged autoclicker with two modes of autoclicking, at your dynamic cursor location or at a prespecified location",
     "homepage": "https://sourceforge.net/projects/orphamielautoclicker/",
     "license": "CC-BY-NC-2.0",
-    "url": "https://sourceforge.net/projects/orphamielautoclicker/files/4.1/AutoClicker.exe",
-    "hash": "1ce7da6f2813c2ad1d2e496be6714e08cd618e6d9fe2df26c2bd4d894c9a6ec1",
+    "architecture": {
+        "64bit": {
+            "url": "https://sourceforge.net/projects/orphamielautoclicker/files/4.1/AutoClicker.exe",
+            "hash": "1ce7da6f2813c2ad1d2e496be6714e08cd618e6d9fe2df26c2bd4d894c9a6ec1"
+        }
+    },
     "pre_install": "$manifest.persist | ForEach-Object { if (-not (Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -Force -ItemType \"file\" | Out-Null } }",
     "shortcuts": [
         [
             "AutoClicker.exe",
-            "AutoClicker"
+            "OP Auto Clicker"
         ]
     ],
     "persist": "ACLib\\ACA_conf.ini"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 4.1.0.0, marking a significant release with infrastructure enhancements.
  * Refined application configuration architecture for improved 64-bit system compatibility.
  * Updated shortcut naming to "OP Auto Clicker" for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->