### PR TITLE
gpg4win: Remove unnecessary env paths

### DIFF
--- a/bucket/gpg4win.json
+++ b/bucket/gpg4win.json
@@ -9,10 +9,6 @@
         "Start-Process \"$dir\\$fname\" -ArgumentList @('/S', \"/D=$dir\\Gpg4win\") -WindowStyle Hidden -Wait",
         "Remove-Item \"$dir\\$fname\""
     ],
-    "env_add_path": [
-        "GnuPG\\bin",
-        "Gpg4win\\bin"
-    ],
     "pre_uninstall": "Start-Process \"$dir\\Gpg4win\\gpg4win-uninstall.exe\" '/S' -Wait",
     "checkver": {
         "url": "https://www.gpg4win.org/get-gpg4win.html",


### PR DESCRIPTION
Removes scoop handling of environment paths

- Removes the `GnuPG\bin` path from the manifest
   - the gpg4win installer adds it anyway to the system env
- Removes the `Gpg4win\bin` path from the manifest
   - This path is not installed by the upstream installer and causes issues

Closes: #17036 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic environment path configuration from the installation setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->