### PR TITLE
tidal: Fix pre_install script

### DIFF
--- a/bucket/tidal.json
+++ b/bucket/tidal.json
@@ -8,7 +8,7 @@
     },
     "url": "https://download.tidal.com/desktop/TIDALSetup.exe#/dl.7z",
     "hash": "7bb068236efdc689f7dd5fc41c908016f701cde52b3000c3979a7a59206a49e2",
-    "pre_install": "Expand-7zipArchive \"$dir\\TIDAL-$version-full.nupkg\" -ExtractDir 'lib\\net45' -Removal",
+    "pre_install": "Expand-7zipArchive \"$dir\\TIDAL-*-full.nupkg\" -ExtractDir 'lib\\net45' -Removal",
     "shortcuts": [
         [
             "TIDAL.exe",


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- tidal: Fix pre_install script.
  - Avoid using specific version in the pre_install_script to prevent decompression errors, since the download URL is not version-specific.


### Related Issues
- Closes #17063
- Relates to #17062

<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TIDAL installation reliability by updating the package extraction process to work with any package version, preventing installation failures due to version-specific filename mismatches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->