### PR TITLE
ccextractor: Update to version 0.96.3, fix autoupdate

### DIFF
--- a/bucket/ccextractor.json
+++ b/bucket/ccextractor.json
@@ -3,8 +3,12 @@
     "description": "Extracts closed captions and teletext subtitles from video streams.",
     "homepage": "https://www.ccextractor.org",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/CCExtractor/ccextractor/releases/download/v0.96.3/CCExtractor.0.96.3_win_portable.zip",
-    "hash": "2d6fad06ba3220e2c2a492d8043b5e506ebac6a4ec281d76391e1407098048ec",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/CCExtractor/ccextractor/releases/download/v0.96.3/CCExtractor.0.96.3_win_portable.zip",
+            "hash": "2d6fad06ba3220e2c2a492d8043b5e506ebac6a4ec281d76391e1407098048ec"
+        }
+    },
     "bin": [
         [
             "ccextractorwinfull.exe",
@@ -21,6 +25,10 @@
         "github": "https://github.com/CCExtractor/ccextractor"
     },
     "autoupdate": {
-        "url": "https://github.com/CCExtractor/ccextractor/releases/download/v$version/CCExtractor.$version_win_portable.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/CCExtractor/ccextractor/releases/download/v$version/CCExtractor.$version_win_portable.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Update version from 0.94 to 0.96.3
- Fix autoupdate URL pattern to match new release naming convention (`CCExtractor.$version_win_portable.zip` instead of `CCExtractor_win_portable.zip`)
- Add architecture field to support 64bit only
- Remove outdated `.Net framework 3.5` note and `vcredist2013` suggestion (no longer required)

## Checklist

- [x] Manifest follows the [contributing guidelines](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Hash is correct
- [x] Autoupdate URL pattern matches release naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to CCExtractor version 0.96.3
  * Removed outdated .Net framework 3.5 requirement notes
  * Removed legacy vcredist suggestion
  * Updated download package URLs and verification checksums for the latest release

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->