### PR TITLE
interpkit: Add version 1.1.0

### DIFF
--- a/bucket/interpkit.json
+++ b/bucket/interpkit.json
@@ -1,0 +1,13 @@
+{
+    "version": "1.1.0",
+    "description": "CLI tool for d/L0 to d/L function table lookup and interpolation.",
+    "homepage": "https://github.com/lainx86/InterpKit",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lainx86/InterpKit/releases/download/v1.1/InterpKit-v1.1-Windows-x64.zip",
+            "hash": "EE518E6485ED1747EBFC3ADC9ED88B5A272273E35D725161B1BF28D16B6241A9"
+        }
+    },
+    "bin": "interpkit.exe"
+}


### PR DESCRIPTION
Adds a manifest for InterpKit, a CLI tool for d/L0 to d/L function table lookup and interpolation.

Source: https://github.com/lainx86/InterpKit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * InterpKit CLI version 1.1.0 now available with official Windows 64-bit binary distribution and verified checksums for integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->