### PR TITLE
yaak@2025.9.3: Fix post_install script

### DIFF
--- a/bucket/yaak.json
+++ b/bucket/yaak.json
@@ -9,7 +9,7 @@
             "hash": "45721a0493dd222ecd4b15daf74eb283e87a06c3abb7b811bdb10f18771fdb45"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Force -Recurse -ErrorAction Ignore",
     "shortcuts": [
         [
             "yaak-app.exe",


### PR DESCRIPTION
<!--
Closes #XXXX
or
Relates to #XXXX
-->
```
Installing 'yaak' (2025.9.3) [64bit] from 'extras' bucket
Yaak_2025.9.3_x64-setup.exe (38.6 MB) [=======================================================================] 100%
Checking hash of Yaak_2025.9.3_x64-setup.exe... OK.
Extracting Yaak_2025.9.3_x64-setup.exe... Done.
Linking D:\Scoop\apps\yaak\current => D:\Scoop\apps\yaak\2025.9.3
Creating shortcut for Yaak (yaak-app.exe)
Running post_install script... Remove-Item: Cannot find path 'D:\Scoop\apps\yaak\current\uninstall.exe' because it does not exist.
Done.
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined post-installation cleanup to target temporary plugin directories while preserving essential uninstall components; cleanup now ignores non-critical errors to prevent interruptions during install.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->