### PR TITLE
veracrypt: Add version 1.26.24

### DIFF
--- a/bucket/veracrypt.json
+++ b/bucket/veracrypt.json
@@ -1,0 +1,56 @@
+{
+    "version": "1.26.24",
+    "description": "VeraCrypt is a free open source disk encryption software for Windows, Mac OSX and Linux.",
+    "homepage": "https://veracrypt.jp/",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://veracrypt.jp/en/VeraCrypt%20License.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://launchpad.net/veracrypt/trunk/1.26.24/+download/VeraCrypt_Setup_x64_1.26.24.msi#/dl.msi_",
+            "hash": "sha512:29e781f50b6ce3cf7833b79d17ac274287262164a29f32d3a01bda0d7412c2899489a68bd33008af1cab734652ceaf9f50d492c76207ddfcc82f1cc874f395f1"
+        }
+    },
+    "pre_install": [
+        "Expand-MsiArchive \"$dir\\$fname\" \"$dir\" -ExtractDir 'VeraCrypt' -Removal",
+        "Remove-Item -Path \"$dir\\VeraCrypt COMReg.exe\" -Force",
+        "Get-ChildItem -Path \"$dir\\*\" -Include 'veracrypt.sys', 'veracrypt.cat', 'VeraCrypt.exe', 'VeraCryptExpander.exe', 'VeraCrypt Format.exe' | Rename-Item -NewName { $_.BaseName + '-x64' + $_.Extension }",
+        "'Configuration.xml', 'Default Keyfiles.xml', 'Favorite Volumes.xml', 'History.xml' | ForEach-Object { Copy-Item (Join-Path $persist_dir $_) (Join-Path $dir $_) -ErrorAction SilentlyContinue; Remove-Item (Join-Path $persist_dir $_) -ErrorAction SilentlyContinue }"
+    ],
+    "bin": [
+        [
+            "VeraCrypt-x64.exe",
+            "veracrypt"
+        ],
+        [
+            "VeraCrypt Format-x64.exe",
+            "veracrypt-format"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "VeraCrypt-x64.exe",
+            "VeraCrypt"
+        ]
+    ],
+    "pre_uninstall": [
+        "ensure \"$persist_dir\" | Out-Null",
+        "'Configuration.xml', 'Default Keyfiles.xml', 'Favorite Volumes.xml', 'History.xml' | ForEach-Object { Copy-Item (Join-Path $dir $_) (Join-Path $persist_dir $_) -ErrorAction SilentlyContinue }"
+    ],
+    "checkver": {
+        "url": "https://veracrypt.io/en/Downloads.html",
+        "regex": "Latest Stable Release - ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://launchpad.net/veracrypt/trunk/$version/+download/VeraCrypt_Setup_x64_$version.msi#/dl.msi_",
+                "hash": {
+                    "url": "https://launchpad.net/veracrypt/trunk/$version/+download/veracrypt-$version-sha512sum.txt",
+                    "find": "$sha512\\s+$basename"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2381

---
To match the file structure of the official Portable installer:
"-x64" has been added to filenames 
The COMReg.exe file has been removed

This makes the installation identical to the official Portable installer, except for some files that are not included in the MSI installer:
Missing donation.js and SM4.html files in docs\html
Missing ARM64 version

Everything else matches the official Portable version, including file names and file hashes.

---

- Copying the data files to and from persist_dir because "persist" doesn't work: the app rewrites the data files instead of writing to the existing one. Deleting files from persist_dir after copying to avoid leaving sensitive data.
- The .io domain is used in checkver for better latency (official mirror).

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VeraCrypt (v1.26.24) support to the Windows package manager with automatic installation, configuration persistence, and update capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->