### PR TITLE
gopeed@1.9.0: Add arm64 version

### DIFF
--- a/bucket/gopeed.json
+++ b/bucket/gopeed.json
@@ -1,8 +1,11 @@
 {
     "version": "1.9.0",
-    "description": "A modern download manager that supports all platforms",
-    "homepage": "https://github.com/GopeedLab/gopeed",
-    "license": "GPL-3.0-only",
+    "description": "A modern download manager that supports all platforms.",
+    "homepage": "https://gopeed.com",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/GopeedLab/gopeed/blob/HEAD/LICENSE"
+    },
     "notes": [
         "Starting with version 1.8.0, all user data is stored in the './storage' directory.",
         "Upgrading Gopeed via Scoop will no longer result in loss of user configuration."
@@ -11,6 +14,10 @@
         "64bit": {
             "url": "https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/Gopeed-v1.9.0-windows-amd64-portable.zip",
             "hash": "fafa8fef33914384d64ba962371367364ac9a063da113ba7b44623ca54f796bc"
+        },
+        "arm64": {
+            "url": "https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/Gopeed-v1.9.0-windows-arm64-portable.zip",
+            "hash": "74d1a7d856acb5391af7352ffd1244f46baa35c07fe533debc3dd89ca9b3988e"
         }
     },
     "pre_install": [
@@ -55,11 +62,16 @@
         ]
     ],
     "persist": "storage",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/GopeedLab/gopeed"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/GopeedLab/gopeed/releases/download/v$version/Gopeed-v$version-windows-amd64-portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/GopeedLab/gopeed/releases/download/v$version/Gopeed-v$version-windows-arm64-portable.zip"
             }
         }
     }


### PR DESCRIPTION
### Summary

Introduces **ARM64** architecture support, and refines manifest metadata for better accuracy and compliance.

### Changes

- **Add ARM64 Support**: Include `arm64` architecture in both the main manifest and `autoupdate` logic, utilizing the official portable ARM64 binaries.
- **Improve Metadata**:
  - Update `homepage` to the official domain: `https://gopeed.com`.
  - Structure the `license` field using a full SPDX identifier (`GPL-3.0-or-later`) and a direct link to the license file.
- **Refactor checkver**: Modernize the `checkver` field into a structured object for better maintainability.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App gopeed -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
gopeed: 1.9.0 (scoop version is 1.9.0)
Forcing autoupdate!
Autoupdating gopeed
DEBUG[1769190827] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769190827] $substitutions.$baseurl                       https://github.com/GopeedLab/gopeed/releases/download/v1.9.0
DEBUG[1769190827] $substitutions.$patchVersion                  0
DEBUG[1769190827] $substitutions.$basename                      Gopeed-v1.9.0-windows-arm64-portable.zip
DEBUG[1769190827] $substitutions.$version                       1.9.0
DEBUG[1769190827] $substitutions.$match1                        1.9.0
DEBUG[1769190827] $substitutions.$matchTail
DEBUG[1769190827] $substitutions.$underscoreVersion             1_9_0
DEBUG[1769190827] $substitutions.$matchHead                     1.9.0
DEBUG[1769190827] $substitutions.$url                           https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/Gopeed-v1.9.0-windows-arm64-portable.zip
DEBUG[1769190827] $substitutions.$cleanVersion                  190
DEBUG[1769190827] $substitutions.$dashVersion                   1-9-0
DEBUG[1769190827] $substitutions.$preReleaseVersion             1.9.0
DEBUG[1769190827] $substitutions.$dotVersion                    1.9.0
DEBUG[1769190827] $substitutions.$majorVersion                  1
DEBUG[1769190827] $substitutions.$basenameNoExt                 Gopeed-v1.9.0-windows-arm64-portable
DEBUG[1769190827] $substitutions.$minorVersion                  9
DEBUG[1769190827] $substitutions.$urlNoExt                      https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/Gopeed-v1.9.0-windows-arm64-portable
DEBUG[1769190827] $substitutions.$buildVersion
DEBUG[1769190827] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1769190830] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/GopeedLab/gopeed/releases/download/v1.9.0/Gopeed-v1.9.0-windows-arm64-portable.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 74d1a7d856acb5391af7352ffd1244f46baa35c07fe533debc3dd89ca9b3988e using Github Mode
Writing updated gopeed manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/gopeed --arch arm64
Installing 'gopeed' (1.9.0) [arm64] from 'Unofficial' bucket
Loading Gopeed-v1.9.0-windows-arm64-portable.zip from cache.
Checking hash of Gopeed-v1.9.0-windows-arm64-portable.zip... OK.
Extracting Gopeed-v1.9.0-windows-arm64-portable.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\gopeed\current => D:\Software\Scoop\Local\apps\gopeed\1.9.0
Creating shortcut for Gopeed (gopeed.exe)
Persisting storage
'gopeed' (1.9.0) was installed successfully!
Notes
-----
Starting with version 1.8.0, all user data is stored in the './storage' directory.
Upgrading Gopeed via Scoop will no longer result in loss of user configuration.
-----
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support with Windows portable release downloads and automatic updates.

* **Chores**
  * Updated software license identifier to GPL-3.0-or-later.
  * Updated project homepage URL.
  * Enhanced description formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->