### PR TITLE
shadowsocks-qtun-plugin: Update to version 0.3.0, fix autoupdate, add installer script

### DIFF
--- a/bucket/shadowsocks-qtun-plugin.json
+++ b/bucket/shadowsocks-qtun-plugin.json
@@ -1,6 +1,6 @@
 {
-    "version": "0.2.0",
-    "description": "Yet another SIP003 plugin based on IETF-QUIC",
+    "version": "0.3.0",
+    "description": "Yet another SIP003 plugin based on IETF-QUIC.",
     "homepage": "https://github.com/shadowsocks/qtun",
     "license": "MIT",
     "suggest": {
@@ -8,9 +8,18 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/shadowsocks/qtun/releases/download/v0.2.0/qtun-v0.2.0.x86_64-pc-windows-msvc.zip",
-            "hash": "6b1103f516677973eb0881c9ae8a1b7b31fc52ffd4bf92556038ac2ff3395a80"
+            "url": "https://github.com/shadowsocks/qtun/releases/download/v0.3.0/qtun-windows-native-v0.3.0.zip",
+            "hash": "3f4fd3857a2c09be776a080398f5b5162487e3b3293407f2d45fefe55b2e94fe"
         }
+    },
+    "installer": {
+        "script": [
+            "$archive = Get-ChildItem -Path $dir -File -Include '*.zip' -Recurse | Select-Object -First 1",
+            "if ($null -ne $archive.Name) {",
+            "    Expand-7zipArchive -Path \"$dir\\$($archive.Name)\" -DestinationPath $dir -Switches '-xr!$* -xr!unins*' -Removal",
+            "    Remove-Item -Path \"$dir\\*sha256\" -Recurse -Force -ErrorAction SilentlyContinue",
+            "}"
+        ]
     },
     "bin": [
         "qtun-client.exe",
@@ -20,11 +29,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/shadowsocks/qtun/releases/download/v$version/qtun-v$version.x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/shadowsocks/qtun/releases/download/v$version/qtun-windows-native-v$version.zip"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
### Summary

Updates `shadowsocks-qtun-plugin` to version **0.3.0** and restructures the manifest for more reliable installation and extraction.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Update version to **0.3.0**
- Update `url` and `hash` for 64-bit architecture
- Modifie archive name and extraction logic to handle wildcard zip files  
- Add installer script to extract the archive and remove unnecessary files (`*sha256`)  
- Update `autoupdate` URL pattern for new release naming conventions

### Notes

- The archive structure changed in 0.3.0, so installer script now handles wildcard extraction and excludes unnecessary files automatically.
- **However, as the structure of the compressed archive released upstream remains unclear, relevant sections of the list may still require modification in future.**

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App shadowsocks-qtun-plugin -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
shadowsocks-qtun-plugin: 0.3.0 (scoop version is 0.3.0)
Forcing autoupdate!
Autoupdating shadowsocks-qtun-plugin
DEBUG[1765112390] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1765112390] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765112390] $substitutions.$baseurl                       https://github.com/shadowsocks/qtun/releases/download/v0.3.0
DEBUG[1765112390] $substitutions.$url                           https://github.com/shadowsocks/qtun/releases/download/v0.3.0/qtun-windows-native-v0.3.0.zip
DEBUG[1765112390] $substitutions.$underscoreVersion             0_3_0
DEBUG[1765112390] $substitutions.$basename                      qtun-windows-native-v0.3.0.zip
DEBUG[1765112390] $substitutions.$dashVersion                   0-3-0
DEBUG[1765112390] $substitutions.$cleanVersion                  030
DEBUG[1765112390] $substitutions.$matchTail
DEBUG[1765112390] $substitutions.$matchHead                     0.3.0
DEBUG[1765112390] $substitutions.$basenameNoExt                 qtun-windows-native-v0.3.0
DEBUG[1765112390] $substitutions.$patchVersion                  0
DEBUG[1765112390] $substitutions.$match1                        0.3.0
DEBUG[1765112390] $substitutions.$preReleaseVersion             0.3.0
DEBUG[1765112390] $substitutions.$version                       0.3.0
DEBUG[1765112390] $substitutions.$urlNoExt                      https://github.com/shadowsocks/qtun/releases/download/v0.3.0/qtun-windows-native-v0.3.0
DEBUG[1765112390] $substitutions.$buildVersion
DEBUG[1765112390] $substitutions.$majorVersion                  0
DEBUG[1765112390] $substitutions.$minorVersion                  3
DEBUG[1765112390] $substitutions.$dotVersion                    0.3.0
DEBUG[1765112390] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1765112391] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/shadowsocks/qtun/releases/download/v0.3.0/qtun-windows-native-v0.3.0.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/shadowsocks/qtun/releases
Downloading qtun-windows-native-v0.3.0.zip to compute hashes!
Loading qtun-windows-native-v0.3.0.zip from cache
Computed hash: 3f4fd3857a2c09be776a080398f5b5162487e3b3293407f2d45fefe55b2e94fe
Writing updated shadowsocks-qtun-plugin manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/shadowsocks-qtun-plugin
Installing 'shadowsocks-qtun-plugin' (0.3.0) [64bit] from 'Unofficial' bucket
Loading qtun-windows-native-v0.3.0.zip from cache.
Checking hash of qtun-windows-native-v0.3.0.zip ... ok.
Extracting qtun-windows-native-v0.3.0.zip ... done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\shadowsocks-qtun-plugin\current => D:\Software\Scoop\Local\apps\shadowsocks-qtun-plugin\0.3.0
Creating shim for 'qtun-client'.
Creating shim for 'qtun-server'.
'shadowsocks-qtun-plugin' (0.3.0) was installed successfully!
'shadowsocks-qtun-plugin' suggests installing 'extras/shadowsocks'.
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated installer with extraction and cleanup features to streamline setup process.

* **Chores**
  * Bumped plugin version from 0.2.0 to 0.3.0 with refined descriptions.
  * Updated 64-bit architecture download URLs and corresponding security checksums for new artifacts.
  * Improved autoupdate configuration to target latest version releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->