### PR TITLE
librehardwaremonitor: Update to version 0.9.5, fix autoupdate

### DIFF
--- a/bucket/librehardwaremonitor.json
+++ b/bucket/librehardwaremonitor.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases/download/v0.9.5/LibreHardwareMonitor.zip",
-            "hash": "1e6c072e38b7848de5fdb7a0b20881a1c1eb46810042f4790483864f7a81a331"
+            "hash": "a37011fb0e623708f884a98588dfe06203753c8863e8a15a0c2336810e5e9e90"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Manually updated LibreHardwareMonitor, since the autoupdate failed due to a new asset naming scheme employed by upstream. Also updated the description to match the new one being used by the repository.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Libre Hardware Monitor to version 0.9.5.
  * Updated public description to clarify project purpose.
  * Moved download metadata to an architecture-specific (64-bit) entry and refreshed the release checksum.
  * Updated packaging and autoupdate configuration to use the new architecture-specific download.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->