### PR TITLE
lintalist: Add version 1.9.26

### DIFF
--- a/bucket/lintalist.json
+++ b/bucket/lintalist.json
@@ -13,18 +13,16 @@
             "hash": "d61997ed18b328a991b6320590f390b94c54fb6e836f358bb8a63f0ea17bb390"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\Settings.ini\")) { New-Item \"$dir\\Settings.ini\" | Out-Null }"
-    ],
-    "persist": [
-        "Settings.ini",
-        "bundles"
-    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\Settings.ini\")) { New-Item \"$dir\\Settings.ini\" | Out-Null }",
     "shortcuts": [
         [
             "lintalist.exe",
             "Lintalist"
         ]
+    ],
+    "persist": [
+        "Settings.ini",
+        "bundles"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
Closes #16855 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package manifest for Lintalist v1.9.26 with 64‑bit and 32‑bit builds, automatic version checking and autoupdate templates, a pre-install step to ensure configuration exists, persistence for Settings.ini and bundle data across updates, and a desktop shortcut for "Lintalist".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->