### PR TITLE
sioyek@2.0.0: Add bin field

### DIFF
--- a/bucket/sioyek.json
+++ b/bucket/sioyek.json
@@ -29,6 +29,7 @@
             "}"
         ]
     },
+    "bin": "sioyek.exe",
     "shortcuts": [
         [
             "sioyek.exe",


### PR DESCRIPTION
Sioyek supports using as CLI liked `sioyek --help`:

<img width="482" height="939" alt="image" src="https://github.com/user-attachments/assets/a48288ca-948b-402e-90ff-7aabc8c776fc" />

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows package manifest to properly identify and configure the executable binary for correct installation and shortcut behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->