### PR TITLE
folge: Add version 1.28.0

### DIFF
--- a/bucket/folge.json
+++ b/bucket/folge.json
@@ -2,22 +2,22 @@
     "version": "1.28.0",
     "description": "Simple, free, and powerful desktop tool for creating, managing, and sharing your processes and knowledge.",
     "homepage": "https://folge.me",
-    "license": "https://folge.me/eula",
-    "##": [
-        "No hash file for autoupdate available",
-        "Installer is 32-bit, but actual application is only 64-bit Windows"
-    ],
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://folge.me/eula"
+    },
     "architecture": {
         "64bit": {
             "url": "https://cdn.folge.me/Folge-1.28.0.exe#/dl.7z",
             "hash": "7d38d141b14c31e0c58cb305f810630c18f3422399d31b43bc80ae314b49f8b8"
         }
     },
-    "extract_dir": "$PLUGINSDIR",
-    "pre_install": [
-        "Get-Item \"$dir\\*\" -Exclude \"app-64.7z\" | Remove-Item",
-        "Expand-7zipArchive \"$dir\\app-64.7z\" \"$dir\" -Removal"
-    ],
+    "installer": {
+        "script": [
+            "Get-Item \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item \"$dir\\`$*\" -Force -Recurse"
+        ]
+    },
     "shortcuts": [
         [
             "Folge.exe",


### PR DESCRIPTION
### Summary
Adds Folge in the windows variant [Folge](https://folge.me/#download) with version `1.28.0`.

### Related issues or pull requests
- Closes #16683
<!--  -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows Scoop package manifest for Folge, enabling users to install and manage Folge via Scoop.
  * Installer extracts the 64‑bit archive, performs cleanup, and creates a desktop/start‑menu shortcut.
  * Includes metadata (description, homepage, license), checksum-verified download, and automatic update/checkver configuration for future releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->