### PR TITLE
sshfs-win-manager: Add version 1.3.1

### DIFF
--- a/bucket/sshfs-win-manager.json
+++ b/bucket/sshfs-win-manager.json
@@ -3,11 +3,13 @@
     "description": "A GUI for SSHFS-Win.",
     "homepage": "https://github.com/evsar3/sshfs-win-manager",
     "license": "MIT",
-    "depends": "nonportable/sshfs-np",
+    "suggest": {
+        "SSHFS": "nonportable/sshfs-np"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/evsar3/sshfs-win-manager/releases/download/v1.3.1/sshfs-win-manager-v1.3.1.zip",
-            "hash": "EBFB09FBDED091068FE011AE5675A91B431F0DE63863D1BA841A2B0147534534"
+            "hash": "ebfb09fbded091068fe011ae5675a91b431f0de63863d1ba841a2b0147534534"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Closes #16836 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSHFS-Win Manager v1.3.1 is now available — includes a 64‑bit installer, start-menu shortcut, and automatic update support via GitHub releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->