### PR TITLE
tablacus-explorer: Add version 25.12.31

### DIFF
--- a/bucket/tablacusexplorer.json
+++ b/bucket/tablacusexplorer.json
@@ -35,7 +35,6 @@
             ]
         }
     },
-    "pre_install": "if (!(Test-Path \"$persist_dir\\config\")) { New-Item -ItemType Directory \"$persist_dir\\config\" | Out-Null }",
     "persist": "config",
     "checkver": {
         "github": "https://github.com/tablacus/TablacusExplorer"


### PR DESCRIPTION
Closes #16861 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Tablacus Explorer (v25.12.31).
  * Enabled automatic version checking and autoupdates from releases.
  * Configured architecture-specific binaries for 64-bit and 32-bit systems.
  * Enabled persistent configuration storage for user settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->