### PR TITLE
task-coach@1.4.6: Update checkver & autopdate, improve metadata

### DIFF
--- a/bucket/task-coach.json
+++ b/bucket/task-coach.json
@@ -1,12 +1,14 @@
 {
-    "version": "1.4.6_rev1",
-    "description": "Todo list manager",
+    "version": "1.4.6",
+    "description": "A free and open-source task manager that supports composite tasks, prioritization, effort tracking, and categorization. It is designed to offer flexible yet straightforward task management suitable for both simple and advanced workflows.",
     "homepage": "https://www.taskcoach.org",
-    "license": "GPL-3.0-only",
-    "url": "https://www.fosshub.com/Task-Coach.html/X-TaskCoach_1.4.6_rev1.zip",
-    "hash": "b73d17b3b5e6ab3407bffd4f0b905e176060001f2f868379d974de313706df61",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://taskcoach.org/license.html"
+    },
+    "url": "https://downloads.sourceforge.net/project/taskcoach/taskcoach/Release-1.4.6/X-TaskCoach_1.4.6_rev1.zip",
+    "hash": "sha1:ceb1af5c1e25a33bff799c259742342caa64e8eb",
     "bin": [
-        "X-TaskCoach.exe",
         [
             "X-TaskCoach.exe",
             "taskcoach"
@@ -20,13 +22,10 @@
     ],
     "persist": [
         "User",
-        "X-TaskCoach.ini"
+        "Documents"
     ],
-    "checkver": {
-        "url": "https://www.fosshub.com/Task-Coach.html",
-        "regex": "X-TaskCoach_([\\w.]+)\\.zip"
-    },
+    "checkver": "Task Coach ([\\d.]+)",
     "autoupdate": {
-        "url": "https://www.fosshub.com/Task-Coach.html/X-TaskCoach_$version.zip"
+        "url": "https://downloads.sourceforge.net/project/taskcoach/taskcoach/Release-$version/X-TaskCoach_$version_rev1.zip"
     }
 }


### PR DESCRIPTION
### Summary

This update corrects metadata fields, improves licensing information, and migrates download sources from FossHub to SourceForge for better stability.

### Related issues or pull requests

- Relates to #16460 

### Changes

- Correcte version from **1.4.6_rev1** to **1.4.6**  
- Update manifest description to a more complete and professional summary  
- Update `license` field to include SPDX identifier and project license URL  
- Replace FossHub URLs with SourceForge’s official project download links  
- Update `persist` entries to reflect the application's actual portable structure  

### Notes

- After testing, I confirmed that `X-TaskCoach.ini` functions as the configuration file for `X-TaskCoach.exe`, similar to a standard `*.exe.config`, and therefore does not require persistence. In contrast, omitting persistence for the `Documents` directory would result in data loss.
- SourceForge assets include fixed suffix `_rev1`, which remains compatible with the updated `autoupdate` logic  

### Testing

```
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App task-coach -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
task-coach: 1.4.6 (scoop version is 1.4.6)
Forcing autoupdate!
Autoupdating task-coach
DEBUG[1764181658] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764181658] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764181658] $substitutions.$baseurl                       https://downloads.sourceforge.net/project/taskcoach/taskcoach/Release-1.4.6
DEBUG[1764181658] $substitutions.$urlNoExt                      https://downloads.sourceforge.net/project/taskcoach/taskcoach/Release-1.4.6/X-TaskCoach_1.4.6_rev1
DEBUG[1764181658] $substitutions.$url                           https://downloads.sourceforge.net/project/taskcoach/taskcoach/Release-1.4.6/X-TaskCoach_1.4.6_rev1.zip
DEBUG[1764181658] $substitutions.$basename                      X-TaskCoach_1.4.6_rev1.zip
DEBUG[1764181658] $substitutions.$patchVersion                  6
DEBUG[1764181658] $substitutions.$cleanVersion                  146
DEBUG[1764181658] $substitutions.$matchTail
DEBUG[1764181658] $substitutions.$underscoreVersion             1_4_6
DEBUG[1764181658] $substitutions.$matchHead                     1.4.6
DEBUG[1764181658] $substitutions.$preReleaseVersion             1.4.6
DEBUG[1764181658] $substitutions.$minorVersion                  4
DEBUG[1764181658] $substitutions.$match1                        1.4.6
DEBUG[1764181658] $substitutions.$majorVersion                  1
DEBUG[1764181658] $substitutions.$dashVersion                   1-4-6
DEBUG[1764181658] $substitutions.$buildVersion
DEBUG[1764181658] $substitutions.$dotVersion                    1.4.6
DEBUG[1764181658] $substitutions.$basenameNoExt                 X-TaskCoach_1.4.6_rev1
DEBUG[1764181658] $substitutions.$version                       1.4.6
DEBUG[1764181658] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1764181659] $regex = "X-TaskCoach_1\.4\.6_rev1\.zip":.*?"sha1":\s*"([a-fA-F0-9]{40})" -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha1:ceb1af5c1e25a33bff799c259742342caa64e8eb using Sourceforge Mode
Writing updated task-coach manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/task-coach
Installing 'task-coach' (1.4.6) [64bit] from 'Unofficial' bucket
Loading X-TaskCoach_1.4.6_rev1.zip from cache.
Checking hash of X-TaskCoach_1.4.6_rev1.zip ... ok.
Extracting X-TaskCoach_1.4.6_rev1.zip ... done.
Linking D:\Software\Scoop\Local\apps\task-coach\current => D:\Software\Scoop\Local\apps\task-coach\1.4.6
Creating shim for 'taskcoach'.
Making D:\Software\Scoop\Local\shims\taskcoach.exe a GUI binary.
Creating shortcut for Task Coach (X-TaskCoach.exe)
Persisting User
Persisting Documents
'task-coach' (1.4.6) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
