### PR TITLE
whipinto@0.8.1: Add arm64 version, update description & homepage

### DIFF
--- a/bucket/whipinto.json
+++ b/bucket/whipinto.json
@@ -1,8 +1,11 @@
 {
     "version": "0.8.1",
-    "description": "From rtp to whip",
-    "homepage": "https://github.com/binbat/live777/",
-    "license": "MPL-2.0",
+    "description": "RTP/RTSP to WHIP tool.",
+    "homepage": "https://live777.pages.dev",
+    "license": {
+        "identifier": "MPL-2.0",
+        "url": "https://github.com/binbat/live777/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/binbat/live777/releases/download/v0.8.1/whipinto-v0.8.1-x86_64-pc-windows-msvc.exe#/whipinto.exe",
@@ -11,6 +14,10 @@
         "32bit": {
             "url": "https://github.com/binbat/live777/releases/download/v0.8.1/whipinto-v0.8.1-i686-pc-windows-msvc.exe#/whipinto.exe",
             "hash": "79bf44cab304d3507feccd985800b3d5ac4a836e78ddbacdf327f8dc8070759c"
+        },
+        "arm64": {
+            "url": "https://github.com/binbat/live777/releases/download/v0.8.1/whipinto-v0.8.1-aarch64-pc-windows-msvc.exe#/whipinto.exe",
+            "hash": "243f2ff6b81a2c5db9ead3fec39201a403f4ad1dc0fa599f743d5c8661124d00"
         }
     },
     "bin": "whipinto.exe",
@@ -24,6 +31,9 @@
             },
             "32bit": {
                 "url": "https://github.com/binbat/live777/releases/download/v$version/whipinto-v$version-i686-pc-windows-msvc.exe#/whipinto.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/binbat/live777/releases/download/v$version/whipinto-v$version-aarch64-pc-windows-msvc.exe#/whipinto.exe"
             }
         }
     }


### PR DESCRIPTION
### Summary

Add arm64 version, update description and homepage.

### Related issues or pull requests

- Relates to #16735 
- Relates to #16736 

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App whipinto -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
whipinto: 0.8.1 (scoop version is 0.8.1)
Forcing autoupdate!
Autoupdating whipinto
DEBUG[1765109521] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765109521] $substitutions.$baseurl                       https://github.com/binbat/live777/releases/download/v0.8.1
DEBUG[1765109521] $substitutions.$url                           https://github.com/binbat/live777/releases/download/v0.8.1/whipinto-v0.8.1-aarch64-pc-windows-msvc.exe
DEBUG[1765109521] $substitutions.$underscoreVersion             0_8_1
DEBUG[1765109521] $substitutions.$basename                      whipinto-v0.8.1-aarch64-pc-windows-msvc.exe
DEBUG[1765109521] $substitutions.$dashVersion                   0-8-1
DEBUG[1765109521] $substitutions.$cleanVersion                  081
DEBUG[1765109521] $substitutions.$matchTail
DEBUG[1765109521] $substitutions.$matchHead                     0.8.1
DEBUG[1765109521] $substitutions.$basenameNoExt                 whipinto-v0.8.1-aarch64-pc-windows-msvc
DEBUG[1765109521] $substitutions.$patchVersion                  1
DEBUG[1765109521] $substitutions.$match1                        0.8.1
DEBUG[1765109521] $substitutions.$preReleaseVersion             0.8.1
DEBUG[1765109521] $substitutions.$version                       0.8.1
DEBUG[1765109521] $substitutions.$urlNoExt                      https://github.com/binbat/live777/releases/download/v0.8.1/whipinto-v0.8.1-aarch64-pc-windows-msvc
DEBUG[1765109521] $substitutions.$buildVersion
DEBUG[1765109521] $substitutions.$majorVersion                  0
DEBUG[1765109521] $substitutions.$minorVersion                  8
DEBUG[1765109521] $substitutions.$dotVersion                    0.8.1
DEBUG[1765109521] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1765109522] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/binbat/live777/releases/download/v0.8.1/whipinto-v0.8.1-aarch64-pc-windows-msvc.exe#/whipinto.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/binbat/live777/releases
Downloading whipinto-v0.8.1-aarch64-pc-windows-msvc.exe to compute hashes!
Loading whipinto-v0.8.1-aarch64-pc-windows-msvc.exe from cache
Computed hash: 243f2ff6b81a2c5db9ead3fec39201a403f4ad1dc0fa599f743d5c8661124d00
Writing updated whipinto manifest
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for arm64 architecture.

* **Chores**
  * Updated license information structure for enhanced metadata organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->