### PR TITLE
mp3directcut@2.39: Update checkver & autoupdate, refine installation scripts

### DIFF
--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -1,5 +1,4 @@
 {
-    "##": "Rename to #/dl.7z cannot be used as download is not stripping rename and fosshub cannot handle it",
     "version": "2.39",
     "description": "Lossless audio editor and recorder for MP3 files.",
     "homepage": "http://mpesch3.de",
@@ -8,13 +7,15 @@
     "hash": "6bc9cda080266f0dc5d6304712ff35f8227d37acac19bf49e3320836098c80b0",
     "installer": {
         "script": [
-            "Expand-7zipArchive \"$dir\\$fname\" -Removal",
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -Removal",
             "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
-            "    Set-Content \"$dir\\mp3DirectCut.ini\" @('[mp3DirectCut]', \"version=$version\") -Encoding Ascii",
+            "    $cfg = @('[mp3DirectCut]', \"file_savepath=$persist_dir\\Recording\", \"version=$version\")",
+            "    Set-Content -Path \"$dir\\mp3DirectCut.ini\" -Value $cfg -Encoding Ascii",
             "} else {",
-            "    (Get-Content \"$persist_dir\\mp3DirectCut.ini\") -replace 'version=.+', \"version=$version\" | Set-Content \"$persist_dir\\mp3DirectCut.ini\" -Encoding Ascii",
+            "    $cfg = Get-Content \"$persist_dir\\mp3DirectCut.ini\"",
+            "    $cfg -replace 'version=.+', \"version=$version\" | Set-Content -Path \"$persist_dir\\mp3DirectCut.ini\" -Encoding Ascii",
             "}",
-            "New-Item \"$dir\\mp3DClocal.ini\" | Out-Null"
+            "New-Item -Path \"$dir\\mp3DClocal.ini\" -ItemType File -Force | Out-Null"
         ]
     },
     "bin": "mp3DirectCut.exe",
@@ -24,13 +25,15 @@
             "mp3DirectCut"
         ]
     ],
-    "persist": "mp3DirectCut.ini",
-    "checkver": "Version ([\\d.]+)",
+    "persist": [
+        "Recording",
+        "mp3DirectCut.ini"
+    ],
+    "checkver": {
+        "url": "https://www.fosshub.com/mp3DirectCut.html",
+        "regex": "\"softwareVersion\">([\\d.]+)<"
+    },
     "autoupdate": {
-        "url": "https://www.fosshub.com/mp3DirectCut.html/mp3DC$cleanVersion.exe",
-        "hash": {
-            "url": "http://mpesch3.de",
-            "regex": "checksum:\\s*$md5"
-        }
+        "url": "https://www.fosshub.com/mp3DirectCut.html/mp3DC$cleanVersion.exe"
     }
 }


### PR DESCRIPTION
### Summary

This includes refactoring installer scripts, expanding the persist list, and switching `checkver` to a stable metadata source on FossHub.

### Related issues or pull requests

- Relates to #16460 

### Changes

- Refactor installer initialization:
  - Added `file_savepath` pointing to `$persist_dir\Recording`
- Add `Recording` to `persist` to retain user-created output folders  
- Update `checkver`:
  - Switch to FossHub HTML metadata (`softwareVersion`) instead of regexing filenames
- Remove the outdated checksum-extraction logic from `mpesch3.de`, since the SHA256 value on that page now contains spaces, and to maintain the simplicity of the manifest.

### Notes

- To ensure reliable automatic updates and simplify the manifest, the `checkver` source has been switched to FossHub.
- The newly added HTML metadata field (softwareVersion) has been tested and proven to remain stable across multiple software pages, as it does not rely on filenames.

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App mp3directcut -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
mp3directcut: 2.39 (scoop version is 2.39)
Forcing autoupdate!
Autoupdating mp3directcut
DEBUG[1764179517] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764179517] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764179517] $substitutions.$baseurl                       https://www.fosshub.com/mp3DirectCut.html
DEBUG[1764179517] $substitutions.$urlNoExt                      https://www.fosshub.com/mp3DirectCut.html/mp3DC239
DEBUG[1764179517] $substitutions.$url                           https://www.fosshub.com/mp3DirectCut.html/mp3DC239.exe
DEBUG[1764179517] $substitutions.$basename                      mp3DC239.exe
DEBUG[1764179517] $substitutions.$patchVersion
DEBUG[1764179517] $substitutions.$cleanVersion                  239
DEBUG[1764179517] $substitutions.$matchTail
DEBUG[1764179517] $substitutions.$underscoreVersion             2_39
DEBUG[1764179517] $substitutions.$matchHead                     2.39
DEBUG[1764179517] $substitutions.$preReleaseVersion             2.39
DEBUG[1764179517] $substitutions.$minorVersion                  39
DEBUG[1764179517] $substitutions.$match1                        2.39
DEBUG[1764179517] $substitutions.$majorVersion                  2
DEBUG[1764179517] $substitutions.$dashVersion                   2-39
DEBUG[1764179517] $substitutions.$buildVersion
DEBUG[1764179517] $substitutions.$dotVersion                    2.39
DEBUG[1764179517] $substitutions.$basenameNoExt                 mp3DC239
DEBUG[1764179517] $substitutions.$version                       2.39
DEBUG[1764179517] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1764179517] $regex = mp3DC239.exe.*?"sha256":"([a-fA-F0-9]{64})" -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 6bc9cda080266f0dc5d6304712ff35f8227d37acac19bf49e3320836098c80b0 using Fosshub Mode
Writing updated mp3directcut manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/mp3directcut
Installing 'mp3directcut' (2.39) [64bit] from 'Unofficial' bucket
Loading mp3DC239.exe from cache.
Checking hash of mp3DC239.exe ... ok.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\mp3directcut\current => D:\Software\Scoop\Local\apps\mp3directcut\2.39
Creating shim for 'mp3DirectCut'.
Making D:\Software\Scoop\Local\shims\mp3directcut.exe a GUI binary.
Creating shortcut for mp3DirectCut (mp3DirectCut.exe)
Persisting Recording
Persisting mp3DirectCut.ini
'mp3directcut' (2.39) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)