### PR TITLE
databricks-cli: Add version 0.278.0

### DIFF
--- a/bucket/databricks-cli.json
+++ b/bucket/databricks-cli.json
@@ -1,4 +1,5 @@
 {
+    "##": "Please keep checkver field as is. We cannot fetch the latest version via the GitHub API, due to the IP restrictions in the Databricks org.",
     "version": "0.278.0",
     "description": "CLI for interacting with the Databricks platform.",
     "homepage": "https://docs.databricks.com/aws/en/dev-tools/cli",
@@ -18,9 +19,8 @@
     },
     "bin": "databricks.exe",
     "checkver": {
-        "url": "https://api.github.com/repositories/491883713/releases",
-        "jsonpath": "$..name",
-        "regex": "(?:v|V)([\\d.]+)"
+        "url": "https://github.com/databricks/cli/releases/latest",
+        "regex": "/tree/(?:v|V)([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Closes #16666

Add manifest for Databricks CLI - the official command-line interface for Databricks.

**Homepage:** https://github.com/databricks/cli
**License:** Databricks License
**Version:** 0.278.0

Features:
- checkver configured to track latest releases via GitHub API
- autoupdate with hash extraction from SHA256SUMS file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Databricks CLI package entry enabling versioned, architecture-aware distribution and automated update checks.
  * Configured Windows installers for x64 and ARM64 (ZIP) with SHA256 integrity verification and automated hash lookup from published checksums to support secure autoupdate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->