### PR TITLE
openvpn: Persist `config-auto` directory

### DIFF
--- a/bucket/openvpn.json
+++ b/bucket/openvpn.json
@@ -28,20 +28,26 @@
         "if ([Environment]::OSVersion.Version.Major -lt 10) { error 'Windows 10 is required since version 2.4.8. Use \"versions/openvpn-w7\" instead'; break }",
         "if (-not (is_admin)) { error 'Administrator privileges are needed for installation'; break }",
         "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"`\"$dir\\setup.msi_`\"\", \"PRODUCTDIR=`\"$dir`\"\", 'ADDLOCAL=OpenVPN.GUI,OpenVPN.Service,OpenVPN.Documentation,OpenVPN.SampleCfg,OpenSSL,EasyRSA,OpenVPN,OpenVPN.GUI.OnLogon,Drivers.TAPWindows6,Drivers,Drivers.Wintun', '/passive') -RunAs | Out-Null",
-        "if (Test-Path \"$persist_dir\\config\") { Copy-Item \"$persist_dir\\config\" \"$dir\\\" -Force -Recurse }",
-        "else { Copy-Item \"$dir\\sample-config\\*\" \"$dir\\config\\\" }",
-        "if (Test-Path \"$persist_dir\\config-auto\") { Copy-Item \"$persist_dir\\config-auto\" \"$dir\\\" -Force -Recurse }",
         "Remove-Item \"$Env:Public\\Desktop\\OpenVPN*.lnk\""
     ],
-    "pre_uninstall": [
-        "# Persist manually because the uninstaller deletes the 'config' folder",
-        "if (Test-Path \"$dir\\config\") {",
-        "    ensure \"$persist_dir\" | Out-Null",
-        "    Copy-Item \"$dir\\config\" \"$persist_dir\\\" -Force -Recurse",
+    "post_install": [
+        "# Persist manually because the uninstaller deletes the 'config' and 'config-auto' folder",
+        "'config', 'config-auto' | ForEach-Object {",
+        "    if (Test-Path -Path \"$persist_dir\\$_\") {",
+        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination $dir -Force -Recurse",
+        "    }",
         "}",
-        "if (Test-Path \"$dir\\config-auto\") {",
-        "    ensure \"$persist_dir\" | Out-Null",
-        "    Copy-Item \"$dir\\config-auto\" \"$persist_dir\\\" -Force -Recurse",
+        "if (-not (Test-Path -Path \"$persist_dir\\config\")) {",
+        "    Copy-Item -Path \"$dir\\sample-config\\*\" -Destination \"$dir\\config\\\" -Force -Recurse",
+        "}"
+    ],
+    "pre_uninstall": [
+        "# Persist manually because the uninstaller deletes the 'config' and 'config-auto' folder",
+        "'config', 'config-auto' | ForEach-Object {",
+        "    if (Test-Path -Path \"$dir\\$_\") {",
+        "        ensure $persist_dir | Out-Null",
+        "        Copy-Item -Path \"$dir\\$_\" -Destination $persist_dir -Force -Recurse",
+        "    }",
         "}",
         "Stop-Process -Name 'openvpn*' -Force -ErrorAction SilentlyContinue"
     ],


### PR DESCRIPTION
Closes #17057

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now restores and preserves both primary and auto-generated VPN configuration files after installation, ensuring a usable config is present.

* **Bug Fixes**
  * Configuration files are reliably saved and restored during uninstall/reinstall processes; missing configs are auto-populated from defaults to prevent failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->