### PR TITLE
imdone: Update to version 1.54.2, add arm64 support, fix checkver & autoupdate

### DIFF
--- a/bucket/imdone.json
+++ b/bucket/imdone.json
@@ -6,13 +6,6 @@
         "identifier": "Proprietary",
         "url": "https://imdone.io/eula"
     },
-    "extract_dir": "$PLUGINSDIR",
-    "shortcuts": [
-        [
-            "imdone.exe",
-            "imdone"
-        ]
-    ],
     "architecture": {
         "64bit": {
             "url": "https://imdone.io/downloads/imdone-1.54.2-x64-portable.exe#/dl.7z",
@@ -23,11 +16,18 @@
             "hash": "6c2f9357c9f835449ba07c88ea9d77bf69e1d2593b09c329fde0dbd1bce7b065"
         }
     },
-    "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-*.7z' | Remove-Item -Force -Recurse",
     "installer": {
-        "script": "Expand-7zipArchive \"$dir\\$PLUGINSDIR\\app-*.7z\" \"$dir\""
+        "script": [
+            "Get-Item \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item \"$dir\\`$*\" -Force -Recurse"
+        ]
     },
-    "post_install": "Remove-Item \"$dir\\app-*.7z\" -Force -ErrorAction SilentlyContinue",
+    "shortcuts": [
+        [
+            "imdone.exe",
+            "imdone"
+        ]
+    ],
     "checkver": {
         "url": "https://imdone.io/api/1.0/downloads",
         "regex": "imdone-([\\d.]+)-x64-portable\\.exe"


### PR DESCRIPTION
- [x] Verified no known issues for application imdone exist
- [x] Verified no open pull requests for application imdone exist

Relates to #16379

Updates manifest for application "imdone":

### Fixes checkver
Test result:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> .\bin\checkver.ps1 imdone
imdone: 1.54.2 (scoop version is 1.54.1) autoupdate available
```

### Confirmed autoupdate:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> .\bin\checkver.ps1 -App imdone -Update
imdone: 1.54.2 (scoop version is 1.54.1) autoupdate available
Autoupdating imdone
Downloading imdone-1.54.2-x64-portable.exe to compute hashes!
imdone-1.54.2-x64-portable.exe (56.8 MB) [============================================================================================================================================================] 100%
Computed hash: 040629db2944ec1b74a1e5bfdd8025d4a39f40acefd0841685cfa67d6653b374
Writing updated imdone manifest
```

### Confirmed Virustotal OK
https://www.virustotal.com/gui/url/1fa63b32b07cf128282b36053becf1020ca9b40df4b03e63b8bd8b9a860c9c5f/details
Everything ok, SHA-256 matches as well.

### Confirmed installation script:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop install .\bucket\imdone.json
WARN  Purging previous failed installation of imdone.
ERROR 'imdone' isn't installed correctly.
Removing older version (1.54.2).
'imdone' was uninstalled.
Installing 'imdone' (1.54.2) [64bit] from 'C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras\bucket\imdone.json'
Loading imdone-1.54.2-x64-portable.exe from cache
Checking hash of imdone-1.54.2-x64-portable.exe ... ok.
Extracting imdone-1.54.2-x64-portable.exe ... done.
Running pre_install script...done.
Running installer script...done.
Linking ~\scoop\apps\imdone\current => ~\scoop\apps\imdone\1.54.2
Creating shortcut for imdone (imdone.exe)
Running post_install script...done.
'imdone' (1.54.2) was installed successfully!
```

### Tested the application
- application seems to run fine in a minimal test
- stores persistent data outside of the scoop folder, so it is correctly persistent


### Confirmed uninstall
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop uninstall imdone
Uninstalling 'imdone' (1.54.2).
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\imdone.lnk
Unlinking ~\scoop\apps\imdone\current
'imdone' was uninstalled.
```
✅Confirmed persistent data is kept, e.g. `~\imdone-tutorial`, which is created for the default project.



- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.54.2
  * Update checks now use the official downloads API with refined matching for 64‑bit portable builds
  * Installer/unpack steps consolidated into a top‑level installer for consistent installation behavior
  * Autoupdate paths updated to reference explicit 64‑bit and ARM64 builds

* **New Features**
  * Official ARM64 portable build added with autoupdate support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->