### PR TITLE
winmemorycleaner: Add version 3.0.5

### DIFF
--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,23 +1,41 @@
 {
-    "version": "3.0.4",
-    "description": "Portable RAM cleaner using native Windows APIs to release memory.",
-    "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
-    "license": {
-        "identifier": "GPL-3.0-or-later",
-        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE"
+  "version": "3.0.5",
+  "description": "Portable RAM cleaner using native Windows APIs to release memory.",
+  "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
+  "license": {
+    "identifier": "GPL-3.0-or-later",
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.5/WinMemoryCleaner.exe",
+      "hash": "75939c777b5c55685607039dfeda45ba7517674a1e3e77b71b5e524aea5ef96b"
     },
-    "notes": "Requires .NET Framework 4.x runtime.",
-    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.4/WinMemoryCleaner.exe",
-    "hash": "174798887f35005a096535ba720633272e146fdcd765e652f86a44c3df6bc606",
-    "bin": "WinMemoryCleaner.exe",
-    "shortcuts": [
-        [
-            "WinMemoryCleaner.exe",
-            "WinMemoryCleaner"
-        ]
-    ],
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+    "32bit": {
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.5/WinMemoryCleaner.exe",
+      "hash": "75939c777b5c55685607039dfeda45ba7517674a1e3e77b71b5e524aea5ef96b"
     }
+  },
+  "bin": "WinMemoryCleaner.exe",
+  "shortcuts": [
+    [
+      "WinMemoryCleaner.exe",
+      "WinMemoryCleaner"
+    ]
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      },
+      "32bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      }
+    }
+  },
+  "notes": [
+    "Requires administrator privileges (UAC prompt).",
+    "Requires .NET Framework 4.x runtime."
+  ]
 }


### PR DESCRIPTION
Adds the initial Scoop manifest for WinMemoryCleaner 3.0.5.

Portable RAM cleaner using native Windows APIs to release memory.

Closes #16604

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows Memory Cleaner version to 3.0.5
  * Reorganized package manifest structure to better support architecture-specific builds for both 64-bit and 32-bit platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->