### PR TITLE
winsshterm@2.41.6: Add environment variable to disable autoupdate

### DIFF
--- a/bucket/winsshterm.json
+++ b/bucket/winsshterm.json
@@ -22,13 +22,6 @@
         }
     },
     "extract_dir": "WinSSHTerm",
-    "bin": "WinSSHTerm.exe",
-    "shortcuts": [
-        [
-            "WinSSHTerm.exe",
-            "WinSSHTerm"
-        ]
-    ],
     "post_install": [
         "$puttyDir = currentdir putty $global",
         "'putty', 'pageant', 'plink', 'puttygen' | ForEach-Object {",
@@ -60,8 +53,15 @@
         "}"
     ],
     "env_set": {
-      "WINSSHTERM_EXE_DISALLOW_AUTO_UPDATE": "TRUE"
+        "WINSSHTERM_EXE_DISALLOW_AUTO_UPDATE": "TRUE"
     },
+    "bin": "WinSSHTerm.exe",
+    "shortcuts": [
+        [
+            "WinSSHTerm.exe",
+            "WinSSHTerm"
+        ]
+    ],
     "persist": [
         "config",
         "tools"


### PR DESCRIPTION
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Hi,

I'm the author of WinSSHTerm, planning to implement an [auto updater](https://github.com/WinSSHTerm/WinSSHTerm/issues/46) in a future release (2.42.0). To be able to decide if the auto updater should be disabled in case it was installed with a package manager like ScoopInstaller, WinSSHTerm will look for a special environment variable. With this pull request it is ensured, that this environment variable is set, and that ScoopInstaller is the sole update source.

Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Auto-update disabled by default via new configuration flag.
* **Bug Fixes**
  * Restored primary executable name and re-added desktop/shortcut entries to ensure launch shortcuts work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->