### PR TITLE
jjui: Add version 0.9.5

### DIFF
--- a/bucket/jjui.json
+++ b/bucket/jjui.json
@@ -13,12 +13,12 @@
             "hash": "7f4de2c7f88c8d9522415194b5a3b2c34a50e38813775151a7b5884584cd3e19"
         }
     },
+    "pre_install": "Get-ChildItem -Path $dir -Filter 'jjui*.exe' -Recurse | Select-Object -First 1 | Rename-Item -NewName 'jjui.exe'",
     "env_set": {
-        "JJUI_CONFIG_DIR": "$dir\\jjui"
+        "JJUI_CONFIG_DIR": "$dir\\config"
     },
     "bin": "jjui.exe",
-    "persist": "jjui",
-    "pre_install": "Get-ChildItem -Path $dir -Filter 'jjui*.exe' -Recurse | Select-Object -First 1 | Rename-Item -NewName 'jjui.exe'",
+    "persist": "config",
     "checkver": {
         "github": "https://github.com/idursun/jjui"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #16433

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added JJUI v0.9.5 Windows distribution manifest for Scoop-style installation.
  * Provides 64-bit and ARM64 packages with architecture-specific downloads and checksums.
  * Enables automatic version updates and a pre-install step to normalize the executable name.
  * Configures JJUI_CONFIG_DIR environment variable, exposes jjui.exe, and preserves a persistent config directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->