### PR TITLE
imo-messenger: Update to version 1.5.2.3, fix extraction, fix checkver

### DIFF
--- a/bucket/imo-messenger.json
+++ b/bucket/imo-messenger.json
@@ -6,20 +6,15 @@
         "identifier": "Freeware",
         "url": "https://imo.im/policies/terms_of_service.html"
     },
-    "url": "https://static-web.imoim.net/as/indigo-static/winapp/1.5.2.3/ImoSetup_1.5.2.3_Release.exe#/dl.exe",
+    "url": "https://static-web.imoim.net/as/indigo-static/winapp/1.5.2.3/ImoSetup_1.5.2.3_Release.exe",
     "hash": "80a53fcf5b06a5c903a080e54b5a9f6d5c38b8e1f2dbfe6a82527c0eb4b14329",
     "installer": {
         "script": [
-            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\tmp\" -Removal",
-            "Expand-MsiArchive \"$dir\\tmp\\AttachedContainer\\ImoInstaller.msi\" \"$dir\\tmp2\"",
-            "movedir \"$dir\\tmp2\\imo\\$version\" \"$dir\"",
-            "Remove-Item \"$dir\\tmp\", \"$dir\\tmp2\" -Recurse"
+            "Expand-DarkArchive -Path \"$dir\\$fname\" -DestinationPath \"$dir\\tmp\" -Removal",
+            "Expand-MsiArchive -Path \"$dir\\tmp\\AttachedContainer\\ImoInstaller.msi\" -DestinationPath $dir -ExtractDir \"imo\\$version\"",
+            "Remove-Item \"$dir\\tmp\" -Force -Recurse"
         ]
     },
-    "pre_uninstall": [
-        "Stop-Process -Name 'ImoDesktopApp' -ErrorAction SilentlyContinue",
-        "Wait-Process -Name 'ImoDesktopApp' -ErrorAction SilentlyContinue -Timeout 10"
-    ],
     "shortcuts": [
         [
             "ImoDesktopApp.exe",
@@ -35,12 +30,12 @@
             "$url = 'https://apiact.imoim.net/imoweb-infrastructure-client/apk/version-list'",
             "$body = @{type = '2'; sub_type = '1'; limit = 1000} | ConvertTo-Json",
             "$response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType 'application/json'",
-            "$latestVersion = $response.data.list | Sort-Object -Property {[int64]$_.pub_time} -Descending | Select-Object -First 1",
+            "$latestVersion = $response.data.list | Sort-Object -Property {[version]$_.name} -Descending | Select-Object -First 1",
             "Write-Output $latestVersion.name"
         ],
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://static-web.imoim.net/as/indigo-static/winapp/$version/ImoSetup_$version_Release.exe#/dl.exe"
+        "url": "https://static-web.imoim.net/as/indigo-static/winapp/$version/ImoSetup_$version_Release.exe"
     }
 }


### PR DESCRIPTION
- [x] Verified there are no open issues for this application
- [x] Verified there are no open pull requests for this application

Relates to #16379

Updates manifest for application:

### Fixes checkver
Test result:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> .\bin\checkver.ps1 imo-messenger
imo-messenger: 1.5.2.3 (scoop version is 1.5.1.8) autoupdate available
```

### Confirmed autoupdate:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> .\bin\checkver.ps1 -App imo-messenger -Update
imo-messenger: 1.5.2.3 (scoop version is 1.5.1.8) autoupdate available
Autoupdating imo-messenger
DEBUG[1766064065.77808] [$updatedProperties] = [url hash] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766064065.82546] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766064065.82546] $substitutions.$buildVersion                  3                                                                                                                                         
DEBUG[1766064065.82546] $substitutions.$match1                        1.5.2.3                                                                                                                                   
DEBUG[1766064065.82546] $substitutions.$preReleaseVersion             1.5.2.3                                                                                                                                   
DEBUG[1766064065.82546] $substitutions.$version                       1.5.2.3                                                                                                                                   
DEBUG[1766064065.82546] $substitutions.$patchVersion                  2                                                                                                                                         
DEBUG[1766064065.82546] $substitutions.$urlNoExt                      https://static-web.imoim.net/as/indigo-static/winapp/1.5.2.3/ImoSetup_1.5.2.3_Release                                                     
DEBUG[1766064065.82546] $substitutions.$dotVersion                    1.5.2.3                                                                                                                                   
DEBUG[1766064065.82546] $substitutions.$cleanVersion                  1523                                                                                                                                      
DEBUG[1766064065.82546] $substitutions.$underscoreVersion             1_5_2_3                                                                                                                                   
DEBUG[1766064065.82546] $substitutions.$minorVersion                  5                                                                                                                                         
DEBUG[1766064065.82546] $substitutions.$url                           https://static-web.imoim.net/as/indigo-static/winapp/1.5.2.3/ImoSetup_1.5.2.3_Release.exe                                                 
DEBUG[1766064065.82546] $substitutions.$majorVersion                  1                                                                                                                                         
DEBUG[1766064065.82546] $substitutions.$matchTail                     .3                                                                                                                                        
DEBUG[1766064065.82546] $substitutions.$basenameNoExt                 ImoSetup_1.5.2.3_Release                                                                                                                  
DEBUG[1766064065.82546] $substitutions.$basename                      ImoSetup_1.5.2.3_Release.exe                                                                                                              
DEBUG[1766064065.82546] $substitutions.$dashVersion                   1-5-2-3                                                                                                                                   
DEBUG[1766064065.82546] $substitutions.$baseurl                       https://static-web.imoim.net/as/indigo-static/winapp/1.5.2.3                                                                              
DEBUG[1766064065.82546] $substitutions.$matchHead                     1.5.2                                                                                                                                     
DEBUG[1766064065.88904] $hashfile_url = $null -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading ImoSetup_1.5.2.3_Release.exe to compute hashes!
ImoSetup_1.5.2.3_Release.exe (58.7 MB) [==============================================================================================================================================================] 100%
Computed hash: 80a53fcf5b06a5c903a080e54b5a9f6d5c38b8e1f2dbfe6a82527c0eb4b14329
Writing updated imo-messenger manifest
```

### Confirmed Virustotal OK
https://www.virustotal.com/gui/url/bfa8733bd737b7da73311823103fab3b73e146dae5a87260f2a711654e8336dc
Everything ok, SHA-256 matches as well.

### Confirmed update is working:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop update imo-messenger
imo-messenger: 1.5.1.8 -> 1.5.2.3
Updating one outdated app:
Updating 'imo-messenger' (1.5.1.8 -> 1.5.2.3)
ERROR The following instances of "imo-messenger" are still running. Close them and try again.

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    145      11     1768       7812       0.00   2100   1 crashpad_handler
    991     101    58516     116732       4.53   2000   1 ImoDesktopApp



Running process detected, skip updating.
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop update imo-messenger
imo-messenger: 1.5.1.8 -> 1.5.2.3
Updating one outdated app:
Updating 'imo-messenger' (1.5.1.8 -> 1.5.2.3)
Downloading new version
Loading ImoSetup_1.5.2.3_Release.exe from cache
Checking hash of ImoSetup_1.5.2.3_Release.exe ... ok.
Running pre_uninstall script...done.
Uninstalling 'imo-messenger' (1.5.1.8)
Unlinking ~\scoop\apps\imo-messenger\current
Installing 'imo-messenger' (1.5.2.3) [64bit] from 'C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras\bucket\imo-messenger.json'
Loading ImoSetup_1.5.2.3_Release.exe from cache
Running installer script...done.
Linking ~\scoop\apps\imo-messenger\current => ~\scoop\apps\imo-messenger\1.5.2.3
Creating shortcut for imo Messenger (ImoDesktopApp.exe)
Persisting data
Persisting Logs
'imo-messenger' (1.5.2.3) was installed successfully!
```

### Confirmed clean installation is working:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop install .\bucket\imo-messenger.json
Installing 'dark' (3.14.1) [64bit] from 'main' bucket
Loading dark-3.14.1.zip from cache
Checking hash of dark-3.14.1.zip ... ok.
Extracting dark-3.14.1.zip ... done.
Linking ~\scoop\apps\dark\current => ~\scoop\apps\dark\3.14.1
Creating shim for 'dark'.
'dark' (3.14.1) was installed successfully!
Installing 'imo-messenger' (1.5.2.3) [64bit] from 'C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras\bucket\imo-messenger.json'
Loading ImoSetup_1.5.2.3_Release.exe from cache
Checking hash of ImoSetup_1.5.2.3_Release.exe ... ok.
Running installer script...done.
Linking ~\scoop\apps\imo-messenger\current => ~\scoop\apps\imo-messenger\1.5.2.3
Creating shortcut for imo Messenger (ImoDesktopApp.exe)
Persisting data
Persisting Logs
'imo-messenger' (1.5.2.3) was installed successfully!
```

### Tested the application
- application seems to run fine in a minimal test
- uses persistent data store correctly


### Confirmed uninstall
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop uninstall imo-messenger
Uninstalling 'imo-messenger' (1.5.2.3).
Running pre_uninstall script...done.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\imo Messenger.lnk
Unlinking ~\scoop\apps\imo-messenger\current
'imo-messenger' was uninstalled.
```
✅Confirmed persistent data is kept in `~\scoop\persist\imo-messenger`



- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Application version bumped to 1.5.2.3.
  * Installation workflow replaced with a scripted installer that expands archives and extracts packages for more reliable setup.
  * Uninstall behavior simplified and integrated into the new installer flow for cleaner removals.
  * Download URLs and verification checksum updated for the new release.
  * Version-check logic improved to select the latest release via version-based sorting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->