### PR TITLE
gatling: Update to version 3.14.9.1, fix checkver & autoupdate

### DIFF
--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.13.5",
+    "version": "3.14.9.1",
     "description": "Async load test tool for web applications",
     "homepage": "https://gatling.io",
     "license": "Apache-2.0",
@@ -9,9 +9,9 @@
             "java/openjdk"
         ]
     },
-    "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.13.5/gatling-charts-highcharts-bundle-3.13.5.zip",
-    "hash": "sha1:373b2e906aea27734bdf5e8b4719d26c82055827",
-    "extract_dir": "gatling-charts-highcharts-bundle-3.13.5",
+    "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.14.9.1/gatling-charts-highcharts-bundle-3.14.9.1-bundle.zip",
+    "hash": "sha1:d40e7e065c1a39887ee7afe27613ef283725ac9b",
+    "extract_dir": "gatling-charts-highcharts-bundle-3.14.9.1",
     "bin": [
         "bin\\gatling.bat",
         "bin\\recorder.bat"
@@ -31,11 +31,25 @@
         "user-files"
     ],
     "checkver": {
-        "url": "https://search.maven.org/solrsearch/select/?q=g:io.gatling.highcharts+AND+a:gatling-charts-highcharts-bundle",
-        "jsonpath": "$.response.docs[0].latestVersion"
+        "script": [
+            "$version_regex = '^(?!\\.)[\\d.]+/$'",
+            "$version_sort = { [version]$_.href.TrimEnd('/') }",
+            "$releases = 'https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/'",
+            "$download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing",
+            "$version_segments = $download_page.links | Where-Object href -Match $version_regex | Sort-Object $version_sort -Descending | Select-Object -Expand href",
+            "foreach ($version_segment in $version_segments) {",
+            "    $version_url = $releases + $version_segment",
+            "    $version_page = Invoke-WebRequest -Uri $version_url -UseBasicParsing",
+            "    if ($null -ne $version_page -and $version_page.Content -match 'href=\"(?<name>.+?zip)\"') {",
+            "        Write-Output \"$version_segment, $($Matches['name'])\"",
+            "        break",
+            "    }",
+            "}"
+        ],
+        "regex": "([\\d.]+)/, (?<name>.+)"
     },
     "autoupdate": {
-        "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$version/gatling-charts-highcharts-bundle-$version.zip",
+        "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$version/$matchName",
         "hash": {
             "url": "$url.sha1"
         },


### PR DESCRIPTION
### Summary

Updates `gatling` to version **3.14.9.1** and fixes checkver & autoupdate.

### Related issues or pull requests

- Relates to #14604 
- Relates to #16379 

### Notes

- It seems that since version 3.11, the upstream has changed the file structure inside the archive. This causes installation of `gatling` to fail for users because the files specified in the `bin` field cannot be found.
- See: #14604
- Unfortunately, I have never used this application and am unable to fix the above issue.


### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App gatling -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
gatling: 3.14.9.1 (scoop version is 3.14.9.1)
Forcing autoupdate!
Autoupdating gatling
DEBUG[1764859805] [$updatedProperties] = [url hash extract_dir] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1764859805] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1764859805] $substitutions.$minorVersion                  14
DEBUG[1764859805] $substitutions.$url                           https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.14.9.1/gatling-charts-highcharts-bundle-3.14.9.1-bundle.…
DEBUG[1764859805] $substitutions.$underscoreVersion             3_14_9_1
DEBUG[1764859805] $substitutions.$majorVersion                  3
DEBUG[1764859805] $substitutions.$match1                        3.14.9.1
DEBUG[1764859805] $substitutions.$patchVersion                  9
DEBUG[1764859805] $substitutions.$version                       3.14.9.1
DEBUG[1764859805] $substitutions.$matchName                     gatling-charts-highcharts-bundle-3.14.9.1-bundle.zip
DEBUG[1764859805] $substitutions.$buildVersion                  1
DEBUG[1764859805] $substitutions.$basename                      gatling-charts-highcharts-bundle-3.14.9.1-bundle.zip
DEBUG[1764859805] $substitutions.$basenameNoExt                 gatling-charts-highcharts-bundle-3.14.9.1-bundle
DEBUG[1764859805] $substitutions.$urlNoExt                      https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.14.9.1/gatling-charts-highcharts-bundle-3.14.9.1-bundle
DEBUG[1764859805] $substitutions.$matchHead                     3.14.9
DEBUG[1764859805] $substitutions.$cleanVersion                  31491
DEBUG[1764859805] $substitutions.$matchTail                     .1
DEBUG[1764859805] $substitutions.$dashVersion                   3-14-9-1
DEBUG[1764859805] $substitutions.$baseurl                       https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.14.9.1
DEBUG[1764859805] $substitutions.$dotVersion                    3.14.9.1
DEBUG[1764859805] $substitutions.$preReleaseVersion             3.14.9.1
DEBUG[1764859805] $hashfile_url = https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.14.9.1/gatling-charts-highcharts-bundle-3.14.9.1-bundle.zip.sha1 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for gatling-charts-highcharts-bundle-3.14.9.1-bundle.zip in https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.14.9.1/gatling-charts-highcharts-bundle-3.14.9.1-bundle.zip.sha1
DEBUG[1764859805] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha1:d40e7e065c1a39887ee7afe27613ef283725ac9b using Extract Mode
Writing updated gatling manifest
```


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Upgraded Gatling from version 3.13.5 to 3.14.9.1
  - Updated download source location and cryptographic verification checksums for the new release
  - Migrated version discovery to an enhanced detection mechanism

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->