### PR TITLE
jasper@1.1.2: Fix checkver, refactor installer logic

### DIFF
--- a/bucket/jasper.json
+++ b/bucket/jasper.json
@@ -1,25 +1,39 @@
 {
     "version": "1.1.2",
-    "description": "Flexible and powerful issue reader for GitHub",
+    "description": "A flexible and powerful issue reader for GitHub.",
     "homepage": "https://jasperapp.io",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/jasperapp/jasper/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jasperapp/jasper/releases/download/v1.1.2/jasper_v1.1.2_windows_setup.exe#/dl.7z",
+            "url": "https://github.com/jasperapp/jasper/releases/download/v1.1.2/jasper_v1.1.2_windows_setup.exe",
             "hash": "d3ff48f0cde1f4f4063c690ca9b89f788ebacde9bf6f081a7bd7d90cfd8ff57e"
         }
     },
-    "pre_install": "Expand-7zipArchive \"$dir\\jasper-$version-full.nupkg\" -ExtractDir 'lib\\net45' -Removal | Out-Null",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -DestinationPath $dir -Switches '-x!*.gif' -Removal",
+            "$nupkg_file = Get-ChildItem -Path $dir -Filter '*.nupkg' -File | Select-Object -ExpandProperty FullName",
+            "Expand-7zipArchive -Path $nupkg_file -DestinationPath \"$dir\\app-$version\" -ExtractDir 'lib\\net45' -Removal",
+            "Move-Item -Path \"$dir\\app-$version\\jasper_ExecutionStub.exe\" -Destination \"$dir\\jasper.exe\"",
+            "New-Item -Path \"$dir\\packages\" -ItemType Directory -Force | Out-Null",
+            "Move-Item -Path \"$dir\\RELEASES\" -Destination \"$dir\\packages\""
+        ]
+    },
     "shortcuts": [
         [
-            "Jasper.exe",
+            "jasper.exe",
             "Jasper"
         ]
     ],
     "checkver": {
-        "github": "https://github.com/jasperapp/jasper"
+        "url": "https://api.github.com/repositories/58461278/releases",
+        "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.browser_download_url =~ /windows/i)])].tag_name",
+        "regex": "(?<=\")(?<tag>v?([\\d.]+))(?=\")"
     },
     "autoupdate": {
-        "url": "https://github.com/jasperapp/jasper/releases/download/v$version/jasper_v$version_windows_setup.exe#/dl.7z"
+        "url": "https://github.com/jasperapp/jasper/releases/download/$matchTag/jasper_v$version_windows_setup.exe"
     }
 }


### PR DESCRIPTION
### Summary

Refactors the `jasper` manifest to better align with upstream packaging behavior, improves installer robustness, and enhances version detection reliability via the GitHub Releases API.

### Related issues or pull requests

- Relates to #16379 

### Changes

- Replace the simple SPDX string with a structured `license` object including the upstream LICENSE URL  
- Refactore the installer logic to properly extract and stage the embedded Squirrel `.nupkg` contents  
- Update `checkver` to query the GitHub Releases API directly  
  - Add a JSONPath filter to ensure only non-prerelease versions with Windows assets are detected 

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App jasper -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
jasper: 1.1.2 (scoop version is 1.1.2)
Forcing autoupdate!
Autoupdating jasper
DEBUG[1766433843] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766433843] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766433843] $substitutions.$matchTag                      v1.1.2
DEBUG[1766433843] $substitutions.$version                       1.1.2
DEBUG[1766433843] $substitutions.$cleanVersion                  112
DEBUG[1766433843] $substitutions.$minorVersion                  1
DEBUG[1766433843] $substitutions.$basenameNoExt                 jasper_v1.1.2_windows_setup
DEBUG[1766433843] $substitutions.$majorVersion                  1
DEBUG[1766433843] $substitutions.$dashVersion                   1-1-2
DEBUG[1766433843] $substitutions.$buildVersion
DEBUG[1766433843] $substitutions.$matchHead                     1.1.2
DEBUG[1766433843] $substitutions.$underscoreVersion             1_1_2
DEBUG[1766433843] $substitutions.$matchTail
DEBUG[1766433843] $substitutions.$preReleaseVersion             1.1.2
DEBUG[1766433843] $substitutions.$dotVersion                    1.1.2
DEBUG[1766433843] $substitutions.$patchVersion                  2
DEBUG[1766433843] $substitutions.$match1                        1.1.2
DEBUG[1766433843] $substitutions.$baseurl                       https://github.com/jasperapp/jasper/releases/download/v1.1.2
DEBUG[1766433843] $substitutions.$urlNoExt                      https://github.com/jasperapp/jasper/releases/download/v1.1.2/jasper_v1.1.2_windows_setup
DEBUG[1766433843] $substitutions.$url                           https://github.com/jasperapp/jasper/releases/download/v1.1.2/jasper_v1.1.2_windows_setup.exe
DEBUG[1766433843] $substitutions.$basename                      jasper_v1.1.2_windows_setup.exe
DEBUG[1766433843] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1766433844] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/jasperapp/jasper/releases/download/v1.1.2/jasper_v1.1.2_windows_setup.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Could not find hash in https://api.github.com/repos/jasperapp/jasper/releases
Downloading jasper_v1.1.2_windows_setup.exe to compute hashes!
Loading jasper_v1.1.2_windows_setup.exe from cache
Computed hash: d3ff48f0cde1f4f4063c690ca9b89f788ebacde9bf6f081a7bd7d90cfd8ff57e
Writing updated jasper manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/jasper
Installing 'jasper' (1.107.1) [64bit] from 'Unofficial' bucket
Loading jasper_v1.1.2_windows_setup.exe from cache.
Checking hash of jasper_v1.1.2_windows_setup.exe ... ok.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\jasper\current => D:\Software\Scoop\Local\apps\jasper\1.1.2
Creating shortcut for Jasper (jasper.exe)
'jasper' (1.1.2) was installed successfully!
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * License information now includes a direct link for reference.

* **Improvements**
  * Updated download mechanism for more direct access.
  * Enhanced version checking and auto-update processes.
  * Minor description refinement for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->