### PR TITLE
powertoys: Fix uninstall script errors for missing registry keys

### DIFF
--- a/scripts/powertoys/uninstall-context.ps1
+++ b/scripts/powertoys/uninstall-context.ps1
@@ -29,7 +29,9 @@
     '{{registry_scope}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}\LocalServer32'
     '{{registry_scope}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}'
 ) | ForEach-Object {
-    Remove-Item $_ -Recurse -Force | Out-Null
+    if (Test-Path $_) {
+        Remove-Item $_ -Recurse -Force | Out-Null
+    }
 }
 
 if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell 3>$null }


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

When updating my powertoys installation I received the following errors:

<img width="1507" height="645" alt="image" src="https://github.com/user-attachments/assets/a79e359a-e167-488b-a303-a1eb5fbc338f" />

I'm assuming this is likely caused because I don't use the apps that are throwing errors and the reg keys are not generated. Added a `Test-Path` check before attempting to remove each registry key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the uninstall process to prevent errors that could occur when certain cleanup paths are missing or already removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->