### PR TITLE
loom@1.0.2, loom-server@1.0.2: Update to version 1.0.2

### DIFF
--- a/bucket/loom-server.json
+++ b/bucket/loom-server.json
@@ -1,0 +1,65 @@
+{
+  "version": "1.0.2",
+  "description": "Loom agent server with multi-agent orchestration and gRPC/HTTP APIs",
+  "homepage": "https://github.com/teradata-labs/loom",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/teradata-labs/loom/releases/download/v1.0.2/looms-windows-amd64.exe.zip",
+      "hash": "98198f3d06c86a35272d077a961878fdfb153fa30f018b23322b985e36d965a0"
+    }
+  },
+  "bin": "looms-windows-amd64.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/teradata-labs/loom/releases/download/v$version/looms-windows-amd64.exe.zip"
+      }
+    }
+  },
+  "post_install": [
+    "Write-Host 'Creating Loom data directory...' -ForegroundColor Green",
+    "New-Item -ItemType Directory -Force -Path \"$env:USERPROFILE\\.loom\" | Out-Null",
+    "New-Item -ItemType Directory -Force -Path \"$env:USERPROFILE\\.loom\\patterns\" | Out-Null",
+    "",
+    "Write-Host 'Downloading patterns...' -ForegroundColor Green",
+    "$patternsUrl = 'https://github.com/teradata-labs/loom/archive/refs/heads/main.zip'",
+    "$tempZip = \"$env:TEMP\\loom-patterns.zip\"",
+    "$tempExtract = \"$env:TEMP\\loom-temp\"",
+    "try {",
+    "    Invoke-WebRequest -Uri $patternsUrl -OutFile $tempZip -ErrorAction Stop",
+    "    Expand-Archive -Path $tempZip -DestinationPath $tempExtract -Force",
+    "    Copy-Item -Path \"$tempExtract\\loom-main\\patterns\\*\" -Destination \"$env:USERPROFILE\\.loom\\patterns\\\" -Recurse -Force",
+    "    Write-Host 'Patterns installed successfully' -ForegroundColor Green",
+    "} catch {",
+    "    Write-Warning \"Failed to download patterns: $_\"",
+    "    Write-Host 'You can manually download patterns from: https://github.com/teradata-labs/loom/tree/main/patterns' -ForegroundColor Yellow",
+    "} finally {",
+    "    if (Test-Path $tempZip) { Remove-Item -Path $tempZip -Force }",
+    "    if (Test-Path $tempExtract) { Remove-Item -Path $tempExtract -Recurse -Force }",
+    "}",
+    "",
+    "Write-Host 'Setting environment variables...' -ForegroundColor Green",
+    "[Environment]::SetEnvironmentVariable('LOOM_DATA_DIR', \"$env:USERPROFILE\\.loom\", 'User')"
+  ],
+  "notes": [
+    "Loom server (looms) installed successfully!",
+    "",
+    "Patterns installed to: $env:USERPROFILE\\.loom\\patterns",
+    "",
+    "Next steps:",
+    "  1. Configure an LLM provider:",
+    "     looms-windows-amd64 config set llm.provider anthropic",
+    "     looms-windows-amd64 config set-key anthropic_api_key",
+    "",
+    "  2. Start the server:",
+    "     looms-windows-amd64 serve",
+    "",
+    "  3. Connect with the TUI client:",
+    "     scoop install loom",
+    "     loom-windows-amd64 --thread weaver",
+    "",
+    "Documentation: https://github.com/teradata-labs/loom#readme"
+  ]
+}

--- a/bucket/loom.json
+++ b/bucket/loom.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.2",
+  "description": "LLM agent framework with natural language agent creation, pattern-guided learning, and multi-agent orchestration",
+  "homepage": "https://github.com/teradata-labs/loom",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/teradata-labs/loom/releases/download/v1.0.2/loom-windows-amd64.exe.zip",
+      "hash": "efd64e6db94911e6f5767c8ab1b8d01fc171523cec08f1aa2955ca7889d57ad4"
+    }
+  },
+  "bin": "loom-windows-amd64.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/teradata-labs/loom/releases/download/v$version/loom-windows-amd64.exe.zip"
+      }
+    }
+  },
+  "notes": [
+    "Loom TUI client installed successfully!",
+    "",
+    "To install the Loom server as well:",
+    "  scoop install loom-server",
+    "",
+    "Quick start:",
+    "  1. Install patterns: New-Item -ItemType Directory -Force $env:USERPROFILE\\.loom\\patterns",
+    "  2. Download patterns from: https://github.com/teradata-labs/loom/tree/main/patterns",
+    "  3. Configure LLM provider (see: https://github.com/teradata-labs/loom#quick-start)",
+    "",
+    "For full installation with patterns and configuration, use:",
+    "  git clone https://github.com/teradata-labs/loom",
+    "  cd loom",
+    "  .\\quickstart.ps1"
+  ]
+}


### PR DESCRIPTION
Updates Loom to version 1.0.2

## Changes
- Update loom to v1.0.2
- Update loom-server to v1.0.2
- Update SHA256 hashes

## Verification
- Release: https://github.com/teradata-labs/loom/releases/tag/v1.0.2
- Binaries verified and hashes calculated from official release

Automated PR from GitHub Actions.