### PR TITLE
he: Add new app

### DIFF
--- a/bucket/he.json
+++ b/bucket/he.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "description": "Un outil CLI puissant pour gérer vos projets Git et GitHub.",
+    "homepage": "https://github.com/Lelio88/he_CLI",
+    "license": "MIT",
+    "url": "https://github.com/Lelio88/he_CLI/archive/refs/tags/v1.0.0.zip",
+    "extract_dir": "he_CLI-1.0.0",
+    "bin": [
+        ["main.ps1", "he"]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Lelio88/he_CLI/archive/refs/tags/v$version.zip",
+        "extract_dir": "he_CLI-$version"
+    },
+    "notes": "Utilisez 'scoop update he' pour les mises à jour."
+}


### PR DESCRIPTION
Description: HE CLI - Git & GitHub project manager wrapper.
Homepage: https://github.com/Lelio88/he_CLI
License: MIT
Bin: main.ps1 -> he

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `he` CLI tool is now available for installation through the Scoop package manager, enabling easy deployment across systems
  * Automatic update mechanism implemented with versioned releases to keep the tool current
  * Users can manage the installation with standard Scoop commands for seamless integration into their workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->