### PR TITLE
so: deprecate manifest

### DIFF
--- a/deprecated/so.json
+++ b/deprecated/so.json
@@ -1,4 +1,7 @@
 {
+    "##": [
+        "Deprecated 2025-12-18: No windows versions since August 2022"
+    ],
     "version": "0.4.9",
     "description": "A terminal interface for StackOverflow",
     "homepage": "https://github.com/samtay/so",


### PR DESCRIPTION
Package should be deprecated in my opinion, because:

- No windows build anymore in current version v0.4.10 since August 2022
- Windows build is reportedly broken [(source)](https://github.com/samtay/so/issues/53)

Also fixed the checkver

Relates to #16379 

- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation Notice**
  * Marked package as deprecated effective 2025-12-18 due to discontinued Windows support since August 2022.

* **Chores**
  * Updated update verification configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->