### PR TITLE
asar7z: Update description & license, improve install/uninstall script logic

### DIFF
--- a/bucket/asar7z.json
+++ b/bucket/asar7z.json
@@ -1,23 +1,50 @@
 {
     "version": "1.5",
-    "description": "7-Zip plugin that allows 7-zip to open, modify, or create Electron .asar archives.",
+    "description": "A plugin for 7-Zip that enables opening, modifying, and creating .asar archives used by Electron-based applications, while noting that encrypted .asar archives cannot be accessed without the specific encryption method defined by the developer.",
     "homepage": "https://www.tc4shell.com/en/7zip/asar/",
-    "license": "Freeware",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.tc4shell.com/en/termsofuse/"
+    },
     "url": "https://www.tc4shell.com/binary/Asar.zip",
     "hash": "ea17751b2d7d607dfc11612e71d0c9d36561e643cdfb2bfb16922a9a0ec6d250",
-    "pre_install": [
-        "$7z_folder = Split-Path (scoop which 7z)",
-        "if (!(Test-Path $7z_folder)) { error 'Could not find 7z.exe in PATH. Abort installation.'; break }",
-        "if ($architecture -eq '64bit') { Copy-Item \"$dir\\Asar.64.dll\" \"$7z_folder\\Formats\\\" -Force }",
-        "elseif ($architecture -eq '32bit') { Copy-Item \"$dir\\Asar.32.dll\" \"$7z_folder\\Formats\\\" -Force }"
-    ],
-    "pre_uninstall": [
-        "$7z_folder = Split-Path (scoop which 7z)",
-        "if (!(Test-Path $7z_folder)) { warn 'Could not find 7z.exe in PATH.' }",
-        "if ($architecture -eq '64bit') { Remove-Item \"$7z_folder\\Formats\\Asar.64.dll\" }",
-        "elseif ($architecture -eq '32bit') { Remove-Item \"$7z_folder\\Formats\\Asar.32.dll\" }"
-    ],
-    "checkver": "Plugin version: ([\\d.]+)",
+    "architecture": {
+        "64bit": {
+            "pre_install": [
+                "Get-ChildItem -Path $dir -Include '*32*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue",
+                "Get-ChildItem -Path $dir -Include '*64*' -Recurse -File | Rename-Item -NewName { $_.Name -replace '\\d{2}\\.(?=dll)', '' }"
+            ]
+        },
+        "32bit": {
+            "pre_install": [
+                "Get-ChildItem -Path $dir -Include '*64*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue",
+                "Get-ChildItem -Path $dir -Include '*32*' -Recurse -File | Rename-Item -NewName { $_.Name -replace '\\d{2}\\.(?=dll)', '' }"
+            ]
+        }
+    },
+    "installer": {
+        "script": [
+            "$7z_path = Get-CommandPath -Command '7z.exe'",
+            "if ($null -eq $7z_path) { abort \"`nCould not locate '7z.exe' in system PATH. Abort installation.\" }",
+            "$formats_dir = Join-Path -Path $(Split-Path -Path $7z_path -Parent) -ChildPath 'Formats'",
+            "if (-not (Test-Path -Path $formats_dir -PathType Container)) {",
+            "    New-Item -Path $formats_dir -ItemType Directory -Force | Out-Null",
+            "}",
+            "Copy-Item -Path \"$dir\\*\" -Destination $formats_dir -Exclude '*.json', 'ReadMe.txt' -Force -Recurse"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$7z_path = Get-CommandPath -Command '7z.exe'",
+            "if ($null -ne $7z_path) {",
+            "    $formats_dir = Join-Path -Path $(Split-Path -Path $7z_path -Parent) -ChildPath 'Formats'",
+            "    Get-ChildItem -Path $dir -Exclude '*.json', 'ReadMe.txt' | ForEach-Object -Process {",
+            "        Remove-Item -Path \"$formats_dir\\$($_.Name)\" -Recurse -Force -ErrorAction SilentlyContinue",
+            "    }",
+            "}"
+        ]
+    },
+    "checkver": "Plugin version:\\s*([\\d.]+)",
     "autoupdate": {
         "url": "https://www.tc4shell.com/binary/Asar.zip"
     }


### PR DESCRIPTION
### Summary

Refactors the `asar7z` manifest to improve installation reliability, 7-Zip discovery, and architecture handling, while aligning description and licensing fields with current Scoop conventions.

### Related issues or pull requests

- Relates to https://github.com/ScoopInstaller/Main/pull/7476
- Relates to https://github.com/ScoopInstaller/Main/pull/7475

### Changes

- Refine description to clearly cover Electron `.asar` usage and encrypted archive limitation  
- Replace simple `license` string with structured `license` object including URL  
- Introduce per-architecture preprocessing to remove unused binaries and normalize DLL naming  
- Replace legacy `pre_install`/`pre_uninstall` logic with explicit `installer`/`uninstaller` scripts  
- Adopte `Get-CommandPath -Command '7z.exe'` for robust 7-Zip path detection instead of `scoop which 7z`  
- Ensure clean removal of installed plugin files during uninstall  

### Notes

- Using the `persistdir` function is only applicable when 7-Zip is installed via Scoop and cannot accommodate scenarios where users enable `use_external_7zip`. Moreover, the installation location depends on the installation path of 7-Zip, meaning that the value of `$global` must be consistent at installation time.
- In addition, when using `scoop which 7z`, if `7z` cannot be found through the `Path` environment variable, it will unavoidably output: `'7z' not found, not a scoop shim, or a broken shim.`
- Neither of these approaches is optimal. This pull request resolves the above issues by using `Get-CommandPath -Command '7z.exe'`.

https://github.com/ScoopInstaller/Main/blob/c368d7c1833e31404c42db2870c562ae9fefe018/bucket/modern7z.json#L17-L26

### Testing

<details>
<summary>The test results are as follows:</summary><br>

```powershell
┏[ ~]
└─> 7z i

7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03

Libs:
 0 : 25.01 : D:\Software\Scoop\Local\apps\7zip\current\7z.dll

┏[ ~]
└─> scoop install Unofficial/asar7z
Installing 'asar7z' (1.5) [64bit] from 'Unofficial' bucket
Loading Asar.zip from cache.
Checking hash of Asar.zip ... ok.
Extracting Asar.zip ... done.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\asar7z\current => D:\Software\Scoop\Local\apps\asar7z\1.5
'asar7z' (1.5) was installed successfully!

┏[ ~]
└─> 7z i

7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03

Libs:
 0 : 25.01 : D:\Software\Scoop\Local\apps\7zip\current\7z.dll
 1 : 0.00 : D:\Software\Scoop\Local\apps\7zip\current\Formats\Asar.dll

┏[ ~]
└─> scoop uninstall asar7z
Uninstalling 'asar7z' (1.5).
Running uninstaller script...done.
Unlinking D:\Software\Scoop\Local\apps\asar7z\current
'asar7z' was uninstalled.

┏[ ~]
└─> 7z i

7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03

Libs:
 0 : 25.01 : D:\Software\Scoop\Local\apps\7zip\current\7z.dll

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added architecture-specific install steps for 32‑bit and 64‑bit and introduced explicit installer and uninstaller routines
  * Improved version-detection pattern for more reliable updates
  * Expanded license metadata to include identifier and reference URL
* **Documentation**
  * Expanded description to clarify archive (.asar) handling and an encryption limitation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->