### PR TITLE
mp3tag@3.33: Fix download & autoupdate URLs

### DIFF
--- a/bucket/mp3tag.json
+++ b/bucket/mp3tag.json
@@ -25,12 +25,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://download.mp3tag.de/mp3tagv333-x64-setup.exe#/dl.7z",
-            "hash": "1040e355c552d8eca649a76446f27f4fc8306ef1c10097feb6592649a426f4df"
+            "url": "https://download.mp3tag.de/mp3tag-v3.33-x64-setup.exe#/dl.7z",
+            "hash": "434d684b8aaa5d2ccd529e873b9a9bdd46369d710dfbb320a08e1b4c36b384e8"
         },
         "32bit": {
-            "url": "https://download.mp3tag.de/mp3tagv333setup.exe#/dl.7z",
-            "hash": "1040e355c552d8eca649a76446f27f4fc8306ef1c10097feb6592649a426f4df"
+            "url": "https://download.mp3tag.de/mp3tag-v3.33-setup.exe#/dl.7z",
+            "hash": "637861298aec102245e6d1b932d9acb2b8a7b735c9fd4975e916757e0416b359"
         }
     },
     "pre_install": [
@@ -69,10 +69,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.mp3tag.de/mp3tagv$cleanVersion-x64-setup.exe#/dl.7z"
+                "url": "https://download.mp3tag.de/mp3tag-v$version-x64-setup.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://download.mp3tag.de/mp3tagv$cleanVersionsetup.exe#/dl.7z"
+                "url": "https://download.mp3tag.de/mp3tag-v$version-setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `mp3tag@3.33`: Fix download & autoupdate URLs.

### Related Issues
- Closes #17067

<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mp3tag package source URLs and checksums for both 32-bit and 64-bit architectures. Autoupdate URL patterns have been revised to align with current version naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->