### PR TITLE
detect-it-easy@3.10: Add shims for `die` & `diel`

### DIFF
--- a/bucket/detect-it-easy.json
+++ b/bucket/detect-it-easy.json
@@ -18,7 +18,11 @@
         "   if(!(Test-Path \"$persist_dir\\$_\")) {New-Item \"$dir\\$_\" -ItemType File | Out-Null}",
         "}"
     ],
-    "bin": "diec.exe",
+    "bin": [
+        "die.exe",
+        "diec.exe",
+        "diel.exe"
+    ],
     "shortcuts": [
         [
             "die.exe",


### PR DESCRIPTION
`die.exe` and `diel.exe` supports input a path liked:

`die C:\Users\User\Downloads\espeak-ng.msi`

<img width="802" height="532" alt="image" src="https://github.com/user-attachments/assets/6c5b4b93-694c-4ee1-a70e-2a464b8adbb9" />

`diel C:\Users\User\Downloads\espeak-ng.msi`

<img width="615" height="297" alt="image" src="https://github.com/user-attachments/assets/fd63a823-861b-442f-a816-1c19149ec0ae" />

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to support recognition of additional executable variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->