### PR TITLE
mobaxterm: Fix persistence

### DIFF
--- a/bucket/mobaxterm.json
+++ b/bucket/mobaxterm.json
@@ -1,7 +1,7 @@
 {
     "version": "25.4",
     "description": "Enhanced terminal for Windows with X11 server, tabbed SSH client, network tools and much more.",
-    "homepage": "https://mobaxterm.mobatek.net/",
+    "homepage": "https://mobaxterm.mobatek.net",
     "license": {
         "identifier": "Freeware",
         "url": "https://mobaxterm.mobatek.net/license.html"
@@ -9,40 +9,46 @@
     "url": "https://download.mobatek.net/2542025111600034/MobaXterm_Portable_v25.4.zip",
     "hash": "d4c4bea83c5a17b574c3f067fe4b02fe33f57f30d50f01f26a23cb8b7212f822",
     "pre_install": [
-        "    # Rename executable",
-        "Get-ChildItem \"$dir\" 'mobaxterm*.exe' | Select-Object -First 1 | Rename-Item -NewName 'MobaXterm.exe'",
-        "    # Create files for persisting",
-        "function PersistsFile([String] $file) {",
-        "    if (!(Test-Path \"$persist_dir\\$file\")) {",
-        "        New-Item \"$dir\\$file\" -Type File | Out-Null",
+        "Get-ChildItem -Path $dir -Filter 'MobaXterm*.exe' -File | Select-Object -First 1 | Rename-Item -NewName 'MobaXterm.exe'",
+        "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "'*.mxt3', '*.mxtpro', 'MobaXterm.ini', 'MobaXterm backup.zip' | ForEach-Object {",
+        "    if (Test-Path -Path \"$persist_dir\\$_\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination $dir -Force",
+        "        return",
         "    }",
-        "}",
-        "@('MobaXterm backup.zip', 'MobaXterm.ini') | ForEach-Object { PersistsFile $_ }"
-    ],
-    "pre_uninstall": [
-        "function UpdatesFile([string] $file) {",
-        "    if ((Get-ChildItem \"$dir\\$file\").LastWriteTime -gt (Get-ChildItem \"$persist_dir\\$file\").LastWriteTime) {",
-        "        [System.IO.File]::WriteAllBytes(\"$persist_dir\\$file\", [System.IO.File]::ReadAllBytes(\"$dir\\$file\"))",
+        "    if ($_ -eq 'MobaXterm.ini') {",
+        "        $cfg = @('[Misc]', 'HomeDir=_MobaFolder_\\home', 'SlashDir=_MobaFolder_\\slash')",
+        "        Set-Content -Path \"$dir\\MobaXterm.ini\" -Value $cfg -Encoding ascii",
         "    }",
-        "}",
-        "@('MobaXterm backup.zip', 'MobaXterm.ini') | ForEach-Object { UpdatesFile $_ }"
+        "}"
     ],
     "bin": "MobaXterm.exe",
     "shortcuts": [
         [
             "MobaXterm.exe",
-            "MobaXterm Personal"
+            "MobaXterm"
         ]
     ],
     "persist": [
-        "MobaXterm.ini",
-        "MobaXterm backup.zip"
+        "home",
+        "slash"
+    ],
+    "pre_uninstall": [
+        "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "'*.mxt3', '*.mxtpro', 'MobaXterm.ini', 'MobaXterm backup.zip' | ForEach-Object {",
+        "    if (Test-Path -Path \"$dir\\$_\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$dir\\$_\" -Destination $persist_dir -Force",
+        "    }",
+        "}",
+        "# Ensure background X server process is terminated to prevent resource lock.",
+        "Stop-Process -Name 'XWin_MobaX' -Force -ErrorAction SilentlyContinue",
+        "Start-Sleep -Milliseconds 1500"
     ],
     "checkver": {
         "url": "https://mobaxterm.mobatek.net/download-home-edition.html",
-        "regex": "//download.mobatek.net/(?<random>[\\d]+)/MobaXterm_Portable_v([\\d.]+)\\.zip"
+        "regex": "mobatek.net/(?<build>[^/]+)/MobaXterm_Portable_v([\\d.]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://download.mobatek.net/$matchRandom/MobaXterm_Portable_v$version.zip"
+        "url": "https://download.mobatek.net/$matchBuild/MobaXterm_Portable_v$version.zip"
     }
 }


### PR DESCRIPTION
### Summary

Refactors the `mobaxterm` manifest to handle its unique file-writing behavior, ensures proper initialization of portable paths, and improves the version detection logic.

### Related issues or pull requests

- Closes #4207 
- Closes #13960 

### Changes

- **Refactor persistence logic**: Replace the standard `persist` field with manual `Copy-Item` in `pre_install` and `pre_uninstall` to accommodate the application overwriting its configuration files.
- **Initialize configuration**: Generate a default `MobaXterm.ini` with `_MobaFolder_` relative paths during the first install to ensure portability for `home` and `slash` directories.
- **Enhance uninstallation reliability**: Implement explicit termination of the `XWin_MobaX` (X server) process and add a delay to ensure resource handles are released.
- **Support additional files**: Add support for persisting `*.mxt3`, `*.mxtpro`, and backup files.

### Notes

- In order to install these plugins, just download them and put them in the same directory than MobaXterm executable.
  - See: https://mobaxterm.mobatek.net/plugins.html
- **Reason for `MobaXterm.ini` initialization**: 
  - If `HomeDir` and `SlashDir` are not explicitly defined, the portable version defaults to storing session data and home directory files in the system temporary folder (`$env:TEMP`). 
  - These temporary files are automatically purged when the MobaXterm process terminates, which prevents the use of plugins. 
  - Initializing the `.ini` with `_MobaFolder_` relative paths ensures that data is stored within the `$dir` directory and persists across sessions.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App mobaxterm -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
mobaxterm: 25.4 (scoop version is 25.4)
Forcing autoupdate!
Autoupdating mobaxterm
DEBUG[1768429364] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1768429364] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1768429364] $substitutions.$matchTail
DEBUG[1768429364] $substitutions.$dashVersion                   25-4
DEBUG[1768429364] $substitutions.$version                       25.4
DEBUG[1768429364] $substitutions.$minorVersion                  4
DEBUG[1768429364] $substitutions.$cleanVersion                  254
DEBUG[1768429364] $substitutions.$url                           https://download.mobatek.net/2542025111600034/MobaXterm_Portable_v25.4.zip
DEBUG[1768429364] $substitutions.$matchBuild                    2542025111600034
DEBUG[1768429364] $substitutions.$baseurl                       https://download.mobatek.net/2542025111600034
DEBUG[1768429364] $substitutions.$matchHead                     25.4
DEBUG[1768429364] $substitutions.$majorVersion                  25
DEBUG[1768429364] $substitutions.$match1                        25.4
DEBUG[1768429364] $substitutions.$basenameNoExt                 MobaXterm_Portable_v25.4
DEBUG[1768429364] $substitutions.$urlNoExt                      https://download.mobatek.net/2542025111600034/MobaXterm_Portable_v25.4
DEBUG[1768429364] $substitutions.$underscoreVersion             25_4
DEBUG[1768429364] $substitutions.$patchVersion
DEBUG[1768429364] $substitutions.$preReleaseVersion             25.4
DEBUG[1768429364] $substitutions.$dotVersion                    25.4
DEBUG[1768429364] $substitutions.$basename                      MobaXterm_Portable_v25.4.zip
DEBUG[1768429364] $substitutions.$buildVersion
DEBUG[1768429364] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading MobaXterm_Portable_v25.4.zip to compute hashes!
Loading MobaXterm_Portable_v25.4.zip from cache
Computed hash: d4c4bea83c5a17b574c3f067fe4b02fe33f57f30d50f01f26a23cb8b7212f822
Writing updated mobaxterm manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/mobaxterm
Installing 'mobaxterm' (25.4) [64bit] from 'Unofficial' bucket
Loading MobaXterm_Portable_v25.4.zip from cache.
Checking hash of MobaXterm_Portable_v25.4.zip ... ok.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\mobaxterm\current => D:\Software\Scoop\Local\apps\mobaxterm\25.4
Creating shim for 'MobaXterm'.
Making D:\Software\Scoop\Local\shims\mobaxterm.exe a GUI binary.
Creating shortcut for MobaXterm (MobaXterm.exe)
Persisting home
Persisting slash
'mobaxterm' (25.4) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Local\apps\mobaxterm\current\*' -Exclude '*.exe', '*.json' -File

        Directory: D:\Software\Scoop\Local\apps\mobaxterm\current

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-----          2025/3/2     19:59       19098964   CygUtils.plugin
-----          2025/3/2     19:59       12634682   CygUtils64.plugin
-a---         2026/1/15     14:32             64   MobaXterm.ini

# After using `MobaXterm` as normal, view the contents of `$dir`
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Local\apps\mobaxterm\current\*' -Exclude '*.exe', '*.json' -File

        Directory: D:\Software\Scoop\Local\apps\mobaxterm\current

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---         2026/1/15     12:58        6978292   Cmake.mxt3
-----          2025/3/2     19:59       19098964   CygUtils.plugin
-----          2025/3/2     19:59       12634682   CygUtils64.plugin
-a---         2026/1/15     12:58       96155351   Emacs.mxt3
-a---         2026/1/15     14:26          55400   MobaXterm.idx
-a---         2026/1/15     14:26           6293   MobaXterm.ini

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop update mobaxterm -f
mobaxterm: 25.4 -> 25.4
Updating one outdated app:
Updating 'mobaxterm' (25.4 -> 25.4)
WARN  The following instances of "mobaxterm" are still running. Scoop is configured to ignore this condition.

 NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     24    17.33      25.53       1.30   20996   1 XWin_MobaX

Downloading new version
Loading MobaXterm_Portable_v25.4.zip from cache.
Checking hash of MobaXterm_Portable_v25.4.zip ... ok.
Running pre_uninstall script...done.
Uninstalling 'mobaxterm' (25.4)
Removing shim 'MobaXterm.shim'.
Removing shim 'MobaXterm.exe'.
Unlinking D:\Software\Scoop\Local\apps\mobaxterm\current
Installing 'mobaxterm' (25.4) [64bit] from 'Unofficial' bucket
Loading MobaXterm_Portable_v25.4.zip from cache.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\mobaxterm\current => D:\Software\Scoop\Local\apps\mobaxterm\25.4
Creating shim for 'MobaXterm'.
Making D:\Software\Scoop\Local\shims\mobaxterm.exe a GUI binary.
Creating shortcut for MobaXterm (MobaXterm.exe)
Persisting home
Persisting slash
'mobaxterm' (25.4) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Local\apps\mobaxterm\current\*' -Exclude '*.exe', '*.json' -File

        Directory: D:\Software\Scoop\Local\apps\mobaxterm\current

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---         2026/1/15     12:58        6978292   Cmake.mxt3
-----          2025/3/2     19:59       19098964   CygUtils.plugin
-----          2025/3/2     19:59       12634682   CygUtils64.plugin
-a---         2026/1/15     12:58       96155351   Emacs.mxt3
-a---         2026/1/15     14:26           6293   MobaXterm.ini

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop uninstall mobaxterm
Uninstalling 'mobaxterm' (25.4).
Running pre_uninstall script...done.
Removing shim 'MobaXterm.shim'.
Removing shim 'MobaXterm.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\MobaXterm.lnk
Unlinking D:\Software\Scoop\Local\apps\mobaxterm\current
Removing older version (_25.4.old).
'mobaxterm' was uninstalled.

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/mobaxterm
Installing 'mobaxterm' (25.4) [64bit] from 'Unofficial' bucket
Loading MobaXterm_Portable_v25.4.zip from cache.
Checking hash of MobaXterm_Portable_v25.4.zip ... ok.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\mobaxterm\current => D:\Software\Scoop\Local\apps\mobaxterm\25.4
Creating shim for 'MobaXterm'.
Making D:\Software\Scoop\Local\shims\mobaxterm.exe a GUI binary.
Creating shortcut for MobaXterm (MobaXterm.exe)
Persisting home
Persisting slash
'mobaxterm' (25.4) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Local\apps\mobaxterm\current\*' -Exclude '*.exe', '*.json' -File

        Directory: D:\Software\Scoop\Local\apps\mobaxterm\current

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---         2026/1/15     12:58        6978292   Cmake.mxt3
-----          2025/3/2     19:59       19098964   CygUtils.plugin
-----          2025/3/2     19:59       12634682   CygUtils64.plugin
-a---         2026/1/15     12:58       96155351   Emacs.mxt3
-a---         2026/1/15     14:26           6293   MobaXterm.ini

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop uninstall mobaxterm -p
Uninstalling 'mobaxterm' (25.4).
Running pre_uninstall script...done.
Removing shim 'MobaXterm.shim'.
Removing shim 'MobaXterm.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\MobaXterm.lnk
Unlinking D:\Software\Scoop\Local\apps\mobaxterm\current
Removing persisted data.
'mobaxterm' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation and uninstallation procedures for improved handling
  * Modified application shortcut label for consistency
  * Adjusted file persistence configuration
  * Enhanced version detection and update mechanism

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->