### PR TITLE
mupdf@1.27.0: Fix checkver & autoupdate, add suggest

### DIFF
--- a/bucket/mupdf.json
+++ b/bucket/mupdf.json
@@ -29,7 +29,7 @@
     ],
     "checkver": {
         "url": "https://mupdf.com/releases?product=MuPDF",
-        "regex": "mupdf-([0-9.]+)-windows\\.zip"
+        "regex": "mupdf-([\\d.]+)-windows\\.zip"
     },
     "autoupdate": {
         "architecture": {
@@ -38,7 +38,7 @@
             }
         },
         "hash": {
-            "url": "https://mupdf.com/releases",
+            "url": "https://mupdf.com/releases?product=MuPDF",
             "regex": "$basename.*?$sha256"
         }
     }


### PR DESCRIPTION
- Fixes the checkver, so no more release candidates are allowed
- Fixes autoupdate hash extraction
- adds dependency `extras/vcredist2022`

Replaces shortcut with `mupdf-gl.exe`, since:
- mupdf-gl is [(source)](https://mupdf.readthedocs.io/en/1.27.0/guide/what-is-mupdf.html)
> The main viewer program that sports the most features
- keeping the old one additionally prevents the mupdf-gl from being recommended by windows to open PDF files

Furthermore:
- [x] Closes https://github.com/ScoopInstaller/Extras/issues/3992

- [x] Verified there are no other open issues for this application in scoop
- [x] Verified there are no other open pull requests for this application
- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Follows general order of fields and ran `.\bin\formatjson.ps1`
- [x] Tab width 4 spaces

### Checkver OK
```
PS C:\Users\WDAGUtilityAccount\scoop\buckets\extras> .\bin\checkver.ps1 mupdf
mupdf: 1.27.0
```

### Autoupdate OK:
```
PS C:\Users\WDAGUtilityAccount\scoop\buckets\extras> .\bin\checkver.ps1 mupdf -f
mupdf: 1.27.0 (scoop version is 1.27.0)
Forcing autoupdate!
Autoupdating mupdf
DEBUG[1766423083.58134] [$updatedProperties] = [hash url] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766423083.64418] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766423083.64418] $substitutions.$buildVersion                                                                                                                                                           
DEBUG[1766423083.64418] $substitutions.$match1                        1.27.0                                                                                                                                   
DEBUG[1766423083.64418] $substitutions.$preReleaseVersion             1.27.0                                                                                                                                   
DEBUG[1766423083.64418] $substitutions.$version                       1.27.0                                                                                                                                   
DEBUG[1766423083.64418] $substitutions.$patchVersion                  0                                                                                                                                        
DEBUG[1766423083.64418] $substitutions.$urlNoExt                      https://casper.mupdf.com/downloads/archive/mupdf-1.27.0-windows                                                                          
DEBUG[1766423083.64418] $substitutions.$dotVersion                    1.27.0                                                                                                                                   
DEBUG[1766423083.64418] $substitutions.$cleanVersion                  1270                                                                                                                                     
DEBUG[1766423083.64418] $substitutions.$underscoreVersion             1_27_0                                                                                                                                   
DEBUG[1766423083.64418] $substitutions.$minorVersion                  27                                                                                                                                       
DEBUG[1766423083.64418] $substitutions.$url                           https://casper.mupdf.com/downloads/archive/mupdf-1.27.0-windows.zip                                                                      
DEBUG[1766423083.64418] $substitutions.$majorVersion                  1                                                                                                                                        
DEBUG[1766423083.64418] $substitutions.$matchTail                                                                                                                                                              
DEBUG[1766423083.64418] $substitutions.$basenameNoExt                 mupdf-1.27.0-windows                                                                                                                     
DEBUG[1766423083.64418] $substitutions.$basename                      mupdf-1.27.0-windows.zip                                                                                                                 
DEBUG[1766423083.64418] $substitutions.$dashVersion                   1-27-0                                                                                                                                   
DEBUG[1766423083.64418] $substitutions.$baseurl                       https://casper.mupdf.com/downloads/archive                                                                                               
DEBUG[1766423083.64418] $substitutions.$matchHead                     1.27.0                                                                                                                                   
DEBUG[1766423083.73772] $hashfile_url = https://mupdf.com/releases?product=MuPDF -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for mupdf-1.27.0-windows.zip in https://mupdf.com/releases?product=MuPDF
DEBUG[1766423083.84726] $regex = mupdf-1\.27\.0-windows\.zip[^}]+SHA256":"(\w+)" -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: f3e60b630453301914e52fb8ec001f6ab56cdb90daf39e533deae3ff214fcff8 using Extract Mode
Writing updated mupdf manifest
```

### Confirmed Virustotal OK
https://www.virustotal.com/gui/file/f3e60b630453301914e52fb8ec001f6ab56cdb90daf39e533deae3ff214fcff8

### Tests
- [x] updated from v1.21.0-rc1 to v1.27.0
- [x] uninstall
- [x] application seems to run fine in a minimal test

### Observations
Stores data outside of scoop:
- `~\.mupdf.history`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Switched package distribution to use the MuPDF GL build.
  * Added a suggested Visual C++ 2022 redistributable.
  * Updated package download sources and autoupdate endpoints to archived/casper hosts.
  * Tightened version-detection to numeric-only version segments.
  * Updated version-check endpoints to filter by the MuPDF product and aligned update hashing endpoints.
  * Added a new MuPDF GL shortcut for improved launcher entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->