### PR TITLE
duplicati: Automatically reinstall service on update

### DIFF
--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -28,7 +28,7 @@
         }
     },
     "post_install": [
-        "if ($env:duplicati_svc_installed -eq $true) {",
+        "if (($cmd -eq 'update') -and ($env:duplicati_svc_installed -eq $true)) {",
         "    info 'Reinstalling service...'",
         "    if (!(is_admin)) { error 'Admin rights required to install Duplicati service'; break }",
         "    Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'install' -WindowStyle 'Hidden'",
@@ -57,7 +57,7 @@
         "    info 'Uninstalling service...'",
         "    if (!(is_admin)) { error 'Admin rights required to remove Duplicati service'; break }",
         "    Stop-Service duplicati",
-        "    $env:duplicati_svc_installed = $true",
+        "    if ($cmd -eq 'update') { $env:duplicati_svc_installed = $true }",
         "    Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'uninstall' -WindowStyle 'Hidden'",
         "}"
     ],


### PR DESCRIPTION
This will automatically
- stop Duplicati's Windows service if `ignore_running_processes` is `true` in `pre_uninstall`
- reinstall the service if it was found and removed by `pre_uninstall`

If there is a better way to communicate between `pre_uninstall` and `post_install` than an environment variable, I would love to hear about it.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in product naming.

* **Improvements**
  * Installer now conditionally reinstates the service configuration after install when an update path is detected.
  * Uninstall flow improved with clearer logging, admin-rights messaging, graceful service stop before uninstall, and preserved state to support conditional reinstall scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->