### PR TITLE
whepfrom@0.8.1: Add arm64 version, update description & homepage, fix bin

### DIFF
--- a/bucket/whepfrom.json
+++ b/bucket/whepfrom.json
@@ -1,8 +1,11 @@
 {
     "version": "0.8.1",
-    "description": "From shep to rtp",
-    "homepage": "https://github.com/binbat/live777/",
-    "license": "MPL-2.0",
+    "description": "WHEP to RTP/RTSP tool.",
+    "homepage": "https://live777.pages.dev",
+    "license": {
+        "identifier": "MPL-2.0",
+        "url": "https://github.com/binbat/live777/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/binbat/live777/releases/download/v0.8.1/whepfrom-v0.8.1-x86_64-pc-windows-msvc.exe#/whepfrom.exe",
@@ -11,9 +14,13 @@
         "32bit": {
             "url": "https://github.com/binbat/live777/releases/download/v0.8.1/whepfrom-v0.8.1-i686-pc-windows-msvc.exe#/whepfrom.exe",
             "hash": "7e71eab6d326244dcb455214db87231e0197f78c054b8e99929efb4ffd54f8a7"
+        },
+        "arm64": {
+            "url": "https://github.com/binbat/live777/releases/download/v0.8.1/whepfrom-v0.8.1-aarch64-pc-windows-msvc.exe#/whepfrom.exe",
+            "hash": "4f9dcbabe794f3fe2c1163b18c68863904eaf8fdcae316d51cf8bb1124ed684e"
         }
     },
-    "bin": "live777.exe",
+    "bin": "whepfrom.exe",
     "checkver": {
         "github": "https://github.com/binbat/live777"
     },
@@ -24,6 +31,9 @@
             },
             "32bit": {
                 "url": "https://github.com/binbat/live777/releases/download/v$version/whepfrom-v$version-i686-pc-windows-msvc.exe#/whepfrom.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/binbat/live777/releases/download/v$version/whepfrom-v$version-aarch64-pc-windows-msvc.exe#/whepfrom.exe"
             }
         }
     }


### PR DESCRIPTION
### Summary

Add arm64 version, update description and homepage.

### Related issues or pull requests

- Relates to #16735 
- Relates to #16737 

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App whepfrom -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
whepfrom: 0.8.1 (scoop version is 0.8.1)
Forcing autoupdate!
Autoupdating whepfrom
DEBUG[1765109271] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765109271] $substitutions.$baseurl                       https://github.com/binbat/live777/releases/download/v0.8.1
DEBUG[1765109271] $substitutions.$url                           https://github.com/binbat/live777/releases/download/v0.8.1/whepfrom-v0.8.1-aarch64-pc-windows-msvc.exe
DEBUG[1765109271] $substitutions.$underscoreVersion             0_8_1
DEBUG[1765109271] $substitutions.$basename                      whepfrom-v0.8.1-aarch64-pc-windows-msvc.exe
DEBUG[1765109271] $substitutions.$dashVersion                   0-8-1
DEBUG[1765109271] $substitutions.$cleanVersion                  081
DEBUG[1765109271] $substitutions.$matchTail
DEBUG[1765109271] $substitutions.$matchHead                     0.8.1
DEBUG[1765109271] $substitutions.$basenameNoExt                 whepfrom-v0.8.1-aarch64-pc-windows-msvc
DEBUG[1765109271] $substitutions.$patchVersion                  1
DEBUG[1765109271] $substitutions.$match1                        0.8.1
DEBUG[1765109271] $substitutions.$preReleaseVersion             0.8.1
DEBUG[1765109271] $substitutions.$version                       0.8.1
DEBUG[1765109271] $substitutions.$urlNoExt                      https://github.com/binbat/live777/releases/download/v0.8.1/whepfrom-v0.8.1-aarch64-pc-windows-msvc
DEBUG[1765109271] $substitutions.$buildVersion
DEBUG[1765109271] $substitutions.$majorVersion                  0
DEBUG[1765109271] $substitutions.$minorVersion                  8
DEBUG[1765109271] $substitutions.$dotVersion                    0.8.1
DEBUG[1765109271] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1765109271] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/binbat/live777/releases/download/v0.8.1/whepfrom-v0.8.1-aarch64-pc-windows-msvc.exe#/whepfrom.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/binbat/live777/releases
Downloading whepfrom-v0.8.1-aarch64-pc-windows-msvc.exe to compute hashes!
Loading whepfrom-v0.8.1-aarch64-pc-windows-msvc.exe from cache
Computed hash: 4f9dcbabe794f3fe2c1163b18c68863904eaf8fdcae316d51cf8bb1124ed684e
Writing updated whepfrom manifest
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support for compatible devices.

* **Chores**
  * Updated product description for clarity.
  * Updated homepage to point to the live site.
  * Enhanced license information with reference URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->