### PR TITLE
qtemu: Update to version 3.0-beta1, fix checkver & autoupdate

### DIFF
--- a/bucket/qtemu.json
+++ b/bucket/qtemu.json
@@ -17,9 +17,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://gitlab.com/api/v4/projects/69072983/repository/tree",
-        "jp": "$.[?(@.name =~ /^[0-9]+\\.[0-9]+(-beta[0-9]*)?$/)]",
-        "regex": "([0-9]+\\.[0-9]+(-beta[0-9]+)?)"
+        "url": "https://gitlab.com/qtemu/gui/-/raw/master/README.md",
+        "regex": "Stable version: ([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
I updated the links for qtemu to use the releases created by the project maintainers which has changed since the original upload of the manifest. 
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes: https://github.com/ScoopInstaller/Extras/issues/16893

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package to 3.0-beta1.
  * Switched 64‑bit download source to the project's GitLab releases, updated portable package naming, and refreshed checksum.
  * Updated version-detection and auto-update templates to recognize 3.0-beta releases and the repository's release layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->