### PR TITLE
iptvnator: Update to version 0.17.1, drop 32bit support

### DIFF
--- a/bucket/iptvnator.json
+++ b/bucket/iptvnator.json
@@ -9,7 +9,7 @@
             "hash": "e6ce8031f231c8a6e89489ea63cbb44def658fcec537c5aef947f75d8d4660b0",
             "installer": {
                 "script": [
-                    "Get-Item \"$dir\\`$PLUGINSDIR\\app-64.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+                    "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath $dir",
                     "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Force -Recurse -ErrorAction Ignore"
                 ]
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Version updated to 0.17.1.
  * Dropped 32‑bit support; app is 64‑bit only.
  * Download assets moved to architecture-specific 64‑bit entries.
  * Installer script steps added for the 64‑bit release (expand and cleanup).
  * Top-level asset fields and post-install removed; auto-update restructured to use the 64‑bit architecture entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->