### PR TITLE
(chore): Relocate process termination logic to uninstaller script for safety

### DIFF
--- a/bucket/apifox.json
+++ b/bucket/apifox.json
@@ -21,10 +21,12 @@
         ]
     ],
     "persist": "UserData",
-    "pre_uninstall": [
-        "Stop-Process -Name 'ApifoxAppAgent' -Force -ErrorAction SilentlyContinue",
-        "Start-Sleep -Milliseconds 1500"
-    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'ApifoxAppAgent' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://docs.apifox.com/changelog.md",
         "regex": "## ([\\d.]+)(?=\\s)"

--- a/bucket/attribute-changer.json
+++ b/bucket/attribute-changer.json
@@ -53,16 +53,6 @@
             "Set-Content \"$dir\\change-ac-language.ps1\" $value -Encoding 'utf8' -Force"
         ]
     },
-    "bin": [
-        "acmain.exe",
-        "change-ac-language.ps1"
-    ],
-    "shortcuts": [
-        [
-            "acmain.exe",
-            "Attribute Changer"
-        ]
-    ],
     "post_install": [
         "$documents = (Get-ChildItem $dir -Filter '*.pdf').Length; $subtract = $documents - 5",
         "Copy-Item \"$dir\\template.ini\" \"$dir\\messages,$documents.ini\"; Copy-Item \"$dir\\template.ini\" \"$dir\\messages.ini\"; Copy-Item \"$dir\\ac,$(($documents - $subtract) - 2).pdf\" \"$dir\\ac.pdf\"",
@@ -73,11 +63,24 @@
         "}",
         "Copy-Item \"$dir\\ac.pdf\" \"$dir\\ac,$documents.pdf\""
     ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\acshell.dll\", '/s') -Verb 'RunAs' -Wait; Stop-Process -Name 'explorer' -Force",
-        "Stop-Process -Name 'dllhost' -ErrorAction 'SilentlyContinue' -Force; Start-Sleep -Seconds 2"
+    "bin": [
+        "acmain.exe",
+        "change-ac-language.ps1"
     ],
+    "shortcuts": [
+        [
+            "acmain.exe",
+            "Attribute Changer"
+        ]
+    ],
+    "pre_uninstall": "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+    "uninstaller": {
+        "script": [
+            "Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\acshell.dll\", '/s') -Wait",
+            "Stop-Process -Name 'dllhost', 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": "(?:v|V)ersion\\s([\\w.]+)",
     "autoupdate": {
         "url": "https://www.petges.lu/pubfiles/ac-$underscoreVersion.exe",

--- a/bucket/audioswitcher.json
+++ b/bucket/audioswitcher.json
@@ -5,7 +5,6 @@
     "license": "MS-PL",
     "url": "https://github.com/xenolightning/AudioSwitcher_v1/releases/download/1.8.0.142/AudioSwitcher.zip",
     "hash": "e675b85a7c8465e02b58148f8d98b4adab78c3a7423160ca78d1237d8469ace4",
-    "pre_install": "Stop-Process -Name AudioSwitcher -Verbose -ErrorAction Ignore",
     "bin": "AudioSwitcher.exe",
     "shortcuts": [
         [
@@ -13,6 +12,12 @@
             "Audio Switcher"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'AudioSwitcher' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "github": "https://github.com/xenolightning/AudioSwitcher_v1"
     },

--- a/bucket/buttercup.json
+++ b/bucket/buttercup.json
@@ -9,13 +9,18 @@
             "hash": "00725c3fe000691bd69e2f675ba8312428b6751ff7a4a43224c6468f818e375a"
         }
     },
-    "pre_uninstall": "Stop-Process -Name 'Buttercup' -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "Buttercup.exe",
             "Buttercup"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'Buttercup' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "github": "https://github.com/buttercup/buttercup-desktop/"
     },

--- a/bucket/coretemp.json
+++ b/bucket/coretemp.json
@@ -6,7 +6,11 @@
         "identifier": "Freeware",
         "url": "https://www.alcpu.com/CoreTemp/terms.html"
     },
-    "notes": "Download language packs by running: \"$dir\\download-language-packs.ps1\" (\"powershell \"$dir\\download-language-packs.ps1\"\" under cmd)",
+    "notes": [
+        "Download the language packs by running either of the following commands:",
+        "- \"$dir\\download-language-packs.ps1\"",
+        "- powershell \"$dir\\download-language-packs.ps1\" (when using Command Prompt)"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://www.alcpu.com/CoreTemp/CoreTemp64.zip",
@@ -18,18 +22,10 @@
         }
     },
     "pre_install": [
-        "Copy-Item \"$bucketsdir\\extras\\scripts\\coretemp\\download-language-packs.ps1\" \"$dir\\\" | Out-Null",
-        "if (Test-Path \"$persist_dir\\CoreTemp.ini\") { Copy-Item \"$persist_dir\\CoreTemp.ini\" \"$dir\\\" | Out-Null }"
+        "Copy-Item \"$bucketsdir\\$bucket\\scripts\\$app\\download-language-packs.ps1\" $dir",
+        "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "if (Test-Path -Path \"$persist_dir\\CoreTemp.ini\" -PathType Leaf) { Copy-Item \"$persist_dir\\CoreTemp.ini\" $dir -Force }"
     ],
-    "pre_uninstall": "Stop-Process -Name 'Core Temp' -ErrorAction SilentlyContinue",
-    "uninstaller": {
-        "script": [
-            "if (Test-Path \"$dir\\CoreTemp.ini\") {",
-            "    ensure \"$persist_dir\" | Out-Null",
-            "    Copy-Item \"$dir\\CoreTemp.ini\" \"$persist_dir\\\" | Out-Null",
-            "}"
-        ]
-    },
     "shortcuts": [
         [
             "Core Temp.exe",
@@ -40,6 +36,16 @@
         "languages",
         "plugins"
     ],
+    "pre_uninstall": [
+        "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "if (Test-Path -Path \"$dir\\CoreTemp.ini\" -PathType Leaf) { Copy-Item \"$dir\\CoreTemp.ini\" $persist_dir -Force }"
+    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'Core Temp' -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://www.alcpu.com/CoreTemp/history.html",
         "regex": "Version ([\\d.]+)"

--- a/bucket/coretemp.json
+++ b/bucket/coretemp.json
@@ -42,7 +42,7 @@
     ],
     "uninstaller": {
         "script": [
-            "Stop-Process -Name 'Core Temp' -ErrorAction SilentlyContinue",
+            "Stop-Process -Name 'Core Temp' -Force -ErrorAction SilentlyContinue",
             "Start-Sleep -Milliseconds 1500"
         ]
     },

--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -6,10 +6,6 @@
         "identifier": "Freeware",
         "url": "https://fastcopy.jp/help/fastcopy_eng.htm#license"
     },
-    "notes": [
-        "If an error occurs when updating or uninstalling, execute the following command then retry:",
-        "`Stop-Process -Name 'explorer'`"
-    ],
     "url": "https://fastcopy.jp/archive/FastCopy5.11.2_installer.exe",
     "hash": "70b273dd08c15d40fac59a217b93be195bacfa47acabd031463a6df800d29fea",
     "pre_install": [
@@ -34,9 +30,15 @@
     ],
     "pre_uninstall": [
         "ensure \"$persist_dir\\Log\" | Out-Null",
-        "Copy-Item \"$dir\\FastCopy.log\", \"$dir\\FastCopy2.ini\", \"$dir\\Log\" -Destination \"$persist_dir\" -Force -Recurse -ErrorAction SilentlyContinue",
-        "Start-Process \"$dir\\setup.exe\" -Args @('/SILENT', '/r') -Wait"
+        "Copy-Item \"$dir\\FastCopy.log\", \"$dir\\FastCopy2.ini\", \"$dir\\Log\" -Destination \"$persist_dir\" -Force -Recurse -ErrorAction SilentlyContinue"
     ],
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\setup.exe\" -Args @('/SILENT', '/r') -Wait",
+            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": "Download v([\\d.]+)",
     "autoupdate": {
         "url": "https://fastcopy.jp/archive/FastCopy$version_installer.exe"

--- a/bucket/folder-marker.json
+++ b/bucket/folder-marker.json
@@ -18,17 +18,6 @@
         "    Invoke-ExternalCommand regsvr32 -ArgumentList @(\"$dir\\ShellExt64.dll\", '/s') -RunAs | Out-Null",
         "}"
     ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\FMADM.dll\", '/s') -RunAs | Out-Null",
-        "Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\ShellExt.dll\", '/s') -RunAs | Out-Null",
-        "if ($architecture -eq '64bit') {",
-        "    Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\ShellExt64.dll\", '/s') -RunAs | Out-Null",
-        "}",
-        "# Restart explorer so that ShellExt(-64).dll can be removed",
-        "Stop-Process -Name 'explorer'; Start-Sleep -Seconds 2",
-        "if (!(Get-Process -Name 'explorer' -ErrorAction SilentlyContinue)) { Start-Process 'explorer' }"
-    ],
     "env_set": {
         "FOLDER_MARKER_DIR": "$dir"
     },
@@ -38,6 +27,19 @@
             "Folder Marker"
         ]
     ],
+    "pre_uninstall": "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+    "uninstaller": {
+        "script": [
+            "Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\FMADM.dll\", '/s') -RunAs | Out-Null",
+            "Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\ShellExt.dll\", '/s') -RunAs | Out-Null",
+            "if ($architecture -eq '64bit') {",
+            "    Invoke-ExternalCommand regsvr32 -ArgumentList @('/u', \"$dir\\ShellExt64.dll\", '/s') -RunAs | Out-Null",
+            "}",
+            "# Restart explorer so that ShellExt(-64).dll can be removed",
+            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://foldermarker.com/en/download/",
         "regex": "Version\\: ([\\d.]+)</p>"

--- a/bucket/iconview.json
+++ b/bucket/iconview.json
@@ -7,32 +7,35 @@
     "architecture": {
         "32bit": {
             "url": "https://www.botproductions.com/iconview/download/IconViewer3.02-Setup-x86.exe#/dl.7z",
-            "hash": "2EB365EA3E2F20848206B0B1835C58CC71E2ACA1323A19319896B3C8E3BF3956",
+            "hash": "2eb365ea3e2f20848206b0b1835c58cc71e2aca1323a19319896b3c8e3bf3956",
             "pre_install": "Remove-Item \"$dir\\Setup.exe\""
         },
         "64bit": {
             "url": "https://www.botproductions.com/iconview/download/IconViewer3.02-Setup-x64.exe#/dl.7z",
-            "hash": "3BE3664CFAC0B9270DA161C2C4C323499B4FE40A8E68A2D34CD4425B12EF223F",
+            "hash": "3be3664cfac0b9270da161c2c4c323499b4fe40a8e68a2d34cd4425b12ef223f",
             "pre_install": "Remove-Item \"$dir\\Setup.exe\", \"$dir\\x86\" -Recurse"
         }
     },
     "installer": {
         "script": [
             "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-            "Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @(\"$dir\\iconview.dll\", '/s'); Start-Sleep -Seconds 2"
+            "Start-Process 'regsvr32' -ArgumentList @(\"$dir\\iconview.dll\", '/s') -Wait; Start-Sleep -Seconds 2"
         ]
     },
-    "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "Start-Process 'regsvr32' -Wait -Verb 'RunAs' -ArgumentList @('/u', \"$dir\\iconview.dll\", '/s')",
-        "Stop-Process -Name 'explorer' -Force; Start-Sleep -Seconds 3;"
-    ],
     "shortcuts": [
         [
             "iconview.chm",
             "IconViewer Help"
         ]
     ],
+    "pre_uninstall": "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+    "uninstaller": {
+        "script": [
+            "Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\iconview.dll\", '/s') -Wait",
+            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://www.botproductions.com/iconview/download.html",
         "regex": "IconViewer\\s([\\d.]+)"

--- a/bucket/jackett.json
+++ b/bucket/jackett.json
@@ -14,7 +14,7 @@
     ],
     "uninstaller": {
         "script": [
-            "'JacketTray', 'JacketConsole', 'JacketService' | ForEach-Object {",
+            "'JackettTray', 'JackettConsole', 'JackettService' | ForEach-Object {",
             "    Stop-Process -Name $_ -Force -ErrorAction SilentlyContinue",
             "}",
             "Start-Sleep -Milliseconds 1500"

--- a/bucket/jackett.json
+++ b/bucket/jackett.json
@@ -6,17 +6,20 @@
     "url": "https://github.com/Jackett/Jackett/releases/download/v0.24.903/Jackett.Binaries.Windows.zip",
     "hash": "979c7b4913f10ff61393096ac2a8790f97248af24da81cc1bae09b6c6efab548",
     "extract_dir": "Jackett",
-    "pre_uninstall": [
-        "'JacketTray', 'JacketConsole', 'JacketService' | ForEach-Object {",
-        "    Stop-Process -Name $_ -ErrorAction SilentlyContinue",
-        "}"
-    ],
     "shortcuts": [
         [
             "JackettTray.exe",
             "Jackett"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "'JacketTray', 'JacketConsole', 'JacketService' | ForEach-Object {",
+            "    Stop-Process -Name $_ -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Jackett/Jackett/releases/download/v$version/Jackett.Binaries.Windows.zip"

--- a/bucket/mellowplayer.json
+++ b/bucket/mellowplayer.json
@@ -18,11 +18,16 @@
         }
     },
     "pre_install": "Expand-InnoArchive \"$dir\\MellowPlayer_Setup.exe\" \"$dir\" -Removal | Out-Null",
-    "pre_uninstall": "Stop-Process -Name 'MellowPlayer' -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "MellowPlayer.exe",
             "MellowPlayer"
         ]
-    ]
+    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'MellowPlayer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    }
 }

--- a/bucket/mobaxterm.json
+++ b/bucket/mobaxterm.json
@@ -39,11 +39,14 @@
         "    if (Test-Path -Path \"$dir\\$_\" -PathType Leaf) {",
         "        Copy-Item -Path \"$dir\\$_\" -Destination $persist_dir -Force",
         "    }",
-        "}",
-        "# Ensure background X server process is terminated to prevent resource lock.",
-        "Stop-Process -Name 'XWin_MobaX' -Force -ErrorAction SilentlyContinue",
-        "Start-Sleep -Milliseconds 1500"
+        "}"
     ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'XWin_MobaX' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://mobaxterm.mobatek.net/download-home-edition.html",
         "regex": "mobatek.net/(?<build>[^/]+)/MobaXterm_Portable_v([\\d.]+)\\.zip"

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -54,18 +54,16 @@
         "data",
         "mp3tag.cfg"
     ],
-    "pre_uninstall": [
-        "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
-        "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
-        "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "    Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') -Wait",
-        "    Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') -Wait",
-        "}"
-    ],
+    "pre_uninstall": "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
     "uninstaller": {
         "script": [
-            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
-            "Start-Sleep -Milliseconds 1500"
+            "if (Test-Path -Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell') {",
+            "    if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+            "    Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') -Wait",
+            "    Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') -Wait",
+            "    Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
+            "    Start-Sleep -Milliseconds 1500",
+            "}"
         ]
     },
     "checkver": {

--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -58,10 +58,16 @@
         "Copy-Item \"$dir\\export\\*\" \"$persist_dir\\export\" -Recurse -ErrorAction SilentlyContinue",
         "if (Test-Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\shellex\\ContextMenuHandlers\\Mp3tagShell\\') {",
         "    if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
-        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s')",
-        "    Start-Process 'regsvr32' -Wait -Verb RunAs -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s')",
+        "    Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\Mp3tagShell.dll\", '/s') -Wait",
+        "    Start-Process 'regsvr32' -ArgumentList @('/u', \"$dir\\Mp3tagShell32.dll\", '/s') -Wait",
         "}"
     ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://www.mp3tag.de/en/download.html",
         "regex": "(?i)<h\\d>Mp3tag\\s+v(?<version>[\\d.]+[a-z]{0,1})</h\\d>"

--- a/bucket/openvpn.json
+++ b/bucket/openvpn.json
@@ -32,24 +32,24 @@
         "else { Copy-Item \"$dir\\sample-config\\*\" \"$dir\\config\\\" }",
         "Remove-Item \"$Env:Public\\Desktop\\OpenVPN*.lnk\""
     ],
+    "bin": "bin\\openvpn.exe",
+    "checkver": {
+        "url": "https://openvpn.net/index.php/open-source/downloads.html",
+        "regex": "OpenVPN-([\\d.]+-I[\\d]+)-amd64\\.msi"
+    },
     "pre_uninstall": [
         "# Persist manually because the uninstaller deletes the 'config' folder",
         "if (Test-Path \"$dir\\config\") {",
         "    ensure \"$persist_dir\" | Out-Null",
         "    Copy-Item \"$dir\\config\" \"$persist_dir\\\" -Force -Recurse",
-        "}",
-        "Stop-Process -Name 'openvpn*' -Force -ErrorAction SilentlyContinue"
+        "}"
     ],
     "uninstaller": {
         "script": [
+            "Stop-Process -Name 'openvpn*' -Force -ErrorAction SilentlyContinue",
             "if (-not (is_admin)) { error 'Admin privileges are needed.'; break }",
-            "Invoke-ExternalCommand msiexec -ArgumentList ('/x', \"`\"$dir\\setup.msi_`\"\", '/passive') -RunAs | Out-Null"
+            "Invoke-ExternalCommand msiexec -ArgumentList ('/x', \"`\"$dir\\setup.msi_`\"\", '/passive') | Out-Null"
         ]
-    },
-    "bin": "bin\\openvpn.exe",
-    "checkver": {
-        "url": "https://openvpn.net/index.php/open-source/downloads.html",
-        "regex": "OpenVPN-([\\d.]+-I[\\d]+)-amd64\\.msi"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/openvpn.json
+++ b/bucket/openvpn.json
@@ -33,10 +33,6 @@
         "Remove-Item \"$Env:Public\\Desktop\\OpenVPN*.lnk\""
     ],
     "bin": "bin\\openvpn.exe",
-    "checkver": {
-        "url": "https://openvpn.net/index.php/open-source/downloads.html",
-        "regex": "OpenVPN-([\\d.]+-I[\\d]+)-amd64\\.msi"
-    },
     "pre_uninstall": [
         "# Persist manually because the uninstaller deletes the 'config' folder",
         "if (Test-Path \"$dir\\config\") {",
@@ -46,10 +42,14 @@
     ],
     "uninstaller": {
         "script": [
-            "Stop-Process -Name 'openvpn*' -Force -ErrorAction SilentlyContinue",
             "if (-not (is_admin)) { error 'Admin privileges are needed.'; break }",
+            "Stop-Process -Name 'openvpn*' -Force -ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 1500",
             "Invoke-ExternalCommand msiexec -ArgumentList ('/x', \"`\"$dir\\setup.msi_`\"\", '/passive') | Out-Null"
         ]
+    },
+    "checkver": {
+        "url": "https://openvpn.net/index.php/open-source/downloads.html",
+        "regex": "OpenVPN-([\\d.]+-I[\\d]+)-amd64\\.msi"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -18,11 +18,6 @@
         "    }",
         "}"
     ],
-    "pre_uninstall": [
-        "Stop-Process -Name 'Playnite.DesktopApp' -ErrorAction SilentlyContinue",
-        "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force",
-        "Copy-Item \"$dir\\themes\" \"$persist_dir\\\" -Recurse -Force -ErrorAction SilentlyContinue"
-    ],
     "bin": [
         [
             "Playnite.DesktopApp.exe",
@@ -44,6 +39,16 @@
         "library",
         "Themes"
     ],
+    "pre_uninstall": [
+        "Copy-Item \"$dir\\config.json\" $persist_dir -ErrorAction SilentlyContinue -Force",
+        "Copy-Item \"$dir\\themes\" $persist_dir -Recurse -Force -ErrorAction SilentlyContinue"
+    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'Playnite.DesktopApp' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "url": "https://api.github.com/repos/JosefNemec/Playnite/releases/latest",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /download\\/[\\d.]+\\/.*?\\.(?:7z|zip)/)].browser_download_url",

--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -5,7 +5,10 @@
     "license": "MIT",
     "notes": [
         "Add PowerToys context menu option by running:",
-        "Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\""
+        "Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
+        "",
+        "If an error occurs when updating or uninstalling, execute the following command then retry:",
+        "`Stop-Process -Name 'explorer'`"
     ],
     "architecture": {
         "64bit": {
@@ -53,12 +56,6 @@
         "    Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
         "}"
     ],
-    "shortcuts": [
-        [
-            "PowerToys.exe",
-            "PowerToys"
-        ]
-    ],
     "uninstaller": {
         "script": [
             "$regpath = 'HKCU:\\Software\\Classes\\powertoys'",
@@ -67,11 +64,18 @@
             "}",
             "if (Test-Path -Path $regpath) {",
             "    Invoke-Expression -Command \"& `\"$dir\\uninstall-context.ps1`\"\"",
-            "}",
-            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
-            "Start-Sleep -Milliseconds 1500"
+            "    if ($cmd -ne 'uninstall') {",
+            "        New-Item -Path $regpath -Force | Out-Null",
+            "    }",
+            "}"
         ]
     },
+    "shortcuts": [
+        [
+            "PowerToys.exe",
+            "PowerToys"
+        ]
+    ],
     "checkver": {
         "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
         "jsonpath": "$[0].assets[*].browser_download_url",

--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -5,10 +5,7 @@
     "license": "MIT",
     "notes": [
         "Add PowerToys context menu option by running:",
-        "Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
-        "",
-        "If an error occurs when updating or uninstalling, execute the following command then retry:",
-        "`Stop-Process -Name 'explorer'`"
+        "Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\""
     ],
     "architecture": {
         "64bit": {
@@ -56,6 +53,12 @@
         "    Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
         "}"
     ],
+    "shortcuts": [
+        [
+            "PowerToys.exe",
+            "PowerToys"
+        ]
+    ],
     "uninstaller": {
         "script": [
             "$regpath = 'HKCU:\\Software\\Classes\\powertoys'",
@@ -64,18 +67,11 @@
             "}",
             "if (Test-Path -Path $regpath) {",
             "    Invoke-Expression -Command \"& `\"$dir\\uninstall-context.ps1`\"\"",
-            "    if ($cmd -ne 'uninstall') {",
-            "        New-Item -Path $regpath -Force | Out-Null",
-            "    }",
-            "}"
+            "}",
+            "Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
         ]
     },
-    "shortcuts": [
-        [
-            "PowerToys.exe",
-            "PowerToys"
-        ]
-    ],
     "checkver": {
         "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
         "jsonpath": "$[0].assets[*].browser_download_url",

--- a/bucket/protonmail-bridge.json
+++ b/bucket/protonmail-bridge.json
@@ -18,13 +18,18 @@
         "}",
         "Remove-Item \"$dir\\dl.exe\", \"$dir\\Bridge-Installer.msi\", \"$dir\\Bridge-Installer.aiui\", \"$dir\\Bridge-Installer*.cab\" -Force -Recurse"
     ],
-    "pre_uninstall": "Stop-Process -Name 'proton-bridge' -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "proton-bridge.exe",
             "ProtonMail Bridge"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'proton-bridge' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "github": "https://github.com/ProtonMail/proton-bridge"
     },

--- a/bucket/smarttaskbar.json
+++ b/bucket/smarttaskbar.json
@@ -8,10 +8,7 @@
     },
     "notes": [
         "Run 'add-smarttaskbar-startup' to add SmartTaskbar to startup programs.",
-        "Run 'remove-smarttaskbar-startup' to remove SmartTaskbar from startup programs.",
-        "",
-        "If an error occurs when updating or uninstalling, execute the following command then retry:",
-        "- `Stop-Process -Name 'explorer' -Force -ErrorAction SilentlyContinue`"
+        "Run 'remove-smarttaskbar-startup' to remove SmartTaskbar from startup programs."
     ],
     "url": "https://github.com/Oliviaophia/SmartTaskbar/releases/download/v1.4.5/SmartTaskbar_Setup.exe",
     "hash": "a7b08377906a3d41bfd54141f8bba8bd5c81cc07e157d7cdb63b23f71fde9a98",
@@ -43,7 +40,11 @@
         ]
     ],
     "uninstaller": {
-        "file": "remove-smarttaskbar-startup.ps1"
+        "script": [
+            "Invoke-Expression -Command \"& `\"$dir\\remove-smarttaskbar-startup.ps1`\"\"",
+            "Stop-Process -Name 'SmartTaskbar', 'explorer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
     },
     "checkver": "github",
     "autoupdate": {

--- a/bucket/stremio.json
+++ b/bucket/stremio.json
@@ -32,7 +32,7 @@
     "uninstaller": {
         "script": [
             "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
-            "Stop-Process -Name 'stremio.exe' -Force -ErrorAction SilentlyContinue",
+            "Stop-Process -Name 'stremio' -Force -ErrorAction SilentlyContinue",
             "Start-Sleep -Milliseconds 1500"
         ]
     },

--- a/bucket/stremio.json
+++ b/bucket/stremio.json
@@ -29,10 +29,13 @@
             "Stremio"
         ]
     ],
-    "pre_uninstall": [
-        "Stop-Process -Name 'stremio.exe' -ErrorAction SilentlyContinue",
-        "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }"
-    ],
+    "uninstaller": {
+        "script": [
+            "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
+            "Stop-Process -Name 'stremio.exe' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "script": [
             "$request = [System.Net.HttpWebRequest]::Create('https://www.strem.io/download?platform=windows&four=true')",

--- a/bucket/tailscale.json
+++ b/bucket/tailscale.json
@@ -37,17 +37,6 @@
         "    }",
         "}"
     ],
-    "pre_uninstall": [
-        "if (!(is_admin)) { error 'Admin rights are required to uninstall'; break }",
-        "Stop-Process -Name 'tailscale-ipn' -Force -ErrorAction SilentlyContinue | Out-Null",
-        "Stop-Service -Name 'Tailscale' -Force -ErrorAction SilentlyContinue | Out-Null"
-    ],
-    "uninstaller": {
-        "script": [
-            "tailscaled.exe uninstall-system-daemon",
-            "if ($cmd -eq 'uninstall') { reg import \"$dir\\remove-startup.reg\" }"
-        ]
-    },
     "bin": [
         "tailscale.exe",
         "tailscale-ipn.exe",
@@ -59,6 +48,15 @@
             "Tailscale"
         ]
     ],
+    "pre_uninstall": "if (!(is_admin)) { error 'Admin rights are required to uninstall'; break }",
+    "uninstaller": {
+        "script": [
+            "Stop-Service -Name 'Tailscale' -Force -ErrorAction SilentlyContinue",
+            "Stop-Process -Name 'tailscale-ipn' -Force -ErrorAction SilentlyContinue",
+            "if ($cmd -eq 'uninstall') { reg import \"$dir\\remove-startup.reg\" }",
+            "tailscaled.exe uninstall-system-daemon"
+        ]
+    },
     "checkver": {
         "url": "https://pkgs.tailscale.com/stable/",
         "regex": "tailscale-setup-([\\d.]+)-amd64\\.msi"

--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -8,15 +8,6 @@
     },
     "url": "https://download.teamviewer.com/download/version_15x/TeamViewerPortable.zip",
     "hash": "5c567d7a3f86d428f9c6a22b0fe53b3fa17b0d10282bd0838019aaa553f7839f",
-    "pre_uninstall": [
-        "# For details, see: https://community.teamviewer.com/English/discussion/49721",
-        "Stop-Process -Name 'teamviewer' -ErrorAction SilentlyContinue",
-        "if (Test-Path \"$dir\\rolloutfile.tv13\") {",
-        "    Write-Host 'Removing rolloutfile.tv13.' -f Yellow",
-        "    icacls \"$dir\\rolloutfile.tv13\" /reset",
-        "    Remove-Item \"$dir\\rolloutfile.tv13\" -Force",
-        "}"
-    ],
     "bin": "teamviewer.exe",
     "shortcuts": [
         [
@@ -25,6 +16,20 @@
         ]
     ],
     "persist": "teamviewer.ini",
+    "pre_uninstall": [
+        "# For details, see: https://community.teamviewer.com/English/discussion/49721",
+        "if (Test-Path \"$dir\\rolloutfile.tv13\") {",
+        "    Write-Host 'Removing rolloutfile.tv13.' -f Yellow",
+        "    icacls \"$dir\\rolloutfile.tv13\" /reset",
+        "    Remove-Item \"$dir\\rolloutfile.tv13\" -Force",
+        "}"
+    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'teamviewer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.26 Safari/537.36",
         "url": "https://www.teamviewer.com/en/download/portal/windows/",

--- a/bucket/workspacer.json
+++ b/bucket/workspacer.json
@@ -11,13 +11,18 @@
         }
     },
     "pre_install": "if ([environment]::OSVersion.Version.Major -lt 10) { error \"$app requires Windows 10 or above\"; break }",
-    "pre_uninstall": "Stop-Process -Name 'workspacer' -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "workspacer.exe",
             "workspacer"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name 'workspacer' -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": {
         "github": "https://github.com/workspacer/workspacer"
     },


### PR DESCRIPTION
### Summary

Refactors multiple manifests to align with Scoop's uninstallation lifecycle. By relocating process and service termination logic from `pre_uninstall` to the `uninstaller` script block, this change ensures that Scoop's built-in running process checks are respected, preventing accidental data loss while ensuring reliability for unattended operations.

### Changes

- **Enhance User Safety & Data Integrity**: Moved `Stop-Process` and `Stop-Service` calls from `pre_uninstall` to `uninstaller.script`. This ensures Scoop can prompt the user if an application is active *before* any termination occurs, preventing silent data loss.
- **Support Unattended Reliability**: 
    - Standardized termination parameters with `-Force -ErrorAction SilentlyContinue`.
    - Added `Start-Sleep -Milliseconds 1500` after termination to ensure file handles are fully released before the directory is deleted by Scoop.
    - This ensures high reliability for users with `ignore_running_processes` enabled.
- **Automate Shell Extension Handling**: Integrated `explorer` and `dllhost` termination into the uninstaller script for manifests with shell integrations (e.g., `fastcopy`, `mp3tag`, `powertoys`, `smarttaskbar`, `attribute-changer`). This removes the need for manual intervention previously mentioned in `notes`.

### Notes

- Because the required changes in the ~~`powertoys`~~, ~~`everything`~~, ~~`simple-dnscrypt`~~, and `filezilla-server` manifests go beyond the scope of this PR, I will submit separate PRs to address those issues when time permits.

> - as Scoop typically [check for running processes](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/libexec/scoop-uninstall.ps1#L65) before the [`uninstaller`](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/libexec/scoop-uninstall.ps1#L77) script runs, using `Stop-Process` in `pre_uninstall` script is risky because it terminates the process **without notifying the users**, which may not be what they intend.
> - It is safe to use Stop-Process/Stop-Service in the `uninstaller` script (or afterwards) to stop background processes/services, as the checks for running processes and the [`ignore_running_processes`](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/libexec/scoop-config.ps1#L101-L104) configuration have already been performed. At that stage, either no related process is running, or the user has **explicitly** configured it to ignore running processes.
> - This design prevents accidental termination of active processes (which could cause data loss), while still providing the flexibility to kill them for users who have configured ignore_running_processes, which allows for truly unattended installations.
> - For more information, see: [ScoopInstaller/Scoop#4713 (comment)](https://github.com/ScoopInstaller/Scoop/pull/4713#issuecomment-1033770780)

- https://github.com/ScoopInstaller/Extras/pull/17011#discussion_r2699642384

<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved and standardized uninstall workflows for 20+ apps (Apifox, Attribute Changer, AudioSwitcher, Buttercup, CoreTemp, FastCopy, Folder Marker, Iconview, Jackett, MellowPlayer, MobaXterm, MP3Tag, OpenVPN, Playnite, ProtonMail Bridge, SmartTaskbar, Stremio, Tailscale, TeamViewer, Workspacer) to better stop processes and add short delays during removal.

* **Documentation**
  * Updated notes and user guidance for select applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->