### PR TITLE
harmonoid: Update to version 0.3.21, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/harmonoid.json
+++ b/bucket/harmonoid.json
@@ -67,12 +67,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v$version/harmonoid-windows-x64-exe.zip",
-                "extract_dir": "harmonoid-windows-x64-exe"
+                "url": "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v$version/harmonoid-windows-x64-exe.zip"
             },
             "arm64": {
-                "url": "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v$version/harmonoid-windows-arm64-exe.zip",
-                "extract_dir": "harmonoid-windows-arm64-exe"
+                "url": "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v$version/harmonoid-windows-arm64-exe.zip"
             }
         }
     }


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `harmonoid`: Update to version 0.3.21, fix autoupdate, add arm64 support.

<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Windows ARM64 support for Arm-based PCs.

* **Chores**
  * Bumped release to 0.3.21.
  * Updated Windows 64-bit distribution package.
  * Improved autoupdate handling and per-architecture installation behavior for multi-architecture deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->