### PR TITLE
ctypes: Rename to 'types', fix checkver, add gui version

### DIFF
--- a/bucket/ctypes.json
+++ b/bucket/ctypes.json
@@ -1,12 +1,19 @@
 {
-    "version": "2.6.5",
+    "##": "Deprecate the manifest after 2026-12-01.",
+    "version": "2.6.6",
     "homepage": "https://ystr.github.io/types/",
     "description": "A file type manager for Windows that allows you to edit program associations, icons, context menus and a few other things.",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-or-later",
+    "notes": [
+        "Notification for using CTypes",
+        "",
+        "This version update is solely to provide relevant notifications and does not include any actual changes.",
+        "The manifest has been renamed to `types`, please switch to installing `extras/types`.",
+        "For more details, see: https://github.com/ScoopInstaller/Extras/pull/16742"
+    ],
     "url": "https://ystr.github.io/types/CTypes.zip",
     "hash": "64a79982140364da2411d2d03513411cfd1a717a686a62f8de807e9bdb9db4a2",
     "env_add_path": ".",
-    "checkver": ">Download\\s([\\d.]+)<",
     "autoupdate": {
         "url": "https://ystr.github.io/types/CTypes.zip"
     }

--- a/bucket/types.json
+++ b/bucket/types.json
@@ -1,0 +1,50 @@
+{
+    "version": "2.6.5",
+    "homepage": "https://ystr.github.io/types/",
+    "description": "A file type manager for Windows that allows you to edit program associations, icons, context menus and a few other things.",
+    "license": "GPL-3.0-or-later",
+    "url": [
+        "https://ystr.github.io/types/Types.zip#/Types-2.6.5.zip",
+        "https://ystr.github.io/types/CTypes.zip#/CTypes-2.6.5.zip"
+    ],
+    "hash": [
+        "531cb8f4af718b32c6d65da19afa8d2830ac8d88d70aa455d86f25d616efebc0",
+        "64a79982140364da2411d2d03513411cfd1a717a686a62f8de807e9bdb9db4a2"
+    ],
+    "bin": [
+        "Types.exe",
+        "CTypes.exe"
+    ],
+    "shortcuts": [
+        [
+            "Types.exe",
+            "Types"
+        ]
+    ],
+    "checkver": {
+        "script": [
+            "$tmp_dir = Join-Path -Path $cachedir -ChildPath 'tmp'",
+            "$download_url = 'https://ystr.github.io/types/Types.zip'",
+            "$download_dir = cache_path $app 'unknown' $download_url",
+            "New-Item -Path $tmp_dir -ItemType Directory -Force | Out-Null",
+            "$args_list = @('x', $download_dir, \"-o`\"$tmp_dir`\"\", '-aoa', '-y')",
+            "$output_options = @{",
+            "    NoNewWindow = $true",
+            "    RedirectStandardError = Join-Path -Path $tmp_dir -ChildPath 'err.txt'",
+            "    RedirectStandardOutput = Join-Path -Path $tmp_dir -ChildPath 'out.txt'",
+            "}",
+            "Invoke-WebRequest -Uri $download_url -OutFile $download_dir -UseBasicParsing",
+            "Start-Process -FilePath '7z.exe' -ArgumentList $args_list @output_options -Wait",
+            "$version_info = [System.Diagnostics.FileVersionInfo]::GetVersionInfo(\"$tmp_dir\\Types.exe\")",
+            "Remove-Item -Path $tmp_dir, $download_dir -Recurse -Force -ErrorAction SilentlyContinue",
+            "Write-Output $version_info.ProductVersion"
+        ],
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": [
+            "https://ystr.github.io/types/Types.zip#/Types-$version.zip",
+            "https://ystr.github.io/types/CTypes.zip#/CTypes-$version.zip"
+        ]
+    }
+}


### PR DESCRIPTION
### Summary

Deprecates the `ctypes` manifest after 2026-12-01 and introduces a unified `types` manifest.  
The new manifest consolidates `CTypes.exe` and `Types.exe` into a single, maintainable manifest with improved version tracking and autoupdate support.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Deprecate `ctypes` manifest and added deprecation notice in version 2.6.6  
- Add `notes` in `ctypes` to inform users to migrate to `extras/types`  
- Introduce `types.json` manifest combining `CTypes` and `Types` binaries  
- Update `license` field to use `GPL-3.0-or-later`  
- Add `checkver` script for dynamic version detection via `Types.exe` file metadata  

### Notes

- The update of `ctypes` to 2.6.6 does not introduce functional changes; it is purely informational  
- Reasons for renaming `ctypes` to `types`
  - The official website refers to the project as `types`; `ctypes` is only its command-line variant.
  - The version number cannot be determined from `CTypes.exe`.

    ```powershell
    ┏[ ~]
    └─> [System.Diagnostics.FileVersionInfo]::GetVersionInfo('.\CTypes.exe')
    
    ProductVersion   FileVersion      FileName
    --------------   -----------      --------
    0.0.0.0          0.0.0.0          ~\CTypes.exe
    ```

  - `CTypes.exe` was released in April 2016, while `Types.exe` was released in December 2017. Since the `ctypes` manifest was added in 2022, it is evident that the version used actually corresponds to `Types.exe`.
  - Most importantly, prior to this PR, no manifest in any bucket was named `types`.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App types -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
types: 2.6.5 (scoop version is 2.6.5) autoupdate available
Forcing autoupdate!
Autoupdating types
DEBUG[1765120606] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1765120606] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765120606] $substitutions.$baseurl                       https://ystr.github.io/types
DEBUG[1765120606] $substitutions.$url                           https://ystr.github.io/types/Types.zip
DEBUG[1765120606] $substitutions.$underscoreVersion             2_6_5
DEBUG[1765120606] $substitutions.$basename                      Types.zip
DEBUG[1765120606] $substitutions.$dashVersion                   2-6-5
DEBUG[1765120606] $substitutions.$cleanVersion                  265
DEBUG[1765120606] $substitutions.$matchTail
DEBUG[1765120606] $substitutions.$matchHead                     2.6.5
DEBUG[1765120606] $substitutions.$basenameNoExt                 Types
DEBUG[1765120606] $substitutions.$patchVersion                  5
DEBUG[1765120606] $substitutions.$match1                        2.6.5
DEBUG[1765120606] $substitutions.$preReleaseVersion             2.6.5
DEBUG[1765120606] $substitutions.$version                       2.6.5
DEBUG[1765120606] $substitutions.$urlNoExt                      https://ystr.github.io/types/Types
DEBUG[1765120606] $substitutions.$buildVersion
DEBUG[1765120606] $substitutions.$majorVersion                  2
DEBUG[1765120606] $substitutions.$minorVersion                  6
DEBUG[1765120606] $substitutions.$dotVersion                    2.6.5
DEBUG[1765120606] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading Types.zip to compute hashes!
Loading Types.zip from cache
Computed hash: 531cb8f4af718b32c6d65da19afa8d2830ac8d88d70aa455d86f25d616efebc0
DEBUG[1765120606] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765120606] $substitutions.$baseurl                       https://ystr.github.io/types
DEBUG[1765120606] $substitutions.$url                           https://ystr.github.io/types/CTypes.zip
DEBUG[1765120606] $substitutions.$underscoreVersion             2_6_5
DEBUG[1765120606] $substitutions.$basename                      CTypes.zip
DEBUG[1765120606] $substitutions.$dashVersion                   2-6-5
DEBUG[1765120606] $substitutions.$cleanVersion                  265
DEBUG[1765120606] $substitutions.$matchTail
DEBUG[1765120606] $substitutions.$matchHead                     2.6.5
DEBUG[1765120606] $substitutions.$basenameNoExt                 CTypes
DEBUG[1765120606] $substitutions.$patchVersion                  5
DEBUG[1765120606] $substitutions.$match1                        2.6.5
DEBUG[1765120606] $substitutions.$preReleaseVersion             2.6.5
DEBUG[1765120606] $substitutions.$version                       2.6.5
DEBUG[1765120606] $substitutions.$urlNoExt                      https://ystr.github.io/types/CTypes
DEBUG[1765120606] $substitutions.$buildVersion
DEBUG[1765120606] $substitutions.$majorVersion                  2
DEBUG[1765120606] $substitutions.$minorVersion                  6
DEBUG[1765120606] $substitutions.$dotVersion                    2.6.5
DEBUG[1765120606] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading CTypes.zip to compute hashes!
Loading CTypes.zip from cache
Computed hash: 64a79982140364da2411d2d03513411cfd1a717a686a62f8de807e9bdb9db4a2
Writing updated types manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/ctypes
Installing 'ctypes' (2.6.6) [64bit] from 'Unofficial' bucket
Loading CTypes.zip from cache.
Checking hash of CTypes.zip ... ok.
Extracting CTypes.zip ... done.
Linking D:\Software\Scoop\Local\apps\ctypes\current => D:\Software\Scoop\Local\apps\ctypes\2.6.6
Adding D:\Software\Scoop\Local\apps\ctypes\current to your path.
'ctypes' (2.6.6) was installed successfully!
Notes
-----
Notification for using CTypes

This version update is solely to provide relevant notifications and does not include any actual changes.
The manifest has been renamed to `types`, please switch to installing `extras/types`.
For more details, see: https://github.com/ScoopInstaller/Extras/pull/16742

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/types
Installing 'types' (2.6.5) [64bit] from 'Unofficial' bucket
Loading Types.zip from cache.
Loading CTypes.zip from cache.
Checking hash of Types.zip ... ok.
Checking hash of CTypes.zip ... ok.
Extracting Types.zip ... done.
Extracting CTypes.zip ... done.
Linking D:\Software\Scoop\Local\apps\types\current => D:\Software\Scoop\Local\apps\types\2.6.5
Creating shim for 'Types'.
Making D:\Software\Scoop\Local\shims\types.exe a GUI binary.
Creating shim for 'CTypes'.
Creating shortcut for Types (Types.exe)
'types' (2.6.5) was installed successfully!
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)