### PR TITLE
pritunl-client: Update to version 1.3.4466.51 and refactor manifest

### DIFF
--- a/bucket/pritunl-client.json
+++ b/bucket/pritunl-client.json
@@ -1,33 +1,102 @@
 {
     "version": "1.3.4466.51",
-    "description": "OpenVPN Client",
+    "description": "A free and open source cross platform OpenVPN client.",
     "homepage": "https://client.pritunl.com",
     "license": {
         "identifier": "Freeware",
-        "url": "https://github.com/pritunl/pritunl-client-electron/blob/master/LICENSE"
+        "url": "https://github.com/pritunl/pritunl-client-electron/blob/HEAD/LICENSE"
     },
+    "suggest": {
+        "Microsoft Visual C++ 2015-2022 Redistributable": "extras/vcredist2022"
+    },
+    "url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4466.51/Pritunl.exe#/dl.exe",
+    "hash": "sha512:704afa0da898efc80aa9897b2cd0d5df8e4732382e0ee5d31461c3d3b80abb68a05a3c6f155039af264619e8a85014c60421400cd75d3d7db512e19040b74f40",
+    "innosetup": true,
     "architecture": {
         "64bit": {
-            "url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4466.51/Pritunl.exe#/dl.exe",
-            "hash": "d6b43bf1832d2f2f3f44d7942bb9d6a6c32f17ec4acc711a2458daa8db7cda8b"
+            "installer": {
+                "script": [
+                    "Get-ChildItem -Path $dir -Include '*,2*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue",
+                    "Get-ChildItem -Path $dir -Include '*,1*' -Recurse -File | Rename-Item -NewName { $_.Name -replace ',\\d', '' }"
+                ]
+            }
+        },
+        "arm64": {
+            "installer": {
+                "script": [
+                    "Get-ChildItem -Path $dir -Include '*,1*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue",
+                    "Get-ChildItem -Path $dir -Include '*,2*' -Recurse -File | Rename-Item -NewName { $_.Name -replace ',\\d', '' }"
+                ]
+            }
         }
     },
-    "innosetup": true,
-    "pre_install": "if (-not (is_admin)) { error 'This package requires admin privileges to install'; break }",
-    "post_install": "Invoke-ExternalCommand \"$dir\\post_install.exe\" -RunAs | Out-Null",
-    "uninstaller": {
-        "script": [
-            "if (-not (is_admin)) { error 'This package requires admin privileges to uninstall'; break }",
-            "Invoke-ExternalCommand \"$dir\\pre_uninstall.exe\" -RunAs | Out-Null",
-            "Remove-Item 'C:\\ProgramData\\Pritunl' -Recurse -Force"
-        ]
-    },
+    "pre_install": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+    "post_install": [
+        "$service_name = 'pritunl'",
+        "$path_regex = [regex]::Escape((Split-Path -Path $dir -Parent))",
+        "Start-Service -Name $service_name -ErrorAction SilentlyContinue",
+        "if ($PSVersionTable.PSVersion -ge [version]::new(6, 0)) {",
+        "    $services = Get-Service -Name $service_name -ErrorAction SilentlyContinue",
+        "} else {",
+        "    $name_filter = \"Name = '$service_name'\"",
+        "    $services = Get-CimInstance -ClassName Win32_Service -Filter $name_filter -ErrorAction SilentlyContinue |",
+        "            Select-Object -Property *, @{ Name = 'BinaryPathName'; Expression = { $_.PathName } }",
+        "}",
+        "$service = $services | Where-Object { $_.BinaryPathName -match $path_regex }",
+        "if ($service -and @($service.Status, $service.State) -contains 'Running') { return }",
+        "if ($service) { abort \"`n[ERROR]  Service '$service_name' exists but failed to start. Installation terminated.\" }",
+        "if ($services) {",
+        "    Write-Host \"`nINFO  Identified a stale or conflicting service instance. Initiating removal...\" -ForegroundColor DarkGray",
+        "    Stop-Service -Name $service_name -Force -ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 1500",
+        "    if ($PSVersionTable.PSVersion -ge [version]::new(6, 0)) {",
+        "        Remove-Service -Name $service_name -ErrorAction SilentlyContinue",
+        "    } else {",
+        "        Start-Process -FilePath 'sc.exe' -ArgumentList @('delete', $service_name) -NoNewWindow -Wait",
+        "    }",
+        "    $timer = [System.Diagnostics.Stopwatch]::StartNew()",
+        "    while ($timer.Elapsed.TotalSeconds -lt 16) {",
+        "        $current_elapsed = $timer.Elapsed.TotalSeconds",
+        "        $percent = [System.Math]::Min(($current_elapsed / 15) * 100, 100)",
+        "        $progress_params = @{",
+        "            Activity = 'Service Management'; PercentComplete = $percent",
+        "            CurrentOperation = \"Elapsed: $current_elapsed s / Timeout: 15 s\"",
+        "            Status = \"Waiting for '$service_name' to be fully de-registered...\"",
+        "        }",
+        "        $check = Get-Service -Name $service_name -ErrorAction SilentlyContinue",
+        "        if ($null -eq $check) {",
+        "            $progress_params['Status'] = 'Service successfully uninstalled.'",
+        "            $progress_params['PercentComplete'] = 100",
+        "            $progress_params['Completed'] = $true",
+        "            Write-Progress @progress_params",
+        "            break",
+        "        }",
+        "        Write-Progress @progress_params",
+        "        Start-Sleep -Milliseconds 2500",
+        "    }",
+        "    $timer.Stop()",
+        "    abort 'Please reboot your computer to complete the uninstallation, then try again.'",
+        "}",
+        "$service_config = @{",
+        "    Name = $service_name",
+        "    BinaryPathName = \"`\"$dir\\pritunl-service.exe`\"\"",
+        "    DisplayName = 'Pritunl Client Helper Service'",
+        "    Description = 'Provides core helper functions for the Pritunl VPN client. Disabling this service will prevent the Pritunl client from functioning correctly.'",
+        "    StartupType = 'Automatic'",
+        "}",
+        "New-Service @service_config | Out-Null",
+        "$failure_actions = [byte[]](",
+        "    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,",
+        "    0x14, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xb8, 0x0b, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,",
+        "    0x88, 0x13, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x88, 0x13, 0x00, 0x00",
+        ")",
+        "$registry_path = \"HKLM:\\SYSTEM\\CurrentControlSet\\Services\\$service_name\"",
+        "Set-ItemProperty -Path $registry_path -Name 'FailureActions' -Value $failure_actions",
+        "Set-ItemProperty -Path $registry_path -Name 'FailureActionsOnNonCrashFailures' -Value 1",
+        "Start-Service -Name $service_name -ErrorAction SilentlyContinue"
+    ],
     "bin": [
-        [
-            "pritunl.exe",
-            "pritunl",
-            "--no-main"
-        ]
+        "pritunl.exe",
+        "pritunl-client.exe"
     ],
     "shortcuts": [
         [
@@ -35,16 +104,28 @@
             "Pritunl"
         ]
     ],
-    "checkver": "([\\d.]+)/Pritunl.exe",
+    "pre_uninstall": "if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+    "uninstaller": {
+        "script": [
+            "Stop-Service -Name 'pritunl' -Force -ErrorAction SilentlyContinue",
+            "Stop-Process -Name 'pritunl', 'pritunl-service' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500",
+            "if ($cmd -ne 'uninstall') { return }",
+            "if ($PSVersionTable.PSVersion -lt [Version]::new(6, 0)) {",
+            "    Start-Process -FilePath 'sc.exe' -ArgumentList @('delete', 'pritunl') -NoNewWindow -Wait",
+            "} else {",
+            "    Remove-Service -Name 'pritunl' -ErrorAction SilentlyContinue",
+            "}"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/pritunl/pritunl-client-electron"
+    },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/pritunl/pritunl-client-electron/releases/download/$version/Pritunl.exe#/dl.exe",
-                "hash": {
-                    "url": "https://raw.githubusercontent.com/pritunl/pritunl-client-electron/master/SHA256",
-                    "regex": "$version[\\r\\n]+$sha256.*?$basename"
-                }
-            }
+        "url": "https://github.com/pritunl/pritunl-client-electron/releases/download/$version/Pritunl.exe#/dl.exe",
+        "hash": {
+            "url": "https://raw.githubusercontent.com/pritunl/pritunl-client-electron/HEAD/SHA512",
+            "regex": "(?s)$version.+?$sha512.+?$basename"
         }
     }
 }


### PR DESCRIPTION
### Summary

Updates `pritunl-client` to version **1.3.4466.51**, refines service installation logic, and adds ARM64 support through post-extraction file management.

### Related issues or pull requests

- Relates to #2055 
- Closes #15194 

### Changes

- **Update version to 1.3.4466.51** and switch to SHA512 hashing.
- **Support multiple architectures** by adding platform-specific extraction scripts for **64bit** and **ARM64**.
- **Refactor service management** by replacing `post_install.exe` with native PowerShell service creation and hardening.
- **Improve uninstallation reliability** by using `Remove-Service` (PS 6.0+) and adding explicit process termination.
- **Modernize pre-install/uninstall checks** by using `abort` for better integration with Scoop's error handling.
- **Update checkver and autoupdate** to use the GitHub API and structured regex for SHA512.
- **Enhance manifest metadata**:
    - Update description and license URL (use `HEAD` instead of `master`).
    - Add `suggest` field for **Microsoft Visual C++ 2015-2022 Redistributable**.
    - Simplify `bin` entries.

### Notes

- The files containing `,1` are for the 64-bit architecture, while those with `,2` are for the ARM64 architecture.
- If profiles on Windows fail to start and a network adapter error is shown use follow the [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=52685) instructions to manually install the required Windows libraries.
  - See: [Windows Connection Error](https://docs.pritunl.com/kb/vpn/debugging/client#windows-connection-error)
- **Regarding `bin` field changes**:
  - The previous manifest included `pritunl.exe` with a `--no-main` flag (added in #2055). However, [official documentation](https://docs.pritunl.com/kb/vpn) provides no information regarding this parameter, and its original purpose remains unclear.
  - Testing indicates that while `--dev-tools` is a [documented flag](https://docs.pritunl.com/kb/vpn/debugging/client#developer-tools), the "Developer Tools" option appears in the UI menu regardless of whether the flag is passed, making it difficult to verify if `pritunl.exe` correctly accepts CLI arguments.
  - `pritunl-client.exe` has been confirmed to accept command-line arguments and is now included in the `bin` field for better accessibility.

    ```powershell
    ┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
    └─> pritunl-client --help
    Pritunl Client Command Line Tool

    Usage:
      pritunl-client [flags]
      pritunl-client [command]

    Available Commands:
      add         Add profile
      completion  Generate the autocompletion script for the specified shell
      disable     Disable autostart for profile
      enable      Enable autostart for profile
      help        Help about any command
      list        List profiles
      logs        Show logs for profile
      remove      Remove profile
      start       Start profile
      stop        Stop profile
      version     Show version
      watch       Watch profiles

    Flags:
      -h, --help   help for pritunl-client

    Use "pritunl-client [command] --help" for more information about a command.
    ```

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App pritunl-client -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
pritunl-client: 1.3.4466.51 (scoop version is 1.3.4466.51)
Forcing autoupdate!
Autoupdating pritunl-client
DEBUG[1768293567] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1768293567] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1768293567] $substitutions.$preReleaseVersion             1.3.4466.51
DEBUG[1768293567] $substitutions.$cleanVersion                  13446651
DEBUG[1768293567] $substitutions.$patchVersion                  4466
DEBUG[1768293567] $substitutions.$baseurl                       https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4466.51
DEBUG[1768293567] $substitutions.$basenameNoExt                 Pritunl
DEBUG[1768293567] $substitutions.$urlNoExt                      https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4466.51/Pritunl
DEBUG[1768293567] $substitutions.$url                           https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4466.51/Pritunl.exe
DEBUG[1768293567] $substitutions.$minorVersion                  3
DEBUG[1768293567] $substitutions.$buildVersion                  51
DEBUG[1768293567] $substitutions.$version                       1.3.4466.51
DEBUG[1768293567] $substitutions.$dashVersion                   1-3-4466-51
DEBUG[1768293567] $substitutions.$dotVersion                    1.3.4466.51
DEBUG[1768293567] $substitutions.$match1                        1.3.4466.51
DEBUG[1768293567] $substitutions.$underscoreVersion             1_3_4466_51
DEBUG[1768293567] $substitutions.$basename                      Pritunl.exe
DEBUG[1768293567] $substitutions.$matchHead                     1.3.4466
DEBUG[1768293567] $substitutions.$matchTail                     .51
DEBUG[1768293567] $substitutions.$majorVersion                  1
DEBUG[1768293567] $hashfile_url = https://raw.githubusercontent.com/pritunl/pritunl-client-electron/HEAD/SHA512 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Pritunl.exe in https://raw.githubusercontent.com/pritunl/pritunl-client-electron/HEAD/SHA512
DEBUG[1768293568] $regex = (?s)1\.3\.4466\.51.+?([a-fA-F0-9]{128}).+?Pritunl\.exe -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: sha512:704afa0da898efc80aa9897b2cd0d5df8e4732382e0ee5d31461c3d3b80abb68a05a3c6f155039af264619e8a85014c60421400cd75d3d7db512e19040b74f40 using Extract Mode
Writing updated pritunl-client manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> $PSVersionTable.PSVersion.Major
5

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-Service -Name 'pritunl'
Get-Service: Cannot find any service with service name 'pritunl'.

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/pritunl-client
Installing 'pritunl-client' (1.3.4466.51) [64bit] from 'Unofficial' bucket
Loading Pritunl.exe from cache.
Checking hash of Pritunl.exe ... ok.
Extracting Pritunl.exe ... done.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\pritunl-client\current => D:\Software\Scoop\Local\apps\pritunl-client\1.3.4466.51
Creating shim for 'pritunl'.
Making D:\Software\Scoop\Local\shims\pritunl.exe a GUI binary.
Creating shim for 'pritunl-client'.
Creating shortcut for Pritunl (pritunl.exe)
Running post_install script...done.
'pritunl-client' (1.3.4466.51) was installed successfully!
'pritunl-client' suggests installing 'extras/vcredist2022'.

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-Service -Name 'pritunl'

Status   Name               DisplayName
------   ----               -----------
Running  pritunl            Pritunl Client Helper Service


┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop config ignore_running_processes $true
'ignore_running_processes' has been set to 'True'

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop update pritunl-client -f
pritunl-client: 1.3.4466.51 -> 1.3.4466.51
Updating one outdated app:
Updating 'pritunl-client' (1.3.4466.51 -> 1.3.4466.51)
WARN  The following instances of "pritunl-client" are still running. Scoop is configured to ignore this condition.

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    319      17    13200      44136       0.13   1852   1 pritunl
    484      22    35952      74152       0.42  20732   1 pritunl
    780      38   252184     276556       1.20  20924   1 pritunl
    348      15    18980      21356       0.31   8228   0 pritunl-service

Downloading new version
Loading Pritunl.exe from cache.
Checking hash of Pritunl.exe ... ok.
Running pre_uninstall script...done.
Uninstalling 'pritunl-client' (1.3.4466.51)
Running uninstaller script...done.
Removing shim 'pritunl.shim'.
Removing shim 'pritunl.exe'.
Removing shim 'pritunl-client.shim'.
Removing shim 'pritunl-client.exe'.
Unlinking D:\Software\Scoop\Local\apps\pritunl-client\current
Installing 'pritunl-client' (1.3.4466.51) [64bit] from 'Unofficial' bucket
Loading Pritunl.exe from cache.
Extracting Pritunl.exe ... done.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\pritunl-client\current => D:\Software\Scoop\Local\apps\pritunl-client\1.3.4466.51
Creating shim for 'pritunl'.
Making D:\Software\Scoop\Local\shims\pritunl.exe a GUI binary.
Creating shim for 'pritunl-client'.
Creating shortcut for Pritunl (pritunl.exe)
Running post_install script...done.
'pritunl-client' (1.3.4466.51) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop uninstall pritunl-client -p
Uninstalling 'pritunl-client' (1.3.4466.51).
Running pre_uninstall script...done.
WARN  The following instances of "pritunl-client" are still running. Scoop is configured to ignore this condition.

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    787      39   253044     278428       2.25  19324   1 pritunl
    655      22    53180      97288       1.73  20924   1 pritunl
    319      17    13344      44048       0.14  21464   1 pritunl
    356      17    21668      23952       0.28  16232   0 pritunl-service

Running uninstaller script...[SC] DeleteService SUCCESS
done.
Removing shim 'pritunl.shim'.
Removing shim 'pritunl.exe'.
Removing shim 'pritunl-client.shim'.
Removing shim 'pritunl-client.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Pritunl.lnk
Unlinking D:\Software\Scoop\Local\apps\pritunl-client\current
Removing older version (_1.3.4466.51.old).
Removing persisted data.
'pritunl-client' was uninstalled.

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-Service -Name 'pritunl'
Get-Service: Cannot find any service with service name 'pritunl'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scripted installers for 64-bit and ARM64 with multi-step post-install service setup and a scripted uninstaller/pre-uninstall flow.
  * Centralized auto-update using GitHub HEAD SHA512 lookup; new update metadata fields (suggest, url, hash).

* **Bug Fixes**
  * Clearer pre-install admin messaging and more robust, platform-aware uninstall/cleanup.

* **Chores**
  * Version bumped to 1.3.4466.51; description, license reference, binaries, and installer metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->