### PR TITLE
everywhere@0.6.0: Fix shortcuts

### DIFF
--- a/bucket/everywhere.json
+++ b/bucket/everywhere.json
@@ -11,7 +11,7 @@
     },
     "shortcuts": [
         [
-            "Everywhere.Windows.exe",
+            "Everywhere.exe",
             "Everywhere"
         ]
     ],


### PR DESCRIPTION
Installed `0.6.0` with errors:

```sh
Installing 'everywhere' (0.6.0) [64bit] from 'Extras' bucket
Loading Everywhere-Windows-x64-v0.6.0.zip from cache
Checking hash of Everywhere-Windows-x64-v0.6.0.zip ... ok.
Extracting Everywhere-Windows-x64-v0.6.0.zip ... done.
Linking ~\Scoop\apps\everywhere\current => ~\Scoop\apps\everywhere\0.6.0
Creating shortcut for Everywhere (Everywhere.Windows.exe) failed: Couldn't find C:\Users\User\Scoop\apps\everywhere\current\Everywhere.Windows.exe
'everywhere' (0.6.0) was installed successfully!
```

The `Everywhere.Windows.exe` should be `Everywhere.exe`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected application executable reference in shortcut configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->