### PR TITLE
folge: Update to version 1.29.1a, fix checkver & autoupdate, run installer

### DIFF
--- a/bucket/folge.json
+++ b/bucket/folge.json
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn.folge.me/Folge-${version}.exe"
+                "url": "https://cdn.folge.me/Folge-$version.exe"
             }
         }
     }


### PR DESCRIPTION
## Description

### Summary

This PR updates the `folge` manifest in the Extras bucket to resolve [issue #17042](https://github.com/ScoopInstaller/Extras/issues/17042), where installation fails due to an outdated extraction method and broken shortcut creation.

### Changes

- Switches the manifest to use the upstream `.exe` installer directly (no longer a 7z SFX archive).
- Updates the installer section to run the `.exe` with silent install arguments (`/S /D=$dir`).
- Updates the hash and autoupdate URL to match the new installer.
- Ensures shortcut creation works by referencing the correct `Folge.exe` path.

### Testing

- Uninstalled previous version, cleared cache, and installed folge using the updated manifest.
- Verified that installation completes successfully and shortcut is created.

### References

- Resolves [#17042](https://github.com/ScoopInstaller/Extras/issues/17042)
- Upstream download: [folge.json](https://github.com/user-attachments/files/24694568/folge.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Application updated to 1.29.1a.
  * Download switched to a direct executable URL and checksum refreshed.
  * Installation simplified to use the executable installer with silent-install arguments.
  * Version detection improved to recognize an optional "a" suffix in releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->