### PR TITLE
aida64extreme: Add aida64.reg.ini, aida64.sst.ini to persistent storage

### DIFF
--- a/bucket/aida64extreme.json
+++ b/bucket/aida64extreme.json
@@ -13,9 +13,14 @@
         "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
         "    Set-Content \"$dir\\$FILE\" @('[Generic]', '', 'NoRegistry=1', 'NetUpdateFreq=0') -Encoding Ascii",
         "}",
-        "if (!(Test-Path \"$persist_dir\\pkey.txt\")) { New-Item \"$dir\\pkey.txt\" | Out-Null }"
+        "'aida64.reg.ini', 'aida64.sst.ini', 'pkey.txt' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "}"
     ],
     "persist": [
+        "Reports",
+        "aida64.reg.ini",
+        "aida64.sst.ini",
         "pkey.txt",
         "aida64.ini"
     ],


### PR DESCRIPTION
These files contain the program settings and the System Stability Test settings respectively.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now ensures multiple required configuration and license files are created if missing, preventing startup issues.
  * Expanded persistence so additional config/report files are preserved across sessions, improving settings continuity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->