### PR TITLE
papercut: Update to version 7.6.2, add arm64 support, fix checkver & autoupdate

### DIFF
--- a/bucket/papercut.json
+++ b/bucket/papercut.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/ChangemakerStudios/Papercut-SMTP",
     "license": "Apache-2.0",
     "suggest": {
-        "Microsoft .NET 9.0 Desktop Runtime": "versions/windowsdesktop-runtime-9.0"
+        ".NET Desktop Runtime 9.0": "versions/windowsdesktop-runtime-9.0"
     },
     "architecture": {
         "64bit": {
@@ -16,8 +16,8 @@
             "hash": "d512703c549b52f8ae9b0a400ea86af8e3019f07e8a31a9a4bc5b48ce0d96da3"
         },
         "arm64": {
-            "url": "https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x86-stable-Portable.zip",
-            "hash": "d512703c549b52f8ae9b0a400ea86af8e3019f07e8a31a9a4bc5b48ce0d96da3"
+            "url": "https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-arm64-stable-Portable.zip",
+            "hash": "de1ea9fcf425061c44d01114bf18ee2cfeea35feaac96489dee1f21c615a1e50"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\rules.json\")) { Set-Content \"$dir\\rules.json\" '[]' -Encoding Ascii }",


### PR DESCRIPTION
- [x] Verified there are no open issues for this application
- [x] Verified there are no open pull requests for this application

Relates to #16379

Updates manifest for application:

### Fixes checkver
Test result:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> .\bin\checkver.ps1 papercut
papercut: 7.6.2
```

### Confirmed autoupdate:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> .\bin\checkver.ps1 papercut -u
papercut: 7.6.2 (scoop version is 7.6.1) autoupdate available
Autoupdating papercut
DEBUG[1766076408.7233] [$updatedProperties] = [url hash] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766076408.87932] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766076408.87932] $substitutions.$buildVersion                                                                                                                                                           
DEBUG[1766076408.87932] $substitutions.$match1                        7.6.2                                                                                                                                    
DEBUG[1766076408.87932] $substitutions.$preReleaseVersion             7.6.2                                                                                                                                    
DEBUG[1766076408.87932] $substitutions.$version                       7.6.2                                                                                                                                    
DEBUG[1766076408.87932] $substitutions.$patchVersion                  2                                                                                                                                        
DEBUG[1766076408.87932] $substitutions.$urlNoExt                      https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x86-stable-Portable                         
DEBUG[1766076408.87932] $substitutions.$dotVersion                    7.6.2                                                                                                                                    
DEBUG[1766076408.87932] $substitutions.$cleanVersion                  762                                                                                                                                      
DEBUG[1766076408.87932] $substitutions.$underscoreVersion             7_6_2                                                                                                                                    
DEBUG[1766076408.87932] $substitutions.$minorVersion                  6                                                                                                                                        
DEBUG[1766076408.87932] $substitutions.$url                           https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x86-stable-Portable.zip                     
DEBUG[1766076408.87932] $substitutions.$majorVersion                  7                                                                                                                                        
DEBUG[1766076408.87932] $substitutions.$matchTail                                                                                                                                                              
DEBUG[1766076408.87932] $substitutions.$basenameNoExt                 PapercutSMTP-win-x86-stable-Portable                                                                                                     
DEBUG[1766076408.87932] $substitutions.$basename                      PapercutSMTP-win-x86-stable-Portable.zip                                                                                                 
DEBUG[1766076408.87932] $substitutions.$dashVersion                   7-6-2                                                                                                                                    
DEBUG[1766076408.87932] $substitutions.$baseurl                       https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2                                                              
DEBUG[1766076408.87932] $substitutions.$matchHead                     7.6.2                                                                                                                                    
DEBUG[1766076408.9417] $hashfile_url = $null -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1766076409.42651] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x86-stable-Portable.zip')].digest -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: d512703c549b52f8ae9b0a400ea86af8e3019f07e8a31a9a4bc5b48ce0d96da3 using Github Mode
DEBUG[1766076409.5983] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766076409.5983] $substitutions.$buildVersion                                                                                                                                                            
DEBUG[1766076409.5983] $substitutions.$match1                        7.6.2                                                                                                                                     
DEBUG[1766076409.5983] $substitutions.$preReleaseVersion             7.6.2                                                                                                                                     
DEBUG[1766076409.5983] $substitutions.$version                       7.6.2                                                                                                                                     
DEBUG[1766076409.5983] $substitutions.$patchVersion                  2                                                                                                                                         
DEBUG[1766076409.5983] $substitutions.$urlNoExt                      https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x64-stable-Portable                          
DEBUG[1766076409.5983] $substitutions.$dotVersion                    7.6.2                                                                                                                                     
DEBUG[1766076409.5983] $substitutions.$cleanVersion                  762                                                                                                                                       
DEBUG[1766076409.5983] $substitutions.$underscoreVersion             7_6_2                                                                                                                                     
DEBUG[1766076409.5983] $substitutions.$minorVersion                  6                                                                                                                                         
DEBUG[1766076409.5983] $substitutions.$url                           https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x64-stable-Portable.zip                      
DEBUG[1766076409.5983] $substitutions.$majorVersion                  7                                                                                                                                         
DEBUG[1766076409.5983] $substitutions.$matchTail                                                                                                                                                               
DEBUG[1766076409.5983] $substitutions.$basenameNoExt                 PapercutSMTP-win-x64-stable-Portable                                                                                                      
DEBUG[1766076409.5983] $substitutions.$basename                      PapercutSMTP-win-x64-stable-Portable.zip                                                                                                  
DEBUG[1766076409.5983] $substitutions.$dashVersion                   7-6-2                                                                                                                                     
DEBUG[1766076409.5983] $substitutions.$baseurl                       https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2                                                               
DEBUG[1766076409.5983] $substitutions.$matchHead                     7.6.2                                                                                                                                     
DEBUG[1766076409.64501] $hashfile_url = $null -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1766076409.67619] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/ChangemakerStudios/Papercut-SMTP/releases/download/7.6.2/PapercutSMTP-win-x64-stable-Portable.zip')].digest -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 181595e37af7f8cba31afcfbc89e76bbd677276286f392d649ac224261bd32a5 using Github Mode
Writing updated papercut manifest
```

### Confirmed Virustotal OK
https://www.virustotal.com/gui/url/284626e6279eb861ad332adb4e452a7ed0bbc8b51892dcb300ab72fc50e1f143
https://www.virustotal.com/gui/url/2130b50197dad94797f1815510d57abfd4291914fe2683fcad627a55c98e3098
Everything ok, SHA-256 matches as well.

### Confirmed update is working:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop install .\bucket\papercut.json
Installing 'papercut' (6.2.0.723) [64bit] from 'C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras\bucket\papercut.json'
Loading Papercut.Smtp.x64.6.2.0.zip from cache
Checking hash of Papercut.Smtp.x64.6.2.0.zip ... ok.
Extracting Papercut.Smtp.x64.6.2.0.zip ... done.
Running pre_install script...done.
Linking ~\scoop\apps\papercut\current => ~\scoop\apps\papercut\6.2.0.723
Creating shortcut for Papercut (Papercut.exe)
Persisting Incoming
Persisting Logs
Persisting rules.json
'papercut' (6.2.0.723) was installed successfully!
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop update papercut
papercut: 6.2.0.723 -> 7.6.2
Updating one outdated app:
Updating 'papercut' (6.2.0.723 -> 7.6.2)
ERROR The following instances of "papercut" are still running. Close them and try again.

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    812      92   113488     176624       5.59   5756   1 Papercut



Running process detected, skip updating.
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop update papercut
papercut: 6.2.0.723 -> 7.6.2
Updating one outdated app:
Updating 'papercut' (6.2.0.723 -> 7.6.2)
Downloading new version
Loading PapercutSMTP-win-x64-stable-Portable.zip from cache
Checking hash of PapercutSMTP-win-x64-stable-Portable.zip ... ok.
Uninstalling 'papercut' (6.2.0.723)
Unlinking ~\scoop\apps\papercut\current
Installing 'windowsdesktop-runtime-9.0' (9.0.11) [64bit] from 'versions' bucket
Loading windowsdesktop-runtime-9.0.11-win-x64.exe from cache
Running pre_install script...done.
Running installer script...done.
Linking ~\scoop\apps\windowsdesktop-runtime-9.0\current => ~\scoop\apps\windowsdesktop-runtime-9.0\9.0.11
'windowsdesktop-runtime-9.0' (9.0.11) was installed successfully!
Notes
-----
You can now remove this installer with 'scoop uninstall -p windowsdesktop-runtime-9.0'
Installing 'papercut' (7.6.2) [64bit] from 'C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras\bucket\papercut.json'
Loading PapercutSMTP-win-x64-stable-Portable.zip from cache
Extracting PapercutSMTP-win-x64-stable-Portable.zip ... done.
Running pre_install script...done.
Linking ~\scoop\apps\papercut\current => ~\scoop\apps\papercut\7.6.2
Creating shortcut for Papercut (Papercut SMTP.exe)
Persisting Incoming
Persisting Logs
Persisting rules.json
'papercut' (7.6.2) was installed successfully!
```

### Confirmed clean installation is working:
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop install .\bucket\papercut.json
Installing 'windowsdesktop-runtime-9.0' (9.0.11) [64bit] from 'versions' bucket
Loading windowsdesktop-runtime-9.0.11-win-x64.exe from cache
Checking hash of windowsdesktop-runtime-9.0.11-win-x64.exe ... ok.
Running pre_install script...done.
Running installer script...done.
Linking ~\scoop\apps\windowsdesktop-runtime-9.0\current => ~\scoop\apps\windowsdesktop-runtime-9.0\9.0.11
'windowsdesktop-runtime-9.0' (9.0.11) was installed successfully!
Notes
-----
You can now remove this installer with 'scoop uninstall -p windowsdesktop-runtime-9.0'
Installing 'papercut' (7.6.2) [64bit] from 'C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras\bucket\papercut.json'
Loading PapercutSMTP-win-x64-stable-Portable.zip from cache
Checking hash of PapercutSMTP-win-x64-stable-Portable.zip ... ok.
Extracting PapercutSMTP-win-x64-stable-Portable.zip ... done.
Running pre_install script...done.
Linking ~\scoop\apps\papercut\current => ~\scoop\apps\papercut\7.6.2
Creating shortcut for Papercut (Papercut SMTP.exe)
Persisting Incoming
Persisting Logs
Persisting rules.json
'papercut' (7.6.2) was installed successfully!
```

### Tested the application
- application seems to run fine in a minimal test
- uses persistent data store correctly


### Confirmed uninstall
```
PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop uninstall papercut
Uninstalling 'papercut' (7.6.2).
ERROR The following instances of "papercut" are still running. Close them and try again.

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    936     145   109120     235616       4.48   5132   1 Papercut



PS C:\Users\WDAGUtilityAccount\Desktop\ScoopExtras> scoop uninstall papercut
Uninstalling 'papercut' (7.6.2).
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Papercut.lnk
Unlinking ~\scoop\apps\papercut\current
'papercut' was uninstalled.
```
✅Confirmed persistent data is kept



- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Apple Silicon (ARM64) build.
  * Added suggestion mapping for .NET Desktop Runtime 9.0.

* **Chores**
  * Updated application version to 7.6.2 and shipped new portable release binaries for 32-bit, 64-bit, and ARM64.
  * Improved auto-update URLs to use the stable portable paths.
  * Renamed displayed executable label to "Papercut SMTP.exe".
* **Chores**
  * Simplified release-check configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->