### PR TITLE
apifox: Improve pre_uninstall logic, update checkver

### DIFF
--- a/bucket/apifox.json
+++ b/bucket/apifox.json
@@ -22,12 +22,12 @@
     ],
     "persist": "UserData",
     "pre_uninstall": [
-        "Stop-Process -Name 'ApifoxAppAgent' -ErrorAction SilentlyContinue",
-        "Wait-Process -Name 'ApifoxAppAgent' -ErrorAction SilentlyContinue -Timeout 30"
+        "Stop-Process -Name 'ApifoxAppAgent' -Force -ErrorAction SilentlyContinue",
+        "Start-Sleep -Milliseconds 1500"
     ],
     "checkver": {
-        "url": "https://docs.apifox.com/changelog",
-        "regex": ">([\\d.]+)<a"
+        "url": "https://docs.apifox.com/changelog.md",
+        "regex": "## ([\\d.]+)(?=\\s)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
### Summary

Improves the `pre_uninstall` behavior of `apifox` to terminate background processes more reliably and updates the version detection mechanism to use the Markdown changelog, increasing both matching speed and accuracy.

### Changes

- Add `-Force` flag to `Stop-Process` to ensure `ApifoxAppAgent` is terminated during uninstallation  
- Replace `Wait-Process` with a short `Start-Sleep` delay to avoid potential blocking situations  
- Switche `checkver` source from HTML changelog to Markdown changelog  
- Update regex to match version numbers in Markdown section headers (`## x.x.x`)    

### Notes

- Using the Markdown changelog avoids HTML parsing ambiguity and makes version extraction more stable

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App apifox -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
apifox: 2.8.0 (scoop version is 2.8.0)
Forcing autoupdate!
Autoupdating apifox
DEBUG[1767696962] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1767696962] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1767696962] $substitutions.$preReleaseVersion             2.8.0
DEBUG[1767696962] $substitutions.$underscoreVersion             2_8_0
DEBUG[1767696962] $substitutions.$match1                        2.8.0
DEBUG[1767696962] $substitutions.$basename                      Apifox-2.8.0.exe
DEBUG[1767696962] $substitutions.$majorVersion                  2
DEBUG[1767696962] $substitutions.$matchHead                     2.8.0
DEBUG[1767696962] $substitutions.$urlNoExt                      https://file-assets.apifox.com/download/2.8.0/Apifox-2.8.0
DEBUG[1767696962] $substitutions.$url                           https://file-assets.apifox.com/download/2.8.0/Apifox-2.8.0.exe
DEBUG[1767696962] $substitutions.$dotVersion                    2.8.0
DEBUG[1767696962] $substitutions.$matchTail
DEBUG[1767696962] $substitutions.$dashVersion                   2-8-0
DEBUG[1767696962] $substitutions.$patchVersion                  0
DEBUG[1767696962] $substitutions.$baseurl                       https://file-assets.apifox.com/download/2.8.0
DEBUG[1767696962] $substitutions.$version                       2.8.0
DEBUG[1767696962] $substitutions.$basenameNoExt                 Apifox-2.8.0
DEBUG[1767696962] $substitutions.$minorVersion                  8
DEBUG[1767696962] $substitutions.$buildVersion
DEBUG[1767696962] $substitutions.$cleanVersion                  280
DEBUG[1767696963] $hashfile_url = https://file-assets.apifox.com/download/2.8.0/latest.yml -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Apifox-2.8.0.exe in https://file-assets.apifox.com/download/2.8.0/latest.yml
DEBUG[1767696964] $regex = sha512: ([a-zA-Z0-9+\/=]{24,88}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha512:284be24510c063d6b6b3c79fc9123c53ca5fe054a84827ea98aff34e4f833b729dff1b3c47d62ab26630a53fd3dc8560402b118293987c4c6db2ed854733f4b0 using Extract Mode
Writing updated apifox manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process termination during uninstallation to ensure applications are properly stopped.

* **Chores**
  * Updated version detection mechanism for better compatibility and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->