### PR TITLE
everything: Update checkver, fix persistence & uninstaller logic

### DIFF
--- a/bucket/everything.json
+++ b/bucket/everything.json
@@ -1,11 +1,26 @@
 {
     "version": "1.4.1.1032",
-    "description": "Locate files and folders by name instantly.",
+    "description": "A file and folder search engine for Windows that instantly locates files and folders by name.",
     "homepage": "https://www.voidtools.com",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://www.voidtools.com/License.txt"
+    },
     "notes": [
-        "To add Everything to right-click context menu, run:",
-        "reg import \"$dir\\install-context.reg\""
+        "To register file associations, please execute the following command:",
+        "reg import \"$dir\\install-associations.reg\"",
+        "To register application startup, please execute the following command:",
+        "reg import \"$dir\\register-startup-entry.reg\"",
+        "To register the context menu entry, please execute the following command:",
+        "reg import \"$dir\\install-context.reg\"",
+        "To register the URL protocol handler, please execute the following command:",
+        "reg import \"$dir\\register-url-handler.reg\"",
+        "",
+        "Please note that the related logic has been changed.",
+        "The context menu must be unregistered and then registered again, even if it was previously registered.",
+        "The following command can be used to unregister it:",
+        "reg import \"$dir\\uninstall-context.reg\"",
+        "No further action is required if this message appears again."
     ],
     "architecture": {
         "64bit": {
@@ -22,24 +37,23 @@
         }
     },
     "pre_install": [
-        "# for arm64",
-        "if ($architecture -eq 'arm64') { Rename-Item \"$dir\\EverythingARM64.exe\" -NewName 'Everything.exe' }",
-        "# END",
-        "ensure \"$persist_dir\" | Out-Null",
-        "if (!(Test-Path \"$persist_dir\\Everything.ini\")) { Start-Process -Wait \"$dir\\Everything.exe\" -Args @('-install-config null') }",
-        "Get-ChildItem \"$persist_dir\\*\" -Include 'Bookmarks.csv', 'Everything.db', 'Everything.ini', 'Filters.csv', 'Search History.csv' | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue"
+        "if ($architecture -eq 'arm64') { Rename-Item -Path \"$dir\\EverythingARM64.exe\" -NewName 'Everything.exe' }",
+        "if (-not (Test-Path -Path \"$persist_dir\\*.ini\" -PathType Leaf)) {",
+        "    Start-Process -FilePath \"$dir\\Everything.exe\" -ArgumentList @('-install-config', 'null') -NoNewWindow -Wait",
+        "}",
+        "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "'*.db', '*.csv', '*.ico', '*.ini', '*.txt' | ForEach-Object {",
+        "    if (Test-Path -Path \"$persist_dir\\$_\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination $dir -Force",
+        "    }",
+        "}"
     ],
     "post_install": [
-        "$app_path = \"$dir\\Everything.exe\".Replace('\\', '\\\\')",
-        "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
-        "    if (Test-Path \"$bucketsdir\\extras\\scripts\\everything\\$_\") {",
-        "        $content = Get-Content \"$bucketsdir\\extras\\scripts\\everything\\$_\"",
-        "        $content = $content.Replace('$app_path', $app_path)",
-        "        if ($global) {",
-        "            $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
-        "        }",
-        "    }",
-        "    $content | Set-Content -Path \"$dir\\$_\" -Encoding ascii",
+        "$everything_dir = $dir -replace '\\\\', '\\\\'",
+        "Get-ChildItem -Path \"$bucketsdir\\$bucket\\scripts\\$app\" -Filter '*.reg' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding utf8",
+        "    if ($global) { $content = $content -replace 'HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE' }",
+        "    $content -replace '{{everything_dir}}', $everything_dir | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding unicode",
         "}"
     ],
     "bin": "Everything.exe",
@@ -49,23 +63,61 @@
             "Everything"
         ]
     ],
-    "pre_uninstall": [
-        "Stop-Process -Name 'Everything' -Force -ErrorAction SilentlyContinue",
-        "$service_installed_in_current_dir_via_scoop = (sc.exe qc Everything) -match $dir.Replace('\\', '\\\\')",
-        "if ($service_installed_in_current_dir_via_scoop) {",
-        "    if ($(Get-Service -Name Everything -ErrorAction SilentlyContinue).Status -ne 'Stopped') {",
-        "        if (!(is_admin) -and $(Get-Service -Name Everything -ErrorAction SilentlyContinue)) { error 'Admin rights are required to stop Everything service'; break }",
-        "        Stop-Service -Name 'Everything' -Force -ErrorAction SilentlyContinue | Out-Null",
-        "    }",
-        "    if ((Get-Service -Name Everything -ErrorAction SilentlyContinue) -and ($cmd -eq 'uninstall')) {",
-        "        if (!(is_admin) -and $(Get-Service -Name Everything -ErrorAction SilentlyContinue)) { error 'Admin rights are required to remove Everything service'; break }",
-        "        sc.exe delete 'Everything'",
-        "    }",
-        "}",
-        "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
-        "Get-ChildItem \"$dir\\*\" -Include 'Bookmarks.csv', 'Everything.db', 'Everything.ini', 'Filters.csv', 'Search History.csv' | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
+    "persist": [
+        "Logs",
+        "HTTP server"
     ],
-    "checkver": "Download Everything ([\\d.]+)",
+    "pre_uninstall": [
+        "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "'*.db', '*.csv', '*.ico', '*.ini', '*.txt' | ForEach-Object {",
+        "    if (Test-Path -Path \"$dir\\$_\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$dir\\$_\" -Destination $persist_dir -Force",
+        "    }",
+        "}"
+    ],
+    "uninstaller": {
+        "script": [
+            "if ($cmd -eq 'uninstall') {",
+            "    Get-ChildItem -Path $dir -Filter 'un*.reg' -File | ForEach-Object j{",
+            "        $registry_file = '\"{0}\"' -f $_.FullName",
+            "        Start-Process -FilePath 'reg.exe' -ArgumentList @('import', $registry_file) -WindowStyle Hidden -Wait",
+            "    }",
+            "}",
+            "$base_service_name = 'Everything'",
+            "$path_regex = [regex]::Escape((Split-Path -Path $dir -Parent))",
+            "$process = Get-Process -Name 'Everything' -ErrorAction SilentlyContinue | Where-Object { $_.Path -match $path_regex }",
+            "if ($process.Count -gt 0) {",
+            "    Write-Host \"`nINFO  Identified $($process.Count) running processes for termination.\" -ForegroundColor DarkGray",
+            "    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue",
+            "}",
+            "if ($PSVersionTable.PSVersion -ge [version]::new(6, 0)) {",
+            "    $services = Get-Service -Name \"*$base_service_name*\" -ErrorAction SilentlyContinue",
+            "} else {",
+            "    $name_filter = \"Name like '%$base_service_name%'\"",
+            "    $services = Get-CimInstance -ClassName Win32_Service -Filter $name_filter -ErrorAction SilentlyContinue |",
+            "            Select-Object -Property *, @{ Name = 'BinaryPathName'; Expression = { $_.PathName } }",
+            "}",
+            "$service = $services | Where-Object { $_.BinaryPathName -match $path_regex }",
+            "if ($null -ne $service) {",
+            "    if (-not (is_admin)) { abort \"`n[ERROR]  $app requires admin rights to $cmd.\" }",
+            "    Stop-Service -Name $service.Name -Force -ErrorAction SilentlyContinue",
+            "    $process.Id | Where-Object -FilterScript { $null -ne $_ } | ForEach-Object {",
+            "        Get-Process -Id $_ -ErrorAction SilentlyContinue | Where-Object -FilterScript { $_.Name -like '*Everything*' }",
+            "    } | Stop-Process -Force -ErrorAction SilentlyContinue",
+            "    Start-Sleep -Milliseconds 1500",
+            "    if ($cmd -ne 'uninstall') { return }",
+            "    if ($PSVersionTable.PSVersion -ge [version]::new(6, 0)) {",
+            "        Remove-Service -Name 'Everything' -ErrorAction SilentlyContinue",
+            "    } else {",
+            "        Start-Process -FilePath 'sc.exe' -ArgumentList @('delete', 'Everything') -NoNewWindow -Wait",
+            "    }",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.voidtools.com/Changes.txt",
+        "regex": "Version\\s*([\\d.]+)(?=\\s)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/scripts/everything/install-associations.reg
+++ b/scripts/everything/install-associations.reg
@@ -1,0 +1,32 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.efu]
+"Content Type"="text/plain"
+"PerceivedType"="text"
+
+[HKEY_CURRENT_USER\Software\Classes\.efu\OpenWithProgIDs]
+"Everything.FileList"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList]
+@="Everything File List"
+"AppUserModelID"="voidtools.Everything"
+"FriendlyTypeName"="Everything File List"
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList\DefaultIcon]
+@="\"{{everything_dir}}\\Everything.exe\",1"
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList\shell]
+@="open"
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList\shell\edit]
+"Icon"="\"{{everything_dir}}\\Everything.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList\shell\edit\command]
+@="\"{{everything_dir}}\\Everything.exe\" -edit \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList\shell\open]
+"Icon"="\"{{everything_dir}}\\Everything.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\Everything.FileList\shell\open\command]
+@="\"{{everything_dir}}\\Everything.exe\" \"%1\""

--- a/scripts/everything/install-context.reg
+++ b/scripts/everything/install-context.reg
@@ -1,23 +1,16 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything]
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\Search Everything...]
 @="Search with &Everything"
-"Icon"="$app_path"
+"Icon"="\"{{everything_dir}}\\Everything.exe\",0"
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything\command]
-@="$app_path -path \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\Search Everything...\command]
+@="\"{{everything_dir}}\\Everything.exe\" -path \"%V\""
 
-[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything]
+
+[HKEY_CURRENT_USER\Software\Classes\Folder\shell\Search Everything...]
 @="Search with &Everything"
-"Icon"="$app_path"
+"Icon"="\"{{everything_dir}}\\Everything.exe\",0"
 
-; %v – For verbs that are none implies all. If there is no parameter passed this is the working directory.
-[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything\command]
-@="$app_path -path \"%V\""
-
-[HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything]
-@="Search with &Everything"
-"Icon"="$app_path"
-
-[HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything\command]
-@="$app_path -path \"%1\""
+[HKEY_CURRENT_USER\Software\Classes\Folder\shell\Search Everything...\command]
+@="\"{{everything_dir}}\\Everything.exe\" -path \"%1\""

--- a/scripts/everything/register-startup-entry.reg
+++ b/scripts/everything/register-startup-entry.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run]
+"Everything"="\"{{everything_dir}}\\Everything.exe\" -startup"

--- a/scripts/everything/register-url-handler.reg
+++ b/scripts/everything/register-url-handler.reg
@@ -1,0 +1,15 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\ES]
+@="URL:Everything Search Protocol"
+"URL Protocol"=""
+
+[HKEY_CURRENT_USER\Software\Classes\ES\DefaultIcon]
+@="\"{{everything_dir}}\\Everything.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\ES\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\ES\shell\open]
+
+[HKEY_CURRENT_USER\Software\Classes\ES\shell\open\command]
+@="\"{{everything_dir}}\\Everything.exe\" -url \"%1\""

--- a/scripts/everything/uninstall-associations.reg
+++ b/scripts/everything/uninstall-associations.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.efu\OpenWithProgIDs]
+"Everything.FileList"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\Everything.FileList]

--- a/scripts/everything/uninstall-context.reg
+++ b/scripts/everything/uninstall-context.reg
@@ -1,8 +1,14 @@
 Windows Registry Editor Version 5.00
 
+[-HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\Search Everything...]
+
+[-HKEY_CURRENT_USER\Software\Classes\Folder\shell\Search Everything...]
+
+; The entries below are retained to remove context menu items created by earlier versions
+; These legacy cleanup rules will be removed after several future updates
+
 [-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything]
-[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything\command]
+
 [-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything]
-[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything\command]
+
 [-HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything]
-[-HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything\command]

--- a/scripts/everything/unregister-startup-entry.reg
+++ b/scripts/everything/unregister-startup-entry.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run]
+"Everything"=-

--- a/scripts/everything/unregister-url-handler.reg
+++ b/scripts/everything/unregister-url-handler.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\ES]


### PR DESCRIPTION
### Summary

Refactors `everything` manifest to ensure reliable data persistence, enhance uninstaller safety with registry cleanup, and modernize version detection.

### Related issues or pull requests

- Relates to #17051 
- Relates to https://github.com/ScoopInstaller/Versions/pull/2279 

### Changes

- **Metadata Refinement**: Updated description and structured the `license` field.
- **Improve Installation Scripting**:
  - Add a check for existing configuration before initializing a default one.
  - Implement manual `Copy-Item` in `pre_install` and `pre_uninstall` for `*.ini`, `*.db`, `*.csv`, etc. 
  - Optimize `post_install` to dynamically process registry scripts with correct escaping and encoding (`unicode`).
- **Relocate & Enhance Uninstaller Logic**:
  - Move process/service termination to the `uninstaller` block for lifecycle compliance.
  - **Registry Cleanup**: Add automatic import of uninstallation registry files (`un*.reg`) during the uninstall phase.
  - **Robust Service Detection**: Implement a dual-path logic for service detection (using `Get-Service` for PS 6+ and `Get-CimInstance` for PS 5.1) with path-based regex validation to ensure only the Scoop-managed service is modified.
- **Modernize Checkver**: Switch the update source to `Changes.txt` for more accurate version tracking.

### Notes

- Some links related to user data are as follows:
  - [Icon](https://www.voidtools.com/support/everything/customizing/#icon)
  - [Named instances](https://www.voidtools.com/support/everything/multiple_instances/#named_instances)
  - [Files created by Everything](https://www.voidtools.com/support/everything/uninstalling_everything/#files_created_by_everything)
  - [Change the default HTTP files](https://www.voidtools.com/support/everything/http/#change_the_default_http_files) and [Custom strings](https://www.voidtools.com/support/everything/http/#custom_strings)
- ~~At present, the only script used to extend `everything` is `(un)install-context.reg`. However, additional scripts could be added in the future, such as those for startup registration or protocol handling. I will submit a separate PR to add them when I have the time. Therefore, I have proactively updated the related logic to use `Get-ChildItem` to dynamically retrieve the names of `.reg` files~~.
- In Windows, service names are unique. Therefore, I believe that once the relevant services matching the criteria are detected, it is sufficient to stop them and remove only the services created by the application, rather than deleting all related services indiscriminately.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App everything -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
everything: 1.4.1.1032 (scoop version is 1.4.1.1032)
Forcing autoupdate!
Autoupdating everything
DEBUG[1769185142] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769185142] $substitutions.$preReleaseVersion             1.4.1.1032
DEBUG[1769185142] $substitutions.$version                       1.4.1.1032
DEBUG[1769185142] $substitutions.$basenameNoExt                 Everything-1.4.1.1032.x64
DEBUG[1769185142] $substitutions.$match1                        1.4.1.1032
DEBUG[1769185142] $substitutions.$matchHead                     1.4.1
DEBUG[1769185142] $substitutions.$baseurl                       https://www.voidtools.com
DEBUG[1769185142] $substitutions.$url                           https://www.voidtools.com/Everything-1.4.1.1032.x64.zip
DEBUG[1769185142] $substitutions.$matchTail                     .1032
DEBUG[1769185142] $substitutions.$cleanVersion                  1411032
DEBUG[1769185142] $substitutions.$majorVersion                  1
DEBUG[1769185142] $substitutions.$dashVersion                   1-4-1-1032
DEBUG[1769185142] $substitutions.$dotVersion                    1.4.1.1032
DEBUG[1769185142] $substitutions.$buildVersion                  1032
DEBUG[1769185142] $substitutions.$underscoreVersion             1_4_1_1032
DEBUG[1769185142] $substitutions.$patchVersion                  1
DEBUG[1769185142] $substitutions.$urlNoExt                      https://www.voidtools.com/Everything-1.4.1.1032.x64
DEBUG[1769185142] $substitutions.$minorVersion                  4
DEBUG[1769185142] $substitutions.$basename                      Everything-1.4.1.1032.x64.zip
DEBUG[1769185142] $hashfile_url = https://www.voidtools.com/Everything-1.4.1.1032.sha256 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for Everything-1.4.1.1032.x64.zip in https://www.voidtools.com/Everything-1.4.1.1032.sha256
DEBUG[1769185143] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*Everything-1\.4\.1\.1032\.x64\.zip(?:\s|$)|Everything-1\.4\.1\.1032\.x64\.zip[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: 698df475ec44e638f66f1b6a32d28fea613cec78d3b6310e6abe53431eeb940c using Extract Mode
DEBUG[1769185143] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769185143] $substitutions.$preReleaseVersion             1.4.1.1032
DEBUG[1769185143] $substitutions.$version                       1.4.1.1032
DEBUG[1769185143] $substitutions.$basenameNoExt                 Everything-1.4.1.1032.ARM64
DEBUG[1769185143] $substitutions.$match1                        1.4.1.1032
DEBUG[1769185143] $substitutions.$matchHead                     1.4.1
DEBUG[1769185143] $substitutions.$baseurl                       https://www.voidtools.com
DEBUG[1769185143] $substitutions.$url                           https://www.voidtools.com/Everything-1.4.1.1032.ARM64.zip
DEBUG[1769185143] $substitutions.$matchTail                     .1032
DEBUG[1769185143] $substitutions.$cleanVersion                  1411032
DEBUG[1769185143] $substitutions.$majorVersion                  1
DEBUG[1769185143] $substitutions.$dashVersion                   1-4-1-1032
DEBUG[1769185143] $substitutions.$dotVersion                    1.4.1.1032
DEBUG[1769185143] $substitutions.$buildVersion                  1032
DEBUG[1769185143] $substitutions.$underscoreVersion             1_4_1_1032
DEBUG[1769185143] $substitutions.$patchVersion                  1
DEBUG[1769185143] $substitutions.$urlNoExt                      https://www.voidtools.com/Everything-1.4.1.1032.ARM64
DEBUG[1769185143] $substitutions.$minorVersion                  4
DEBUG[1769185143] $substitutions.$basename                      Everything-1.4.1.1032.ARM64.zip
DEBUG[1769185143] $hashfile_url = https://www.voidtools.com/Everything-1.4.1.1032.sha256 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for Everything-1.4.1.1032.ARM64.zip in https://www.voidtools.com/Everything-1.4.1.1032.sha256
Could not find hash in https://www.voidtools.com/Everything-1.4.1.1032.sha256
Downloading Everything-1.4.1.1032.ARM64.zip to compute hashes!
Loading Everything-1.4.1.1032.ARM64.zip from cache
Computed hash: 23dca1a64574bf30c9988bbaf5f1d201a0ec7ee9a15e12270ae92a52183cccc8
Writing updated everything manifest


# The currently installed `Everything` does not have the service installed,
# but the globally installed `Everything` does have the service installed.

┏[ ~]
└─> Test-Administrator
False

┏[ ~]
└─> scoop install Unofficial/everything
Installing 'everything' (1.4.1.1032) [64bit] from 'Unofficial' bucket
Loading Everything-1.4.1.1032.x64.zip from cache.
Checking hash of Everything-1.4.1.1032.x64.zip... OK.
Extracting Everything-1.4.1.1032.x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\everything\current => D:\Software\Scoop\Local\apps\everything\1.4.1.1032
Creating shim for 'Everything'.
Making D:\Software\Scoop\Local\shims\everything.exe a GUI binary.
Creating shortcut for Everything (Everything.exe)
Persisting Logs
Persisting HTTP server
Running post_install script... Done.
'everything' (1.4.1.1032) was installed successfully!
Notes
-----
To add Everything to right-click context menu, run:
reg import "D:\Software\Scoop\Local\apps\everything\current\install-context.reg"
-----

┏[ ~]
└─> Get-Service -Name 'Everything' | ForEach-Object -MemberName BinaryPathName
"D:\Software\Scoop\Global\apps\Everything\current\everything.exe" -svc

┏[ ~]
└─> scoop update everything -f
everything: 1.4.1.1032 -> 1.4.1.1032
Updating one outdated app:
Updating 'everything' (1.4.1.1032 -> 1.4.1.1032)
Downloading new version
Loading Everything-1.4.1.1032.x64.zip from cache.
Checking hash of Everything-1.4.1.1032.x64.zip... OK.
Running pre_uninstall script... Done.
Uninstalling 'everything' (1.4.1.1032)
Running uninstaller script... Done.
Removing shim 'Everything.shim'.
Removing shim 'Everything.exe'.
Unlinking D:\Software\Scoop\Local\apps\everything\current
Installing 'everything' (1.4.1.1032) [64bit] from 'Unofficial' bucket
Loading Everything-1.4.1.1032.x64.zip from cache.
Extracting Everything-1.4.1.1032.x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\everything\current => D:\Software\Scoop\Local\apps\everything\1.4.1.1032
Creating shim for 'Everything'.
Making D:\Software\Scoop\Local\shims\everything.exe a GUI binary.
Creating shortcut for Everything (Everything.exe)
Persisting Logs
Persisting HTTP server
Running post_install script... Done.
'everything' (1.4.1.1032) was installed successfully!
Notes
-----
To add Everything to right-click context menu, run:
reg import "D:\Software\Scoop\Local\apps\everything\current\install-context.reg"
-----

┏[ ~]
└─> scoop uninstall everything -p
Uninstalling 'everything' (1.4.1.1032).
Running pre_uninstall script... Done.
WARN  The following instances of "everything" are still running. Scoop is configured to ignore this condition.

 NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     17     3.45      24.48       0.09   15864   1 everything

Running uninstaller script... Done.
Removing shim 'Everything.shim'.
Removing shim 'Everything.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Everything.lnk
Unlinking D:\Software\Scoop\Local\apps\everything\current
Removing older version (_1.4.1.1032.old).
Removing persisted data.
'everything' was uninstalled.


# The currently installed `Everything` has installed a service.

┏[ ~]
└─> Test-Administrator
False

┏[ ~]
└─> Get-Service -Name 'Everything' | ForEach-Object -MemberName BinaryPathName
"D:\Software\Scoop\Local\apps\everything\current\everything.exe" -svc

┏[ ~]
└─> scoop update everything -f
everything: 1.4.1.1032 -> 1.4.1.1032
Updating one outdated app:
Updating 'everything' (1.4.1.1032 -> 1.4.1.1032)
Downloading new version
Loading Everything-1.4.1.1032.x64.zip from cache.
Checking hash of Everything-1.4.1.1032.x64.zip... OK.
Running pre_uninstall script... Done.
Uninstalling 'everything' (1.4.1.1032)
Running uninstaller script...
[ERROR]  everything requires admin rights to update.

┏[ ~]
└─[ Error, check your command]> sudo scoop update everything -f
everything: 1.4.1.1032 -> 1.4.1.1032
Updating one outdated app:
Updating 'everything' (1.4.1.1032 -> 1.4.1.1032)
WARN  The following instances of "everything" are still running. Scoop is configured to ignore this condition.

 NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     11     1.93      11.59       0.03    9484   0 everything

Downloading new version
Loading Everything-1.4.1.1032.x64.zip from cache.
Checking hash of Everything-1.4.1.1032.x64.zip... OK.
Running pre_uninstall script... Done.
Uninstalling 'everything' (1.4.1.1032)
Running uninstaller script... Done.
Removing shim 'Everything.shim'.
Removing shim 'Everything.exe'.
Unlinking D:\Software\Scoop\Local\apps\everything\current
Installing 'everything' (1.4.1.1032) [64bit] from 'Unofficial' bucket
Loading Everything-1.4.1.1032.x64.zip from cache.
Extracting Everything-1.4.1.1032.x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\everything\current => D:\Software\Scoop\Local\apps\everything\1.4.1.1032
Creating shim for 'Everything'.
Making D:\Software\Scoop\Local\shims\everything.exe a GUI binary.
Creating shortcut for Everything (Everything.exe)
Persisting Logs
Persisting HTTP server
Running post_install script... Done.
'everything' (1.4.1.1032) was installed successfully!
Notes
-----
To add Everything to right-click context menu, run:
reg import "D:\Software\Scoop\Local\apps\everything\current\install-context.reg"
-----

┏[ ~]
└─> sudo scoop uninstall everything -p
Uninstalling 'everything' (1.4.1.1032).
Running pre_uninstall script... Done.
WARN  The following instances of "everything" are still running. Scoop is configured to ignore this condition.

 NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     17     3.39      24.46       0.17   10004   1 everything
     11     2.00      11.50       0.02   10256   0 everything
     23   126.90     150.52      12.55   18764   1 everything

Running uninstaller script... Done.
Removing shim 'Everything.shim'.
Removing shim 'Everything.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Everything.lnk
Unlinking D:\Software\Scoop\Local\apps\everything\current
Removing older version (_1.4.1.1032.old).
Removing persisted data.
'everything' was uninstalled.

┏[ ~]
└─> Get-Service -Name 'Everything' | ForEach-Object -MemberName BinaryPathName
Get-Service: Cannot find any service with service name 'Everything'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License now includes an explicit URL.
  * Structured version-check (url + regex) added.
  * Declared persistence for Logs and HTTP server.
  * Added an explicit uninstaller script to handle cleanup and service/process stop.

* **Refactor**
  * Install/uninstall flows rewritten for more robust persistence handling, registry templating/encoding, and safer path/registration handling.

* **Documentation**
  * Notes updated with separate commands for registering/unregistering associations, startup, context menu, and URL handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->