### PR TITLE
fvm@4.0.5: Fix bin

### DIFF
--- a/bucket/fvm.json
+++ b/bucket/fvm.json
@@ -6,11 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/leoafarias/fvm/releases/download/4.0.5/fvm-4.0.5-windows-x64.zip",
-            "hash": "51040562aca33e96867e43f5b71ce9b6d626736ec1435322e151624a086a56a2"
+            "hash": "51040562aca33e96867e43f5b71ce9b6d626736ec1435322e151624a086a56a2",
+            "bin": "fvm.exe"
         },
         "arm64": {
             "url": "https://github.com/leoafarias/fvm/releases/download/4.0.5/fvm-4.0.5-windows-arm64.zip",
-            "hash": "dcd5e4143a6e46ba5bb1354817d949e8048c7285d8bd592bc2367bf221813f9f"
+            "hash": "dcd5e4143a6e46ba5bb1354817d949e8048c7285d8bd592bc2367bf221813f9f",
+            "bin": "fvm.bat"
         }
     },
     "extract_dir": "fvm",
@@ -20,7 +22,6 @@
         "   New-Item \"$dir\\.settings\" -ItemType File | Out-Null",
         "}"
     ],
-    "bin": "fvm.exe",
     "env_set": {
         "FVM_CACHE_PATH": "$dir"
     },


### PR DESCRIPTION
Relates to: #17061
```
Line |
 191 |              $bin = (Get-Command $target).Source
     |                      ~~~~~~~~~~~~~~~~~~~
     | The term 'fvm.bat' is not recognized as a name of a cmdlet, function, script file, or executable program. Check
     | the spelling of the name, or if a path was included, verify that the path is correct and try again.
Can't shim 'fvm.bat': File doesn't exist.
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed executable configuration so the correct binary is selected per architecture (improves reliability for different platforms; removes a one-size-fits-all default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->