### PR TITLE
sts: Update to version 5.0.1, fix shortcuts & autoupdate

### DIFF
--- a/bucket/sts.json
+++ b/bucket/sts.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.32.2",
+    "version": "5.0.1",
     "description": "Spring Tools for Eclipse",
     "homepage": "https://spring.io/tools",
     "license": "EPL-1.0",
@@ -7,8 +7,8 @@
     "notes": "For Windows 32bit, please use \"sts396\" in versions bucket.",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.spring.io/spring-tools/release/STS4/4.32.2.RELEASE/dist/e4.37/spring-tools-for-eclipse-4.32.2.RELEASE-e4.37.0-win32.win32.x86_64.zip#/dl.zip_",
-            "hash": "a6e379ca472488103871c513202231a44ab9c82c6d766428540691e0628e9df9"
+            "url": "https://cdn.spring.io/spring-tools/release/dist/5.0.1.RELEASE/e4.38/spring-tools-for-eclipse-5.0.1.RELEASE-e4.38.0-win32.win32.x86_64.zip#/dl.zip_",
+            "hash": "b705de70268c89dfb35a6b1867ca379fc6b04399500f7003f3b5856a5eb542cd"
         }
     },
     "pre_install": [
@@ -18,8 +18,8 @@
     ],
     "shortcuts": [
         [
-            "SpringToolSuite4.exe",
-            "Spring Tool Suite"
+            "SpringToolsForEclipse.exe",
+            "Spring Tools For Eclipse"
         ]
     ],
     "checkver": {
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn.spring.io/spring-tools/release/STS4/$version.RELEASE/dist/e$matchShort/spring-tools-for-eclipse-$version.RELEASE-e$matchEclipse-win32.win32.x86_64.zip#/dl.zip_",
+                "url": "https://cdn.spring.io/spring-tools/release/dist/$version.RELEASE/e$matchShort/spring-tools-for-eclipse-$version.RELEASE-e$matchEclipse-win32.win32.x86_64.zip#/dl.zip_",
                 "hash": {
                     "url": "$url.sha256"
                 }


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `sts`: Update to version 5.0.1, fix shortcuts & autoupdate.

<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 5.0.1
  * Renamed application shortcut from "Spring Tool Suite" to "Spring Tools For Eclipse"
  * Updated distribution URLs and verification checksums for the new release

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->