### PR TITLE
prime95@30.19b20: Persist `results.txt` & `prime.txt`

### DIFF
--- a/bucket/prime95.json
+++ b/bucket/prime95.json
@@ -17,7 +17,7 @@
         }
     },
     "pre_install": [
-        "'results.txt','prime.txt' | ForEach-Object {",
+        "'results.txt', 'prime.txt' | ForEach-Object {",
         "    if (-not (Test-Path -Path (Join-Path -Path $persist_dir -ChildPath $_))) {",
         "        New-Item -ItemType File -Path (Join-Path -Path $dir -ChildPath $_) | Out-Null",
         "    }",


### PR DESCRIPTION
`results.txt` is the log file.
`prime.txt` is the config file.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now auto-creates missing result and indicator files/directories during initial setup.
  * User result data is preserved across updates to prevent loss of progress.
  * Version detection tightened to more accurately match expected update archives, reducing update mismatches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->