### PR TITLE
linqpad: Update to version 9.4.6, fix checkver

### DIFF
--- a/bucket/linqpad.json
+++ b/bucket/linqpad.json
@@ -62,9 +62,12 @@
         }
     },
     "checkver": {
+        "url": "https://www.linqpad.net/Download.aspx",
         "script": [
+            "$match = $page -match 'Download LINQPad (?<majorVersion>\\d)'",
+            "if (-not $match) {return '' }",
             "try {",
-            "    $res = Invoke-WebRequest -Uri https://www.linqpad.net/GetFile.aspx?LINQPad9.zip -Method Head -MaximumRedirection 0 -ErrorAction Ignore",
+            "    $res = Invoke-WebRequest -Uri \"https://www.linqpad.net/GetFile.aspx?LINQPad$($Matches.majorVersion).zip\" -Method Head -MaximumRedirection 0 -ErrorAction Ignore",
             "} catch [Microsoft.PowerShell.Commands.HttpResponseException] {",
             "    $releaseUrl = $_.Exception.Response.Headers.Location.ToString()",
             "}",


### PR DESCRIPTION
* Bump the major version number in the checkver URL.
* Run `checkver.ps1 linqpad -update` to fetch the new version.

Closes #16831

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded LINQPad from 8.10.4 to 9.4.6.
  * Updated download URL and integrity hash to the LINQPad 9 release.
  * Renamed executables and shortcuts to reflect LINQPad 9 (including x86/64 variants).
* **Improvements**
  * Enhanced version-check and autoupdate logic to handle major-version substitution and more robust URL determination and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->