### PR TITLE
goshs@1.1.3: Fix checkver & autoupdate

### DIFF
--- a/bucket/goshs.json
+++ b/bucket/goshs.json
@@ -1,10 +1,10 @@
 {
     "version": "1.1.3",
-    "description": "A SimpleHTTPServer written in Go, enhanced with features and with a nice design",
+    "description": "A SimpleHTTPServer written in Go, enhanced with features and with a nice design.",
     "homepage": "https://goshs.de",
     "license": {
         "identifier": "MIT",
-        "url": "https://github.com/patrickhener/goshs/blob/main/LICENSE"
+        "url": "https://github.com/patrickhener/goshs/blob/HEAD/LICENSE"
     },
     "architecture": {
         "64bit": {
@@ -27,18 +27,19 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/patrickhener/goshs"
+        "github": "https://github.com/patrickhener/goshs",
+        "regex": "(?i)tag/(?<tag>v?([\\d.]+))(?=\")"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/patrickhener/goshs/releases/download/v$version/goshs_windows_x86_64.tar.gz"
+                "url": "https://github.com/patrickhener/goshs/releases/download/$matchTag/goshs_windows_x86_64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/patrickhener/goshs/releases/download/v$version/goshs_windows_386.tar.gz"
+                "url": "https://github.com/patrickhener/goshs/releases/download/$matchTag/goshs_windows_386.tar.gz"
             },
             "arm64": {
-                "url": "https://github.com/patrickhener/goshs/releases/download/v$version/goshs_windows_arm64.tar.gz"
+                "url": "https://github.com/patrickhener/goshs/releases/download/$matchTag/goshs_windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
### Summary

Improves the `goshs` manifest by refining metadata consistency and making the `checkver` and `autoupdate` logic more robust against upstream changes.

### Related commit

- https://github.com/ScoopInstaller/Extras/commit/e04cc8d4c201ab919392e2b71f88ee1fe48eff77

### Changes

- Refactor `checkver` to use the GitHub Releases API with JSONPath and regex-based tag extraction
- Improve `autoupdate` URLs to rely on `$matchTag` instead of assuming a fixed `v$version` prefix

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App goshs -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
goshs: 1.1.3 (scoop version is 1.1.3)
Forcing autoupdate!
Autoupdating goshs
DEBUG[1766247912] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766247912] $substitutions.$underscoreVersion             1_1_3
DEBUG[1766247912] $substitutions.$urlNoExt                      https://github.com/patrickhener/goshs/releases/download/1.1.3/goshs_windows_arm64.tar
DEBUG[1766247912] $substitutions.$matchTag                      1.1.3
DEBUG[1766247912] $substitutions.$url                           https://github.com/patrickhener/goshs/releases/download/1.1.3/goshs_windows_arm64.tar.gz
DEBUG[1766247912] $substitutions.$dashVersion                   1-1-3
DEBUG[1766247912] $substitutions.$minorVersion                  1
DEBUG[1766247912] $substitutions.$dotVersion                    1.1.3
DEBUG[1766247912] $substitutions.$patchVersion                  3
DEBUG[1766247912] $substitutions.$basenameNoExt                 goshs_windows_arm64.tar
DEBUG[1766247912] $substitutions.$preReleaseVersion             1.1.3
DEBUG[1766247912] $substitutions.$buildVersion
DEBUG[1766247912] $substitutions.$majorVersion                  1
DEBUG[1766247912] $substitutions.$cleanVersion                  113
DEBUG[1766247912] $substitutions.$version                       1.1.3
DEBUG[1766247912] $substitutions.$match1                        1.1.3
DEBUG[1766247912] $substitutions.$baseurl                       https://github.com/patrickhener/goshs/releases/download/1.1.3
DEBUG[1766247912] $substitutions.$matchTail
DEBUG[1766247912] $substitutions.$matchHead                     1.1.3
DEBUG[1766247912] $substitutions.$basename                      goshs_windows_arm64.tar.gz
DEBUG[1766247912] $hashfile_url = https://github.com/patrickhener/goshs/releases/download/1.1.3/checksums.txt -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for goshs_windows_arm64.tar.gz in https://github.com/patrickhener/goshs/releases/download/1.1.3/checksums.txt
DEBUG[1766247913] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*goshs_windows_arm64\.tar\.gz(?:\s|$)|goshs_windows_arm64\.tar\.gz[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:99:13
Found: 025c7e905671ce372d13d0f454bde79fd52020e9271505b697c4fcd7a6fdf0e2 using Extract Mode
Writing updated goshs manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for version detection and download mechanism to use tag-based identification instead of version-based placeholders.
  * Minor documentation updates to manifest metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->