### PR TITLE
webview2: Add version 144.0.3719.93

### DIFF
--- a/bucket/webview2.json
+++ b/bucket/webview2.json
@@ -6,7 +6,7 @@
         "identifier": "Proprietary",
         "url": "https://developer.microsoft.com/microsoft-edge/api/eula/webview2"
     },
-    "notes": "Overrides any natively installed Runtime through environment variable 'WEBVIEW2_BROWSER_EXECUTABLE_FOLDER'.",
+    "notes": "Overrides any natively installed Runtime through environment variable 'WEBVIEW2_BROWSER_EXECUTABLE_FOLDER'. This is architecture-specific: Applications must match the runtime architecture, for example install the 32-bit build (--arch 32bit) to support 32-bit applications.",
     "architecture": {
         "32bit": {
             "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/6c876eab-3bbf-4715-bfaf-e5bb2925457d/Microsoft.WebView2.FixedVersionRuntime.144.0.3719.93.x86.cab#/dl.7z",


### PR DESCRIPTION
Adds webview2 v144.0.3719.93 in a portable way

Closes: https://github.com/ScoopInstaller/Nonportable/issues/389
Relates: https://github.com/ScoopInstaller/Extras/pull/16985

- [x] Tested x86/x64/arm64 installation
- ⚠️Uses environment variable that prioritizes this location over other webview2 installations
   - I could not find a better way of installing it in a portable manner


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebView2 Runtime is now available for installation on Windows with dedicated 32-bit, 64-bit, and ARM64 packages.
  * Architecture-specific installation targets and an environment variable are configured so apps can locate the runtime.
  * Automatic version checking and autoupdate support for each architecture have been added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->