### PR TITLE
mu-editor@1.2.0: Improve shortcut

### DIFF
--- a/bucket/mu-editor.json
+++ b/bucket/mu-editor.json
@@ -19,9 +19,9 @@
     "extract_dir": "Mu Editor",
     "shortcuts": [
         [
-            "Mu Editor.vbs",
+            "Python\\pythonw.exe",
             "Mu Editor",
-            "",
+            "-I -m mu",
             "icon.ico"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- The Start Menu Shortcut that is created when installing the `mu-editor` manifest points to a VBS script that is set up to run a python command
- By changing it to run this command directly (like the shortcut created when running the MSI installer), we can improve startup times by bypassing the script entirely, and make the install less dependent on `.vbs` file associations.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Closes #17002


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mu Editor launcher configuration to execute through Python directly with optimized parameters, replacing the previous batch file approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->