### PR TITLE
wireshark: Fix pre_install script

### DIFF
--- a/bucket/wireshark.json
+++ b/bucket/wireshark.json
@@ -24,8 +24,8 @@
     },
     "pre_install": [
         "'$PLUGINSDIR', 'vc_redist*', 'uninstall-wireshark.exe' | ForEach-Object { \"$dir/$_\" } | Remove-Item -Recurse -ErrorAction Ignore",
-        "Rename-Item (Get-ChildItem \"$dir/npcap-*.exe\" | Select-Object -First 1) \"npcap-installer.exe\"",
-        "Rename-Item (Get-ChildItem \"$dir/USBPcapSetup-*.exe\" | Select-Object -First 1) \"USBPcap-installer.exe\"",
+        "Get-ChildItem -Path \"$dir/npcap-*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'npcap-installer.exe'",
+        "Get-ChildItem -Path \"$dir/USBPcapSetup-*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'USBPcap-installer.exe'",
         "$data = \"$persist_dir/Data\"",
         "$preferences = \"$data/preferences\"",
         "if (!(Test-Path $preferences)) {",


### PR DESCRIPTION
pre-install powershell 5.1 compatibility fix

Changes
- The previous code was running fine in powershell v7.5.4, but not in v5.1.26100.6584
- small ASCII fix in the description

Relates to: #15294
Closes: https://github.com/ScoopInstaller/Extras/issues/17050

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Fixed punctuation for consistent display in installer text.
  * Updated installer name shown in notes for clearer messaging.
  * Changed installer-handling logic to target a single matching installer file instead of bulk renames, improving detection reliability and reducing risk of unintended file changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->