### PR TITLE
raspberry-pi-imager: Update telemetry opt-out registry path

### DIFF
--- a/bucket/raspberry-pi-imager.json
+++ b/bucket/raspberry-pi-imager.json
@@ -3,7 +3,10 @@
     "description": "Tool for writing an Raspberry Pi OS images to SD cards.",
     "homepage": "https://www.raspberrypi.org/software",
     "license": "Apache-2.0",
-    "notes": "To opt out of telemetry, run: Set-ItemProperty 'HKCU:/Software/Raspberry Pi/Raspberry Pi Imager' telemetry false",
+    "notes": [
+        "To opt out of telemetry, run:",
+        "Set-ItemProperty 'HKCU:/Software/Raspberry Pi/Raspberry Pi Imager' telemetry false"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/raspberrypi/rpi-imager/releases/download/v2.0.3/imager-v2.0.3.exe",


### PR DESCRIPTION
## Summary
Update the telemetry opt-out instructions for Raspberry Pi Imager to reflect the new registry structure. The previous registry path is no longer valid in latest version.

## Changes Made
- Updated the registry path in the `notes` field from `HKCU:/Software/Raspberry Pi/Imager` to `HKCU:/Software/Raspberry Pi/Raspberry Pi Imager`

## Testing
Verified on Windows 11 with Raspberry Pi Imager v2.0.3 that the new registry path exists and the telemetry setting works as expected.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry opt-out instructions: now presented as a two-line command, with a corrected Windows registry path and a clearer boolean value ("false") for the telemetry setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->