### PR TITLE
twinkle-tray@1.17.1: Update pre_install script

### DIFF
--- a/bucket/twinkle-tray.json
+++ b/bucket/twinkle-tray.json
@@ -9,7 +9,7 @@
             "hash": "b0b80d78e20d2229a0cae3c0fcd1d7d065225fb6ca538ebbb42552701aaac9fb",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall Twinkle Tray.exe\" -Recurse -Force -ErrorAction SilentlyContinue"
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\Uninstall Twinkle Tray.exe\" -Recurse -Force -ErrorAction SilentlyContinue"
             ]
         }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR does the following:
- Modifies the `pre_install` script to delete the leftover '$R0' folder (holding the app uninstaller).
In previous versions, this no longer existed, and the uninstaller was held at the root of the archive. However, the app has now reverted to holding it in the folder again. This update ensures that it's caught in either case.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #14685

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer cleanup configuration to remove additional temporary files during installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->