### PR TITLE
php(-nts)-xdebug: Update to version 3.4.7-84, fix checkver & autoupdate

### DIFF
--- a/bucket/php-nts-xdebug.json
+++ b/bucket/php-nts-xdebug.json
@@ -3,7 +3,7 @@
     "description": "An extension for PHP to assist with debugging and development. (Non Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
-        "identifier": "Xdebug-1.01",
+        "identifier": "Xdebug-1.03",
         "url": "https://xdebug.org/license"
     },
     "notes": [

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -3,7 +3,7 @@
     "description": "An extension for PHP to assist with debugging and development. (Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
-        "identifier": "Xdebug-1.01",
+        "identifier": "Xdebug-1.03",
         "url": "https://xdebug.org/license"
     },
     "notes": [


### PR DESCRIPTION
### Summary

Updates both `php-xdebug` and `php-nts-xdebug` to version **3.4.7-84**, corrects upstream asset naming changes, rebuilds the `checkver` / `autoupdate` logic to ensure reliable version detection and hashing, and improves the manifest metadata for accuracy and future maintainability.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Updated version to **3.4.7-84** for both manifests
- Improved `license` field
- Updated download URLs and SHA256 hashes to match the latest upstream assets
- Rewrote `checkver` using a PowerShell script to:
  - Parse asset names from *historical* downloads instead of the main page  
  - Extract Xdebug version and PHP API version via regex groups  
  - Sort and select the newest compatible file dynamically
- Updated `autoupdate` to:
  - Use `$matchName` for fully dynamic asset resolution
  - Add a new hash-matching regex compatible with the historical download page
- Unified logic between the TS and NTS manifests for maintainability

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App php-* -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f                
php-nts-xdebug: 3.4.7-84 (scoop version is 3.4.7-8.4) autoupdate available                                                                     
Forcing autoupdate!
Autoupdating php-nts-xdebug
DEBUG[1763823212] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1763823212] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1763823212] $substitutions.$patchVersion                  7
DEBUG[1763823212] $substitutions.$minorVersion                  4
DEBUG[1763823212] $substitutions.$matchHead                     3.4.7
DEBUG[1763823212] $substitutions.$underscoreVersion             3_4_7_84
DEBUG[1763823212] $substitutions.$baseurl                       https://xdebug.org/files
DEBUG[1763823212] $substitutions.$urlNoExt                      https://xdebug.org/files/php_xdebug-3.4.7-8.4-nts-vs17-x86_64
DEBUG[1763823212] $substitutions.$version                       3.4.7-84
DEBUG[1763823212] $substitutions.$majorVersion                  3
DEBUG[1763823212] $substitutions.$dashVersion                   3-4-7-84
DEBUG[1763823212] $substitutions.$match1                        3.4.7-84
DEBUG[1763823212] $substitutions.$matchTail                     -84
DEBUG[1763823212] $substitutions.$preReleaseVersion             84
DEBUG[1763823212] $substitutions.$basenameNoExt                 php_xdebug-3.4.7-8.4-nts-vs17-x86_64
DEBUG[1763823212] $substitutions.$url                           https://xdebug.org/files/php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll
DEBUG[1763823212] $substitutions.$buildVersion
DEBUG[1763823212] $substitutions.$matchName                     php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll
DEBUG[1763823212] $substitutions.$cleanVersion                  34784
DEBUG[1763823212] $substitutions.$dotVersion                    3.4.7.84
DEBUG[1763823212] $substitutions.$basename                      php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll
DEBUG[1763823212] $hashfile_url = https://xdebug.org/download/historical -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll in https://xdebug.org/download/historical
DEBUG[1763823213] $regex = "SHA256:&nbsp;([a-fA-F0-9]{64})" href='/files/php_xdebug-3\.4\.7-8\.4-nts-vs17-x86_64\.dll' -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 1585d961e311bf138ff4cd98d04c3092c4fa00f8133b26f70a6bf946d23c43aa using Extract Mode
Writing updated php-nts-xdebug manifest
php-xdebug: 3.4.7-84 (scoop version is 3.4.7-8.4) autoupdate available
Forcing autoupdate!
Autoupdating php-xdebug
DEBUG[1763823214] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1763823214] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1763823214] $substitutions.$patchVersion                  7
DEBUG[1763823214] $substitutions.$minorVersion                  4
DEBUG[1763823214] $substitutions.$matchHead                     3.4.7
DEBUG[1763823214] $substitutions.$underscoreVersion             3_4_7_84
DEBUG[1763823214] $substitutions.$baseurl                       https://xdebug.org/files
DEBUG[1763823214] $substitutions.$urlNoExt                      https://xdebug.org/files/php_xdebug-3.4.7-8.4-ts-vs17-x86_64
DEBUG[1763823214] $substitutions.$version                       3.4.7-84
DEBUG[1763823214] $substitutions.$majorVersion                  3
DEBUG[1763823214] $substitutions.$dashVersion                   3-4-7-84
DEBUG[1763823214] $substitutions.$match1                        3.4.7-84
DEBUG[1763823214] $substitutions.$matchTail                     -84
DEBUG[1763823214] $substitutions.$preReleaseVersion             84
DEBUG[1763823214] $substitutions.$basenameNoExt                 php_xdebug-3.4.7-8.4-ts-vs17-x86_64
DEBUG[1763823214] $substitutions.$url                           https://xdebug.org/files/php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll
DEBUG[1763823214] $substitutions.$buildVersion
DEBUG[1763823214] $substitutions.$matchName                     php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll
DEBUG[1763823214] $substitutions.$cleanVersion                  34784
DEBUG[1763823214] $substitutions.$dotVersion                    3.4.7.84
DEBUG[1763823214] $substitutions.$basename                      php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll
DEBUG[1763823214] $hashfile_url = https://xdebug.org/download/historical -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll in https://xdebug.org/download/historical
DEBUG[1763823215] $regex = "SHA256:&nbsp;([a-fA-F0-9]{64})" href='/files/php_xdebug-3\.4\.7-8\.4-ts-vs17-x86_64\.dll' -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 15e5c20a7ac0576f9cc0cd437b2adc2dad71d49904388760ff9145c22b46cb1a using Extract Mode
Writing updated php-xdebug manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/php-xdebug
Installing 'php-xdebug' (3.4.7-84) [64bit] from 'Unofficial' bucket
Loading php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll from cache.
Checking hash of php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll ... ok.
Linking D:\Software\Scoop\Local\apps\php-xdebug\current => D:\Software\Scoop\Local\apps\php-xdebug\3.4.7-84            
Running post_install script...
PHP was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:

zend_extension=D:\Software\Scoop\Local\apps\php-xdebug\current\php_xdebug.dll
[xdebug]
xdebug.mode=debug
xdebug.start_with_request=yes
xdebug.discover_client_host=true

to your php.ini file
done.
'php-xdebug' (3.4.7-84) was installed successfully!
Notes
-----
Xdebug is already enabled if PHP was installed through scoop!
Otherwise add 'D:\Software\Scoop\Local\apps\php-xdebug\current\php_xdebug.dll' to your php.ini
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Xdebug updated to version 3.4.7 with PHP 8.4 support
  * License information and package verification mechanisms updated

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->