### PR TITLE
msikombustor: Update to version 4.1.36, fix checkver & autoupdate

### DIFF
--- a/bucket/msikombustor.json
+++ b/bucket/msikombustor.json
@@ -1,14 +1,14 @@
 {
-    "version": "4.1.33.0",
+    "version": "4.1.36",
     "description": "A standalone benchmark/stability test tool based on software from the maker of Furmark.",
-    "homepage": "https://geeks3d.com/furmark/kombustor/downloads/",
+    "homepage": "https://www.geeks3d.com/furmark/kombustor/",
     "license": "Freeware",
+    "innosetup": true,
     "architecture": {
         "64bit": {
-            "url": "https://gpuscore.top/msi/MSI_Kombustor4_Setup_v4.1.33.0_x64.exe",
-            "hash": "bcfd3363a187353e664c603aba9f08772b802e7a5924e1ed55206c205ae259b3",
+            "url": "https://geeks3d.com/dl/get/837#/MSI_Kombustor_Setup_v4.1.36_x64.exe",
+            "hash": "f578cbcc7487596756c6b5c9b3f8419375f5232f087154c8ec318196b871eb65",
             "bin": [
-                "MSI-Kombustor-x64.exe",
                 [
                     "MSI-Kombustor-x64.exe",
                     "MSI-Kombustor"
@@ -22,12 +22,18 @@
             ]
         }
     },
-    "innosetup": true,
-    "checkver": "Version ([\\d.]+) -",
+    "checkver": {
+        "url": "https://geeks3d.com/furmark/kombustor/downloads/",
+        "regex": "dl/show/(?<tag>\\d+)(?!.+zip).+?Kombustor\\s+([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gpuscore.top/msi/MSI_Kombustor4_Setup_v$version_x64.exe"
+                "url": "https://geeks3d.com/dl/get/$matchTag#/MSI_Kombustor_Setup_v$version_x64.exe",
+                "hash": {
+                    "url": "https://geeks3d.com/dl/show/$matchTag",
+                    "regex": "(?i)sha256.+?$sha256<"
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `msikombustor` to version **4.1.36**, refines the manifest structure, and improves the update/verification workflow for long-term maintainability.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Update version to **4.1.36**
- Update homepage to the canonical product page
- Update download URL and SHA256 hash for the 64-bit installer
- Update `checkver` regex
- Enhance `autoupdate`:
  - Added dynamic hash retrieval from Geeks3D download page  
  - Ensures the manifest remains valid even if upstream packaging changes

### Testing

```
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App msikombustor -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
msikombustor: 4.1.36 (scoop version is 4.1.36)
Forcing autoupdate!
Autoupdating msikombustor
DEBUG[1764845006] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764845006] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764845006] $substitutions.$baseurl                       https://gpuscore.top/msi
DEBUG[1764845006] $substitutions.$match1                        4.1.36
DEBUG[1764845006] $substitutions.$underscoreVersion             4_1_36
DEBUG[1764845006] $substitutions.$basenameNoExt                 MSI_Kombustor4_Setup_v4.1.36_x64
DEBUG[1764845006] $substitutions.$urlNoExt                      https://gpuscore.top/msi/MSI_Kombustor4_Setup_v4.1.36_x64
DEBUG[1764845006] $substitutions.$matchTag                      837
DEBUG[1764845006] $substitutions.$basename                      MSI_Kombustor4_Setup_v4.1.36_x64.exe
DEBUG[1764845006] $substitutions.$matchHead                     4.1.36
DEBUG[1764845006] $substitutions.$preReleaseVersion             4.1.36
DEBUG[1764845006] $substitutions.$url                           https://gpuscore.top/msi/MSI_Kombustor4_Setup_v4.1.36_x64.exe
DEBUG[1764845006] $substitutions.$dashVersion                   4-1-36
DEBUG[1764845006] $substitutions.$dotVersion                    4.1.36
DEBUG[1764845006] $substitutions.$cleanVersion                  4136
DEBUG[1764845006] $substitutions.$majorVersion                  4
DEBUG[1764845006] $substitutions.$buildVersion
DEBUG[1764845006] $substitutions.$matchTail
DEBUG[1764845006] $substitutions.$patchVersion                  36
DEBUG[1764845006] $substitutions.$version                       4.1.36
DEBUG[1764845006] $substitutions.$minorVersion                  1
DEBUG[1764845006] $hashfile_url = https://geeks3d.com/dl/show/837 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for MSI_Kombustor4_Setup_v4.1.36_x64.exe in https://geeks3d.com/dl/show/837
DEBUG[1764845007] $regex = (?i)sha256.+?([a-fA-F0-9]{64})< -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: f578cbcc7487596756c6b5c9b3f8419375f5232f087154c8ec318196b871eb65 using Extract Mode
Writing updated msikombustor manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/msikombustor
Installing 'msikombustor' (4.1.36) [64bit] from 'Unofficial' bucket
Loading MSI_Kombustor4_Setup_v4.1.36_x64.exe from cache.
Checking hash of MSI_Kombustor4_Setup_v4.1.36_x64.exe ... ok.
Extracting MSI_Kombustor4_Setup_v4.1.36_x64.exe ... done.
Linking D:\Software\Scoop\Local\apps\msikombustor\current => D:\Software\Scoop\Local\apps\msikombustor\4.1.36
Creating shim for 'MSI-Kombustor'.
Making D:\Software\Scoop\Local\shims\msi-kombustor.exe a GUI binary.
Creating shortcut for MSI Kombustor (MSI-Kombustor-x64.exe)
'msikombustor' (4.1.36) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Version upgraded to 4.1.36 and 64‑bit installer package refreshed.
  * Project homepage URL updated.
  * Installer metadata now marks the package as using Inno Setup.

* **New/Improved**
  * Automated update detection and autoupdate flow enhanced to use structured version parsing and dynamic release/hash retrieval for more reliable updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->