### PR TITLE
(chore): Set SCOOP_BRANCH to develop in workflows

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -15,3 +15,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SKIP_UPDATED: '1'
+        SCOOP_BRANCH: develop

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -13,3 +13,4 @@ jobs:
       if: startsWith(github.event.comment.body, '/verify')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -13,3 +13,4 @@ jobs:
       if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,3 +12,4 @@ jobs:
       uses: ScoopInstaller/GithubActions@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCOOP_BRANCH: develop


### PR DESCRIPTION
### Motivation
With the next Scoop-Core release date still unconfirmed, relying on the [develop](https://github.com/ScoopInstaller/Scoop/commits/develop) branch makes sense as it already includes the fixes we need. Otherwise, we'd have to use workarounds that would just need to be cleaned up later. Switching to develop prevents this unnecessary back-and-forth.

- https://github.com/ScoopInstaller/Scoop/pull/6535
- https://github.com/ScoopInstaller/Scoop/pull/6561
- https://github.com/ScoopInstaller/Scoop/pull/6490
- https://github.com/ScoopInstaller/Scoop/pull/6547

### Changes
This PR makes the following changes:
- Set `SCOOP_BRANCH` to `develop` in workflows.

### Related Issues
e.g.,
- #17063 : Relies on https://github.com/ScoopInstaller/Scoop/pull/6490  to function properly.
  > tidal: The remote server returned an error: (403) HTTP Forbidden.
  > URL https://tidal.com/ is not valid

<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configurations to support branch parameter management across multiple automated processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->