### PR TITLE
fix(servy): switch to installer-based manifest to avoid innounp incompatibility

### DIFF
--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -9,8 +9,16 @@
             "hash": "1126aaecb151fe91140c39e247631c1043700bc8733b7a3b48e18525e124c578"
         }
     },
+    "notes": [
+        "Installer requires admin privileges.",
+        "Installs into Scoop's managed folder ($dir).",
+        "Installer updates system PATH for global CLI access.",
+        "Supports clean uninstallation via unins*.exe."
+    ],
+    "pre_install": "if (-not (is_admin)) { throw 'This package requires admin privileges to install' }",
     "installer": {
         "args": [
+            "/DIR=\"$dir\"",
             "/VERYSILENT",
             "/SUPPRESSMSGBOXES",
             "/NORESTART"
@@ -18,7 +26,7 @@
     },
     "uninstaller": {
         "script": [
-            "$installDir = Join-Path $env:ProgramFiles 'Servy'",
+            "$installDir = $dir",
             "if (Test-Path $installDir) {",
             "    $uninstaller = Get-ChildItem $installDir -Filter 'unins*.exe' -ErrorAction SilentlyContinue |",
             "                                 Sort-Object LastWriteTime -Descending |",
@@ -32,6 +40,17 @@
             "}"
         ]
     },
+    "bin": "servy-cli.exe",
+    "shortcuts": [
+        [
+            "Servy.exe",
+            "Servy"
+        ],
+        [
+            "Servy.Manager.exe",
+            "Servy Manager"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/aelassas/servy"
     },


### PR DESCRIPTION
This PR switches Servy to an installer-based Scoop manifest to avoid incompatibility with `innounp` and modern Inno Setup versions.

After releasing Servy 4.0, the current manifest fails during installation with the following error:
```
innounp - the Inno Setup Unpacker, Version 2.65.2 (11/09/2025)

Inno Setup archive:           servy-4.0-x64-installer.exe
=> Signature detected: Inno Setup Setup Data (6.6.1)
This is not directly supported, but i'll try to unpack it as version 6502
Inno Setup version detected:  6.6.1 (Unicode)
Critical error: The setup files are corrupted. Please obtain a new copy of the program.
```

This error is caused by `innounp` not fully supporting Inno Setup 6.6.x.

The installer itself is valid and signed.

This PR resolves the issue by:

* Switching from `innounp` extraction to an installer-based manifest
* Using silent install and uninstall flags
* Supporting multiple Inno Setup uninstaller filenames (`unins*.exe`)

This PR restores successful installation via Scoop. Without it, users cannot install Servy.

Related issue: https://github.com/aelassas/servy/issues/28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured installer and uninstaller support with pre-install checks, silent-install arguments, and an automated uninstaller flow.
  * Added user-visible notes describing installer behavior and uninstallation.

* **Improvements**
  * Replaced legacy installer flag with a clearer manifest layout for installer/uninstaller configuration.
  * Updated product description wording to reference pre-launch and post-launch scripts and parameters.
  * Retained existing update/version retrieval behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->