### PR TITLE
librewolf: Update to version 147.0-1, switch to Codeberg releases, remove 32-bit version

### DIFF
--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -1,19 +1,15 @@
 {
-    "version": "146.0.1-1",
+    "version": "147.0-1",
     "description": "A fork of Firefox, focused on privacy, security and freedom.",
     "homepage": "https://librewolf.net/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/146.0.1-1/librewolf-146.0.1-1-windows-x86_64-portable.zip",
-            "hash": "f251cfb6a80bc4d5128ace2dcb2582dca0f7e993ca1ea5a23727649910d5dca0"
-        },
-        "32bit": {
-            "url": "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/146.0.1-1/librewolf-146.0.1-1-windows-i686-portable.zip",
-            "hash": "4e373cb643e739e220fc99f06f1a2bc29a0477c6d9dccf71d94fca26a80d5c14"
+            "url": "https://codeberg.org/api/packages/librewolf/generic/librewolf/147.0-1/librewolf-147.0-1-windows-x86_64-portable.zip",
+            "hash": "1dff1c5828abc144def4b1c1fc598e8b6cd427f34055acb3db6e9f64377712d0"
         }
     },
-    "extract_dir": "librewolf-146.0.1-1",
+    "extract_dir": "librewolf-147.0-1",
     "pre_install": [
         "'LibreWolf-WinUpdater.exe', 'ScheduledTask-Create.ps1', 'ScheduledTask-Remove.ps1' | ForEach-Object { \"$dir/$_\" } | Remove-Item",
         "",
@@ -47,16 +43,13 @@
         "Copy-Item \"$dir/LibreWolf/*.js\", \"$dir/LibreWolf/*.cfg\" \"$persist_dir/LibreWolf\" -Exclude librewolf.cfg"
     ],
     "checkver": {
-        "url": "https://gitlab.com/api/v4/projects/44042130/releases/permalink/latest",
+        "url": "https://codeberg.org/api/v1/repos/librewolf/bsys6/releases/latest",
         "jsonpath": "$.tag_name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/$version/librewolf-$version-windows-x86_64-portable.zip"
-            },
-            "32bit": {
-                "url": "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/$version/librewolf-$version-windows-i686-portable.zip"
+                "url": "https://codeberg.org/api/packages/librewolf/generic/librewolf/$version/librewolf-$version-windows-x86_64-portable.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- LibreWolf now uses Codeberg's CI instead of GitLab's: https://codeberg.org/librewolf
- The 32-bit version will not be built anymore: https://codeberg.org/librewolf/bsys6/commit/c0a4d71b51a0862ae23995d0d367ad27cb18ae3c

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 147.0-1
  * Removed 32-bit architecture support
  * Package source location and configuration updated

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->