### PR TITLE
opencode-desktop: Add version 1.1.25

### DIFF
--- a/bucket/opencode-desktop.json
+++ b/bucket/opencode-desktop.json
@@ -9,8 +9,13 @@
             "hash": "2b4b80e8e0587a24faaa532ff6c6f9cdd4fbd860b6caf349f85acdcc5641d236"
         }
     },
-    "pre_install": "if (Test-Path \"$dir\\`$PLUGINSDIR\") { Remove-Item -Recurse -Force \"$dir\\`$PLUGINSDIR\" }",
-    "bin": "opencode-cli.exe",
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse -ErrorAction Ignore",
+    "bin": [
+        [
+            "opencode-cli.exe",
+            "opencode"
+        ]
+    ],
     "shortcuts": [
         [
             "OpenCode.exe",


### PR DESCRIPTION
This is Desktop version includes bin file `opencode-cli.exe`.

The CLI version will be in Main bucket.

<img width="623" height="156" alt="image" src="https://github.com/user-attachments/assets/87aa4e7a-430f-4039-9072-cd6b1ad58bf2" />

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows 64-bit package manifest for OpenCode Desktop, enabling automated updates, version checks, and Start Menu shortcut integration.
* **Chores**
  * Pre-install cleanup of legacy plugin data to ensure clean upgrades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->