### PR TITLE
pdf-xchange-editor@10.8.2.407: Fix download & autoupdate URLs

### DIFF
--- a/bucket/pdf-xchange-editor.json
+++ b/bucket/pdf-xchange-editor.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.pdf-xchange.com/downloads/PDFXEdit10_Portable_x64.zip",
+            "url": "https://downloads.pdf-xchange.com/10.8.2.407/PDFXEdit10_Portable_x64.zip",
             "hash": "83837415cd16bb166d2e3dac0c5dd42c471f70a646a1c5c36e0e92cdfb5afb34"
         },
         "32bit": {
-            "url": "https://www.pdf-xchange.com/downloads/PDFXEdit10_Portable_x86.zip",
+            "url": "https://downloads.pdf-xchange.com/10.8.2.407/PDFXEdit10_Portable_x86.zip",
             "hash": "dc7b9c8bdd2e3078f4af754ad1b957a74475b86b30e69144f11e908d4e523c20"
         }
     },
@@ -53,10 +53,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.pdf-xchange.com/downloads/PDFXEdit10_Portable_x64.zip"
+                "url": "https://downloads.pdf-xchange.com/$version/PDFXEdit10_Portable_x64.zip"
             },
             "32bit": {
-                "url": "https://www.pdf-xchange.com/downloads/PDFXEdit10_Portable_x86.zip"
+                "url": "https://downloads.pdf-xchange.com/$version/PDFXEdit10_Portable_x86.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Download URL schema changed on hosting website

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #17038
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated download and auto-update server infrastructure for improved reliability and faster delivery of application updates across both 64-bit and 32-bit systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->