### PR TITLE
diagram-designer@1.30.0: Update checkver, fix extraction

### DIFF
--- a/bucket/diagram-designer.json
+++ b/bucket/diagram-designer.json
@@ -4,7 +4,7 @@
     "homepage": "https://logicnet.dk/DiagramDesigner/",
     "license": {
         "identifier": "MIT",
-        "url": "https://github.com/FluidSynth/fluidsynth/blob/master/LICENSE"
+        "url": "https://github.com/meesoft/DiagramDesigner/blob/master/LICENSE"
     },
     "notes": "Template palettes can be downloaded from 'https://github.com/meesoft/DiagramDesigner/tree/master/TemplatePalettes'",
     "url": "https://www.fosshub.com/Diagram-Designer.html/DiagramDesignerSetup.1.30.0.msi",


### PR DESCRIPTION
### Summary

Improves the diagram-designer manifest by correcting its license information, adding missing metadata, and updating the version detection logic to rely on FossHub’s structured metadata. 

### Related issues or pull requests

- Relates to #16460 

### Changes

- Replace generic `Freeware` license declaration:
  - Update to `MIT`
  - Add explicit `license.url` field
- Add missing `extract_dir` (`APPDIR`) to ensure proper MSI extraction results
- Update `checkver` to use FossHub’s `softwareVersion` metadata

### Notes

- The newly added HTML metadata field (softwareVersion) has been tested and proven to remain stable across multiple software pages, as it does not rely on filenames.
- Add the `extract_dir` field to resolve the following issue:

```
Creating shortcut for Diagram Designer (DiagramDesigner.exe) failed: Couldn't find D:\Software\Scoop\Local\apps\diagram-designer\current\DiagramDesigner.exe
```

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App diagram-designer -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
diagram-designer: 1.30.0 (scoop version is 1.30.0)
Forcing autoupdate!
Autoupdating diagram-designer
DEBUG[1764180551] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764180551] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764180551] $substitutions.$baseurl                       https://www.fosshub.com/Diagram-Designer.html
DEBUG[1764180551] $substitutions.$urlNoExt                      https://www.fosshub.com/Diagram-Designer.html/DiagramDesignerSetup.1.30.0
DEBUG[1764180551] $substitutions.$url                           https://www.fosshub.com/Diagram-Designer.html/DiagramDesignerSetup.1.30.0.msi
DEBUG[1764180551] $substitutions.$basename                      DiagramDesignerSetup.1.30.0.msi
DEBUG[1764180551] $substitutions.$patchVersion                  0
DEBUG[1764180551] $substitutions.$cleanVersion                  1300
DEBUG[1764180551] $substitutions.$matchTail
DEBUG[1764180551] $substitutions.$underscoreVersion             1_30_0
DEBUG[1764180551] $substitutions.$matchHead                     1.30.0
DEBUG[1764180551] $substitutions.$preReleaseVersion             1.30.0
DEBUG[1764180551] $substitutions.$minorVersion                  30
DEBUG[1764180551] $substitutions.$match1                        1.30.0
DEBUG[1764180551] $substitutions.$majorVersion                  1
DEBUG[1764180551] $substitutions.$dashVersion                   1-30-0
DEBUG[1764180551] $substitutions.$buildVersion
DEBUG[1764180551] $substitutions.$dotVersion                    1.30.0
DEBUG[1764180551] $substitutions.$basenameNoExt                 DiagramDesignerSetup.1.30.0
DEBUG[1764180551] $substitutions.$version                       1.30.0
DEBUG[1764180551] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1764180551] $regex = DiagramDesignerSetup.1.30.0.msi.*?"sha256":"([a-fA-F0-9]{64})" -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 0df1070ecc634204d93f4a85394f1f9680d9cd1a6d184e123dc980e59ede3d6f using Fosshub Mode
Writing updated diagram-designer manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/diagram-designer
Installing 'diagram-designer' (1.30.0) [64bit] from 'Unofficial' bucket
Loading DiagramDesignerSetup.1.30.0.msi from cache.
Checking hash of DiagramDesignerSetup.1.30.0.msi ... ok.
Extracting DiagramDesignerSetup.1.30.0.msi ... done.
Linking D:\Software\Scoop\Local\apps\diagram-designer\current => D:\Software\Scoop\Local\apps\diagram-designer\1.30.0
Creating shortcut for Diagram Designer (DiagramDesigner.exe)
'diagram-designer' (1.30.0) was installed successfully!
Notes
-----
Template palettes can be downloaded from 'https://github.com/meesoft/DiagramDesigner/tree/master/TemplatePalettes'
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Product description punctuation clarified for consistency.
  * License information now documented as MIT with an official source link.
  * Installation flow enhanced with a conditional step to better handle packaged files during install.
  * Version-check updated to use a specific upstream page and improved pattern matching for more reliable update detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->