### PR TITLE
mpv.net: Update to version 7.1.2.0, add arm64 version, fix autoupdate

### DIFF
--- a/bucket/mpv.net.json
+++ b/bucket/mpv.net.json
@@ -11,6 +11,10 @@
         "64bit": {
             "url": "https://github.com/mpvnet-player/mpv.net/releases/download/v7.1.2.0/mpv.net-v7.1.2.0-portable-x64.zip",
             "hash": "33cba35bc6a8ebbb441a68cb9f3d26c366a2457f6a969ce50b95b0e7dd163431"
+        },
+        "arm64": {
+            "url": "https://github.com/mpvnet-player/mpv.net/releases/download/v7.1.2.0/mpv.net-v7.1.2.0-portable-ARM64.zip",
+            "hash": "085bbc3e9c409df0cedb643b769018eb8a2845a22de70b86dac58578aceb15c0"
         }
     },
     "bin": "mpvnet.com",
@@ -26,6 +30,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/mpvnet-player/mpv.net/releases/download/v$version/mpv.net-v$version-portable-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/mpvnet-player/mpv.net/releases/download/v$version/mpv.net-v$version-portable-ARM64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- New ARM64 support: https://github.com/mpvnet-player/mpv.net/blob/main/docs/changelog.md#v7111-beta-2024-07-20
- Switch to .NET 10 LTS: https://github.com/mpvnet-player/mpv.net/blob/main/docs/changelog.md#v7115-beta-2025-11-20

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 7.1.2.0 and upgraded suggested .NET Desktop Runtime from 6.0 to 10.0.
  * Updated 64-bit download URL and verification hash; adjusted auto-update URL for 64-bit builds.
  * Added ARM64 distribution with its own download, hash, and auto-update entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->