### PR TITLE
hwinfo: Update to version 8.40-5900, fix download & autoupdate URLs

### DIFF
--- a/bucket/hwinfo.json
+++ b/bucket/hwinfo.json
@@ -1,41 +1,42 @@
 {
-    "version": "8.34-5870",
-    "description": "Comprehensive Hardware Analysis, Monitoring and Reporting for Windows and DOS",
-    "homepage": "https://www.hwinfo.com/",
+    "version": "8.40-5900",
+    "description": "Comprehensive Hardware Analysis, Monitoring and Reporting for Windows and DOS.",
+    "homepage": "https://www.hwinfo.com",
     "license": {
         "identifier": "Freeware",
-        "url": "https://www.hwinfo.com/licenses"
+        "url": "https://www.hwinfo.com/licenses/"
     },
-    "url": "https://downloads.sourceforge.net/project/hwinfo/Windows_Portable/hwi_834.zip",
-    "hash": "sha1:56336618ff7766e38e9afa79fe2b31ef41522eea",
+    "url": "https://www.sac.sk/download/utildiag/hwi_840.zip",
+    "hash": "c06212d303dfe49f454620321e0ae54eea2557b78a2515aa940a51d67365863c",
     "architecture": {
         "64bit": {
             "pre_install": [
-                "Get-ChildItem -Path $dir -Include '*32*', '*ARM*' -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue",
-                "Get-ChildItem -Path \"$dir\\*64*\" -Recurse | Rename-Item -NewName { $_.FullName -replace '\\d{2}\\.', '.' }"
+                "Get-ChildItem -Path $dir -Include '*32*', '*ARM*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue",
+                "Get-ChildItem -Path $dir -Include '*64*' -Recurse -File | Rename-Item -NewName { $_.Name -replace '\\d{2}(?=\\.exe)', '' }"
             ]
         },
         "32bit": {
             "pre_install": [
-                "Get-ChildItem -Path \"$dir\\*32*\" -Recurse | Rename-Item -NewName { $_.FullName -replace '\\d{2}\\.', '.' }",
-                "Get-ChildItem -Path $dir -Include '*64*' -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue"
+                "Get-ChildItem -Path $dir -Include '*64*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue",
+                "Get-ChildItem -Path $dir -Include '*32*' -Recurse -File | Rename-Item -NewName { $_.Name -replace '\\d{2}(?=\\.exe)', '' }"
             ]
         },
         "arm64": {
             "pre_install": [
-                "Get-ChildItem -Path \"$dir\\*ARM*\" -Recurse | Rename-Item -NewName { $_.FullName -replace '_.+\\.', '.' }",
-                "Get-ChildItem -Path $dir -Include '*32*', '*64*' -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue"
+                "Get-ChildItem -Path $dir -Include '*ARM*' -Recurse -File | Rename-Item -NewName { $_.Name -replace '_.+(?=\\.exe)', '' }",
+                "Get-ChildItem -Path $dir -Include '*32*', '*64*' -Recurse -File | Remove-Item -Force -ErrorAction SilentlyContinue"
             ]
         }
     },
     "installer": {
         "script": [
             "$setting_name = if ($architecture -match '\\d{2}(?=bit)') { 'HWiNFO{0}.INI' -f $matches[0] } else { 'HWiNFO_ARM64.INI' }",
-            "if (-not (Test-Path \"$persist_dir\\$setting_name\")) {",
-            "    Set-Content -Path \"$dir\\$setting_name\" -Value '[Settings]', 'AutoUpdate=0' -Encoding ASCII",
+            "if (-not (Test-Path -Path \"$persist_dir\\$setting_name\" -PathType Leaf)) {",
+            "    $cfg = @('[Settings]', 'AutoUpdate=0', 'AutoUpdateBetaDisable=1')",
+            "    Set-Content -Path \"$dir\\$setting_name\" -Value $cfg -Encoding ascii",
             "}",
-            "persist_data @{ persist = \"$setting_name\" } $original_dir $persist_dir",
-            "Get-ChildItem -Path $persist_dir -File -Include '*64_KEY.txt' -Recurse | Copy-Item -Destination $dir -Force"
+            "persist_data @{ persist = $setting_name } $original_dir $persist_dir",
+            "Get-ChildItem -Path $persist_dir -Include '*64_KEY.txt' -Recurse -File | Copy-Item -Destination $dir -Force"
         ]
     },
     "bin": "HWiNFO.exe",
@@ -46,15 +47,15 @@
         ]
     ],
     "pre_uninstall": [
-        "Get-ChildItem -Path $dir -File -Include '*64_KEY.txt' -Recurse | Copy-Item -Destination $persist_dir -Force",
+        "Get-ChildItem -Path $dir -Include '*64_KEY.txt' -Recurse -File | Copy-Item -Destination $persist_dir -Force",
         "$setting_name = if ($architecture -match '\\d{2}(?=bit)') { 'HWiNFO{0}.INI' -f $matches[0] } else { 'HWiNFO_ARM64.INI' }",
-        "unlink_persist_data @{ persist = \"$setting_name\" } $dir"
+        "unlink_persist_data @{ persist = $setting_name } $dir"
     ],
     "checkver": {
         "url": "https://www.hwinfo.com/ver.txt",
-        "regex": "^([\\d.-]+)"
+        "regex": "([\\d.-]+)"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/hwinfo/Windows_Portable/hwi_$majorVersion$minorVersion.zip"
+        "url": "https://www.sac.sk/download/utildiag/hwi_$majorVersion$minorVersion.zip"
     }
 }


### PR DESCRIPTION
### Summary

Updates `hwinfo` to version **8.40-5900**, migrates the download source for better reliability, and refines the installation scripts for improved maintainability.

### Changes

- **Update version to 8.40-5900** and update SHA256 hash.
- **Normalize metadata**: Refine description, homepage URL, and license field formatting.
- **Switch download source**: Move from SourceForge to `sac.sk` for more direct artifact access.
- **Refine architecture scripts**:
    - Improve `pre_install` regex to more accurately rename executables (e.g., `HWiNFO64.exe`).
    - Explicitly use `-File` flag with `Get-ChildItem` to prevent accidental directory operations

### Notes

- The regex change in executable renaming (`\d{2}(?=\.exe)`) is safer as it specifically targets the bit-architecture suffix while preserving the extension.
- **Reason for switching download source**: 
  - Version **8.40-5900** was released on 2026/01/08, but the SourceForge repository has not been updated since. 
  - Furthermore, the [official HWiNFO download page](https://www.hwinfo.com/download/) has removed SourceForge as a provider. Switching the source back to `sac.sk` ensures reliable access to the latest stable releases.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App hwinfo -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
hwinfo: 8.40-5900 (scoop version is 8.40-5900)
Forcing autoupdate!
Autoupdating hwinfo
DEBUG[1768432164] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1768432164] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1768432164] $substitutions.$matchTail                     -5900
DEBUG[1768432164] $substitutions.$dashVersion                   8-40-5900
DEBUG[1768432164] $substitutions.$version                       8.40-5900
DEBUG[1768432164] $substitutions.$minorVersion                  40
DEBUG[1768432164] $substitutions.$cleanVersion                  8405900
DEBUG[1768432164] $substitutions.$url                           https://www.sac.sk/download/utildiag/hwi_840.zip
DEBUG[1768432164] $substitutions.$baseurl                       https://www.sac.sk/download/utildiag
DEBUG[1768432164] $substitutions.$matchHead                     8.40
DEBUG[1768432164] $substitutions.$majorVersion                  8
DEBUG[1768432164] $substitutions.$match1                        8.40-5900
DEBUG[1768432164] $substitutions.$basenameNoExt                 hwi_840
DEBUG[1768432164] $substitutions.$urlNoExt                      https://www.sac.sk/download/utildiag/hwi_840
DEBUG[1768432164] $substitutions.$underscoreVersion             8_40_5900
DEBUG[1768432164] $substitutions.$patchVersion
DEBUG[1768432164] $substitutions.$preReleaseVersion             5900
DEBUG[1768432164] $substitutions.$dotVersion                    8.40.5900
DEBUG[1768432164] $substitutions.$basename                      hwi_840.zip
DEBUG[1768432164] $substitutions.$buildVersion
DEBUG[1768432164] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading hwi_840.zip to compute hashes!
Loading hwi_840.zip from cache
Computed hash: c06212d303dfe49f454620321e0ae54eea2557b78a2515aa940a51d67365863c
Writing updated hwinfo manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install hwinfo -g
Installing 'hwinfo' (8.40-5900) [64bit] from 'Unofficial' bucket
Loading hwi_840.zip from cache.
Checking hash of hwi_840.zip ... ok.
Extracting hwi_840.zip ... done.
Running pre_install script...done.
Running installer script...Persisting HWiNFO64.INI
done.
Linking D:\Software\Scoop\Global\apps\hwinfo\current => D:\Software\Scoop\Global\apps\hwinfo\8.40-5900
Creating shim for 'HWiNFO'.
Making D:\Software\Scoop\Global\shims\hwinfo.exe a GUI binary.
Creating shortcut for HWiNFO (HWiNFO.exe)
'hwinfo' (8.40-5900) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Global\apps\hwinfo\current\*' -Exclude '*.json' -File

        Directory: D:\Software\Scoop\Global\apps\hwinfo\current

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---          2026/1/8     15:21        9802216 󰣆  HWiNFO.exe
la---         2026/1/15     15:09             51   HWiNFO64.INI

# After using `MobaXterm` as normal, view the contents of `$dir`
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> HWiNFO
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> Get-ChildItem -Path 'D:\Software\Scoop\Global\apps\hwinfo\current\*' -Exclude '*.json' -File

        Directory: D:\Software\Scoop\Global\apps\hwinfo\current

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---          2026/1/8     15:21        9802216 󰣆  HWiNFO.exe
la---         2026/1/15     15:12            120   HWiNFO64.INI

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> $app = 'hwinfo'
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> $persist_file = @('HWiNFO64.INI')
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> $persist_file | ForEach-Object {
     $dir = Invoke-Expression ('scoop prefix {0}' -f $app)
     if (-not (Test-Path -Path $dir)) { return }
     (Get-Item -Path "$dir\$_").LinkType
 }
HardLink

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop uninstall hwinfo -g -p
Uninstalling 'hwinfo' (8.40-5900).
Running pre_uninstall script...done.
Removing shim 'HWiNFO.shim'.
Removing shim 'HWiNFO.exe'.
Removing shortcut C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Scoop Apps\HWiNFO.lnk
Unlinking D:\Software\Scoop\Global\apps\hwinfo\current
Removing persisted data.
'hwinfo' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to new version with corrected installer metadata, license information, and alternate download source.

* **Bug Fixes**
  * Enhanced installation process with improved file filtering and name handling.
  * Improved uninstallation reliability with better file operations and data management.
  * Refined script initialization with enhanced path validation and configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->