### PR TITLE
iris: Add version 1.3.6

### DIFF
--- a/bucket/iris.json
+++ b/bucket/iris.json
@@ -1,25 +1,20 @@
 {
     "version": "1.3.6",
-    "description": "Fast, minimal, config-driven file management engine built in Rust",
+    "description": "Fast, minimal, config-driven file management engine built in Rust.",
     "homepage": "https://github.com/lordaimer/iris",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lordaimer/iris/releases/download/v1.3.6/iris-windows-amd64.exe",
+            "url": "https://github.com/lordaimer/iris/releases/download/v1.3.6/iris-windows-amd64.exe#/iris.exe",
             "hash": "055baa9fe5c8744fd6775a5f33452dcae0b0aa9cfe802baa58b670067f529b97"
         }
     },
-    "bin": [
-        [
-            "iris-windows-amd64.exe",
-            "iris"
-        ]
-    ],
+    "bin": "iris.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lordaimer/iris/releases/download/v$version/iris-windows-amd64.exe"
+                "url": "https://github.com/lordaimer/iris/releases/download/v$version/iris-windows-amd64.exe#/iris.exe"
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Scoop package manifest to enable installing Iris on Windows 64‑bit via Scoop. Provides version 1.3.6, description, homepage, MIT license, download URL and SHA256 checksum, executable mapping to iris.exe, and an autoupdate template that uses GitHub releases for future updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->