### PR TITLE
vscode: Refactor manifest and align registry scripts with official installer

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -1,18 +1,22 @@
 {
     "version": "1.117.0",
-    "description": "Lightweight but powerful source code editor",
-    "homepage": "https://code.visualstudio.com/",
+    "description": "Visual Studio Code is a lightweight yet powerful, cross-platform source code editor providing rich support for development, debugging, and extension-based customization for modern web and cloud workloads.",
+    "homepage": "https://code.visualstudio.com",
     "license": {
         "identifier": "Freeware",
-        "url": "https://code.visualstudio.com/License/"
+        "url": "https://code.visualstudio.com/License"
     },
     "notes": [
-        "Add Visual Studio Code as a context menu option by running:",
-        "reg import \"$dir\\install-context.reg\"",
-        "For file associations, run:",
+        "To register file associations, please execute the following command:",
         "reg import \"$dir\\install-associations.reg\"",
-        "For github integration, run:",
-        "reg import \"$dir\\install-github-integration.reg\""
+        "To register the context menu entry, please execute the following command:",
+        "reg import \"$dir\\install-context.reg\"",
+        "To register the installed program entry (required for integration with other applications), please execute the following command:",
+        "reg import \"$dir\\register-installed-program.reg\"",
+        "",
+        "Please note that the related logic has been changed.",
+        "All previously registered entries must be unregistered and then registered again.",
+        "No further action is required if this message appears again."
     ],
     "architecture": {
         "64bit": {
@@ -24,54 +28,91 @@
             "hash": "6961a2aa26ac8303c4eee7545e7c4fc79d915caa6ffd159daf7d53299b2cdd2e"
         }
     },
+    "pre_install": [
+        "ensure \"$persist_dir\\data\\user-data\" | Out-Null",
+        "if (-not (Test-Path -Path \"$persist_dir\\data\\user-data\\*\") -and (Test-Path -Path \"$env:AppData\\Code\\*\")) {",
+        "    Write-Host \"`nINFO  Migrating user data to '$persist_dir\\data'...\" -ForegroundColor DarkGray",
+        "    Copy-Item -Path \"$env:AppData\\Code\\*\" -Destination \"$persist_dir\\data\\user-data\" -Force -Recurse",
+        "}",
+        "'argv.json', 'extensions' | ForEach-Object {",
+        "    if (-not (Test-Path -Path \"$persist_dir\\data\\$_\") -and (Test-Path -Path \"$HOME\\.vscode\\$_\")) {",
+        "        Write-Host \"INFO  Migrating $_ to '$persist_dir\\data'...\" -ForegroundColor DarkGray",
+        "        Copy-Item -Path \"$HOME\\.vscode\\$_\" -Destination \"$persist_dir\\data\" -Force -Recurse",
+        "    }",
+        "}",
+        "$remove_list = @('argv.json', 'extensions') | ForEach-Object { \"$HOME\\.vscode\\$_\" }",
+        "$remove_list + @(\"$env:AppData\\Code\") | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue",
+        "$settings_file = \"$persist_dir\\data\\user-data\\User\\settings.json\"",
+        "if (-not (Test-Path -Path $settings_file -PathType Leaf)) {",
+        "    New-Item -Path $settings_file -ItemType File -Force | Out-Null",
+        "    $settings = @{ 'update.mode'= 'none'; 'update.enableWindowsBackgroundUpdates' = $false }",
+        "    $settings | ConvertTo-Json -Depth 5 | Set-Content -Path $settings_file -NoNewline -Encoding utf8",
+        "}"
+    ],
+    "post_install": [
+        "$vscode_dir = $dir -replace '\\\\', '\\\\'",
+        "$product_json_file = Get-ChildItem -Path $dir -Include '*.json' -Depth 3 -File |",
+        "        Where-Object { $_.DirectoryName -match 'app$' -and $_.BaseName -match '^product' } |",
+        "        Select-Object -ExpandProperty FullName -First 1",
+        "if (Test-Path -Path $product_json_file -PathType Leaf) {",
+        "    $scope = if ($global) { '' } else { 'User' }",
+        "    $arch_map = @{ '64bit' = 'x64'; 'arm64' = 'arm64' }",
+        "    $product_metadata = Get-Content -Path $product_json_file -Encoding utf8 | ConvertFrom-Json",
+        "    $product_property_key = 'win32{0}{1}AppId' -f $arch_map[$architecture], $scope",
+        "    $product_identity_guid = $product_metadata.$product_property_key -replace '^{{(.+)}$', '$1'",
+        "}",
+        "Get-ChildItem -Path \"$bucketsdir\\$bucket\\scripts\\$app\" -Filter '*.reg' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding utf8",
+        "    if ($global) { $content = $content -replace 'HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE' }",
+        "    if ($product_identity_guid) { $content = $content -replace '(?<={).+(?=}_is1)', $product_identity_guid }",
+        "    $content -replace '{{vscode_dir}}', $vscode_dir | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding unicode",
+        "}",
+        "$register_installed_file = '\"{0}\\register-installed-program.reg\"' -f $dir",
+        "Start-Process -FilePath 'reg.exe' -ArgumentList @('import', $register_installed_file) -WindowStyle Hidden -Wait",
+        "ensure \"$dir\\resources\\app\\resources\\win32\" | Out-Null",
+        "$original_resources_dir = Get-ChildItem -Path $dir -Include '*.ico' -Depth 5 -File |",
+        "        Where-Object { $_.DirectoryName -match 'resources\\\\win32$' } | Select-Object -ExpandProperty DirectoryName -First 1",
+        "Copy-Item -Path \"$original_resources_dir\\*\" -Destination \"$dir\\resources\\app\\resources\\win32\" -Force",
+        "$data_dir = \"$original_dir\\data\" -replace '\\\\', '/'",
+        "$extensions_file = \"$dir\\data\\extensions\\extensions.json\"",
+        "if (Test-Path -Path $extensions_file -PathType Leaf) {",
+        "    Write-Host \"`nINFO  Adjusting path in extensions file...\" -ForegroundColor DarkGray",
+        "    $cfg = Get-Content -Path $extensions_file -Encoding utf8 | ConvertFrom-Json",
+        "    $cfg | ForEach-Object {",
+        "        $_.location.PSObject.Properties.Remove('_sep')",
+        "        $_.location.PSObject.Properties.Remove('fsPath')",
+        "        $_.location.PSObject.Properties.Remove('external')",
+        "        $_.location.path = $_.location.path -replace '(?<=/).+(?=/extensions)', $data_dir",
+        "        if (-not $_.identifier.uuid -and $_.metadata.id) {",
+        "            $_.identifier | Add-Member -NotePropertyName uuid -NotePropertyValue $_.metadata.id",
+        "        }",
+        "    }",
+        "    , @($cfg) | ConvertTo-Json -Depth 5 -Compress | Set-Content -Path $extensions_file -NoNewline -Encoding utf8",
+        "}"
+    ],
     "env_add_path": "bin",
     "shortcuts": [
         [
-            "code.exe",
+            "Code.exe",
             "Visual Studio Code"
         ]
     ],
-    "post_install": [
-        "$dirpath = \"$dir\".Replace('\\', '\\\\')",
-        "$exepath = \"$dir\\Code.exe\".Replace('\\', '\\\\')",
-        "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context', 'install-github-integration', 'uninstall-github-integration' | ForEach-Object {",
-        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",
-        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\"",
-        "    $content = $content.Replace('$codedir', $dirpath)",
-        "    $content = $content.Replace('$code', $exepath)",
-        "    if ($global) {",
-        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
-        "    }",
-        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
-        "  }",
-        "}",
-        "if (!(Test-Path \"$dir\\data\\extensions\") -and (Test-Path \"$env:USERPROFILE\\.vscode\\extensions\")) {",
-        "    info '[Portable Mode] Copying extensions...'",
-        "    Copy-Item \"$env:USERPROFILE\\.vscode\\extensions\" \"$dir\\data\" -Recurse",
-        "}",
-        "if (!(Test-Path \"$dir\\data\\user-data\") -and (Test-Path \"$env:AppData\\Code\")) {",
-        "    info '[Portable Mode] Copying user data...'",
-        "    Copy-Item \"$env:AppData\\Code\" \"$dir\\data\\user-data\" -Recurse",
-        "}",
-        "$extensions_file = \"$dir\\data\\extensions\\extensions.json\"",
-        "if ((Test-Path \"$extensions_file\")) {",
-        "    info 'Adjusting path in extensions file...'",
-        "    (Get-Content \"$extensions_file\") -replace '(?<=vscode(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
-        "}"
-    ],
+    "persist": "data",
     "uninstaller": {
         "script": [
-            "if ($cmd -eq 'uninstall')",
-            "{",
-            "   reg import \"$dir\\uninstall-context.reg\" ",
-            "   reg import \"$dir\\uninstall-github-integration.reg\" ",
+            "$unregister_installed_file = '\"{0}\\unregister-installed-program.reg\"' -f $dir",
+            "Start-Process -FilePath 'reg.exe' -ArgumentList @('import', $unregister_installed_file) -WindowStyle Hidden -Wait",
+            "if ($cmd -ne 'uninstall') { return }",
+            "Get-ChildItem -Path $dir -Filter 'un*.reg' -File |",
+            "        Where-Object { $_.BaseName -notmatch 'installed' } | ForEach-Object {",
+            "    $registry_file = '\"{0}\"' -f $_.FullName",
+            "    Start-Process -FilePath 'reg.exe' -ArgumentList @('import', $registry_file) -WindowStyle Hidden -Wait",
             "}"
         ]
     },
-    "persist": "data",
     "checkver": {
         "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/stable/latest",
-        "jsonpath": "$.name"
+        "jsonpath": "$.productVersion"
     },
     "autoupdate": {
         "architecture": {

--- a/scripts/vscode/install-associations.reg
+++ b/scripts/vscode/install-associations.reg
@@ -1,2575 +1,3725 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\Classes\.ascx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ascx"=""
+[HKEY_CURRENT_USER\Software\Classes\.adoc\OpenWithProgIDs]
+"VSCode.adoc"=hex(0):
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.adoc]
+@="AsciiDoc Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="AsciiDoc Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.adoc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.adoc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.adoc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.adoc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.ascx\OpenWithProgIDs]
+"VSCode.ascx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ascx]
 @="ASCX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ASCX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ascx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\xml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ascx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ascx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ascx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.asp\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.asp"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp]
+[HKEY_CURRENT_USER\Software\Classes\.asp\OpenWithProgIDs]
+"VSCode.asp"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.asp]
 @="ASP Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ASP Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.asp\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.asp\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.asp\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.asp\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.aspx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.aspx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx]
+[HKEY_CURRENT_USER\Software\Classes\.aspx\OpenWithProgIDs]
+"VSCode.aspx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.aspx]
 @="ASPX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ASPX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.aspx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.aspx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.aspx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.aspx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bash"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash]
+[HKEY_CURRENT_USER\Software\Classes\.bash\OpenWithProgIDs]
+"VSCode.bash"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash]
 @="Bash Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Bash Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash_login\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bash_login"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login]
+[HKEY_CURRENT_USER\Software\Classes\.bashrc\OpenWithProgIDs]
+"VSCode.bashrc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bashrc]
+@="Bash Configuration Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Bash Configuration Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bashrc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bashrc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bashrc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bashrc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.bash_login\OpenWithProgIDs]
+"VSCode.bash_login"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_login]
 @="Bash Login Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Bash Login Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_login\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_login\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_login\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_login\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash_logout\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bash_logout"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout]
+[HKEY_CURRENT_USER\Software\Classes\.bash_logout\OpenWithProgIDs]
+"VSCode.bash_logout"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_logout]
 @="Bash Logout Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Bash Logout Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_logout\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_logout\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_logout\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.bash_profile\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bash_profile"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile]
-@="Bash Profile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_logout\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bashrc\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bashrc"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc]
-@="Bash RC Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\.bash_profile\OpenWithProgIDs]
+"VSCode.bash_profile"=hex(0):
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bib\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bib"=""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_profile]
+@="Bash Profile Configuration Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Bash Profile Configuration Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib]
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_profile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_profile\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_profile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bash_profile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.bib\OpenWithProgIDs]
+"VSCode.bib"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bib]
 @="BibTeX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="BibTeX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bib\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bib\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bib\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bib\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bowerrc\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.bowerrc"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc]
+[HKEY_CURRENT_USER\Software\Classes\.bowerrc\OpenWithProgIDs]
+"VSCode.bowerrc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bowerrc]
 @="Bower RC Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Bower RC Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\bower.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bowerrc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\bower.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bowerrc\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bowerrc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.c++\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.c++"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++]
-@="C++ Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.bowerrc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.c\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.c"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c]
+[HKEY_CURRENT_USER\Software\Classes\.c\OpenWithProgIDs]
+"VSCode.c"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c]
 @="C Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\c.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\c.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.c\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cc\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cc"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc]
+[HKEY_CURRENT_USER\Software\Classes\.c++\OpenWithProgIDs]
+"VSCode.c++"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c++]
 @="C++ Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c++\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c++\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c++\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.c++\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cfg\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cfg"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg]
+[HKEY_CURRENT_USER\Software\Classes\.cc\OpenWithProgIDs]
+"VSCode.cc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cc]
+@="C++ Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.cfg\OpenWithProgIDs]
+"VSCode.cfg"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cfg]
 @="Configuration Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Configuration Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cfg\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cfg\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cfg\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cfg\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cjs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cjs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs]
+[HKEY_CURRENT_USER\Software\Classes\.cjs\OpenWithProgIDs]
+"VSCode.cjs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cjs]
 @="JavaScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JavaScript Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cjs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\javascript.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cjs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cjs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cjs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.clj\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.clj"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj]
+[HKEY_CURRENT_USER\Software\Classes\.clj\OpenWithProgIDs]
+"VSCode.clj"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clj]
 @="Clojure Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Clojure Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clj\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clj\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clj\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clj\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cljs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cljs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs]
+[HKEY_CURRENT_USER\Software\Classes\.cljs\OpenWithProgIDs]
+"VSCode.cljs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljs]
 @="ClojureScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ClojureScript Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cljx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cljx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx]
+[HKEY_CURRENT_USER\Software\Classes\.cljx\OpenWithProgIDs]
+"VSCode.cljx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljx]
 @="CLJX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="CLJX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cljx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.clojure\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.clojure"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure]
+[HKEY_CURRENT_USER\Software\Classes\.clojure\OpenWithProgIDs]
+"VSCode.clojure"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clojure]
 @="Clojure Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Clojure Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clojure\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clojure\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clojure\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.clojure\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cls\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cls"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls]
+[HKEY_CURRENT_USER\Software\Classes\.cls\OpenWithProgIDs]
+"VSCode.cls"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cls]
 @="LaTeX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="LaTeX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cls\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cls\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cls\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.code-workspace\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.code-workspace"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace]
-@="Code Workspace Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cls\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cmake\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cmake"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake]
+[HKEY_CURRENT_USER\Software\Classes\.cmake\OpenWithProgIDs]
+"VSCode.cmake"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cmake]
 @="CMake Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="CMake Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cmake\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cmake\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cmake\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cmake\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.coffee\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.coffee"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee]
+[HKEY_CURRENT_USER\Software\Classes\.code-workspace\OpenWithProgIDs]
+"VSCode.code-workspace"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.code-workspace]
+@="Code Workspace Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Code Workspace Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.code-workspace\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.code-workspace\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.code-workspace\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.code-workspace\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.coffee\OpenWithProgIDs]
+"VSCode.coffee"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.coffee]
 @="CoffeeScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="CoffeeScript Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.coffee\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.coffee\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.coffee\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.coffee\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.config\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.config"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.config]
+[HKEY_CURRENT_USER\Software\Classes\.conf\OpenWithProgIDs]
+"VSCode.conf"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.conf]
 @="Configuration Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Configuration Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.config\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.conf\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.config\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.conf\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.config\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.conf\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.conf\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.containerfile\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.containerfile"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile]
+[HKEY_CURRENT_USER\Software\Classes\.config\OpenWithProgIDs]
+"VSCode.config"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.config]
+@="Configuration Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Configuration Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.config\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.config\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.config\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.config\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.containerfile\OpenWithProgIDs]
+"VSCode.containerfile"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.containerfile]
 @="Containerfile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Containerfile Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.containerfile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.containerfile\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.containerfile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.containerfile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cpp\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cpp"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp]
+[HKEY_CURRENT_USER\Software\Classes\.cpp\OpenWithProgIDs]
+"VSCode.cpp"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cpp]
 @="C++ Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cpp\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cpp\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cpp\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cpp\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs]
+[HKEY_CURRENT_USER\Software\Classes\.cs\OpenWithProgIDs]
+"VSCode.cs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cs]
 @="C# Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C# Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\csharp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\csharp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cshtml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cshtml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml]
+[HKEY_CURRENT_USER\Software\Classes\.cshtml\OpenWithProgIDs]
+"VSCode.cshtml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cshtml]
 @="CSHTML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="CSHTML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cshtml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cshtml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cshtml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cshtml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.csproj\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.csproj"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj]
+[HKEY_CURRENT_USER\Software\Classes\.csproj\OpenWithProgIDs]
+"VSCode.csproj"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csproj]
 @="C# Project Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C# Project Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csproj\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\xml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csproj\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csproj\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csproj\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.css\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.css"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.css]
+[HKEY_CURRENT_USER\Software\Classes\.css\OpenWithProgIDs]
+"VSCode.css"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.css]
 @="CSS Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="CSS Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.css\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\css.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.css\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\css.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.css\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.css\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.css\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.css\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.css\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.csv\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.csv"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv]
+[HKEY_CURRENT_USER\Software\Classes\.csv\OpenWithProgIDs]
+"VSCode.csv"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csv]
 @="Comma Separated Values Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Comma Separated Values Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csv\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csv\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csv\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csv\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.csx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.csx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx]
+[HKEY_CURRENT_USER\Software\Classes\.csx\OpenWithProgIDs]
+"VSCode.csx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csx]
 @="C# Script Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C# Script Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\csharp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\csharp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.csx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ctp\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ctp"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp]
+[HKEY_CURRENT_USER\Software\Classes\.ctp\OpenWithProgIDs]
+"VSCode.ctp"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ctp]
 @="CakePHP Template Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="CakePHP Template Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ctp\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ctp\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ctp\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ctp\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cxx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.cxx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx]
+[HKEY_CURRENT_USER\Software\Classes\.cxx\OpenWithProgIDs]
+"VSCode.cxx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cxx]
 @="C++ Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cxx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cxx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cxx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.cxx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dart\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.dart"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart]
+[HKEY_CURRENT_USER\Software\Classes\.dart\OpenWithProgIDs]
+"VSCode.dart"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dart]
 @="Dart Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Dart Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dart\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dart\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dart\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dart\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.diff\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.diff"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff]
+[HKEY_CURRENT_USER\Software\Classes\.diff\OpenWithProgIDs]
+"VSCode.diff"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.diff]
 @="Diff Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Diff Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.diff\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.diff\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.diff\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.diff\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dockerfile\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.dockerfile"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile]
+[HKEY_CURRENT_USER\Software\Classes\.dockerfile\OpenWithProgIDs]
+"VSCode.dockerfile"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerfile]
 @="Dockerfile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Dockerfile Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerfile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerfile\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerfile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerfile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dot\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.dot"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot]
+[HKEY_CURRENT_USER\Software\Classes\.dockerignore\OpenWithProgIDs]
+"VSCode.dockerignore"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerignore]
+@="Docker Ignore Source File"
+"AlwaysShowExt"=""
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Docker Ignore Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerignore\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerignore\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerignore\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dockerignore\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.dot\OpenWithProgIDs]
+"VSCode.dot"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dot]
 @="Dot Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Dot Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dot\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dot\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dot\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dot\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dtd\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.dtd"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd]
+[HKEY_CURRENT_USER\Software\Classes\.dtd\OpenWithProgIDs]
+"VSCode.dtd"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dtd]
 @="Document Type Definition Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Document Type Definition Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dtd\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\xml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dtd\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dtd\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.dtd\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.editorconfig\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.editorconfig"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig]
+[HKEY_CURRENT_USER\Software\Classes\.editorconfig\OpenWithProgIDs]
+"VSCode.editorconfig"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.editorconfig]
 @="Editor Config Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Editor Config Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.editorconfig\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.editorconfig\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.editorconfig\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.editorconfig\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.edn\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.edn"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn]
+[HKEY_CURRENT_USER\Software\Classes\.edn\OpenWithProgIDs]
+"VSCode.edn"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.edn]
 @="Extensible Data Notation Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Extensible Data Notation Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.edn\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.edn\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.edn\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.edn\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.erb\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.erb"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb]
+[HKEY_CURRENT_USER\Software\Classes\.env\OpenWithProgIDs]
+"VSCode.env"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.env]
+@="Environment Configuration Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Environment Configuration File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.env\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.env\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.env\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.env\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.erb\OpenWithProgIDs]
+"VSCode.erb"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.erb]
 @="Ruby Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Ruby Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\ruby.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.erb\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\ruby.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.erb\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.erb\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.erb\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.eyaml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.eyaml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml]
+[HKEY_CURRENT_USER\Software\Classes\.eyaml\OpenWithProgIDs]
+"VSCode.eyaml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyaml]
 @="Hiera Eyaml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Hiera Eyaml Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyaml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\yaml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyaml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyaml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyaml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.eyml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.eyml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml]
+[HKEY_CURRENT_USER\Software\Classes\.eyml\OpenWithProgIDs]
+"VSCode.eyml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyml]
 @="Hiera Eyaml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Hiera Eyaml Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\yaml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.eyml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.fs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs]
+[HKEY_CURRENT_USER\Software\Classes\.fish\OpenWithProgIDs]
+"VSCode.fish"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fish]
+@="Fish Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Fish Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fish\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fish\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fish\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fish\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.fs\OpenWithProgIDs]
+"VSCode.fs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fs]
 @="F# Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="F# Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fsi\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.fsi"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi]
+[HKEY_CURRENT_USER\Software\Classes\.fsi\OpenWithProgIDs]
+"VSCode.fsi"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsi]
 @="F# Signature Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="F# Signature Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsi\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsi\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsi\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsi\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fsscript\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.fsscript"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript]
+[HKEY_CURRENT_USER\Software\Classes\.fsscript\OpenWithProgIDs]
+"VSCode.fsscript"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsscript]
 @="F# Script Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="F# Script Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsscript\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsscript\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsscript\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsscript\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fsx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.fsx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx]
+[HKEY_CURRENT_USER\Software\Classes\.fsx\OpenWithProgIDs]
+"VSCode.fsx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsx]
 @="F# Script Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="F# Script Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.fsx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gemspec\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.gemspec"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec]
+[HKEY_CURRENT_USER\Software\Classes\.gemspec\OpenWithProgIDs]
+"VSCode.gemspec"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gemspec]
 @="Gemspec Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Gemspec Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\ruby.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gemspec\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\ruby.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gemspec\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gemspec\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gemspec\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gitattributes\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.gitattributes"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes]
+[HKEY_CURRENT_USER\Software\Classes\.gitattributes\OpenWithProgIDs]
+"VSCode.gitattributes"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitattributes]
 @="Git Attributes Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AlwaysShowExt"=""
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Git Attributes Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitattributes\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitattributes\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitattributes\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitattributes\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gitconfig\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.gitconfig"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig]
+[HKEY_CURRENT_USER\Software\Classes\.gitconfig\OpenWithProgIDs]
+"VSCode.gitconfig"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitconfig]
 @="Git Config Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AlwaysShowExt"=""
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Git Config Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitconfig\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitconfig\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitconfig\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitconfig\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gitignore\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.gitignore"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore]
+[HKEY_CURRENT_USER\Software\Classes\.gitignore\OpenWithProgIDs]
+"VSCode.gitignore"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitignore]
 @="Git Ignore Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AlwaysShowExt"=""
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Git Ignore Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitignore\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitignore\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitignore\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gitignore\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.go\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.go"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.go]
+[HKEY_CURRENT_USER\Software\Classes\.go\OpenWithProgIDs]
+"VSCode.go"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.go]
 @="Go Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Go Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.go\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\go.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.go\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\go.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.go\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.go\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.go\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.go\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.go\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gradle\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.gradle"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle]
+[HKEY_CURRENT_USER\Software\Classes\.gradle\OpenWithProgIDs]
+"VSCode.gradle"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gradle]
 @="Gradle Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Gradle Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gradle\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gradle\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gradle\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.gradle\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.groovy\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.groovy"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy]
+[HKEY_CURRENT_USER\Software\Classes\.groovy\OpenWithProgIDs]
+"VSCode.groovy"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.groovy]
 @="Groovy Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Groovy Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.groovy\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.groovy\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.groovy\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.groovy\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.h\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.h"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h]
+[HKEY_CURRENT_USER\Software\Classes\.h\OpenWithProgIDs]
+"VSCode.h"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h]
 @="C Header Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C Header Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\c.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\c.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.handlebars\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.handlebars"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars]
+[HKEY_CURRENT_USER\Software\Classes\.h++\OpenWithProgIDs]
+"VSCode.h++"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h++]
+@="C++ Header Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Header Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h++\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h++\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h++\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.h++\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.handlebars\OpenWithProgIDs]
+"VSCode.handlebars"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.handlebars]
 @="Handlebars Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Handlebars Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.handlebars\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.handlebars\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.handlebars\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.handlebars\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hbs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.hbs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs]
+[HKEY_CURRENT_USER\Software\Classes\.hbs\OpenWithProgIDs]
+"VSCode.hbs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hbs]
 @="Handlebars Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Handlebars Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hbs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hbs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hbs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hbs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.h++\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.h++"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++]
+[HKEY_CURRENT_USER\Software\Classes\.hh\OpenWithProgIDs]
+"VSCode.hh"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hh]
 @="C++ Header Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Header Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hh\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hh\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hh\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hh\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hh\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.hh"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh]
+[HKEY_CURRENT_USER\Software\Classes\.hpp\OpenWithProgIDs]
+"VSCode.hpp"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hpp]
 @="C++ Header Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Header Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hpp\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hpp\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hpp\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.hpp\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.hpp"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp]
-@="C++ Header Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hpp\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.htm\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.htm"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm]
+[HKEY_CURRENT_USER\Software\Classes\.htm\OpenWithProgIDs]
+"VSCode.htm"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.htm]
 @="HTML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="HTML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.htm\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.htm\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.htm\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.htm\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.html\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.html"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.html]
+[HKEY_CURRENT_USER\Software\Classes\.html\OpenWithProgIDs]
+"VSCode.html"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.html]
 @="HTML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="HTML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.html\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.html\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.html\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.html\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.html\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.html\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.html\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hxx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.hxx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx]
+[HKEY_CURRENT_USER\Software\Classes\.hxx\OpenWithProgIDs]
+"VSCode.hxx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hxx]
 @="C++ Header Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="C++ Header Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hxx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\cpp.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hxx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hxx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.hxx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ini\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ini"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini]
+[HKEY_CURRENT_USER\Software\Classes\.ini\OpenWithProgIDs]
+"VSCode.ini"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ini]
 @="INI Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="INI Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ini\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ini\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ini\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ini\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ipynb\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ipynb"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb]
+[HKEY_CURRENT_USER\Software\Classes\.inputrc\OpenWithProgIDs]
+"VSCode.inputrc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.inputrc]
+@="Readline Configuration Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Readline Configuration Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.inputrc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.inputrc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.inputrc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.inputrc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.ipynb\OpenWithProgIDs]
+"VSCode.ipynb"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ipynb]
 @="Jupyter Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Jupyter Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ipynb\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ipynb\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ipynb\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ipynb\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jade\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jade"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade]
+[HKEY_CURRENT_USER\Software\Classes\.jade\OpenWithProgIDs]
+"VSCode.jade"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jade]
 @="Jade Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Jade Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\jade.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jade\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\jade.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jade\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jade\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jade\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jav\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jav"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav]
+[HKEY_CURRENT_USER\Software\Classes\.jav\OpenWithProgIDs]
+"VSCode.jav"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jav]
 @="Java Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Java Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\java.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jav\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\java.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jav\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jav\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jav\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.java\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.java"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.java]
+[HKEY_CURRENT_USER\Software\Classes\.java\OpenWithProgIDs]
+"VSCode.java"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.java]
 @="Java Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Java Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.java\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\java.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.java\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\java.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.java\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.java\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.java\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.java\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.java\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.js\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.js"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.js]
+[HKEY_CURRENT_USER\Software\Classes\.js\OpenWithProgIDs]
+"VSCode.js"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.js]
 @="JavaScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JavaScript Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.js\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.js\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\javascript.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.js\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.js\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.js\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.js\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.jsx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jsx"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx]
-@="JavaScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\react.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.js\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jscsrc\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jscsrc"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc]
+[HKEY_CURRENT_USER\Software\Classes\.jscsrc\OpenWithProgIDs]
+"VSCode.jscsrc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jscsrc]
 @="JSCS RC Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JSCS RC Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jscsrc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\javascript.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jscsrc\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jscsrc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jscsrc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jshintrc\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jshintrc"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc]
+[HKEY_CURRENT_USER\Software\Classes\.jshintrc\OpenWithProgIDs]
+"VSCode.jshintrc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshintrc]
 @="JSHint RC Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JSHint RC Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshintrc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\javascript.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshintrc\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshintrc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshintrc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jshtm\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jshtm"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm]
+[HKEY_CURRENT_USER\Software\Classes\.jshtm\OpenWithProgIDs]
+"VSCode.jshtm"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshtm]
 @="JavaScript HTML Template Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JavaScript HTML Template Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshtm\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshtm\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshtm\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jshtm\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.json\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.json"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.json]
+[HKEY_CURRENT_USER\Software\Classes\.json\OpenWithProgIDs]
+"VSCode.json"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json]
 @="JSON Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JSON Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.json\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\json.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\json.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.json\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.json\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jsp\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.jsp"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp]
+[HKEY_CURRENT_USER\Software\Classes\.json5\OpenWithProgIDs]
+"VSCode.json5"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json5]
+@="JSON5 Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JSON5 Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json5\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\json.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json5\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json5\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.json5\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.jsonc\OpenWithProgIDs]
+"VSCode.jsonc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonc]
+@="JSON with Comments Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JSON with Comments Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\json.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.jsonld\OpenWithProgIDs]
+"VSCode.jsonld"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonld]
+@="JSON for Linked Data Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JSON for Linked Data Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonld\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\json.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonld\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonld\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsonld\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.jsp\OpenWithProgIDs]
+"VSCode.jsp"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsp]
 @="Java Server Pages Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Java Server Pages Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsp\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsp\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsp\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsp\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
-[HKEY_CURRENT_USER\Software\Classes\.less\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.less"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.less]
-@="LESS Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.less\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\less.ico\""
+[HKEY_CURRENT_USER\Software\Classes\.jsx\OpenWithProgIDs]
+"VSCode.jsx"=hex(0):
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.less\shell\open]
-"Icon"="\"$code\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.less\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.log\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.log"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.log]
-@="Log file Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.log\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.log\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.log\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.lua\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.lua"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua]
-@="Lua Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.m\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.m"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.m]
-@="Objective C Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.m\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.m\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.m\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.makefile\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.makefile"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile]
-@="Makefile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.markdown\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.markdown"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.md\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.md"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.md]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.md\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.md\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.md\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mdoc\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mdoc"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc]
-@="MDoc Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mdown\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mdown"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mdtext\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mdtext"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mdtxt\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mdtxt"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mdwn\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mdwn"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mk\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mk"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk]
-@="Makefile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mkd\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mkd"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mkdn\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mkdn"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn]
-@="Markdown Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.ml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ml"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml]
-@="OCaml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mli\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mli"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli]
-@="OCaml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli\shell\open\command]
-@="\"$code\" \"%1\""
-
-
-[HKEY_CURRENT_USER\Software\Classes\.mjs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.mjs"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs]
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsx]
 @="JavaScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JavaScript Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\react.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsx\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.jsx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.npmignore\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.npmignore"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore]
+[HKEY_CURRENT_USER\Software\Classes\.less\OpenWithProgIDs]
+"VSCode.less"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.less]
+@="LESS Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="LESS Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.less\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\less.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.less\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.less\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.less\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.log\OpenWithProgIDs]
+"VSCode.log"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.log]
+@="Log file Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Log file Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.log\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.log\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.log\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.log\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.lua\OpenWithProgIDs]
+"VSCode.lua"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.lua]
+@="Lua Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Lua Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.lua\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.lua\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.lua\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.lua\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.m\OpenWithProgIDs]
+"VSCode.m"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.m]
+@="Objective C Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Objective C Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.m\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.m\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.m\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.m\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.makefile\OpenWithProgIDs]
+"VSCode.makefile"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.makefile]
+@="Makefile Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Makefile Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.makefile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.makefile\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.makefile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.makefile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.markdown\OpenWithProgIDs]
+"VSCode.markdown"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.markdown]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.markdown\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.markdown\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.markdown\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.markdown\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.md\OpenWithProgIDs]
+"VSCode.md"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.md]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.md\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.md\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.md\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.md\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mdoc\OpenWithProgIDs]
+"VSCode.mdoc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdoc]
+@="MDoc Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="MDoc Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdoc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdoc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdoc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdoc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mdown\OpenWithProgIDs]
+"VSCode.mdown"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdown]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdown\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdown\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdown\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdown\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mdtext\OpenWithProgIDs]
+"VSCode.mdtext"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtext]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtext\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtext\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtext\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtext\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mdtxt\OpenWithProgIDs]
+"VSCode.mdtxt"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtxt]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtxt\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtxt\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtxt\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdtxt\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mdwn\OpenWithProgIDs]
+"VSCode.mdwn"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdwn]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdwn\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdwn\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdwn\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mdwn\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mjs\OpenWithProgIDs]
+"VSCode.mjs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mjs]
+@="JavaScript Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="JavaScript Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mjs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\javascript.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mjs\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mjs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mjs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mk\OpenWithProgIDs]
+"VSCode.mk"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mk]
+@="Makefile Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Makefile Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mk\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mk\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mk\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mk\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mkd\OpenWithProgIDs]
+"VSCode.mkd"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkd]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkd\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkd\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkd\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkd\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mkdn\OpenWithProgIDs]
+"VSCode.mkdn"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkdn]
+@="Markdown Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Markdown Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkdn\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\markdown.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkdn\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkdn\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mkdn\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.ml\OpenWithProgIDs]
+"VSCode.ml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ml]
+@="OCaml Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="OCaml Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ml\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.mli\OpenWithProgIDs]
+"VSCode.mli"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mli]
+@="OCaml Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="OCaml Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mli\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mli\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mli\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.mli\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.npmignore\OpenWithProgIDs]
+"VSCode.npmignore"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.npmignore]
 @="NPM Ignore Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AlwaysShowExt"=""
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="NPM Ignore Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.npmignore\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.npmignore\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.npmignore\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.npmignore\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.php\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.php"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.php]
+[HKEY_CURRENT_USER\Software\Classes\.nu\OpenWithProgIDs]
+"VSCode.nu"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.nu]
+@="Nushell Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Nushell Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.nu\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.nu\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.nu\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.nu\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.php\OpenWithProgIDs]
+"VSCode.php"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.php]
 @="PHP Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="PHP Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.php\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\php.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.php\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\php.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.php\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.php\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.php\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.php\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.php\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.phtml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.phtml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml]
+[HKEY_CURRENT_USER\Software\Classes\.phtml\OpenWithProgIDs]
+"VSCode.phtml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.phtml]
 @="PHP HTML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="PHP HTML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.phtml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.phtml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.phtml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.phtml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pl\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pl"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl]
+[HKEY_CURRENT_USER\Software\Classes\.pl\OpenWithProgIDs]
+"VSCode.pl"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl]
 @="Perl Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pl6\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pl6"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6]
+[HKEY_CURRENT_USER\Software\Classes\.pl6\OpenWithProgIDs]
+"VSCode.pl6"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl6]
 @="Perl 6 Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl 6 Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl6\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl6\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl6\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pl6\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.plist\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.plist"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist]
+[HKEY_CURRENT_USER\Software\Classes\.plist\OpenWithProgIDs]
+"VSCode.plist"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.plist]
 @="Properties file Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Properties file Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\plist.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.plist\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.plist\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.plist\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.plist\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pm\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pm"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm]
+[HKEY_CURRENT_USER\Software\Classes\.pm\OpenWithProgIDs]
+"VSCode.pm"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm]
 @="Perl Module Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl Module Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pm6\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pm6"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6]
+[HKEY_CURRENT_USER\Software\Classes\.pm6\OpenWithProgIDs]
+"VSCode.pm6"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm6]
 @="Perl 6 Module Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl 6 Module Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm6\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm6\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm6\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pm6\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pod\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pod"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod]
+[HKEY_CURRENT_USER\Software\Classes\.pod\OpenWithProgIDs]
+"VSCode.pod"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pod]
 @="Perl POD Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl POD Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pod\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pod\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pod\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pod\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pp\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pp"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp]
+[HKEY_CURRENT_USER\Software\Classes\.pp\OpenWithProgIDs]
+"VSCode.pp"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pp]
 @="Perl Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pp\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pp\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pp\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pp\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.profile\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.profile"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile]
+[HKEY_CURRENT_USER\Software\Classes\.profile\OpenWithProgIDs]
+"VSCode.profile"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.profile]
 @="Profile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Profile Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.profile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\config.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.profile\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.profile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.profile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.properties\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.properties"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties]
+[HKEY_CURRENT_USER\Software\Classes\.properties\OpenWithProgIDs]
+"VSCode.properties"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.properties]
 @="Properties Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Properties Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.properties\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.properties\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.properties\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.properties\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ps1\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ps1"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1]
+[HKEY_CURRENT_USER\Software\Classes\.ps1\OpenWithProgIDs]
+"VSCode.ps1"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1]
 @="PowerShell Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="PowerShell Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\powershell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\powershell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.psd1\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.psd1"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1]
+[HKEY_CURRENT_USER\Software\Classes\.ps1xml\OpenWithProgIDs]
+"VSCode.ps1xml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1xml]
+@="PowerShell XML Definition Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="PowerShell XML Definition Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1xml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\powershell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1xml\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1xml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ps1xml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.psd1\OpenWithProgIDs]
+"VSCode.psd1"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psd1]
 @="PowerShell Module Manifest Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="PowerShell Module Manifest Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\powershell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psd1\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\powershell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psd1\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psd1\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psd1\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.psgi\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.psgi"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi]
+[HKEY_CURRENT_USER\Software\Classes\.psgi\OpenWithProgIDs]
+"VSCode.psgi"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psgi]
 @="Perl CGI Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl CGI Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psgi\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psgi\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psgi\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psgi\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.psm1\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.psm1"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1]
+[HKEY_CURRENT_USER\Software\Classes\.psm1\OpenWithProgIDs]
+"VSCode.psm1"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psm1]
 @="PowerShell Module Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="PowerShell Module Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\powershell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psm1\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\powershell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psm1\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psm1\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.psm1\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.py\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.py"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.py]
+[HKEY_CURRENT_USER\Software\Classes\.py\OpenWithProgIDs]
+"VSCode.py"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.py]
 @="Python Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Python Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.py\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\python.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.py\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\python.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.py\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.py\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.py\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.py\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.py\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pyi\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.pyi"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi]
+[HKEY_CURRENT_USER\Software\Classes\.pyi\OpenWithProgIDs]
+"VSCode.pyi"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pyi]
 @="Python Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Python Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\python.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pyi\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\python.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pyi\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pyi\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.pyi\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.r\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.r"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.r]
+[HKEY_CURRENT_USER\Software\Classes\.r\OpenWithProgIDs]
+"VSCode.r"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.r]
 @="R Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="R Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.r\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.r\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.r\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.r\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.r\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.r\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.r\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rb\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.rb"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb]
+[HKEY_CURRENT_USER\Software\Classes\.rb\OpenWithProgIDs]
+"VSCode.rb"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rb]
 @="Ruby Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Ruby Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\ruby.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rb\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\ruby.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rb\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rb\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rb\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rhistory\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.rhistory"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory]
+[HKEY_CURRENT_USER\Software\Classes\.rdf\OpenWithProgIDs]
+"VSCode.rdf"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rdf]
+@="RDF Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="RDF Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rdf\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\xml.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rdf\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rdf\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rdf\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.reg\OpenWithProgIDs]
+"VSCode.reg"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.reg]
+@="Windows Registry Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Windows Registry Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.reg\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.reg\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.reg\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.reg\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.rhistory\OpenWithProgIDs]
+"VSCode.rhistory"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rhistory]
 @="R History Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="R History Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rhistory\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rhistory\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rhistory\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rhistory\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rprofile\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.rprofile"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile]
+[HKEY_CURRENT_USER\Software\Classes\.rprofile\OpenWithProgIDs]
+"VSCode.rprofile"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rprofile]
 @="R Profile Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="R Profile Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rprofile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rprofile\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rprofile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rprofile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.rs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs]
+[HKEY_CURRENT_USER\Software\Classes\.rs\OpenWithProgIDs]
+"VSCode.rs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rs]
 @="Rust Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Rust Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rst\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.rst"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst]
+[HKEY_CURRENT_USER\Software\Classes\.rst\OpenWithProgIDs]
+"VSCode.rst"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rst]
 @="Restructured Text Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Restructured Text Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rst\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rst\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rst\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rst\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rt\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.rt"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt]
+[HKEY_CURRENT_USER\Software\Classes\.rt\OpenWithProgIDs]
+"VSCode.rt"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rt]
 @="Rich Text Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Rich Text Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rt\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rt\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rt\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.rt\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.sass\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.sass"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass]
+[HKEY_CURRENT_USER\Software\Classes\.sass\OpenWithProgIDs]
+"VSCode.sass"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sass]
 @="Sass Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Sass Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\sass.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sass\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\sass.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sass\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sass\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sass\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.scss\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.scss"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss]
+[HKEY_CURRENT_USER\Software\Classes\.scss\OpenWithProgIDs]
+"VSCode.scss"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.scss]
 @="Sass Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Sass Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\sass.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.scss\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\sass.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.scss\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.scss\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.scss\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.sh\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.sh"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh]
+[HKEY_CURRENT_USER\Software\Classes\.sh\OpenWithProgIDs]
+"VSCode.sh"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sh]
 @="SH Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="SH Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sh\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sh\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sh\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sh\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.shtml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.shtml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml]
+[HKEY_CURRENT_USER\Software\Classes\.shtml\OpenWithProgIDs]
+"VSCode.shtml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.shtml]
 @="SHTML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="SHTML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.shtml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.shtml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.shtml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.shtml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.sql\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.sql"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql]
+[HKEY_CURRENT_USER\Software\Classes\.sql\OpenWithProgIDs]
+"VSCode.sql"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sql]
 @="SQL Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="SQL Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\sql.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sql\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\sql.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sql\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sql\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.sql\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.svg\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.svg"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg]
+[HKEY_CURRENT_USER\Software\Classes\.svg\OpenWithProgIDs]
+"VSCode.svg"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.svg]
 @="SVG Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="SVG Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.svg\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.svg\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.svg\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.svgz\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.svgz"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz]
-@="SVGZ Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.svg\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.t\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.t"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.t]
+[HKEY_CURRENT_USER\Software\Classes\.t\OpenWithProgIDs]
+"VSCode.t"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.t]
 @="Perl Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Perl Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.t\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.t\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.t\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.t\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.t\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.t\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.t\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.tex\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.tex"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex]
+[HKEY_CURRENT_USER\Software\Classes\.tex\OpenWithProgIDs]
+"VSCode.tex"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tex]
 @="LaTeX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="LaTeX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tex\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tex\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tex\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-
-[HKEY_CURRENT_USER\Software\Classes\.ts\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.ts"=""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts]
-@="TypeScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\typescript.ico\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts\shell\open]
-"Icon"="\"$code\""
-
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tex\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.toml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.toml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml]
+[HKEY_CURRENT_USER\Software\Classes\.toml\OpenWithProgIDs]
+"VSCode.toml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.toml]
 @="Toml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Toml Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.toml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.toml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.toml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.toml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.tsx\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.tsx"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx]
+[HKEY_CURRENT_USER\Software\Classes\.ts\OpenWithProgIDs]
+"VSCode.ts"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ts]
 @="TypeScript Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="TypeScript Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\react.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ts\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\typescript.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ts\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ts\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.ts\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.txt\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.txt"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt]
+[HKEY_CURRENT_USER\Software\Classes\.tsx\OpenWithProgIDs]
+"VSCode.tsx"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tsx]
+@="TypeScript Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="TypeScript Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tsx\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\react.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tsx\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tsx\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.tsx\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.txt\OpenWithProgIDs]
+"VSCode.txt"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.txt]
 @="Text Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Text Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.txt\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.txt\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.txt\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.txt\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.vb\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.vb"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb]
+[HKEY_CURRENT_USER\Software\Classes\.vb\OpenWithProgIDs]
+"VSCode.vb"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vb]
 @="Visual Basic Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Visual Basic Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vb\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vb\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vb\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vb\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.vue\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.vue"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue]
+[HKEY_CURRENT_USER\Software\Classes\.vbs\OpenWithProgIDs]
+"VSCode.vbs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vbs]
+@="VBScript Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="VBScript Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vbs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vbs\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vbs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vbs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.vue\OpenWithProgIDs]
+"VSCode.vue"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vue]
 @="VUE Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="VUE Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\vue.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vue\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\vue.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vue\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vue\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.vue\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.wxi\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.wxi"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi]
+[HKEY_CURRENT_USER\Software\Classes\.wxi\OpenWithProgIDs]
+"VSCode.wxi"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxi]
 @="WiX Include Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="WiX Include Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxi\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxi\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxi\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxi\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.wxl\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.wxl"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl]
+[HKEY_CURRENT_USER\Software\Classes\.wxl\OpenWithProgIDs]
+"VSCode.wxl"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxl]
 @="WiX Localization Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="WiX Localization Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxl\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxl\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxl\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxl\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.wxs\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.wxs"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs]
+[HKEY_CURRENT_USER\Software\Classes\.wxs\OpenWithProgIDs]
+"VSCode.wxs"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxs]
 @="WiX Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="WiX Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxs\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxs\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxs\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.wxs\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.xaml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.xaml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml]
+[HKEY_CURRENT_USER\Software\Classes\.xaml\OpenWithProgIDs]
+"VSCode.xaml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xaml]
 @="XAML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="XAML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xaml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\xml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xaml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xaml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xaml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.xhtml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.xhtml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml]
+[HKEY_CURRENT_USER\Software\Classes\.xhtml\OpenWithProgIDs]
+"VSCode.xhtml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xhtml]
 @="HTML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="HTML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xhtml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\html.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xhtml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xhtml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xhtml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.xml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.xml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml]
+[HKEY_CURRENT_USER\Software\Classes\.xml\OpenWithProgIDs]
+"VSCode.xml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xml]
 @="XML Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="XML Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\xml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.xml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.yaml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.yaml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml]
+[HKEY_CURRENT_USER\Software\Classes\.yaml\OpenWithProgIDs]
+"VSCode.yaml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yaml]
 @="Yaml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Yaml Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yaml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\yaml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yaml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yaml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yaml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.yml\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.yml"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml]
+[HKEY_CURRENT_USER\Software\Classes\.yml\OpenWithProgIDs]
+"VSCode.yml"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yml]
 @="Yaml Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="Yaml Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yml\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\yaml.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yml\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yml\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.yml\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
 
-[HKEY_CURRENT_USER\Software\Classes\.zsh\OpenWithProgids]
-"CodeOSS"=""
-"CodeOSS.zsh"=""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh]
+[HKEY_CURRENT_USER\Software\Classes\.zlogin\OpenWithProgIDs]
+"VSCode.zlogin"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogin]
+@="ZSH Login Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ZSH Login Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogin\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogin\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogin\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogin\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zlogout\OpenWithProgIDs]
+"VSCode.zlogout"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogout]
+@="ZSH Logout Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ZSH Logout Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogout\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogout\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogout\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zlogout\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zprofile\OpenWithProgIDs]
+"VSCode.zprofile"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zprofile]
+@="ZSH Profile Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ZSH Profile Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zprofile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zprofile\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zprofile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zprofile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zsh\OpenWithProgIDs]
+"VSCode.zsh"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zsh]
 @="ZSH Source File"
-"AppUserModelID"="Microsoft.CodeOSS"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ZSH Source File"
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zsh\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh\shell\open]
-"Icon"="\"$code\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zsh\shell]
 
-[HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh\shell\open\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zsh\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zsh\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zshenv\OpenWithProgIDs]
+"VSCode.zshenv"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshenv]
+@="ZSH Environment Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ZSH Environment Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshenv\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshenv\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshenv\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshenv\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zshrc\OpenWithProgIDs]
+"VSCode.zshrc"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshrc]
+@="ZSH Configuration Source File"
+"AppUserModelID"="Microsoft.VisualStudioCode"
+"FriendlyTypeName"="ZSH Configuration Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshrc\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\shell.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshrc\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshrc\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCode.zshrc\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\Software\Classes\VSCodeSourceFile]
+@="Visual Studio Code Source File"
+"FriendlyTypeName"="Visual Studio Code Source File"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCodeSourceFile\DefaultIcon]
+@="\"{{vscode_dir}}\\resources\\app\\resources\\win32\\default.ico\""
+
+[HKEY_CURRENT_USER\Software\Classes\VSCodeSourceFile\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\VSCodeSourceFile\shell\open]
+"FriendlyAppName"="Visual Studio Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\VSCodeSourceFile\shell\open\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""

--- a/scripts/vscode/install-context.reg
+++ b/scripts/vscode/install-context.reg
@@ -1,19 +1,32 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Code]
-@="Open with &Code"
-"Icon"="$code"
-[HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Code\command]
-@="\"$code\" \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\*\shell\VSCode]
+@="Open w&ith Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Code]
-@="Open with &Code"
-"Icon"="$code"
-[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Code\command]
-@="\"$code\" \"%V\""
+[HKEY_CURRENT_USER\Software\Classes\*\shell\VSCode\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%1\""
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Code]
-@="Open with &Code"
-"Icon"="$code"
-[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Code\command]
-@="\"$code\" \"%V\""
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\VSCode]
+@="Open w&ith Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\VSCode\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%V\""
+
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\VSCode]
+@="Open w&ith Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\VSCode\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%V\""
+
+
+[HKEY_CURRENT_USER\Software\Classes\Drive\shell\VSCode]
+@="Open w&ith Code"
+"Icon"="\"{{vscode_dir}}\\Code.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\Drive\shell\VSCode\command]
+@="\"{{vscode_dir}}\\Code.exe\" \"%V\""

--- a/scripts/vscode/register-installed-program.reg
+++ b/scripts/vscode/register-installed-program.reg
@@ -1,0 +1,10 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1]
+"DisplayIcon"="\"{{vscode_dir}}\\Code.exe\",0"
+"DisplayName"="Microsoft Visual Studio Code"
+"HelpLink"="https://code.visualstudio.com/"
+"InstallLocation"="{{vscode_dir}}"
+"Publisher"="Microsoft Corporation"
+"URLInfoAbout"="https://code.visualstudio.com/"
+"URLUpdateInfo"="https://code.visualstudio.com/"

--- a/scripts/vscode/uninstall-associations.reg
+++ b/scripts/vscode/uninstall-associations.reg
@@ -1,1002 +1,969 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\Classes\.ascx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ascx"=-
+[HKEY_CURRENT_USER\Software\Classes\.adoc\OpenWithProgIDs]
+"VSCode.adoc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.adoc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.asp\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.asp"=-
+[HKEY_CURRENT_USER\Software\Classes\.ascx\OpenWithProgIDs]
+"VSCode.ascx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ascx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.aspx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.aspx"=-
+[HKEY_CURRENT_USER\Software\Classes\.asp\OpenWithProgIDs]
+"VSCode.asp"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.asp]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bash"=-
+[HKEY_CURRENT_USER\Software\Classes\.aspx\OpenWithProgIDs]
+"VSCode.aspx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.aspx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash_login\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bash_login"=-
+[HKEY_CURRENT_USER\Software\Classes\.bash\OpenWithProgIDs]
+"VSCode.bash"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bash]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash_logout\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bash_logout"=-
+[HKEY_CURRENT_USER\Software\Classes\.bashrc\OpenWithProgIDs]
+"VSCode.bashrc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bashrc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bash_profile\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bash_profile"=-
+[HKEY_CURRENT_USER\Software\Classes\.bash_login\OpenWithProgIDs]
+"VSCode.bash_login"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bash_login]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bashrc\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bashrc"=-
+[HKEY_CURRENT_USER\Software\Classes\.bash_logout\OpenWithProgIDs]
+"VSCode.bash_logout"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bash_logout]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bib\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bib"=-
+[HKEY_CURRENT_USER\Software\Classes\.bash_profile\OpenWithProgIDs]
+"VSCode.bash_profile"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bash_profile]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.bowerrc\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.bowerrc"=-
+[HKEY_CURRENT_USER\Software\Classes\.bib\OpenWithProgIDs]
+"VSCode.bib"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bib]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.c++\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.c++"=-
+[HKEY_CURRENT_USER\Software\Classes\.bowerrc\OpenWithProgIDs]
+"VSCode.bowerrc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.bowerrc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.c\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.c"=-
+[HKEY_CURRENT_USER\Software\Classes\.c\OpenWithProgIDs]
+"VSCode.c"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.c]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.c]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cc\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cc"=-
+[HKEY_CURRENT_USER\Software\Classes\.c++\OpenWithProgIDs]
+"VSCode.c++"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.c++]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cfg\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cfg"=-
+[HKEY_CURRENT_USER\Software\Classes\.cc\OpenWithProgIDs]
+"VSCode.cc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cjs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cjs"=-
+[HKEY_CURRENT_USER\Software\Classes\.cfg\OpenWithProgIDs]
+"VSCode.cfg"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cfg]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.clj\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.clj"=-
+[HKEY_CURRENT_USER\Software\Classes\.cjs\OpenWithProgIDs]
+"VSCode.cjs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cjs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cljs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cljs"=-
+[HKEY_CURRENT_USER\Software\Classes\.clj\OpenWithProgIDs]
+"VSCode.clj"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.clj]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cljx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cljx"=-
+[HKEY_CURRENT_USER\Software\Classes\.cljs\OpenWithProgIDs]
+"VSCode.cljs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cljs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.clojure\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.clojure"=-
+[HKEY_CURRENT_USER\Software\Classes\.cljx\OpenWithProgIDs]
+"VSCode.cljx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cljx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cls\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cls"=-
+[HKEY_CURRENT_USER\Software\Classes\.clojure\OpenWithProgIDs]
+"VSCode.clojure"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.clojure]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.code-workspace\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.code-workspace"=-
+[HKEY_CURRENT_USER\Software\Classes\.cls\OpenWithProgIDs]
+"VSCode.cls"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cls]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cmake\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cmake"=-
+[HKEY_CURRENT_USER\Software\Classes\.cmake\OpenWithProgIDs]
+"VSCode.cmake"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cmake]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.coffee\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.coffee"=-
+[HKEY_CURRENT_USER\Software\Classes\.code-workspace\OpenWithProgIDs]
+"VSCode.code-workspace"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.code-workspace]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.config\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.config"=-
+[HKEY_CURRENT_USER\Software\Classes\.coffee\OpenWithProgIDs]
+"VSCode.coffee"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.config]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.coffee]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.containerfile\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.containerfile"=-
+[HKEY_CURRENT_USER\Software\Classes\.conf\OpenWithProgIDs]
+"VSCode.conf"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.conf]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cpp\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cpp"=-
+[HKEY_CURRENT_USER\Software\Classes\.config\OpenWithProgIDs]
+"VSCode.config"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.config]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cs"=-
+[HKEY_CURRENT_USER\Software\Classes\.containerfile\OpenWithProgIDs]
+"VSCode.containerfile"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.containerfile]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cshtml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cshtml"=-
+[HKEY_CURRENT_USER\Software\Classes\.cpp\OpenWithProgIDs]
+"VSCode.cpp"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cpp]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.csproj\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.csproj"=-
+[HKEY_CURRENT_USER\Software\Classes\.cs\OpenWithProgIDs]
+"VSCode.cs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.css\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.css"=-
+[HKEY_CURRENT_USER\Software\Classes\.cshtml\OpenWithProgIDs]
+"VSCode.cshtml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.css]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cshtml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.csv\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.csv"=-
+[HKEY_CURRENT_USER\Software\Classes\.csproj\OpenWithProgIDs]
+"VSCode.csproj"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.csproj]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.csx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.csx"=-
+[HKEY_CURRENT_USER\Software\Classes\.css\OpenWithProgIDs]
+"VSCode.css"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.css]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ctp\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ctp"=-
+[HKEY_CURRENT_USER\Software\Classes\.csv\OpenWithProgIDs]
+"VSCode.csv"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.csv]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.cxx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.cxx"=-
+[HKEY_CURRENT_USER\Software\Classes\.csx\OpenWithProgIDs]
+"VSCode.csx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.csx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dart\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.dart"=-
+[HKEY_CURRENT_USER\Software\Classes\.ctp\OpenWithProgIDs]
+"VSCode.ctp"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ctp]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.diff\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.diff"=-
+[HKEY_CURRENT_USER\Software\Classes\.cxx\OpenWithProgIDs]
+"VSCode.cxx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.cxx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dockerfile\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.dockerfile"=-
+[HKEY_CURRENT_USER\Software\Classes\.dart\OpenWithProgIDs]
+"VSCode.dart"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.dart]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dot\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.dot"=-
+[HKEY_CURRENT_USER\Software\Classes\.diff\OpenWithProgIDs]
+"VSCode.diff"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.diff]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.dtd\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.dtd"=-
+[HKEY_CURRENT_USER\Software\Classes\.dockerfile\OpenWithProgIDs]
+"VSCode.dockerfile"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.dockerfile]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.editorconfig\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.editorconfig"=-
+[HKEY_CURRENT_USER\Software\Classes\.dockerignore\OpenWithProgIDs]
+"VSCode.dockerignore"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.dockerignore]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.edn\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.edn"=-
+[HKEY_CURRENT_USER\Software\Classes\.dot\OpenWithProgIDs]
+"VSCode.dot"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.dot]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.erb\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.erb"=-
+[HKEY_CURRENT_USER\Software\Classes\.dtd\OpenWithProgIDs]
+"VSCode.dtd"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.dtd]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.eyaml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.eyaml"=-
+[HKEY_CURRENT_USER\Software\Classes\.editorconfig\OpenWithProgIDs]
+"VSCode.editorconfig"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.editorconfig]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.eyml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.eyml"=-
+[HKEY_CURRENT_USER\Software\Classes\.edn\OpenWithProgIDs]
+"VSCode.edn"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.edn]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.fs"=-
+[HKEY_CURRENT_USER\Software\Classes\.env\OpenWithProgIDs]
+"VSCode.env"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.env]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fsi\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.fsi"=-
+[HKEY_CURRENT_USER\Software\Classes\.erb\OpenWithProgIDs]
+"VSCode.erb"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.erb]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fsscript\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.fsscript"=-
+[HKEY_CURRENT_USER\Software\Classes\.eyaml\OpenWithProgIDs]
+"VSCode.eyaml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.eyaml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.fsx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.fsx"=-
+[HKEY_CURRENT_USER\Software\Classes\.eyml\OpenWithProgIDs]
+"VSCode.eyml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.eyml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gemspec\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.gemspec"=-
+[HKEY_CURRENT_USER\Software\Classes\.fish\OpenWithProgIDs]
+"VSCode.fish"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.fish]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gitattributes\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.gitattributes"=-
+[HKEY_CURRENT_USER\Software\Classes\.fs\OpenWithProgIDs]
+"VSCode.fs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.fs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gitconfig\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.gitconfig"=-
+[HKEY_CURRENT_USER\Software\Classes\.fsi\OpenWithProgIDs]
+"VSCode.fsi"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.fsi]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gitignore\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.gitignore"=-
+[HKEY_CURRENT_USER\Software\Classes\.fsscript\OpenWithProgIDs]
+"VSCode.fsscript"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.fsscript]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.go\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.go"=-
+[HKEY_CURRENT_USER\Software\Classes\.fsx\OpenWithProgIDs]
+"VSCode.fsx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.go]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.fsx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.gradle\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.gradle"=-
+[HKEY_CURRENT_USER\Software\Classes\.gemspec\OpenWithProgIDs]
+"VSCode.gemspec"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.gemspec]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.groovy\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.groovy"=-
+[HKEY_CURRENT_USER\Software\Classes\.gitattributes\OpenWithProgIDs]
+"VSCode.gitattributes"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.gitattributes]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.h\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.h"=-
+[HKEY_CURRENT_USER\Software\Classes\.gitconfig\OpenWithProgIDs]
+"VSCode.gitconfig"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.h]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.gitconfig]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.handlebars\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.handlebars"=-
+[HKEY_CURRENT_USER\Software\Classes\.gitignore\OpenWithProgIDs]
+"VSCode.gitignore"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.gitignore]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hbs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.hbs"=-
+[HKEY_CURRENT_USER\Software\Classes\.go\OpenWithProgIDs]
+"VSCode.go"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.go]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.h++\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.h++"=-
+[HKEY_CURRENT_USER\Software\Classes\.gradle\OpenWithProgIDs]
+"VSCode.gradle"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.gradle]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hh\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.hh"=-
+[HKEY_CURRENT_USER\Software\Classes\.groovy\OpenWithProgIDs]
+"VSCode.groovy"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.groovy]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hpp\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.hpp"=-
+[HKEY_CURRENT_USER\Software\Classes\.h\OpenWithProgIDs]
+"VSCode.h"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.h]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.htm\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.htm"=-
+[HKEY_CURRENT_USER\Software\Classes\.h++\OpenWithProgIDs]
+"VSCode.h++"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.h++]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.html\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.html"=-
+[HKEY_CURRENT_USER\Software\Classes\.handlebars\OpenWithProgIDs]
+"VSCode.handlebars"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.html]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.handlebars]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.hxx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.hxx"=-
+[HKEY_CURRENT_USER\Software\Classes\.hbs\OpenWithProgIDs]
+"VSCode.hbs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.hbs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ini\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ini"=-
+[HKEY_CURRENT_USER\Software\Classes\.hh\OpenWithProgIDs]
+"VSCode.hh"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.hh]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ipynb\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ipynb"=-
+[HKEY_CURRENT_USER\Software\Classes\.hpp\OpenWithProgIDs]
+"VSCode.hpp"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.hpp]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jade\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jade"=-
+[HKEY_CURRENT_USER\Software\Classes\.htm\OpenWithProgIDs]
+"VSCode.htm"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.htm]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jav\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jav"=-
+[HKEY_CURRENT_USER\Software\Classes\.html\OpenWithProgIDs]
+"VSCode.html"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.html]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.java\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.java"=-
+[HKEY_CURRENT_USER\Software\Classes\.hxx\OpenWithProgIDs]
+"VSCode.hxx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.java]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.hxx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.js\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.js"=-
+[HKEY_CURRENT_USER\Software\Classes\.ini\OpenWithProgIDs]
+"VSCode.ini"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.js]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ini]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jsx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jsx"=-
+[HKEY_CURRENT_USER\Software\Classes\.inputrc\OpenWithProgIDs]
+"VSCode.inputrc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.inputrc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jscsrc\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jscsrc"=-
+[HKEY_CURRENT_USER\Software\Classes\.ipynb\OpenWithProgIDs]
+"VSCode.ipynb"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ipynb]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jshintrc\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jshintrc"=-
+[HKEY_CURRENT_USER\Software\Classes\.jade\OpenWithProgIDs]
+"VSCode.jade"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jade]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jshtm\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jshtm"=-
+[HKEY_CURRENT_USER\Software\Classes\.jav\OpenWithProgIDs]
+"VSCode.jav"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jav]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.json\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.json"=-
+[HKEY_CURRENT_USER\Software\Classes\.java\OpenWithProgIDs]
+"VSCode.java"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.json]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.java]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.jsp\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.jsp"=-
+[HKEY_CURRENT_USER\Software\Classes\.js\OpenWithProgIDs]
+"VSCode.js"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.js]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.less\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.less"=-
+[HKEY_CURRENT_USER\Software\Classes\.jscsrc\OpenWithProgIDs]
+"VSCode.jscsrc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.less]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jscsrc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.log\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.log"=-
+[HKEY_CURRENT_USER\Software\Classes\.jshintrc\OpenWithProgIDs]
+"VSCode.jshintrc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.log]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jshintrc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.lua\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.lua"=-
+[HKEY_CURRENT_USER\Software\Classes\.jshtm\OpenWithProgIDs]
+"VSCode.jshtm"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jshtm]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.m\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.m"=-
+[HKEY_CURRENT_USER\Software\Classes\.json\OpenWithProgIDs]
+"VSCode.json"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.m]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.json]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.makefile\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.makefile"=-
+[HKEY_CURRENT_USER\Software\Classes\.json5\OpenWithProgIDs]
+"VSCode.json5"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.json5]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.markdown\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.markdown"=-
+[HKEY_CURRENT_USER\Software\Classes\.jsonc\OpenWithProgIDs]
+"VSCode.jsonc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jsonc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.md\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.md"=-
+[HKEY_CURRENT_USER\Software\Classes\.jsonld\OpenWithProgIDs]
+"VSCode.jsonld"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.md]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jsonld]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mdoc\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mdoc"=-
+[HKEY_CURRENT_USER\Software\Classes\.jsp\OpenWithProgIDs]
+"VSCode.jsp"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jsp]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mdown\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mdown"=-
+[HKEY_CURRENT_USER\Software\Classes\.jsx\OpenWithProgIDs]
+"VSCode.jsx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.jsx]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mdtext\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mdtext"=-
+[HKEY_CURRENT_USER\Software\Classes\.less\OpenWithProgIDs]
+"VSCode.less"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.less]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mdtxt\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mdtxt"=-
+[HKEY_CURRENT_USER\Software\Classes\.log\OpenWithProgIDs]
+"VSCode.log"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.log]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mdwn\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mdwn"=-
+[HKEY_CURRENT_USER\Software\Classes\.lua\OpenWithProgIDs]
+"VSCode.lua"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.lua]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mk\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mk"=-
+[HKEY_CURRENT_USER\Software\Classes\.m\OpenWithProgIDs]
+"VSCode.m"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.m]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mkd\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mkd"=-
+[HKEY_CURRENT_USER\Software\Classes\.makefile\OpenWithProgIDs]
+"VSCode.makefile"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.makefile]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mkdn\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mkdn"=-
+[HKEY_CURRENT_USER\Software\Classes\.markdown\OpenWithProgIDs]
+"VSCode.markdown"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.markdown]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ml"=-
+[HKEY_CURRENT_USER\Software\Classes\.md\OpenWithProgIDs]
+"VSCode.md"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.md]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mli\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mli"=-
+[HKEY_CURRENT_USER\Software\Classes\.mdoc\OpenWithProgIDs]
+"VSCode.mdoc"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mdoc]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.mjs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.mjs"=-
+[HKEY_CURRENT_USER\Software\Classes\.mdown\OpenWithProgIDs]
+"VSCode.mdown"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mdown]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.npmignore\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.npmignore"=-
+[HKEY_CURRENT_USER\Software\Classes\.mdtext\OpenWithProgIDs]
+"VSCode.mdtext"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mdtext]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.php\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.php"=-
+[HKEY_CURRENT_USER\Software\Classes\.mdtxt\OpenWithProgIDs]
+"VSCode.mdtxt"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.php]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mdtxt]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.phtml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.phtml"=-
+[HKEY_CURRENT_USER\Software\Classes\.mdwn\OpenWithProgIDs]
+"VSCode.mdwn"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mdwn]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pl\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pl"=-
+[HKEY_CURRENT_USER\Software\Classes\.mjs\OpenWithProgIDs]
+"VSCode.mjs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mjs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pl6\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pl6"=-
+[HKEY_CURRENT_USER\Software\Classes\.mk\OpenWithProgIDs]
+"VSCode.mk"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mk]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.plist\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.plist"=-
+[HKEY_CURRENT_USER\Software\Classes\.mkd\OpenWithProgIDs]
+"VSCode.mkd"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mkd]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pm\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pm"=-
+[HKEY_CURRENT_USER\Software\Classes\.mkdn\OpenWithProgIDs]
+"VSCode.mkdn"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mkdn]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pm6\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pm6"=-
+[HKEY_CURRENT_USER\Software\Classes\.ml\OpenWithProgIDs]
+"VSCode.ml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pod\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pod"=-
+[HKEY_CURRENT_USER\Software\Classes\.mli\OpenWithProgIDs]
+"VSCode.mli"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.mli]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pp\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pp"=-
+[HKEY_CURRENT_USER\Software\Classes\.npmignore\OpenWithProgIDs]
+"VSCode.npmignore"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.npmignore]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.profile\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.profile"=-
+[HKEY_CURRENT_USER\Software\Classes\.nu\OpenWithProgIDs]
+"VSCode.nu"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.nu]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.properties\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.properties"=-
+[HKEY_CURRENT_USER\Software\Classes\.php\OpenWithProgIDs]
+"VSCode.php"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.php]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ps1\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ps1"=-
+[HKEY_CURRENT_USER\Software\Classes\.phtml\OpenWithProgIDs]
+"VSCode.phtml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.phtml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.psd1\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.psd1"=-
+[HKEY_CURRENT_USER\Software\Classes\.pl\OpenWithProgIDs]
+"VSCode.pl"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pl]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.psgi\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.psgi"=-
+[HKEY_CURRENT_USER\Software\Classes\.pl6\OpenWithProgIDs]
+"VSCode.pl6"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pl6]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.psm1\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.psm1"=-
+[HKEY_CURRENT_USER\Software\Classes\.plist\OpenWithProgIDs]
+"VSCode.plist"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.plist]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.py\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.py"=-
+[HKEY_CURRENT_USER\Software\Classes\.pm\OpenWithProgIDs]
+"VSCode.pm"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.py]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pm]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.pyi\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.pyi"=-
+[HKEY_CURRENT_USER\Software\Classes\.pm6\OpenWithProgIDs]
+"VSCode.pm6"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pm6]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.r\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.r"=-
+[HKEY_CURRENT_USER\Software\Classes\.pod\OpenWithProgIDs]
+"VSCode.pod"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.r]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pod]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rb\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.rb"=-
+[HKEY_CURRENT_USER\Software\Classes\.pp\OpenWithProgIDs]
+"VSCode.pp"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pp]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rhistory\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.rhistory"=-
+[HKEY_CURRENT_USER\Software\Classes\.profile\OpenWithProgIDs]
+"VSCode.profile"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.profile]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rprofile\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.rprofile"=-
+[HKEY_CURRENT_USER\Software\Classes\.properties\OpenWithProgIDs]
+"VSCode.properties"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.properties]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.rs"=-
+[HKEY_CURRENT_USER\Software\Classes\.ps1\OpenWithProgIDs]
+"VSCode.ps1"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ps1]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rst\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.rst"=-
+[HKEY_CURRENT_USER\Software\Classes\.ps1xml\OpenWithProgIDs]
+"VSCode.ps1xml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ps1xml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.rt\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.rt"=-
+[HKEY_CURRENT_USER\Software\Classes\.psd1\OpenWithProgIDs]
+"VSCode.psd1"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.psd1]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.sass\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.sass"=-
+[HKEY_CURRENT_USER\Software\Classes\.psgi\OpenWithProgIDs]
+"VSCode.psgi"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.psgi]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.scss\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.scss"=-
+[HKEY_CURRENT_USER\Software\Classes\.psm1\OpenWithProgIDs]
+"VSCode.psm1"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.psm1]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.sh\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.sh"=-
+[HKEY_CURRENT_USER\Software\Classes\.py\OpenWithProgIDs]
+"VSCode.py"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.py]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.shtml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.shtml"=-
+[HKEY_CURRENT_USER\Software\Classes\.pyi\OpenWithProgIDs]
+"VSCode.pyi"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.pyi]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.sql\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.sql"=-
+[HKEY_CURRENT_USER\Software\Classes\.r\OpenWithProgIDs]
+"VSCode.r"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.r]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.svg\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.svg"=-
+[HKEY_CURRENT_USER\Software\Classes\.rb\OpenWithProgIDs]
+"VSCode.rb"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rb]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.svgz\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.svgz"=-
+[HKEY_CURRENT_USER\Software\Classes\.rdf\OpenWithProgIDs]
+"VSCode.rdf"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rdf]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.t\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.t"=-
+[HKEY_CURRENT_USER\Software\Classes\.reg\OpenWithProgIDs]
+"VSCode.reg"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.t]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.reg]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.tex\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.tex"=-
+[HKEY_CURRENT_USER\Software\Classes\.rhistory\OpenWithProgIDs]
+"VSCode.rhistory"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rhistory]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.ts\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.ts"=-
+[HKEY_CURRENT_USER\Software\Classes\.rprofile\OpenWithProgIDs]
+"VSCode.rprofile"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rprofile]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.toml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.toml"=-
+[HKEY_CURRENT_USER\Software\Classes\.rs\OpenWithProgIDs]
+"VSCode.rs"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rs]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.tsx\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.tsx"=-
+[HKEY_CURRENT_USER\Software\Classes\.rst\OpenWithProgIDs]
+"VSCode.rst"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rst]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.txt\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.txt"=-
+[HKEY_CURRENT_USER\Software\Classes\.rt\OpenWithProgIDs]
+"VSCode.rt"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.rt]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.vb\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.vb"=-
+[HKEY_CURRENT_USER\Software\Classes\.sass\OpenWithProgIDs]
+"VSCode.sass"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.sass]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.vue\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.vue"=-
+[HKEY_CURRENT_USER\Software\Classes\.scss\OpenWithProgIDs]
+"VSCode.scss"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.scss]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.wxi\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.wxi"=-
+[HKEY_CURRENT_USER\Software\Classes\.sh\OpenWithProgIDs]
+"VSCode.sh"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.sh]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.wxl\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.wxl"=-
+[HKEY_CURRENT_USER\Software\Classes\.shtml\OpenWithProgIDs]
+"VSCode.shtml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.shtml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.wxs\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.wxs"=-
+[HKEY_CURRENT_USER\Software\Classes\.sql\OpenWithProgIDs]
+"VSCode.sql"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.sql]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.xaml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.xaml"=-
+[HKEY_CURRENT_USER\Software\Classes\.svg\OpenWithProgIDs]
+"VSCode.svg"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.svg]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.xhtml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.xhtml"=-
+[HKEY_CURRENT_USER\Software\Classes\.t\OpenWithProgIDs]
+"VSCode.t"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.t]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.xml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.xml"=-
+[HKEY_CURRENT_USER\Software\Classes\.tex\OpenWithProgIDs]
+"VSCode.tex"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.tex]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.yaml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.yaml"=-
+[HKEY_CURRENT_USER\Software\Classes\.toml\OpenWithProgIDs]
+"VSCode.toml"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.toml]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.yml\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.yml"=-
+[HKEY_CURRENT_USER\Software\Classes\.ts\OpenWithProgIDs]
+"VSCode.ts"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.ts]
 
 
-[HKEY_CURRENT_USER\Software\Classes\.zsh\OpenWithProgids]
-"CodeOSS"=-
-"CodeOSS.zsh"=-
+[HKEY_CURRENT_USER\Software\Classes\.tsx\OpenWithProgIDs]
+"VSCode.tsx"=-
 
-[-HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh]
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.tsx]
 
+
+[HKEY_CURRENT_USER\Software\Classes\.txt\OpenWithProgIDs]
+"VSCode.txt"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.txt]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.vb\OpenWithProgIDs]
+"VSCode.vb"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.vb]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.vbs\OpenWithProgIDs]
+"VSCode.vbs"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.vbs]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.vue\OpenWithProgIDs]
+"VSCode.vue"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.vue]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.wxi\OpenWithProgIDs]
+"VSCode.wxi"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.wxi]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.wxl\OpenWithProgIDs]
+"VSCode.wxl"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.wxl]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.wxs\OpenWithProgIDs]
+"VSCode.wxs"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.wxs]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.xaml\OpenWithProgIDs]
+"VSCode.xaml"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.xaml]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.xhtml\OpenWithProgIDs]
+"VSCode.xhtml"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.xhtml]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.xml\OpenWithProgIDs]
+"VSCode.xml"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.xml]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.yaml\OpenWithProgIDs]
+"VSCode.yaml"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.yaml]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.yml\OpenWithProgIDs]
+"VSCode.yml"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.yml]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zlogin\OpenWithProgIDs]
+"VSCode.zlogin"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.zlogin]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zlogout\OpenWithProgIDs]
+"VSCode.zlogout"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.zlogout]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zprofile\OpenWithProgIDs]
+"VSCode.zprofile"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.zprofile]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zsh\OpenWithProgIDs]
+"VSCode.zsh"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.zsh]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zshenv\OpenWithProgIDs]
+"VSCode.zshenv"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.zshenv]
+
+
+[HKEY_CURRENT_USER\Software\Classes\.zshrc\OpenWithProgIDs]
+"VSCode.zshrc"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCode.zshrc]
+
+
+[-HKEY_CURRENT_USER\Software\Classes\VSCodeSourceFile]

--- a/scripts/vscode/uninstall-context.reg
+++ b/scripts/vscode/uninstall-context.reg
@@ -1,8 +1,9 @@
 Windows Registry Editor Version 5.00
 
-[-HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Code]
-[-HKEY_CURRENT_USER\Software\Classes\*\shell\Open with &Code\command]
-[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Code]
-[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Code\command]
-[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Code]
-[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Code\command]
+[-HKEY_CURRENT_USER\Software\Classes\*\shell\VSCode]
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\VSCode]
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\VSCode]
+
+[-HKEY_CURRENT_USER\Software\Classes\Drive\shell\VSCode]

--- a/scripts/vscode/unregister-installed-program.reg
+++ b/scripts/vscode/unregister-installed-program.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1]


### PR DESCRIPTION
### Summary

Refactors the `vscode` manifest to improve portability, data migration, and maintainability.  

Separately, the registry (`.reg`) scripts have been updated to better align with entries and behavior observed in the official Visual Studio Code installer.

### Related issues or pull requests

- Closes #15301 

### Changes

- Refactore the manifest to improve:
  - Data and extension migration
  - Maintainability and consistency with Scoop conventions
- Update registry (`.reg`) scripts based on entries generated by the **official VS Code installer**, ensuring:
  - Compatibility with Windows file association and shell integration mechanisms
- Refactore `notes` to better reflect available registry integration options  
- Improve `post_install` logic to dynamically apply registry templates and support both user-level and global installs  
- Improve `uninstaller` behavior to properly unregister registry entries  
- Update `checkver` to rely on `productVersion` for more reliable version detection 

### Notes

- Add a `pre_install` script to ensure extension paths are adjusted correctly. The rationale behind this logic is as follows:
  - Based on testing, only the most recently installed extension contains the `_sep`, `fsPath`, and `external` fields within the `location` object in `extensions.json`.
  - This behavior is easy to verify: after installing extension A and then extension B, extension A’s `location` object no longer contains the above fields, and a `uuid` field is added to its `identifier` object, with the value equal to `metadata.id`.
  - When extension B is uninstalled, the application only removes B’s entry from `extensions.json`; the previously modified metadata for extension A remains unchanged.
  - The `pre_install` script intentionally emulates this behavior. It assumes that the application can derive the other two path representations from `location.path` alone (as evidenced by the current structure of `extensions.json`). Updating all three path variants would introduce unnecessary complexity, so the script limits itself to normalizing `location.path` only, which is sufficient and consistent with observed behavior.
- The file association registrations in `install-associations.reg` are derived from the official installer. In addition to the existing associations, this update adds support for `.json5`, `.jsonc`, `.zshrc`, and other related file types.
- The contents of `install-context.reg` are also based on the official installer. The only difference is that the official installer registers the relevant values as `REG_EXPAND_SZ`, whereas this PR uses `REG_SZ`. Both registry value types function correctly in this context.
- The current naming of `install-github-integration.reg` is potentially misleading. It has therefore been renamed to `register-installed-program.reg`, and the corresponding entries in the `notes` field have been updated accordingly.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ ~]
└─> jq '
   map({
     identifier,
     location: (
       .location
       | with_entries(
           if (.value | type) == "string"
           then .value |= gsub("<username>"; "USERNAME")
           else .
           end
         )
       )
   })
 ' "$HOME\.vscode\extensions\extensions.json"
[
  {
    "identifier": {
      "id": "arthurlobo.easy-codesnap",
      "uuid": "74ee6421-4ae5-4bdc-b642-afa6fd1a2522"
    },
    "location": {
      "$mid": 1,
      "path": "/c:/Users/USERNAME/.vscode/extensions/arthurlobo.easy-codesnap-1.36.1",
      "scheme": "file"
    }
  },
  {
    "identifier": {
      "id": "usernamehw.errorlens"
    },
    "location": {
      "$mid": 1,
      "fsPath": "c:\\Users\\USERNAME\\.vscode\\extensions\\usernamehw.errorlens-3.26.0",
      "_sep": 1,
      "external": "file:///c%3A/Users/USERNAME/.vscode/extensions/usernamehw.errorlens-3.26.0",
      "path": "/c:/Users/USERNAME/.vscode/extensions/usernamehw.errorlens-3.26.0",
      "scheme": "file"
    }
  }
]

┏[ ~]
└─> scoop install Unofficial/vscode
Installing 'vscode' (1.107.1) [64bit] from 'Unofficial' bucket
Loading dl.7z from cache.
Checking hash of dl.7z ... ok.
Extracting dl.7z ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\vscode\current => D:\Software\Scoop\Local\apps\vscode\1.107.1
Creating shortcut for Visual Studio Code (Code.exe)
Adding D:\Software\Scoop\Local\apps\vscode\current\bin to your path.
Persisting data
Running post_install script...INFO  [Portable Mode] Migrating user data to 'D:\Software\Scoop\Local\apps\vscode\current\data'...
INFO  [Portable Mode] Migrating argv.json to 'D:\Software\Scoop\Local\apps\vscode\current\data'...
INFO  [Portable Mode] Migrating extensions to 'D:\Software\Scoop\Local\apps\vscode\current\data'...
INFO  Adjusting path in extensions file...
done.
'vscode' (1.107.1) was installed successfully!
Notes
-----
To register file associations, please execute the following command:
- `reg import "D:\Software\Scoop\Local\apps\vscode\current\register-file-associations.reg"`
To register the context menu entry, please execute the following command:
- `reg import "D:\Software\Scoop\Local\apps\vscode\current\register-context-menu.reg"`
To register the installed program entry (required for integration with other applications), please execute the following command:
- `reg import "D:\Software\Scoop\Local\apps\vscode\current\register-installed-program.reg"`

┏[ ~]
└─> jq 'map({ identifier, location })' "D:\Software\Scoop\Local\apps\vscode\current\data\extensions\extensions.json"
[
  {
    "identifier": {
      "id": "arthurlobo.easy-codesnap",
      "uuid": "74ee6421-4ae5-4bdc-b642-afa6fd1a2522"
    },
    "location": {
      "$mid": 1,
      "path": "/D:/Software/Scoop/Local/apps/vscode/1.107.1/data/extensions/arthurlobo.easy-codesnap-1.36.1",
      "scheme": "file"
    }
  },
  {
    "identifier": {
      "id": "usernamehw.errorlens",
      "uuid": "9d8c32ab-354c-4daf-a9bf-20b633734435"
    },
    "location": {
      "$mid": 1,
      "path": "/D:/Software/Scoop/Local/apps/vscode/1.107.1/data/extensions/usernamehw.errorlens-3.26.0",
      "scheme": "file"
    }
  }
]
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portable mode support: manifest fields for pre/post-install hooks, persistence, shortcuts, and PATH additions.
  * Unified context-menu and file-association entries for VSCode with standardized commands and icons.
  * Metadata parsing updated to use productVersion for version checks.

* **Chores**
  * Install/uninstall flows revised to migrate user data and extensions to portable locations and standardize registration/uninstaller behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->