### PR TITLE
pscompletions@6.2.6: Fix persistence

### DIFF
--- a/bucket/pscompletions.json
+++ b/bucket/pscompletions.json
@@ -20,7 +20,8 @@
     ],
     "post_install": [
         "if (Test-Path \"$dir\\completions.original\") {",
-        "    Get-ChildItem \"$dir\\completions.original\" | Copy-Item -Destination \"$dir\\completions\" -Recurse -Force",
+        "    Copy-Item -Path \"$dir\\completions.original\\*\" -Destination \"$dir\\completions\" -Force -Recurse",
+        "    Remove-Item \"$dir\\completions.original\" -Force -Recurse | Out-Null",
         "}"
     ],
     "psmodule": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-install script support in the package manifest to update completion files during installation and remove legacy completion entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->