### PR TITLE
ida-free: Deprecate manifest

### DIFF
--- a/deprecated/ida-free.json
+++ b/deprecated/ida-free.json
@@ -1,4 +1,7 @@
 {
+    "##": [
+        "Deprecated 2025-12-18: New IDA Free versions require registration and cannot be installed via silent install."
+    ],
     "version": "8.4.240527",
     "description": "A multi-processor disassembler and debugger that offers so many features it is hard to describe them all",
     "homepage": "https://hex-rays.com/ida-free/",


### PR DESCRIPTION
I beleive IDA Free should be deprecated, because:

- Newer versions require registration [(source)](https://hex-rays.com/faqs/why-i-need-to-have-a-my-hex-rays-account-to-download-ida-free) and the generation of a system-sepcific (free) license key
- IDA 8.4.240527 (SP2) was released in May 27, 2024 [(source)](https://docs.hex-rays.com/release-notes/8_4sp2). Since then there have been multiple newer versions released. Newest version is 9.2 from September 2025 [(source)](https://hex-rays.com/blog/ida-9.2-release)
- Checkver and Autoupdate are broken

Relates to #16379

- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation notice indicating IDA Free versions from December 18, 2025 onward require user registration and no longer support silent installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->