### PR TITLE
raspberry-pi-imager: Update to version 2.0.0, fix autoupdate

### DIFF
--- a/bucket/raspberry-pi-imager.json
+++ b/bucket/raspberry-pi-imager.json
@@ -3,8 +3,13 @@
     "description": "Tool for writing an Raspberry Pi OS images to SD cards.",
     "homepage": "https://www.raspberrypi.org/software",
     "license": "Apache-2.0",
-    "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v2.0.0/imager-v2.0.0.exe",
-    "hash": "a4f32e3a83c075ec61be6a44237e7abaaf52c6f4e1534174e14473c1458136c8",
+    "notes": "To opt out of telemetry, run: Set-ItemProperty 'HKCU:/Software/Raspberry Pi/Imager' telemetry 0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v2.0.0/imager-v2.0.0.exe",
+            "hash": "a4f32e3a83c075ec61be6a44237e7abaaf52c6f4e1534174e14473c1458136c8"
+        }
+    },
     "innosetup": true,
     "bin": "rpi-imager.exe",
     "shortcuts": [
@@ -13,11 +18,14 @@
             "Raspberry PI Imager"
         ]
     ],
-    "notes": "To opt out of telemetry, run: Set-ItemProperty 'HKCU:/Software/Raspberry Pi/Imager' telemetry 0",
     "checkver": {
         "github": "https://github.com/raspberrypi/rpi-imager"
     },
     "autoupdate": {
-        "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v$version/imager-v$version.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v$version/imager-v$version.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR updates raspberry-pi-imager to v2.0.0.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Raspberry Pi Imager to version 2.0.0.
  * Refreshed official 64‑bit download links and associated checksums for the 2.0.0 release.
  * Adjusted the auto-update URL pattern to the 2.0.0 naming and made update settings architecture-specific (64‑bit).
  * Added a top‑level note explaining telemetry opt-out guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->