### PR TITLE
tablacus-explorer: Add version 25.12.31

### DIFF
--- a/bucket/tablacus-explorer.json
+++ b/bucket/tablacus-explorer.json
@@ -7,34 +7,24 @@
     "hash": "98a43d91dd2c640d34b5474c5b0521cb1fc12ca7c012a0c86686c899defed77d",
     "architecture": {
         "64bit": {
-            "bin": [
-                [
-                    "TE64.exe",
-                    "te.exe"
-                ]
-            ],
-            "shortcuts": [
-                [
-                    "TE64.exe",
-                    "Tablacus Explorer"
-                ]
-            ]
+            "pre_install": "Rename-Item -Path \"$dir\\TE64.exe\" -NewName 'TE.exe'"
         },
         "32bit": {
-            "bin": [
-                [
-                    "TE32.exe",
-                    "te.exe"
-                ]
-            ],
-            "shortcuts": [
-                [
-                    "TE32.exe",
-                    "Tablacus Explorer"
-                ]
-            ]
+            "pre_install": "Rename-Item -Path \"$dir\\TE32.exe\" -NewName 'TE.exe'"
         }
     },
+    "bin": [
+        [
+            "TE.exe",
+            "te.exe"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "TE.exe",
+            "Tablacus Explorer"
+        ]
+    ],
     "persist": "config",
     "checkver": {
         "github": "https://github.com/tablacus/TablacusExplorer"


### PR DESCRIPTION
Continue to do https://github.com/ScoopInstaller/Extras/pull/16862.

Closes #16861 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tablacus Explorer is now available via the Scoop package manager for simplified installation and management.
  * Adds automatic updates from GitHub releases, supports both 64-bit and 32-bit installations, preserves application settings across updates, and creates usable shortcuts for easy access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->