### PR TITLE
fvm: Update to version 4.0.5, drop 32bit support

### DIFF
--- a/bucket/fvm.json
+++ b/bucket/fvm.json
@@ -1,20 +1,16 @@
 {
-    "version": "4.0.0",
+    "version": "4.0.5",
     "description": "Flutter Version Management: A simple CLI to manage Flutter SDK versions.",
     "homepage": "https://fvm.app/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/leoafarias/fvm/releases/download/4.0.0/fvm-4.0.0-windows-x64.zip",
-            "hash": "346f431f1d2114b33641301add22e86ae620dc498dfc0ae258dae592b9df9c45"
-        },
-        "32bit": {
-            "url": "https://github.com/leoafarias/fvm/releases/download/4.0.0/fvm-4.0.0-windows-ia32.zip",
-            "hash": "18e79c65333fa30f643eeab70d3c1db775375fefd175c316968530236d2e8280"
+            "url": "https://github.com/leoafarias/fvm/releases/download/4.0.5/fvm-4.0.5-windows-x64.zip",
+            "hash": "51040562aca33e96867e43f5b71ce9b6d626736ec1435322e151624a086a56a2"
         },
         "arm64": {
-            "url": "https://github.com/leoafarias/fvm/releases/download/4.0.0/fvm-4.0.0-windows-arm64.zip",
-            "hash": "42aac51626484fdd2e8b4003041234d140e7b7ec4351c1da7ad1891e5ae1b0cb"
+            "url": "https://github.com/leoafarias/fvm/releases/download/4.0.5/fvm-4.0.5-windows-arm64.zip",
+            "hash": "dcd5e4143a6e46ba5bb1354817d949e8048c7285d8bd592bc2367bf221813f9f"
         }
     },
     "extract_dir": "fvm",
@@ -39,9 +35,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/leoafarias/fvm/releases/download/$version/fvm-$version-windows-x64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/leoafarias/fvm/releases/download/$version/fvm-$version-windows-ia32.zip"
             },
             "arm64": {
                 "url": "https://github.com/leoafarias/fvm/releases/download/$version/fvm-$version-windows-arm64.zip"


### PR DESCRIPTION
Update fvm to version 4.0.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release to 4.0.5.
  * Updated Windows 64-bit and ARM64 download links and checksums to 4.0.5.
  * Removed Windows 32-bit support and related update entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->