### PR TITLE
bitmessage: Deprecate manifest

### DIFF
--- a/deprecated/bitmessage.json
+++ b/deprecated/bitmessage.json
@@ -1,4 +1,7 @@
 {
+    "##": [
+        "Deprecated 2025-12-18: Bitmessage is no longer actively maintained. Last release was in 2018."
+    ],
     "version": "0.6.3.2",
     "description": "A P2P communications protocol used to send encrypted messages to another person or to many subscribers.",
     "homepage": "https://bitmessage.org/",


### PR DESCRIPTION
I believe bitmessage should be deprecated, because:

- The last release 0.6.3.2 was in [February 2018](https://github.com/Bitmessage/PyBitmessage/releases)
- The 64-bit version was dropped "there won't be a 64bit Windows binary for 0.6.3.2 due to a lack of time", even though this is a critical security release "Version 0.6.2 has a bug that can be exploited for remote code execution. This is an emergency release [...]" [(source)](https://github.com/Bitmessage/PyBitmessage/releases)
- Autoupdate for 64 bit is not working
- Based on an unmaintained Python 2 version [(source)](https://github.com/Bitmessage/PyBitmessage/issues/2271)

Relates to #16379

- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked Bitmessage as deprecated. The messaging application is no longer actively maintained, with the last official release dating back to 2018.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->