### PR TITLE
opera-gx@125.0.5729.58: Update installer script & checkver

### DIFF
--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -8,27 +8,27 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup_x64.exe#/dl.7z",
+            "url": "https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup_x64.exe",
             "hash": "22b4528b07dfc1dec2833b1f081128f83ab9f49128c030a35370cc95c36ff00e"
         },
         "32bit": {
-            "url": "https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup.exe#/dl.7z",
+            "url": "https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup.exe",
             "hash": "bb281e91708e86ec91c0f5a35c357e570423b3eb40fc457a8767b8742dad1c68"
         }
     },
     "installer": {
         "script": [
-            "Remove-Item -Path \"$dir\\*_list\" -Force -ErrorAction SilentlyContinue",
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -DestinationPath $dir -Removal",
             "$version, 'autoupdate' | ForEach-Object { ensure \"$dir\\$_\" | Out-Null }",
             "Move-Item -Path \"$dir\\opera_autoupdate*\" -Destination \"$dir\\autoupdate\" -Force",
+            "Remove-Item -Path \"$dir\\*\" -Include '*_list' -Force -ErrorAction SilentlyContinue",
             "$exclude_list = @('Assets', $version, 'autoupdate', 'Resources.pri', 'opera.visualelementsmanifest.xml')",
             "Get-ChildItem -Path $dir | Where-Object { $exclude_list -notcontains $_.Name } | ForEach-Object {",
-            "    $destination_dir = Join-Path $dir \"$version\\$($_.Name)\"",
-            "    Move-Item -Path $_.FullName -Destination $destination_dir -Force -ErrorAction SilentlyContinue",
+            "    Move-Item -Path $_.FullName -Destination \"$dir\\$version\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
-            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir -Force",
-            "$cfg = @{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json",
-            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -Encoding ASCII"
+            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir",
+            "$cfg = @{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 5",
+            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -Encoding ascii"
         ]
     },
     "shortcuts": [
@@ -40,29 +40,29 @@
     "persist": "profile",
     "checkver": {
         "script": [
-            "$version_regex = '^(?!\\.)[\\d.]+/$'",
+            "$path_regex = '^(?!\\.)[\\d.]+/$'",
             "$version_sort = { [version]$_.href.TrimEnd('/') }",
-            "$releases = 'https://get.opera.com/pub/opera_gx/'",
-            "$download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing",
-            "$version_segments = $download_page.links | Where-Object href -Match $version_regex | Sort-Object $version_sort -Descending | Select-Object -Expand href",
-            "foreach ($version_segment in $version_segments) {",
-            "    $version_url = $releases + $version_segment",
-            "    $version_page = Invoke-WebRequest -Uri $version_url -UseBasicParsing",
-            "    if ($null -ne $version_page -and $version_page.Content -match 'win') {",
-            "        Write-Output $version_segment",
-            "        break",
-            "    }",
+            "$releases_url = 'https://get.opera.com/pub/opera_gx/'",
+            "$releases_page = Invoke-WebRequest -Uri $releases_url -UseBasicParsing -ErrorAction Stop",
+            "$path_segments = $releases_page.links | Where-Object { $_.href -match $path_regex } |",
+            "        Sort-Object -Property $version_sort -Descending | ForEach-Object -MemberName href",
+            "foreach ($path_segment in $path_segments.TrimEnd('/')) {",
+            "    $release_url = 'https://get.opera.com/pub/opera_gx/{0}/win/' -f $path_segment",
+            "    $download_page = Invoke-WebRequest -Uri $release_url -UseBasicParsing -ErrorAction Stop",
+            "    $installer_name = $download_page.Links | Where-Object { $_.href -match '(?<=Setup\\w+)\\.exe$' } |",
+            "            Select-Object -ExpandProperty href -First 1",
+            "    if ($null -ne $installer_name) { Write-Output $installer_name; break }",
             "}"
         ],
-        "regex": "([\\d.]+)/"
+        "regex": "Opera_GX_([\\d.]+)_Setup"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://get.opera.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup_x64.exe#/dl.7z"
+                "url": "https://get.opera.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup_x64.exe"
             },
             "32bit": {
-                "url": "https://get.opera.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup.exe#/dl.7z"
+                "url": "https://get.opera.com/pub/opera_gx/$version/win/Opera_GX_$version_Setup.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
### Summary

Refactors the `opera-gx` manifest to improve installation reliability and enhance the version detection logic.

### Related issues or pull requests

- Relates to #16987  

### Changes

- **Improve `installer` script**:
    - Replace implicit extraction with `Expand-7zipArchive` for better control.
- **Improve `checkver` script**:
    - Improve the scraper to use `Invoke-WebRequest` with `-ErrorAction Stop` for better error handling.
    - Update regex to `Opera_GX_([\d.]+)_Setup` for more precise version capturing from the filename.
    - Refine the iteration logic to target the Windows-specific setup path more accurately.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App opera-gx -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
opera-gx: 125.0.5729.58 (scoop version is 125.0.5729.58)
Forcing autoupdate!
Autoupdating opera-gx
DEBUG[1768171415] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1768171415] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1768171415] $substitutions.$matchTail                     .58
DEBUG[1768171415] $substitutions.$baseurl                       https://get.opera.com/pub/opera_gx/125.0.5729.58/win
DEBUG[1768171415] $substitutions.$urlNoExt                      https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup
DEBUG[1768171415] $substitutions.$cleanVersion                  1250572958
DEBUG[1768171415] $substitutions.$underscoreVersion             125_0_5729_58
DEBUG[1768171415] $substitutions.$matchHead                     125.0.5729
DEBUG[1768171415] $substitutions.$basename                      Opera_GX_125.0.5729.58_Setup.exe
DEBUG[1768171415] $substitutions.$url                           https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup.exe
DEBUG[1768171415] $substitutions.$match1                        125.0.5729.58
DEBUG[1768171415] $substitutions.$minorVersion                  0
DEBUG[1768171415] $substitutions.$basenameNoExt                 Opera_GX_125.0.5729.58_Setup
DEBUG[1768171415] $substitutions.$buildVersion                  58
DEBUG[1768171415] $substitutions.$majorVersion                  125
DEBUG[1768171415] $substitutions.$patchVersion                  5729
DEBUG[1768171415] $substitutions.$dashVersion                   125-0-5729-58
DEBUG[1768171415] $substitutions.$preReleaseVersion             125.0.5729.58
DEBUG[1768171415] $substitutions.$version                       125.0.5729.58
DEBUG[1768171415] $substitutions.$dotVersion                    125.0.5729.58
DEBUG[1768171415] $hashfile_url = https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup.exe.sha256sum -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Opera_GX_125.0.5729.58_Setup.exe in https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup.exe.sha256sum
DEBUG[1768171415] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: bb281e91708e86ec91c0f5a35c357e570423b3eb40fc457a8767b8742dad1c68 using Extract Mode
DEBUG[1768171415] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1768171415] $substitutions.$matchTail                     .58
DEBUG[1768171415] $substitutions.$baseurl                       https://get.opera.com/pub/opera_gx/125.0.5729.58/win
DEBUG[1768171415] $substitutions.$urlNoExt                      https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup_x64
DEBUG[1768171415] $substitutions.$cleanVersion                  1250572958
DEBUG[1768171415] $substitutions.$underscoreVersion             125_0_5729_58
DEBUG[1768171415] $substitutions.$matchHead                     125.0.5729
DEBUG[1768171415] $substitutions.$basename                      Opera_GX_125.0.5729.58_Setup_x64.exe
DEBUG[1768171415] $substitutions.$url                           https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup_x64.exe
DEBUG[1768171415] $substitutions.$match1                        125.0.5729.58
DEBUG[1768171415] $substitutions.$minorVersion                  0
DEBUG[1768171415] $substitutions.$basenameNoExt                 Opera_GX_125.0.5729.58_Setup_x64
DEBUG[1768171415] $substitutions.$buildVersion                  58
DEBUG[1768171415] $substitutions.$majorVersion                  125
DEBUG[1768171415] $substitutions.$patchVersion                  5729
DEBUG[1768171415] $substitutions.$dashVersion                   125-0-5729-58
DEBUG[1768171415] $substitutions.$preReleaseVersion             125.0.5729.58
DEBUG[1768171415] $substitutions.$version                       125.0.5729.58
DEBUG[1768171415] $substitutions.$dotVersion                    125.0.5729.58
DEBUG[1768171415] $hashfile_url = https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup_x64.exe.sha256sum -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Opera_GX_125.0.5729.58_Setup_x64.exe in https://get.opera.com/pub/opera_gx/125.0.5729.58/win/Opera_GX_125.0.5729.58_Setup_x64.exe.sha256sum
DEBUG[1768171416] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 22b4528b07dfc1dec2833b1f081128f83ab9f49128c030a35370cc95c36ff00e using Extract Mode
Writing updated opera-gx manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/opera-gx
Installing 'opera-gx' (125.0.5729.58) [64bit] from 'Unofficial' bucket
Loading Opera_GX_125.0.5729.58_Setup_x64.exe from cache.
Checking hash of Opera_GX_125.0.5729.58_Setup_x64.exe ... ok.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\opera-gx\current => D:\Software\Scoop\Local\apps\opera-gx\125.0.5729.58
Creating shortcut for Opera GX (opera.exe)
Persisting profile
'opera-gx' (125.0.5729.58) was installed successfully!
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined Opera GX installation process with direct setup executable downloads, eliminating archive extraction steps
  * Enhanced installer file organization and configuration handling for improved reliability
  * Refined version detection mechanism for more robust automatic updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->