### PR TITLE
chromium-clang: Add version

### DIFF
--- a/bucket/chromium-clang.json
+++ b/bucket/chromium-clang.json
@@ -1,0 +1,50 @@
+{
+    "version": "144.0.7510.0-r1540236",
+    "description": "Chromium browser compiled with the Clang/LLVM compiler.",
+    "homepage": "https://github.com/RobRich999/Chromium_Clang",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/RobRich999/Chromium_Clang/releases/download/v144.0.7510.0-r1540236-win64-avx2/chrome.zip",
+            "hash": "sha1:68d70d0f1719a04b06d3299346cff5c251b4bdcc"
+        }
+    },
+    "extract_dir": "chrome-win32",
+    "bin": [
+        [
+            "chrome.exe",
+            "chromium",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "shortcuts": [
+        [
+            "chrome.exe",
+            "Chromium",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "post_install": [
+        "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$env:LocalAppData\\Chromium\\User Data\")) {",
+        "    info '[Portable Mode]: Copying user data...'",
+        "    Copy-Item \"$env:LocalAppData\\Chromium\\User Data\\*\" \"$dir\\User Data\" -Recurse",
+        "}"
+    ],
+    "persist": "User Data",
+    "checkver": {
+        "url": "https://api.github.com/repos/RobRich999/Chromium_Clang/tags",
+        "jsonpath": "$..name",
+        "regex": "v([\\d.\\-r]+)-win64-avx2"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/RobRich999/Chromium_Clang/releases/download/v$version-win64-avx2/chrome.zip",
+                "hash": {
+                    "url": "https://api.github.com/repos/RobRich999/Chromium_Clang/releases/tags/v$version-win64-avx2",
+                    "regex": "chrome.zip - $sha1\\\\r\\\\n"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add version 144.0.7510.0-r1540236-win64-avx2

### Why this? Because

- Thorium has long release cycle, not safe
- Thorium is not using CI builds
- Better than Thorium 

### Notes:

- **hash regex doesn't work! please help**
- Commit title is too long
- AVX2
- I'll finish indentation when everything is done.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a portable Chromium build compiled with Clang/LLVM.
  * Includes a portable launcher and shortcuts that use a persistent local user-data directory.
  * Installer preserves and copies existing user data when present.
  * Automatic update checks against GitHub releases to keep the build current.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->