### PR TITLE
vipsdisp@4.1.3: Add bin field, add arm64 support, update GitHub repo URLs

### DIFF
--- a/bucket/vipsdisp.json
+++ b/bucket/vipsdisp.json
@@ -1,12 +1,16 @@
 {
     "version": "4.1.3",
     "description": "Tiny libvips / gtk+4 image viewer",
-    "homepage": "https://github.com/jcupitt/vipsdisp",
+    "homepage": "https://github.com/libvips/vipsdisp",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jcupitt/vipsdisp/releases/download/v4.1.3/vipsdisp-x86_64-4.1.3.zip",
+            "url": "https://github.com/libvips/vipsdisp/releases/download/v4.1.3/vipsdisp-x86_64-4.1.3.zip",
             "hash": "b9c9f9881da5d63410068306b9e152ecdf1f35f309ab5359f514e6abf254a06b"
+        },
+        "arm64": {
+            "url": "https://github.com/libvips/vipsdisp/releases/download/v4.1.3/vipsdisp-aarch64-4.1.3.zip",
+            "hash": "059c480c28586b9e208f5756d4ec393bdb5556126d6ed288876fd0f930f22717"
         }
     },
     "bin": "bin\\vipsdisp.exe",
@@ -20,7 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jcupitt/vipsdisp/releases/download/v$version/vipsdisp-x86_64-$version.zip"
+                "url": "https://github.com/libvips/vipsdisp/releases/download/v$version/vipsdisp-x86_64-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/libvips/vipsdisp/releases/download/v$version/vipsdisp-aarch64-$version.zip"
             }
         }
     }


### PR DESCRIPTION
The `vipsdisp.exe` can be used as `vipsdisp <image>` to open an image file.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native arm64 build so users on ARM devices can install the app.
* **Chores**
  * Declared the executable entry point for improved package manager discovery.
  * Updated project homepage and download sources to a new upstream host and refreshed auto-update links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->