### PR TITLE
fontbase: Update to version 2.24.9, fix checkver

### DIFF
--- a/bucket/fontbase.json
+++ b/bucket/fontbase.json
@@ -22,9 +22,9 @@
             "FontBase"
         ]
     ],
-"checkver": {
+    "checkver": {
         "url": "https://releases.fontba.se/win/latest.yml",
-        "regex": "version:\\s+([\\d.]+)"
+        "regex": "(?m)^version:\\s*([0-9]+(?:\\.[0-9]+)*)\\s*$"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
fontbase: Update to 2.24.9

Fixed the 404 download error by updating the version to 2.24.9.
Updated 'checkver' URL to use 'latest.yml' to fix future updates.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated FontBase to version 2.24.9.
  * Replaced 64-bit installer link and updated its hash for secure verification.
  * Improved auto-update detection by switching to the latest.yml-based version retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->