### PR TITLE
tauon: Update to version 8.2.2, fix autoupdate

### DIFF
--- a/bucket/tauon.json
+++ b/bucket/tauon.json
@@ -1,12 +1,15 @@
 {
-    "version": "8.1.2",
+    "version": "8.2.2",
     "description": "Tauon Music Box is a free, open-source, lightweight music player for Windows built with Electron",
     "homepage": "https://github.com/Taiko2k/Tauon",
-    "license": "GPL-3.0",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/Taiko2k/Tauon/blob/master/LICENSE"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Taiko2k/Tauon/releases/download/v8.1.2/TauonMusicBox-windows-portable.7z",
-            "hash": "6dd118b6c523a20742b4d2359f11076404b7721a8cbc6f68cec5cbbc7bd70185"
+            "url": "https://github.com/Taiko2k/Tauon/releases/download/v8.2.2/TauonMusicBox-windows.7z",
+            "hash": "444edaf2f1edcf534c5657156cf9e198a81c2415481af537b03e2591277f0672"
         }
     },
     "shortcuts": [
@@ -19,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Taiko2k/Tauon/releases/download/v$version/TauonMusicBox-windows-portable.7z"
+                "url": "https://github.com/Taiko2k/Tauon/releases/download/v$version/TauonMusicBox-windows.7z"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `tauon` to version **8.2.2**, refreshes download source, and improves the manifest metadata for accuracy and future maintainability.

### Related issues or pull requests

- Relates to https://github.com/Taiko2k/Tauon/issues/1884
- Relates to #16379 
- Closes #16549 

### Changes

- Updated version to **8.2.2**
- Switched asset from `TauonMusicBox-windows-portable.7z` to `TauonMusicBox-windows.7z`
- Improved `license` field  
  - Added SPDX identifier `GPL-3.0-or-later`  
  - Added direct link to upstream license

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App tauon -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f
tauon: 8.2.2 (scoop version is 8.2.2)
Forcing autoupdate!
Autoupdating tauon
DEBUG[1763797307] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1763797307] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1763797307] $substitutions.$patchVersion                  2
DEBUG[1763797307] $substitutions.$matchTail
DEBUG[1763797307] $substitutions.$urlNoExt                      https://github.com/Taiko2k/Tauon/releases/download/v8.2.2/TauonMusicBox-windows
DEBUG[1763797307] $substitutions.$match1                        8.2.2
DEBUG[1763797307] $substitutions.$buildVersion
DEBUG[1763797307] $substitutions.$basename                      TauonMusicBox-windows.7z
DEBUG[1763797307] $substitutions.$cleanVersion                  822
DEBUG[1763797307] $substitutions.$baseurl                       https://github.com/Taiko2k/Tauon/releases/download/v8.2.2
DEBUG[1763797307] $substitutions.$matchHead                     8.2.2
DEBUG[1763797307] $substitutions.$preReleaseVersion             8.2.2
DEBUG[1763797307] $substitutions.$url                           https://github.com/Taiko2k/Tauon/releases/download/v8.2.2/TauonMusicBox-windows.7z
DEBUG[1763797307] $substitutions.$version                       8.2.2
DEBUG[1763797307] $substitutions.$underscoreVersion             8_2_2
DEBUG[1763797307] $substitutions.$basenameNoExt                 TauonMusicBox-windows
DEBUG[1763797307] $substitutions.$dashVersion                   8-2-2
DEBUG[1763797307] $substitutions.$majorVersion                  8
DEBUG[1763797307] $substitutions.$minorVersion                  2
DEBUG[1763797307] $substitutions.$dotVersion                    8.2.2
DEBUG[1763797307] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1763797308] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/Taiko2k/Tauon/releases/download/v8.2.2/TauonMusicBox-windows.7z')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 444edaf2f1edcf534c5657156cf9e198a81c2415481af537b03e2591277f0672 using Github Mode
Writing updated tauon manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/tauon
Installing 'tauon' (8.2.2) [64bit] from 'Unofficial' bucket
Loading TauonMusicBox-windows.7z from cache.
Checking hash of TauonMusicBox-windows.7z ... ok.
Extracting TauonMusicBox-windows.7z ... done.
Linking D:\Software\Scoop\Local\apps\tauon\current => D:\Software\Scoop\Local\apps\tauon\8.2.2
Creating shortcut for Tauon Music Box (Tauon Music Box.exe)
'tauon' (8.2.2) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 8.2.2
  * Enhanced license information with detailed identifier and reference link
  * Switched Windows package from portable to standard format
  * Updated autoupdate mechanism to reflect new package format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->