### PR TITLE
basecamp: Deprecate manifest

### DIFF
--- a/deprecated/basecamp.json
+++ b/deprecated/basecamp.json
@@ -1,6 +1,6 @@
 {
     "##": [
-        "Deprecated 2025-12-17: Basecamp 2 is no longer available for windows.",
+        "Deprecated 2025-12-17: Basecamp 3 is no longer available for windows as a stand-alone app.",
         "Basecamp 3 and 4 switched to a portable web app model"
     ],
     "version": "2.4.3",


### PR DESCRIPTION
Recommendation to deprecate Basecamp 2, because:

- Basecamp switched to version 4 at least since September 2022 [(source)](https://3.basecamp-help.com/article/28-thinking-about-switching-from-basecamp-2-to-4)
- Basecamp (4) switched to a portable web app based solution for Windows [(source)](https://basecamp.com/apps)
- Download links, checkver and autoupdate are no longer working

Relates to #16379

- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation notice: Basecamp 3 is no longer available for Windows as a stand-alone app (effective 2025-12-17).
  * Clarified that Basecamp 3 and 4 have transitioned to a portable web app model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->