### PR TITLE
nomeiryoui@3.4.0: Remove architecture field, add shortcuts

### DIFF
--- a/bucket/nomeiryoui.json
+++ b/bucket/nomeiryoui.json
@@ -4,12 +4,17 @@
     "homepage": "https://github.com/Tatsu-syo/noMeiryoUI",
     "license": "MIT",
     "url": "https://github.com/Tatsu-syo/noMeiryoUI/releases/download/TAG-3.4.0/noMeiryoUI3.4.0.zip",
-    "hash": "97B7D4EB6B04C9A4A617267823FA98C75AE5559765ECB5C1192EE473D4E78EC8",
-    "pre_install": "New-Item -Type File -Path \"$dir\\noMeiryoUI.ini\"",
-    "bin": [
+    "hash": "97b7d4eb6b04c9a4a617267823fa98c75ae5559765ecb5c1192ee473d4e78ec8",
+    "pre_install": [
+        "if (-not (Test-Path \"$persist_dir\\noMeiryoUI.ini\")) {",
+        "    New-Item -Path \"$dir\\noMeiryoUI.ini\" -ItemType File -Force | Out-Null",
+        "}"
+    ],
+    "bin": "noMeiryoUI.exe",
+    "shortcuts": [
         [
             "noMeiryoUI.exe",
-            "noMeiryoUI"
+            "No!! Meiryo UI"
         ]
     ],
     "persist": "noMeiryoUI.ini",


### PR DESCRIPTION
The [Detect-It-Easy](https://github.com/horsicq/Detect-It-Easy) show it be 32-bit. So can write its `architecture` to `url`.

<img width="802" height="532" alt="image" src="https://github.com/user-attachments/assets/dc5b494c-7c25-4511-a301-e95d23d2ec13" />


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified distribution and autoupdate into a single, architecture-agnostic configuration to simplify updates.
* **Bug Fixes**
  * Adjusted installation behavior and executable mapping to improve install consistency.
* **Other**
  * Updated shipped shortcut label to "No!! Meiryo UI" for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->