### PR TITLE
copy-dialog-lunar-lander: Add version 1.2

### DIFF
--- a/bucket/copy-dialog-lunar-lander.json
+++ b/bucket/copy-dialog-lunar-lander.json
@@ -1,10 +1,10 @@
 {
     "version": "1.2",
-    "description": "Copy Dialog Lunar Lander is a small open‑source Windows game that turns the file copy progress dialog into a playable lunar lander overlay.",
+    "description": "Copy Dialog Lunar Lander is a small open-source Windows game that turns the file copy progress dialog into a playable lunar lander overlay.",
     "homepage": "https://github.com/Sanakan8472/copy-dialog-lunar-lander",
     "license": "MIT",
     "url": "https://github.com/Sanakan8472/copy-dialog-lunar-lander/releases/download/v1.2/CopyDialogLunarLander.msi",
-    "hash": "7C7F51589099D03C696128729FFCD9CD51AE32600701BB5F4ED4DEF8E43D1267",
+    "hash": "7c7f51589099d03c696128729ffcd9cd51ae32600701bb5f4ed4def8e43d1267",
     "shortcuts": [
         [
             "CopyDialogLunarLander.exe",


### PR DESCRIPTION
Closes #16857 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new package manifest enabling installation of Copy Dialog Lunar Lander v1.2 through the package catalog. Includes user-facing metadata (description, homepage, license), download location and verification, shortcut mapping, and automatic update configuration so the package can be discovered, installed, and kept up to date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->