### PR TITLE
tsukimi@0.19.4: Remove checkver, add Windows support notes

### DIFF
--- a/bucket/tsukimi.json
+++ b/bucket/tsukimi.json
@@ -1,8 +1,16 @@
 {
     "version": "0.19.4",
-    "description": "A simple third-party Emby client",
+    "description": "A simple third-party Jellyfin client.",
     "homepage": "https://github.com/tsukinaha/tsukimi",
-    "license": "GPL-3.0-or-later",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/tsukinaha/tsukimi/blob/HEAD/LICENSE"
+    },
+    "notes": [
+        "Starting from version 0.20.0, the upstream project no longer provides Windows packages in the GitHub releases.",
+        "Version 0.19.4 is the last stable Windows release, though full functionality is not guaranteed.",
+        "Users seeking a stable Jellyfin client on Windows should consider alternative solutions."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/tsukinaha/tsukimi/releases/download/v0.19.4/tsukimi-x86_64-windows-gnu.7z",
@@ -11,14 +19,10 @@
     },
     "shortcuts": [
         [
-            "bin/tsukimi.exe",
+            "bin\\tsukimi.exe",
             "Tsukimi"
         ]
     ],
-    "checkver": {
-        "url": "https://api.github.com/repositories/766925713/releases/latest",
-        "regex": "/v([\\w-.]+)"
-    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
### Summary

Updates the `tsukimi` manifest to improve license declaration, description clarity, and add notes regarding Windows support.

### Related issues or pull requests

- Relates to #16379 
- Relates to https://github.com/tsukinaha/tsukimi/issues/507

### Changes

- Update `license` field to include full SPDX identifier and URL
- Adjuste shortcut path to use backslashes for Windows compatibility
- Remove obsolete `checkver` field since upstream releases for Windows are no longer maintained

### Notes

- The following is some relevant information that has been released.

```markdown
[v0.20.0](https://github.com/tsukinaha/tsukimi/releases/tag/v0.20.0)

This version dropped Windows package in public release and removed some tricks for Windows.
You can still get Windows package not for publish in workflow artifacts.


[v0.19.3](https://github.com/tsukinaha/tsukimi/releases/tag/v0.19.3)

Warning: The Windows package is provided without any guarantee of full functionality.
```

-  For further details, please refer to https://github.com/tsukinaha/tsukimi/issues/507

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/tsukimi
Installing 'tsukimi' (0.19.4) [64bit] from 'Unofficial' bucket
Loading tsukimi-x86_64-windows-gnu.7z from cache.
Checking hash of tsukimi-x86_64-windows-gnu.7z ... ok.
Extracting tsukimi-x86_64-windows-gnu.7z ... done.
Linking D:\Software\Scoop\Local\apps\tsukimi\current => D:\Software\Scoop\Local\apps\tsukimi\0.19.4
Creating shortcut for Tsukimi (tsukimi.exe)
'tsukimi' (0.19.4) was installed successfully!
Notes
-----
Starting from version 0.20.0, the upstream project no longer provides Windows packages in the GitHub releases.
Version 0.19.4 is the last stable Windows release, though full functionality is not guaranteed.
Users seeking a stable Jellyfin client on Windows should consider alternative solutions.
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated app description to reflect support for Jellyfin instead of Emby.

* **Documentation**
  * License field now includes direct link to the license file.
  * Added guidance notes about Windows package availability and installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->