### PR TITLE
soulseekqt: Update to version 2024.6.30, fix checkver & autoupdate, add 32bit version

### DIFF
--- a/bucket/soulseekqt.json
+++ b/bucket/soulseekqt.json
@@ -1,15 +1,19 @@
 {
-    "version": "2024-2-1",
+    "version": "2024.6.30",
     "description": "File sharing network.",
-    "homepage": "http://www.slsknet.org/news/node/1",
+    "homepage": "https://www.slsknet.org/news/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.slsknet.org/news/node/682"
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.slsknet.org/SoulseekQt/Windows/SoulseekQt-2024-2-1-64bit.exe",
-            "hash": "34c13a6969fcab41b75ac514d8d42069d0dc2bf13f024c1b0590aef38991cc08"
+            "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30-64bit.exe",
+            "hash": "b2db0e41afe444ad597045d06df4d4672fa6cf2be8ce3474cd61e8118f3cd4d6"
+        },
+        "32bit": {
+            "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30-32bit.exe",
+            "hash": "cce7d17ec1a1f22d973eeabb71aafed98996b56d9ce7b03583d6d0dd2a2a39af"
         }
     },
     "innosetup": true,
@@ -20,11 +24,18 @@
             "SoulseekQt"
         ]
     ],
-    "checkver": "SoulseekQt-([\\d-]+)-64bit",
+    "checkver": {
+        "url": "https://www.slsknet.org/news/node/1",
+        "regex": "SoulseekQt-(\\d+)-(\\d+)-(\\d+(?:-\\d+)?)-64bit",
+        "replace": "${1}.${2}.${3}"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.slsknet.org/SoulseekQt/Windows/SoulseekQt-$version-64bit.exe"
+                "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-$dashVersion-64bit.exe"
+            },
+            "32bit": {
+                "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-$dashVersion-32bit.exe"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `soulseekqt` to version **2024.6.30**, adds 32-bit architecture support, and restructures the manifest for improved maintainability and accurate version detection.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Update version to **2024.6.30**
- Update homepage to `https://www.slsknet.org/news/`
- Add 32-bit architecture URLs and hashes for completeness
- Update `checkver` to parse version from `SoulseekQt-YYYY-M-D-64bit` format using regex
- Update `autoupdate` URLs to use `$dashVersion` for both 64-bit and 32-bit builds

### Notes

- The download URLs now use Backblaze B2 CDN for reliability
- `checkver` regex ensures proper parsing of the new date-based versioning scheme

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App soulseekqt -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
soulseekqt: 2024.6.30 (scoop version is 2024.6.30)
Forcing autoupdate!
Autoupdating soulseekqt
DEBUG[1765112871] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1765112871] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765112871] $substitutions.$baseurl                       https://f004.backblazeb2.com/file/SoulseekQt
DEBUG[1765112871] $substitutions.$match3                        30
DEBUG[1765112871] $substitutions.$url                           https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30-32bit.exe
DEBUG[1765112871] $substitutions.$underscoreVersion             2024_6_30
DEBUG[1765112871] $substitutions.$basename                      SoulseekQt-2024-6-30-32bit.exe
DEBUG[1765112871] $substitutions.$dashVersion                   2024-6-30
DEBUG[1765112871] $substitutions.$cleanVersion                  2024630
DEBUG[1765112871] $substitutions.$matchTail
DEBUG[1765112871] $substitutions.$matchHead                     2024.6.30
DEBUG[1765112871] $substitutions.$match2                        6
DEBUG[1765112871] $substitutions.$basenameNoExt                 SoulseekQt-2024-6-30-32bit
DEBUG[1765112871] $substitutions.$patchVersion                  30
DEBUG[1765112871] $substitutions.$match1                        2024
DEBUG[1765112871] $substitutions.$preReleaseVersion             2024.6.30
DEBUG[1765112871] $substitutions.$version                       2024.6.30
DEBUG[1765112871] $substitutions.$urlNoExt                      https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30-32bit
DEBUG[1765112871] $substitutions.$buildVersion
DEBUG[1765112871] $substitutions.$majorVersion                  2024
DEBUG[1765112871] $substitutions.$minorVersion                  6
DEBUG[1765112871] $substitutions.$dotVersion                    2024.6.30
DEBUG[1765112871] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading SoulseekQt-2024-6-30-32bit.exe to compute hashes!
Loading SoulseekQt-2024-6-30-32bit.exe from cache
Computed hash: cce7d17ec1a1f22d973eeabb71aafed98996b56d9ce7b03583d6d0dd2a2a39af
... ...
Writing updated soulseekqt manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/soulseekqt
Installing 'soulseekqt' (2024.6.30) [64bit] from 'Unofficial' bucket
Loading SoulseekQt-2024-6-30-64bit.exe from cache.
Checking hash of SoulseekQt-2024-6-30-64bit.exe ... ok.
Extracting SoulseekQt-2024-6-30-64bit.exe ... done.
Linking D:\Software\Scoop\Local\apps\soulseekqt\current => D:\Software\Scoop\Local\apps\soulseekqt\2024.6.30
Creating shim for 'SoulseekQt'.
Making D:\Software\Scoop\Local\shims\soulseekqt.exe a GUI binary.
Creating shortcut for SoulseekQt (SoulseekQt.exe)
'soulseekqt' (2024.6.30) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
