### PR TITLE
ios-webkit-debug-proxy: Fix checkver, update license

### DIFF
--- a/bucket/ios-webkit-debug-proxy.json
+++ b/bucket/ios-webkit-debug-proxy.json
@@ -2,7 +2,7 @@
     "version": "1.9.1",
     "description": "A DevTools proxy (Chrome Remote Debugging Protocol) for iOS devices (Safari Remote Web Inspector).",
     "homepage": "https://github.com/google/ios-webkit-debug-proxy",
-    "license": "BSD-3-Clause",
+    "license": "Apache-2.0, GPL-2.0-or-later, LGPL-2.1-or-later, OpenSSL",
     "architecture": {
         "64bit": {
             "url": "https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.9.1/ios-webkit-debug-proxy-1.9.1-win64-bin.zip",
@@ -10,11 +10,15 @@
         }
     },
     "bin": "ios_webkit_debug_proxy.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://api.github.com/repositories/8165161/releases",
+        "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.browser_download_url =~ /win64/i)])].tag_name",
+        "regex": "(?<=\")(?<tag>v?([\\d.]+))(?=\")"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/google/ios-webkit-debug-proxy/releases/download/v$version/ios-webkit-debug-proxy-$version-win64-bin.zip"
+                "url": "https://github.com/google/ios-webkit-debug-proxy/releases/download/$matchTag/ios-webkit-debug-proxy-$version-win64-bin.zip"
             }
         }
     }


### PR DESCRIPTION
### Summary

Improves the `ios-webkit-debug-proxy` manifest by correcting license metadata and making version detection more reliable through explicit GitHub Releases API querying and asset-based filtering.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Update the `license` field to reflect the complete set of licenses included in the distribution
- Replace the shorthand `checkver: github` with an explicit GitHub Releases API endpoint  

### Notes

- The license information in the GitHub project is outdated; the currently applicable licenses can be found in the `$dir` directory.

  ```powershell
  ┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
  └─> Get-ChildItem -Path D:\Software\Scoop\Local\apps\ios-webkit-debug-proxy\current -Filter '*.txt'
  
          Directory: D:\Software\Scoop\Local\apps\ios-webkit-debug-proxy\current
  
  
  Mode                LastWriteTime         Length Name
  ----                -------------         ------ ----
  -a---         2024/5/28     11:43          11358 󰈙  COPYING.APACHEv2.0.txt
  -a---         2024/5/28     11:43          18092 󰈙  COPYING.GPLv2.txt
  -a---         2024/5/28     11:43          26434 󰈙  COPYING.LGPLv2.1.txt
  -a---         2024/5/28     11:43           6128 󰈙  COPYING.OPENSSL.txt
  
  ```

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App ios-webkit-debug-proxy -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
ios-webkit-debug-proxy: 1.9.1 (scoop version is 1.9.1)
Forcing autoupdate!
Autoupdating ios-webkit-debug-proxy
DEBUG[1766433496] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766433496] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766433496] $substitutions.$matchTag                      v1.9.1
DEBUG[1766433496] $substitutions.$version                       1.9.1
DEBUG[1766433496] $substitutions.$cleanVersion                  191
DEBUG[1766433496] $substitutions.$minorVersion                  9
DEBUG[1766433496] $substitutions.$basenameNoExt                 ios-webkit-debug-proxy-1.9.1-win64-bin
DEBUG[1766433496] $substitutions.$majorVersion                  1
DEBUG[1766433496] $substitutions.$dashVersion                   1-9-1
DEBUG[1766433496] $substitutions.$buildVersion
DEBUG[1766433496] $substitutions.$matchHead                     1.9.1
DEBUG[1766433496] $substitutions.$underscoreVersion             1_9_1
DEBUG[1766433496] $substitutions.$matchTail
DEBUG[1766433496] $substitutions.$preReleaseVersion             1.9.1
DEBUG[1766433496] $substitutions.$dotVersion                    1.9.1
DEBUG[1766433496] $substitutions.$patchVersion                  1
DEBUG[1766433496] $substitutions.$match1                        1.9.1
DEBUG[1766433496] $substitutions.$baseurl                       https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.9.1
DEBUG[1766433496] $substitutions.$urlNoExt                      https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.9.1/ios-webkit-debug-proxy-1.9.1-win64-bin
DEBUG[1766433496] $substitutions.$url                           https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.9.1/ios-webkit-debug-proxy-1.9.1-win64-bin.zip
DEBUG[1766433496] $substitutions.$basename                      ios-webkit-debug-proxy-1.9.1-win64-bin.zip
DEBUG[1766433496] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1766433497] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.9.1/ios-webkit-debug-proxy-1.9.1-win64-bin.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/google/ios-webkit-debug-proxy/releases
Downloading ios-webkit-debug-proxy-1.9.1-win64-bin.zip to compute hashes!
Loading ios-webkit-debug-proxy-1.9.1-win64-bin.zip from cache
Computed hash: f1c7a62ae956ea9ad6fb3ae4cf13f3df882b0d52a7fcc34a0e4e728e0e364fed
Writing updated ios-webkit-debug-proxy manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package license information to reflect multiple licensing terms
  * Enhanced version detection and update mechanism for improved reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->