### PR TITLE
conemu@23.07.24: Update checkver & autoupdate, improve pre_install script

### DIFF
--- a/bucket/conemu.json
+++ b/bucket/conemu.json
@@ -4,7 +4,7 @@
     "homepage": "https://conemu.github.io",
     "license": {
         "identifier": "BSD-3-Clause",
-        "url": "https://github.com/ConEmu/ConEmu/blob/master/LICENSE"
+        "url": "https://github.com/ConEmu/ConEmu/blob/master/Release/ConEmu/License.txt"
     },
     "url": "https://github.com/ConEmu/ConEmu/releases/download/v23.07.24/ConEmuPack.230724.7z",
     "hash": "2a9b98ebecaede62665ef427b05b3a5ccdac7bd3202414fc0f4c10825b4f4ea2",


### PR DESCRIPTION
### Summary

Updates metadata to reference the renamed upstream repository (`Maximus5/ConEmu` → `ConEmu/ConEmu`), and improves XML initialization logic for reliability and maintainability.

### Related issues or pull requests

- Relates to #16460 

### Changes

- Update download and automatic update URLs
- Replace string-based license field with structured `license.identifier` and `license.url`
- Improve `pre_install` to:
  - Load and manipulate XML using PowerShell's native XML handling
  - Remove comment nodes before injection
  - Ensure update-related values are overridden (`Update.UseBuilds`, `Update.CheckHourly`, `Update.CheckOnStartup`)
- Move `ConEmu.xml` to a structured `persist` mapping for clearer configuration persistence

### Notes

- The manifest’s version check relies on the official GitHub repository, while the hash values on FossHub depend on manual uploads by their staff, which always occur later. Therefore, keeping the `hash` field provides little practical value.
- The program-generated `ConEmu.xml` is created directly under `$dir`, so the installation logic has been adjusted accordingly to maintain consistency. The changes to the `persist` field are intended to preserve compatibility with previous installations.

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App conemu -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
conemu: 23.07.24 (scoop version is 23.07.24)
Forcing autoupdate!
Autoupdating conemu
DEBUG[1764178035] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764178035] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764178035] $substitutions.$baseurl                       https://github.com/ConEmu/ConEmu/releases/download/v23.07.24
DEBUG[1764178035] $substitutions.$urlNoExt                      https://github.com/ConEmu/ConEmu/releases/download/v23.07.24/ConEmuPack.230724
DEBUG[1764178035] $substitutions.$url                           https://github.com/ConEmu/ConEmu/releases/download/v23.07.24/ConEmuPack.230724.7z
DEBUG[1764178035] $substitutions.$basename                      ConEmuPack.230724.7z
DEBUG[1764178035] $substitutions.$patchVersion                  24
DEBUG[1764178035] $substitutions.$cleanVersion                  230724
DEBUG[1764178035] $substitutions.$matchTail
DEBUG[1764178035] $substitutions.$underscoreVersion             23_07_24
DEBUG[1764178035] $substitutions.$matchHead                     23.07.24
DEBUG[1764178035] $substitutions.$preReleaseVersion             23.07.24
DEBUG[1764178035] $substitutions.$minorVersion                  07
DEBUG[1764178035] $substitutions.$match1                        23.07.24
DEBUG[1764178035] $substitutions.$majorVersion                  23
DEBUG[1764178035] $substitutions.$dashVersion                   23-07-24
DEBUG[1764178035] $substitutions.$buildVersion
DEBUG[1764178035] $substitutions.$dotVersion                    23.07.24
DEBUG[1764178035] $substitutions.$basenameNoExt                 ConEmuPack.230724
DEBUG[1764178035] $substitutions.$version                       23.07.24
DEBUG[1764178035] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1764178036] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/ConEmu/ConEmu/releases/download/v23.07.24/ConEmuPack.230724.7z')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/ConEmu/ConEmu/releases
Downloading ConEmuPack.230724.7z to compute hashes!
Loading ConEmuPack.230724.7z from cache
Computed hash: 2a9b98ebecaede62665ef427b05b3a5ccdac7bd3202414fc0f4c10825b4f4ea2
Writing updated conemu manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/conemu
Installing 'conemu' (23.07.24) [64bit] from 'Unofficial' bucket
Loading ConEmuPack.230724.7z from cache.
Checking hash of ConEmuPack.230724.7z ... ok.
Extracting ConEmuPack.230724.7z ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\conemu\current => D:\Software\Scoop\Local\apps\conemu\23.07.24
Creating shim for 'ConEmu'.
Making D:\Software\Scoop\Local\shims\conemu.exe a GUI binary.
Creating shortcut for ConEmu (ConEmu64.exe)
Persisting ConEmu.xml
'conemu' (23.07.24) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Source repository updated to reference the official ConEmu organization
  * License information now includes explicit documentation reference
  * Configuration persistence mechanism refined
  * Version checking now points to official repository

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->