### PR TITLE
kelivo: Add version 1.1.6

### DIFF
--- a/bucket/kelivo.json
+++ b/bucket/kelivo.json
@@ -1,11 +1,11 @@
 {
-    "version": "1.1.6+23",
-    "description": "A Flutter LLM Chat Client",
+    "version": "1.1.6",
+    "description": "A Flutter LLM Chat Client.",
     "homepage": "https://kelivo.psycheas.top/",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Chevey339/kelivo/releases/download/v1.1.6/Kelivo_windows_1.1.6+23.zip",
+            "url": "https://github.com/Chevey339/kelivo/releases/download/v1.1.6/Kelivo_windows_1.1.6%2B23.zip",
             "hash": "14fc86d393a6b882f3b1a98efbc68ce77cdcd8873a1c7f5406bac6c97202246c"
         }
     },
@@ -16,15 +16,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Chevey339/kelivo/releases/latest",
-        "jsonpath": "$.assets[*].name",
-        "regex": "Kelivo_windows_(?<ver>[\\d.]+)\\+(?<build>\\d+)\\.zip",
-        "replace": "${ver}+${build}"
+        "github": "https://github.com/Chevey339/kelivo",
+        "regex": "Kelivo_windows_(?<version>[\\d.]+)\\+(?<build>\\d+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Chevey339/kelivo/releases/download/v$matchVer/Kelivo_windows_$matchVer+$matchBuild.zip"
+                "url": "https://github.com/Chevey339/kelivo/releases/download/v$version/Kelivo_windows_$version%2B$matchBuild.zip"
             }
         }
     }


### PR DESCRIPTION
#16944 

I'm submitting a manifest file for the Kelivo application, but I encountered a formatting issue when handling the download URL.

The actual filename in GitHub Releases is: `Kelivo_windows_1.1.6+23.zip`
- The `+23` after the version number appears to be a build number or revision number
- This number changes with each release (e.g., previous versions might be `+22`, `+21`, etc.)

My current manifest hardcodes `+23` in the URL:
```json
"url": "https://github.com/Chevey339/kelivo/releases/download/v1.1.6/Kelivo_windows_1.1.6+23.zip"
```

But this prevents `autoupdate` from working properly because:
1. I don't know the pattern of how this number changes
2. I cannot predict future version build numbers
3. This number is not directly included in the version tag

### Need Help
1. How can I correctly obtain or match this build number?
2. Is there a way to automatically extract the complete filename from the releases page?
3. Or should I use a different URL pattern?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Scoop package manifest to distribute the Kelivo Windows client (version 1.1.6). Includes package metadata, a desktop shortcut, and autoupdate configured to track GitHub releases; update logic captures both version and build metadata and uses placeholders for automatic downloads so users can install and receive updates via Scoop.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->