### PR TITLE
everythingtoolbar: Fix pre_install script logic

### DIFF
--- a/bucket/everythingtoolbar.json
+++ b/bucket/everythingtoolbar.json
@@ -22,8 +22,8 @@
         }
     },
     "pre_install": [
-        "Get-ChildItem -Path $dir -Include '*,1*' -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue",
-        "Get-ChildItem -Path $dir -Include '*,2*' -Recurse | Rename-Item -NewName { $_.FullName -replace ',2\\.', '.' }"
+        "Get-ChildItem -Path $dir -Include '*,1*' -Recurse | Rename-Item -NewName { $_.Name -replace ',1\\.', '.' }",
+        "Get-ChildItem -Path $dir -Include '*,2*' -Recurse | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
### Summary

Fixes the `pre_install` logic of `everythingtoolbar` to correctly rename files with `,1.` suffix and safely remove those with `,2.` suffix, preventing unintended deletion and improving script robustness.

### Related issues or pull requests

- Relates to #16663 

### Changes

- Replace deletion of `*,1*` files with proper renaming using `Name` instead of `FullName`
- Reorder operations to first rename `*,1*` entries and then remove `*,2*`

### Notes

- After manually extracting the EverythingToolbar installer using `innounp`, an `install_script.iss` file is obtained, which contains the installation rules. From this file, it can be seen that when `IsLauncherSelected` is detected, the installer extracts files matching `*,1*` to the installation directory while removing `,1` from their filenames.
- Since EverythingToolbar was added to the Extras bucket, the installed variant has always been the Launcher version. I believe that even though the hashes of `*,1*` and `*,2*` are currently identical, the behavior should still follow the rules defined in `install_script.iss`.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\cache]
└─> scoop install Unofficial/everythingtoolbar
Installing 'everythingtoolbar' (2.1.1) [64bit] from 'Unofficial' bucket
Loading EverythingToolbar-2.1.1-x64.exe from cache.
Checking hash of EverythingToolbar-2.1.1-x64.exe ... ok.
Extracting EverythingToolbar-2.1.1-x64.exe ... done.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\everythingtoolbar\current => D:\Software\Scoop\Local\apps\everythingtoolbar\2.1.1
Creating shortcut for EverythingToolbar (EverythingToolbar.Launcher.exe)
'everythingtoolbar' (2.1.1) was installed successfully!
'everythingtoolbar' suggests installing 'versions/windowsdesktop-runtime-8.0'.

┏[ D:\Software\Scoop\Local\cache]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Local\apps\everythingtoolbar\current' -Filter '*,*' -Recurse
┏[ D:\Software\Scoop\Local\cache]
└─>
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the pre-installation process sequence to enhance installation workflow and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->