### PR TITLE
shaderglass: Update to version 1.2.3.1, fix checkver & autoupdate

### DIFF
--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -11,17 +11,20 @@
     },
     "bin": "ShaderGlass.exe",
     "shortcuts": [
-        ["ShaderGlass.exe", "ShaderGlass"]
+        [
+            "ShaderGlass.exe",
+            "ShaderGlass"
+        ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/mausimus/ShaderGlass/releases/latest",
-        "jsonpath": "$.assets[*].browser_download_url",
-        "regex": "/download/v(?<tag>[\\d.]+)/ShaderGlass-(?<version>[\\d.]+)-win-x64\\.zip"
+        "url": "https://api.github.com/repositories/308317827/releases/latest",
+        "jsonpath": "$..browser_download_url",
+        "regex": "/download/(?<tag>v?[\\d.]+)/ShaderGlass-(?<version>[\\d.]+)-win-x64\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mausimus/ShaderGlass/releases/download/v$matchTag/ShaderGlass-$matchVersion-win-x64.zip"
+                "url": "https://github.com/mausimus/ShaderGlass/releases/download/$matchTag/ShaderGlass-$version-win-x64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Latest ShaderGlass release includes hotfix assets which the version does not match the GitHub tag (e.g. 1.2.3.1 under tag v1.2.3).

This change updates checkver and autoupdate to extract the version from release assets and use the tag separately, allowing automated updates to work more correctly for the tagging strategy the author use3s there
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped ShaderGlass to version 1.2.3.1.
  * Updated 64‑bit download URL and integrity hash for the new release.
  * Improved version-detection configuration (now uses a URL/jsonpath/regex object) for more reliable checks.
  * Adjusted auto-update URL templating to use matched tags for correct artifact resolution.
  * Preserved existing shortcuts and package metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->