### PR TITLE
pdf-xchange-editor@10.7.6.404: Added valid hash

### DIFF
--- a/bucket/pdf-xchange-editor.json
+++ b/bucket/pdf-xchange-editor.json
@@ -13,7 +13,7 @@
         },
         "32bit": {
             "url": "https://www.pdf-xchange.com/downloads/PDFXEdit10_Portable_x86.zip",
-            "hash": "ad33c6bdeefaf9bd06f4ded187edc205ef162989ac888cfa8b62350207a7a6bf"
+            "hash": "84b9bf3fdafe2d4d26ffb25d1b932d58a03a18fe9bcbfdb65e5e734da60ad928"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Current hash is invalid for some reason

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PDF‑XChange Editor package information — refreshed installer checksums for 32‑ and 64‑bit builds to ensure package integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

/verify