### PR TITLE
stranslate@2.0.2: Persist user data, remove post_install script

### DIFF
--- a/bucket/stranslate.json
+++ b/bucket/stranslate.json
@@ -1,13 +1,13 @@
 {
     "version": "2.0.2",
     "description": "A ready-to-use, ready-to-go translation and OCR tool developed by WPF",
-    "homepage": "https://stranslate.zggsong.com/",
+    "homepage": "https://stranslate.zggsong.com",
     "license": {
         "identifier": "MIT",
         "url": "https://github.com/STranslate/STranslate/blob/main/LICENSE"
     },
     "suggest": {
-        "runtime": "versions/windowsdesktop-runtime-10.0"
+        ".NET Desktop Runtime 10.0": "versions/windowsdesktop-runtime-10.0"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Updated version, description, homepage, and download URLs in stranslate.json.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


## Summary

- .net runtime has changed to .net 10
- the repository owner has been updated to the STranslate organization
- change the name of the packaged file
- directory changes after software deployment
- hash validation uses GitHub's default method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * License entry converted to a structured object with identifier and URL.
  * Removed obsolete post-install entry.
  * Added a persistent configuration field ("persist").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->