### PR TITLE
mupdf@1.27.0: Remove extract_dir

### DIFF
--- a/bucket/mupdf.json
+++ b/bucket/mupdf.json
@@ -3,8 +3,12 @@
     "description": "A lightweight PDF, XPS, and E-book viewer",
     "homepage": "https://mupdf.com",
     "license": "AGPL-3.0-only",
-    "url": "https://mupdf.com/downloads/archive/mupdf-1.27.0-windows.zip",
-    "hash": "sha1:a28405ca405dbc3f518fdba9d65c21d6ee4e4812",
+    "architecture": {
+        "64bit": {
+            "url": "https://mupdf.com/downloads/archive/mupdf-1.27.0-windows.zip",
+            "hash": "f3e60b630453301914e52fb8ec001f6ab56cdb90daf39e533deae3ff214fcff8"
+        }
+    },
     "bin": [
         "mupdf.exe",
         "mupdf-gl.exe",
@@ -21,11 +25,14 @@
         "regex": "mupdf-([\\w.-]+)-windows\\.zip"
     },
     "autoupdate": {
-        "url": "https://mupdf.com/downloads/archive/mupdf-$version-windows.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://mupdf.com/downloads/archive/mupdf-$version-windows.zip"
+            }
+        },
         "hash": {
             "url": "https://www.mupdf.com/releases/",
-            "regex": "$basename.*?$sha1"
-        },
-        "extract_dir": "mupdf-$matchHead-windows"
+            "regex": "$basename.*?$sha256"
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
As of version 1.27.0, the archive file for mupdf no longer has a folder which contains the program's files as they are all in the root of the archive. Update the manifest to remove `extract_dir` so as to account for this.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #16780 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Download metadata moved into a per-architecture (64-bit) block so 64-bit builds have explicit URL and checksum.
  * Autoupdate adjusted to reference the architecture block, now uses SHA-256 checksums and an updated regex.
  * Top-level extract_dir removed; no changes to shortcuts, bins, or version-check logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->