### PR TITLE
filezilla: Update to version 3.69.5, fix checkver, refactor manifest

### DIFF
--- a/bucket/filezilla.json
+++ b/bucket/filezilla.json
@@ -1,42 +1,50 @@
 {
-    "##": "This package should be updated manually. See #9179 for details",
-    "version": "3.69.1",
+    "##": [
+        "The author of FileZilla explicitly prohibits the use of package managers to download files, as this places undue load on their servers.",
+        "Consequently, Scoop must not use any FileZilla-related URLs for downloading or automatic updates.",
+        "For further information, please refer to the following resources:",
+        "- https://github.com/ScoopInstaller/Extras/issues/9179",
+        "- https://forum.filezilla-project.org/viewtopic.php?f=1&t=55635&p=192010&hilit=winget#p192010"
+    ],
+    "version": "3.69.5",
     "description": "Fast and reliable cross-platform FTP, FTPS and SFTP client with lots of useful features and an intuitive graphical user interface.",
-    "homepage": "https://filezilla-project.org/",
+    "homepage": "https://filezilla-project.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://packages.chocolatey.org/filezilla.3.69.1.nupkg",
-    "hash": "5632950c6e67e5692260edeb9ea37f560d04d791e55f6ccdd78c9b9c81060b44",
+    "url": "https://packages.chocolatey.org/filezilla.3.69.5.nupkg",
+    "hash": "614bfc4155a16c5c06ef2dce560b3676a0f002700d3c4cdb8d581ba00b8eb2dd",
     "extract_dir": "tools",
-    "pre_install": [
-        "$arch = 'x86'",
-        "if (\"$architecture\" -Match '64bit' -or \"$architecture\" -Match 'arm64') { $arch = 'x64' }",
-        "Expand-7zipArchive \"$dir\\FileZilla_*_$arch.exe\" \"$dir\" -Removal",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\*.ps1\", \"$dir\\FileZilla_*.exe\" -Recurse -Force",
-        "@'",
-        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>",
-        "<FileZilla3>",
-        "  <Settings>",
-        "    <Setting name=\"Config Location\">config</Setting>",
-        "    <Setting name=\"Disable update check\">1</Setting>",
-        "  </Settings>",
-        "</FileZilla3>",
-        "'@ | Out-File \"$dir\\fzdefaults.xml\" -Encoding Ascii",
-        "",
-        "$oldfzdefault = \"$persist_dir\\fzdefaults.xml\"",
-        "if (Test-Path \"$oldfzdefault\") {",
-        "    Write-Host 'Adopting new persist configuration...' -f Yellow",
-        "    $oldConfigDir = \"$((Get-Item \"$persist_dir\").PSDrive.Root)filezilla\"",
-        "    $newConfigDir = \"$persist_dir\\config\"",
-        "    if (Test-Path \"$oldConfigDir\") {",
-        "        Write-Host \"Moving existing configuration from '$oldConfigDir' to '$newConfigDir'\" -f Yellow",
-        "        if (Test-Path \"$newConfigDir\") {",
-        "            Move-Item \"$oldConfigDir\\*\" \"$newConfigDir\"",
-        "        } else { ",
-        "            Move-Item \"$oldConfigDir\" \"$newConfigDir\"",
-        "        }",
-        "    }",
-        "    Rename-Item \"$oldfzdefault\" \"fzdefaults.xml.bak\"",
-        "}"
+    "architecture": {
+        "64bit": {
+            "pre_install": [
+                "Get-ChildItem -Path $dir -Exclude '*64*' -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue",
+                "Get-ChildItem -Path $dir -include '*.exe' -Recurse | Rename-Item -NewName 'setup.exe'"
+            ]
+        },
+        "32bit": {
+            "pre_install": [
+                "Get-ChildItem -Path $dir -Exclude '*32*' -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue",
+                "Get-ChildItem -Path $dir -include '*.exe' -Recurse | Rename-Item -NewName 'setup.exe'"
+            ]
+        }
+    },
+    "installer": {
+        "script": [
+            "Expand-7zipArchive -Path \"$dir\\setup.exe\" -DestinationPath $dir -Switches '-xr!$* -xr!unins*' -Removal",
+            "[xml]$xml = Get-Content -Path \"$dir\\docs\\fzdefaults.xml.example\" -Encoding ascii",
+            "$comments = $xml.ChildNodes | Where-Object { $_.NodeType.ToString() -eq 'Comment' }",
+            "$comments | ForEach-Object { $_.ParentNode.RemoveChild($_) | Out-Null }",
+            "$xml.SelectSingleNode('//Setting[@name=''Disable update check'']').InnerText = '1'",
+            "$xml.SelectSingleNode('//Setting[@name=''Cache directory'']').InnerText = 'data\\cache'",
+            "$xml.SelectSingleNode('//Setting[@name=''Config Location'']').InnerText = 'data\\config'",
+            "$xml.Save(\"$dir\\fzdefaults.xml\")"
+        ]
+    },
+    "post_install": [
+        "# Data Migration (Removed on 1 December 2026)",
+        "if (-not (Test-Path \"$persist_dir\\config\")) { return }",
+        "ensure \"$persist_dir\\data\\config\" | Out-Null",
+        "Copy-Item -Path \"$persist_dir\\config\\*\" -Destination \"$persist_dir\\data\\config\" -Force -Recurse",
+        "Remove-Item -Path \"$persist_dir\\config\" -Recurse -Force -ErrorAction SilentlyContinue"
     ],
     "bin": "filezilla.exe",
     "shortcuts": [
@@ -45,10 +53,10 @@
             "FileZilla"
         ]
     ],
-    "persist": "config",
+    "persist": "data",
     "checkver": {
         "url": "https://community.chocolatey.org/packages/filezilla",
-        "regex": "<meta property=\"og:title\" content=\"FileZilla ([\\d.]+)\">"
+        "regex": "FileZilla <span>([\\d.]+)<"
     },
     "autoupdate": {
         "url": "https://packages.chocolatey.org/filezilla.$version.nupkg",


### PR DESCRIPTION
### Summary

Updates `filezilla` to version **3.69.5** and refactors the manifest to comply with the upstream policy, improve maintainability, and simplify the installation process.

### Related issues or pull requests

- Closes #16667 
- Relates to #9179 
- Relates to #2425 

### Changes

- Update version to **3.69.5**  
- Refactore installer script logic
  - Replace the manual `pre_install` script with architecture-specific `pre_install` handling for 64-bit and 32-bit builds
  - Add installer script to handle extraction and `fzdefaults.xml` modifications
  - Add `post_install` script to migrate existing user data.
- Update `checkver` regex to match Chocolatey package title  

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App filezilla -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
filezilla: 3.69.5 (scoop version is 3.69.5)
Forcing autoupdate!
Autoupdating filezilla
DEBUG[1764356765] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764356765] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764356765] $substitutions.$dashVersion                   3-69-5
DEBUG[1764356765] $substitutions.$match1                        3.69.5
DEBUG[1764356765] $substitutions.$matchTail
DEBUG[1764356765] $substitutions.$url                           https://packages.chocolatey.org/filezilla.3.69.5.nupkg
DEBUG[1764356765] $substitutions.$patchVersion                  5
DEBUG[1764356765] $substitutions.$baseurl                       https://packages.chocolatey.org
DEBUG[1764356765] $substitutions.$urlNoExt                      https://packages.chocolatey.org/filezilla.3.69.5
DEBUG[1764356765] $substitutions.$matchHead                     3.69.5
DEBUG[1764356765] $substitutions.$basename                      filezilla.3.69.5.nupkg
DEBUG[1764356765] $substitutions.$version                       3.69.5
DEBUG[1764356765] $substitutions.$cleanVersion                  3695
DEBUG[1764356765] $substitutions.$basenameNoExt                 filezilla.3.69.5
DEBUG[1764356765] $substitutions.$minorVersion                  69
DEBUG[1764356765] $substitutions.$majorVersion                  3
DEBUG[1764356765] $substitutions.$buildVersion
DEBUG[1764356765] $substitutions.$underscoreVersion             3_69_5
DEBUG[1764356765] $substitutions.$preReleaseVersion             3.69.5
DEBUG[1764356765] $substitutions.$dotVersion                    3.69.5
DEBUG[1764356765] $hashfile_url = https://community.chocolatey.org/packages/filezilla/3.69.5 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for filezilla.3.69.5.nupkg in https://community.chocolatey.org/packages/filezilla/3.69.5
DEBUG[1764356765] $regex = ([a-fA-F0-9]{64}).*?filezilla\.3\.69\.5\.nupkg -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 614bfc4155a16c5c06ef2dce560b3676a0f002700d3c4cdb8d581ba00b8eb2dd using Extract Mode
Writing updated filezilla manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/filezilla
Installing 'filezilla' (3.69.5) [64bit] from 'Unofficial' bucket
Loading filezilla.3.69.5.nupkg from cache.
Installing 'filezilla' (3.69.5) [64bit] from 'Unofficial' bucket
Loading filezilla.3.69.5.nupkg from cache.
Checking hash of filezilla.3.69.5.nupkg ... ok.
Extracting filezilla.3.69.5.nupkg ... done.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\filezilla\current => D:\Software\Scoop\Local\apps\filezilla\3.69.5
Creating shim for 'filezilla'.
Making D:\Software\Scoop\Local\shims\filezilla.exe a GUI binary.
Creating shortcut for FileZilla (filezilla.exe)
Persisting data
Running post_install script...done.
'filezilla' (3.69.5) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Version upgraded to 3.69.5
  * Package source updated
  * Homepage URL corrected

* **Improvements**
  * Installation process now includes architecture-specific handling for 64-bit and 32-bit systems
  * Configuration migration workflow enhanced
  * Data persistence location modified
  * Version detection mechanism updated

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->