### PR TITLE
vscode: Support version-specific hash extraction

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -78,14 +78,14 @@
             "64bit": {
                 "url": "https://update.code.visualstudio.com/$version/win32-x64-archive/stable#/dl.7z",
                 "hash": {
-                    "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/stable/latest",
+                    "url": "https://update.code.visualstudio.com/api/versions/$version/win32-x64-archive/stable",
                     "jsonpath": "$.sha256hash"
                 }
             },
             "arm64": {
                 "url": "https://update.code.visualstudio.com/$version/win32-arm64-archive/stable#/dl.7z",
                 "hash": {
-                    "url": "https://update.code.visualstudio.com/api/update/win32-arm64-archive/stable/latest",
+                    "url": "https://update.code.visualstudio.com/api/versions/$version/win32-arm64-archive/stable",
                     "jsonpath": "$.sha256hash"
                 }
             }


### PR DESCRIPTION
Use the API to fetch an exact version's hash, rather than always using the latest update.  This allows checkversion.ps1 to be run on vscode with an explicit version, making it easier to update to a specific VSCode version.

Closes #16920; should not conflict with [16868](https://github.com/ScoopInstaller/Extras/pull/16868) as this targets a different part of the manifest.

<!-- Provide a general summary of your changes in the title above -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal update hash retrieval URLs to use version-specific API endpoints. This allows checkversion.ps1 to be run on vscode with an explicit version, making it easier to target a specific VSCode version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->