### PR TITLE
webview2: Add Microsoft Edge WebView2

### DIFF
--- a/bucket/webview2.json
+++ b/bucket/webview2.json
@@ -1,0 +1,49 @@
+{
+    "version": "143.0.3650.139",
+    "description": "Embed web content (HTML, CSS, and JavaScript) in your native applications with Microsoft Edge WebView2",
+    "license": "Freeware",
+    "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/webview2",
+    "architecture": {
+        "64bit": {
+            "url": "https://go.microsoft.com/fwlink/?linkid=2124701#/setup.exe",
+            "hash": "6ae5cd7823d64e666bf6ab7c3a9b4465e925aeb9665f9c5db7deb1b528720a21"
+        },
+        "32bit": {
+            "url": "https://go.microsoft.com/fwlink/?linkid=2099617#/setup.exe",
+            "hash": "4669f3ec27181466d7b5334ec539633b20f5d642cb23dfc65423fe1830e7e30a"
+        },
+        "arm64": {
+            "url": "https://go.microsoft.com/fwlink/?linkid=2099616#/setup.exe",
+            "hash": "922a52bb5294d9b7223eec0334a25f427308d1f1169616d710a77834c93fb50a"
+        }
+    },
+    "installer": {
+        "script": [
+            "if (-not (is_admin)) { error 'Run as an administrator to install.'; break }",
+            "if ((Start-Process -FilePath \"$dir\\$fname\" -ArgumentList @('/silent', '/install') -Verb RunAs -PassThru -Wait).ExitCode -ne 0) { error 'Something went wrong with the install.'; break }",
+            "Remove-Item \"$dir\\$fname\" -Force"
+        ]
+    },
+    "checkver": {
+        "url": "https://msedgedriver.microsoft.com/LATEST_STABLE",
+        "regex": "([\\d.]+)"
+    },
+    "notes": [
+        "This package is now a stub & can be removed safely.",
+        "It is recommended to keep this stub, if you want updates via Scoop.",
+        "You may remove Microsoft Edge WebView2 via Windows Settings or Control Panel."
+    ],
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://go.microsoft.com/fwlink/?linkid=2124701#/setup.exe"
+            },
+            "32bit": {
+                "url": "https://go.microsoft.com/fwlink/?linkid=2099617#/setup.exe"
+            },
+            "arm64": {
+                "url": "https://go.microsoft.com/fwlink/?linkid=2099616#/setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This PR adds the Microsoft Edge WebView2 standalone installer.

It does the following:

- Check for the latest Edge build.

  - Any Edge derivatives share the same build number.

- Download the correct installer for the system's architecture.

- Run the installer as an admin & silently.
  
  - This is done to install WebView2 system wide.
  - Some apps refuse to resolve the user install of WebView2.

- Later discards the underlying installer & makes the package a stub.
  
  - This is what the `vcredist` package does once its done installing.
  
  - Leaving it as a stub allows Scoop to auto-update it, if required.

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebView2 runtime is now installable via Scoop for Windows with multi-architecture support (64-bit, 32-bit, ARM64) and automatic updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->