### PR TITLE
innounpacker: Update to version 2.1.2, fix checkver

### DIFF
--- a/bucket/innounpacker.json
+++ b/bucket/innounpacker.json
@@ -15,7 +15,10 @@
             "InnoUnpacker"
         ]
     ],
-    "checkver": "InnoUnpacker ([\\d.]+)",
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/changelog.txt",
+        "regex": "([\\d.]+) \\(.+\\)"
+    },
     "autoupdate": {
         "url": "https://www.rathlev-home.de/tools/download/innounpacker.zip"
     }


### PR DESCRIPTION
Looks like tool was updated day or two ago. But version number on the website was not updated :/

I tried to look onto it, but did not found any other ways to check current version...

P.S: Well.. Looks like it is usual thing for innounpacker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release to 2.1.2.
  * Updated update-check configuration to point at the project's changelog and use a refined version extraction pattern.
  * Updated published package hash to the new release checksum.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->