### PR TITLE
opera@126.0.5750.18: Add arm64 version, update installer script & checkver

### DIFF
--- a/bucket/opera.json
+++ b/bucket/opera.json
@@ -1,34 +1,38 @@
 {
     "version": "126.0.5750.18",
-    "description": "Fast, secure, easy-to-use browser.",
-    "homepage": "https://www.opera.com/",
+    "description": "A fast, secure, easy-to-use browser.",
+    "homepage": "https://www.opera.com",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.opera.com/eula/computers"
     },
     "architecture": {
         "64bit": {
-            "url": "https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_x64.exe#/dl.7z",
+            "url": "https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_x64.exe",
             "hash": "467b9cc15979927ebc8bca4dfbe31f1c15f239a12af9113fe9f3ba4ea5091efd"
         },
         "32bit": {
-            "url": "https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup.exe#/dl.7z",
+            "url": "https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup.exe",
             "hash": "3727e8d9651139f74d7b1970d3e853de423d546605b0577fdb18678086ce57ce"
+        },
+        "arm64": {
+            "url": "https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_arm64.exe",
+            "hash": "a12a44911f5ad97ff12aa3349bb3cdc4acd972041363229f22b93fb41d181351"
         }
     },
     "installer": {
         "script": [
-            "Remove-Item -Path \"$dir\\*_list\" -Force -ErrorAction SilentlyContinue",
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -DestinationPath $dir -Removal",
             "$version, 'autoupdate' | ForEach-Object { ensure \"$dir\\$_\" | Out-Null }",
             "Move-Item -Path \"$dir\\opera_autoupdate*\" -Destination \"$dir\\autoupdate\" -Force",
+            "Remove-Item -Path \"$dir\\*\" -Include '*_list' -Force -ErrorAction SilentlyContinue",
             "$exclude_list = @('Assets', $version, 'autoupdate', 'Resources.pri', 'opera.visualelementsmanifest.xml')",
             "Get-ChildItem -Path $dir | Where-Object { $exclude_list -notcontains $_.Name } | ForEach-Object {",
-            "    $destination_dir = Join-Path $dir \"$version\\$($_.Name)\"",
-            "    Move-Item -Path $_.FullName -Destination $destination_dir -Force -ErrorAction SilentlyContinue",
+            "    Move-Item -Path $_.FullName -Destination \"$dir\\$version\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
             "}",
-            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir -Force",
-            "$cfg = @{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json",
-            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -Encoding ASCII"
+            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir",
+            "$cfg = @{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 5",
+            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -Encoding ascii"
         ]
     },
     "shortcuts": [
@@ -40,29 +44,32 @@
     "persist": "profile",
     "checkver": {
         "script": [
-            "$version_regex = '^(?!\\.)[\\d.]+/$'",
+            "$path_regex = '^(?!\\.)[\\d.]+/$'",
             "$version_sort = { [version]$_.href.TrimEnd('/') }",
-            "$releases = 'https://get.geo.opera.com/pub/opera/desktop/'",
-            "$download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing",
-            "$version_segments = $download_page.links | Where-Object href -Match $version_regex | Sort-Object $version_sort -Descending | Select-Object -Expand href",
-            "foreach ($version_segment in $version_segments) {",
-            "    $version_url = $releases + $version_segment",
-            "    $version_page = Invoke-WebRequest -Uri $version_url -UseBasicParsing",
-            "    if ($null -ne $version_page -and $version_page.Content -match 'win') {",
-            "        Write-Output $version_segment",
-            "        break",
-            "    }",
+            "$releases_url = 'https://get.geo.opera.com/pub/opera/desktop/'",
+            "$releases_page = Invoke-WebRequest -Uri $releases_url -UseBasicParsing -ErrorAction Stop",
+            "$path_segments = $releases_page.links | Where-Object { $_.href -match $path_regex } |",
+            "        Sort-Object -Property $version_sort -Descending | ForEach-Object -MemberName href",
+            "foreach ($path_segment in $path_segments.TrimEnd('/')) {",
+            "    $release_url = 'https://get.geo.opera.com/pub/opera/desktop/{0}/win/' -f $path_segment",
+            "    $download_page = Invoke-WebRequest -Uri $release_url -UseBasicParsing -ErrorAction Stop",
+            "    $installer_name = $download_page.Links | Where-Object { $_.href -match '(?<=Setup\\w+)\\.exe$' } |",
+            "            Select-Object -ExpandProperty href -First 1",
+            "    if ($null -ne $installer_name) { Write-Output $installer_name; break }",
             "}"
         ],
-        "regex": "([\\d.]+)/"
+        "regex": "Opera_([\\d.]+)_Setup"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://get.geo.opera.com/pub/opera/desktop/$version/win/Opera_$version_Setup_x64.exe#/dl.7z"
+                "url": "https://get.geo.opera.com/pub/opera/desktop/$version/win/Opera_$version_Setup_x64.exe"
             },
             "32bit": {
-                "url": "https://get.geo.opera.com/pub/opera/desktop/$version/win/Opera_$version_Setup.exe#/dl.7z"
+                "url": "https://get.geo.opera.com/pub/opera/desktop/$version/win/Opera_$version_Setup.exe"
+            },
+            "arm64": {
+                "url": "https://get.geo.opera.com/pub/opera/desktop/$version/win/Opera_$version_Setup_arm64.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
### Summary

Refactors the `opera` manifest to add **ARM64** support, optimizes the installation process, and enhances the version detection logic for better reliability.

### Related issues or pull requests

- Relates to #16986 

### Changes

- **Add `arm64` architecture** support for Windows.
- **Improve `installer` script**:
    - Replace implicit extraction with `Expand-7zipArchive` for better control.
- **Enhance `checkver` logic**:
    - Improve the scraper to use `Invoke-WebRequest` with `-ErrorAction Stop` for better error handling.
    - Update the regex to `Opera_([\d.]+)_Setup` for more precise version matching.
    - Refine the iteration logic to target the Windows-specific setup path more accurately.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App opera -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
opera: 126.0.5750.18 (scoop version is 126.0.5750.18)
Forcing autoupdate!
Autoupdating opera
DEBUG[1768170679] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1768170679] $substitutions.$matchTail                     .18
DEBUG[1768170679] $substitutions.$baseurl                       https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win
DEBUG[1768170679] $substitutions.$urlNoExt                      https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_arm64
DEBUG[1768170679] $substitutions.$cleanVersion                  1260575018
DEBUG[1768170679] $substitutions.$underscoreVersion             126_0_5750_18
DEBUG[1768170679] $substitutions.$matchHead                     126.0.5750
DEBUG[1768170679] $substitutions.$basename                      Opera_126.0.5750.18_Setup_arm64.exe
DEBUG[1768170679] $substitutions.$url                           https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_arm64.exe
DEBUG[1768170679] $substitutions.$match1                        126.0.5750.18
DEBUG[1768170679] $substitutions.$minorVersion                  0
DEBUG[1768170679] $substitutions.$basenameNoExt                 Opera_126.0.5750.18_Setup_arm64
DEBUG[1768170679] $substitutions.$buildVersion                  18
DEBUG[1768170679] $substitutions.$majorVersion                  126
DEBUG[1768170679] $substitutions.$patchVersion                  5750
DEBUG[1768170679] $substitutions.$dashVersion                   126-0-5750-18
DEBUG[1768170679] $substitutions.$preReleaseVersion             126.0.5750.18
DEBUG[1768170679] $substitutions.$version                       126.0.5750.18
DEBUG[1768170679] $substitutions.$dotVersion                    126.0.5750.18
DEBUG[1768170679] $hashfile_url = https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_arm64.exe.sha256sum -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Opera_126.0.5750.18_Setup_arm64.exe in https://get.geo.opera.com/pub/opera/desktop/126.0.5750.18/win/Opera_126.0.5750.18_Setup_arm64.exe.sha256sum
DEBUG[1768170680] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: a12a44911f5ad97ff12aa3349bb3cdc4acd972041363229f22b93fb41d181351 using Extract Mode
Writing updated opera manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/opera --arch arm64
Installing 'opera' (126.0.5750.18) [arm64] from 'Unofficial' bucket
Loading Opera_126.0.5750.18_Setup_arm64.exe from cache.
Checking hash of Opera_126.0.5750.18_Setup_arm64.exe ... ok.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\opera\current => D:\Software\Scoop\Local\apps\opera\126.0.5750.18
Creating shortcut for Opera (opera.exe)
Persisting profile
'opera' (126.0.5750.18) was installed successfully!
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support, enabling Opera installations on ARM64-compatible systems with corresponding ARM64-specific installer files and updates

* **Bug Fixes**
  * Corrected homepage URL configuration by removing extraneous trailing slashes from manifest values
  * Updated and consolidated installer and autoupdate URL handling to improve consistency, reliability, and version parsing
  * Enhanced installation script file processing operations with improved cleanup and destination path handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->