### PR TITLE
link-shell-extension: Add version 3.9.3.5

### DIFF
--- a/bucket/link-shell-extension.json
+++ b/bucket/link-shell-extension.json
@@ -1,0 +1,53 @@
+{
+    "version": "3.9.3.5",
+    "description": "Link Shell Extension. Offers  the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
+    "homepage": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://schinagl.priv.at/nt/hardlinkshellext/license.txt"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_X64.exe#/HardLinkShellExt.exe",
+            "hash": "ca3f26ebf49dc4ea8b5d8c0154acca0de59a8689e5907fe748ffaeaa357ff3a0"
+        },
+        "32bit": {
+            "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_win32.exe#/HardLinkShellExt.exe",
+            "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b"
+        }
+    },
+    "installer": {
+        "script": "Invoke-ExternalCommand -FilePath \"$dir\\HardLinkShellExt.exe\" -Args @('/S', '/noredist', '/Language=English', \"/D=$dir\") -RunAs | Out-Null"
+    },
+    "uninstaller": {
+        "64bit": {
+            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_X64.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
+        },
+        "32bit": {
+            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_win32.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
+        }
+    },
+    "shortcuts": [
+        [
+            "LSEConfig.exe",
+            "Link Shell Extension Configuration"
+        ]
+    ],
+    "checkver": {
+        "url": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
+        "regex": ">Last Updated .+ Version ([\\d.]+)<"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/$cleanVersion/HardLinkShellExt_X64.exe#/HardLinkShellExt.exe"
+            },
+            "32bit": {
+                "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/$cleanVersion/HardLinkShellExt_win32.exe#/HardLinkShellExt.exe"
+            }
+        }
+    }
+}

--- a/bucket/link-shell-extension.json
+++ b/bucket/link-shell-extension.json
@@ -1,6 +1,6 @@
 {
     "version": "3.9.3.5",
-    "description": "Link Shell Extension. Offers  the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
+    "description": "Link Shell Extension. Offers the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links and a folder cloning or copy process.",
     "homepage": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
     "license": {
         "identifier": "Proprietary",

--- a/bucket/link-shell-extension.json
+++ b/bucket/link-shell-extension.json
@@ -26,7 +26,10 @@
         }
     },
     "installer": {
-        "script": "Invoke-ExternalCommand -FilePath \"$dir\\HardLinkShellExt.exe\" -Args @('/S', '/noredist', '/Language=English', \"/D=$dir\") -RunAs | Out-Null"
+        "script": [
+            "Invoke-ExternalCommand -FilePath \"$dir\\HardLinkShellExt.exe\" -Args @('/S', '/noredist', '/Language=English', \"/D=$dir\") -RunAs | Out-Null",
+            "Remove-Item \"$dir\\HardLinkShellExt.exe\" -ErrorAction SilentlyContinue"
+        ]
     },
     "shortcuts": [
         [

--- a/bucket/link-shell-extension.json
+++ b/bucket/link-shell-extension.json
@@ -12,14 +12,14 @@
     "architecture": {
         "64bit": {
             "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_X64.exe#/HardLinkShellExt.exe",
-            "hash": "ca3f26ebf49dc4ea8b5d8c0154acca0de59a8689e5907fe748ffaeaa357ff3a0"，
+            "hash": "ca3f26ebf49dc4ea8b5d8c0154acca0de59a8689e5907fe748ffaeaa357ff3a0",
             "uninstaller": {
                 "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_X64.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
             }
         },
         "32bit": {
             "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_win32.exe#/HardLinkShellExt.exe",
-            "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b"，
+            "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b",
             "uninstaller": {
                 "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_win32.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
             }

--- a/bucket/link-shell-extension.json
+++ b/bucket/link-shell-extension.json
@@ -12,23 +12,21 @@
     "architecture": {
         "64bit": {
             "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_X64.exe#/HardLinkShellExt.exe",
-            "hash": "ca3f26ebf49dc4ea8b5d8c0154acca0de59a8689e5907fe748ffaeaa357ff3a0"
+            "hash": "ca3f26ebf49dc4ea8b5d8c0154acca0de59a8689e5907fe748ffaeaa357ff3a0"，
+            "uninstaller": {
+                "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_X64.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
+            }
         },
         "32bit": {
             "url": "https://schinagl.priv.at/nt/hardlinkshellext/save/3935/HardLinkShellExt_win32.exe#/HardLinkShellExt.exe",
-            "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b"
+            "hash": "b7e7227e960f025be992c398dafacd03c416adf5210d3fc0ff1d5b5771afdc4b"，
+            "uninstaller": {
+                "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_win32.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
+            }
         }
     },
     "installer": {
         "script": "Invoke-ExternalCommand -FilePath \"$dir\\HardLinkShellExt.exe\" -Args @('/S', '/noredist', '/Language=English', \"/D=$dir\") -RunAs | Out-Null"
-    },
-    "uninstaller": {
-        "64bit": {
-            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_X64.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
-        },
-        "32bit": {
-            "script": "Invoke-ExternalCommand -FilePath \"$dir\\uninst-HardLinkShellExt_win32.exe\" -Args @('/S' , '/noredist') -RunAs | Out-Null"
-        }
     },
     "shortcuts": [
         [


### PR DESCRIPTION
Closes ScoopInstaller/Nonportable#577 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added package-manager support for Link Shell Extension with 32-bit and 64-bit installers and uninstallers.
  * Includes automatic version detection (checkver) and autoupdate URLs for both architectures.
  * Adds installer shortcuts and a suggested dependency on vcredist; packaged under a proprietary license with provided homepage and description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->