### PR TITLE
spacesniffer: Update to version 2.1.0.21, fix checkver & autoupdate

### DIFF
--- a/bucket/spacesniffer.json
+++ b/bucket/spacesniffer.json
@@ -1,34 +1,39 @@
 {
-    "version": "2.0.5.18",
+    "version": "2.1.0.21",
     "description": "A tool application that lets you understand how folders and files are structured on your disks.",
     "homepage": "https://www.uderzo.it/main_products/space_sniffer/index.html",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://www.uderzo.it/main_products/space_sniffer/index.html"
-    },
+    "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://www.uderzo.it/main_products/space_sniffer/files/spacesniffer_2_0_5_18_x64.zip",
-            "hash": "sha1:fe10c6b601f1ed7d89fd3c5807de7c63f294ee0b"
+            "url": "https://www.uderzo.it/main_products/space_sniffer/files/spacesniffer_2_1_0_21_x64.zip",
+            "hash": "sha1:ea8a8de988958f49615a919219ffe5982eb2e8a9"
         }
     },
-    "bin": "SpaceSniffer.exe",
+    "pre_install": [
+        "if (-not (Test-Path -Path \"$persist_dir\\SpaceSnifferConfig.xml\" -PathType Leaf)) {",
+        "    New-Item -Path \"$dir\\SpaceSnifferConfig.xml\" -ItemType File -Force | Out-Null",
+        "}"
+    ],
     "shortcuts": [
         [
             "SpaceSniffer.exe",
             "SpaceSniffer"
         ]
     ],
-    "checkver": "Latest release is ([\\d.]+)",
+    "persist": "SpaceSnifferConfig.xml",
+    "checkver": {
+        "url": "https://www.uderzo.it/main_products/space_sniffer/release_notes.html",
+        "regex": "Release\\s*([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.uderzo.it/main_products/space_sniffer/files/spacesniffer_$underscoreVersion_x64.zip",
-                "hash": {
-                    "url": "https://www.uderzo.it/main_products/space_sniffer/download_alt.html",
-                    "regex": "<td>$sha1</td>"
-                }
+                "url": "https://www.uderzo.it/main_products/space_sniffer/files/spacesniffer_$underscoreVersion_x64.zip"
             }
+        },
+        "hash": {
+            "url": "https://www.uderzo.it/main_products/space_sniffer/download_alt.html",
+            "regex": "(?s)$basename.+?>$sha1"
         }
     }
 }


### PR DESCRIPTION
### Summary

Updates `spacesniffer` to version **2.1.0.21**, implements configuration persistence, and refines the update detection logic.

### Changes

- **Update** version to **2.1.0.21**.
- **Implement** persistence for `SpaceSnifferConfig.xml` to preserve user settings across updates.
- **Add** a `pre_install` script to initialize an empty configuration file if it doesn't exist, ensuring the `persist` logic hooks correctly.
- **Refactor** `checkver` to use the official release notes page for more reliable version tracking.
- **Improve** `autoupdate` hash detection by using a more robust multiline regex (`(?s)$basename.+?>$sha1`).

### Notes

- Version 2.1.0.21 was released on [January 20, 2026](https://www.uderzo.it/main_products/space_sniffer/download_alt.html#:~:text=Release%20notes%20%2D%2020/01/2026), but the manifest was not updated in a timely manner because the corresponding version information was not updated on the official homepage.
- `SpaceSniffer.exe` does not appear to support command-line arguments. Tests with `SpaceSniffer .` and `SpaceSniffer 'D:\'` did not produce the expected results, so the `bin` field has been removed.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App spacesniffer -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
spacesniffer: 2.1.0.21 (scoop version is 2.1.0.21)
Forcing autoupdate!
Autoupdating spacesniffer
DEBUG[1769386435] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1769386435] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769386435] $substitutions.$buildVersion                  21
DEBUG[1769386435] $substitutions.$dashVersion                   2-1-0-21
DEBUG[1769386435] $substitutions.$matchTail                     .21
DEBUG[1769386435] $substitutions.$patchVersion                  0
DEBUG[1769386435] $substitutions.$dotVersion                    2.1.0.21
DEBUG[1769386435] $substitutions.$preReleaseVersion             2.1.0.21
DEBUG[1769386435] $substitutions.$matchHead                     2.1.0
DEBUG[1769386435] $substitutions.$urlNoExt                      https://www.uderzo.it/main_products/space_sniffer/files/spacesniffer_2_1_0_21_x64
DEBUG[1769386435] $substitutions.$version                       2.1.0.21
DEBUG[1769386435] $substitutions.$url                           https://www.uderzo.it/main_products/space_sniffer/files/spacesniffer_2_1_0_21_x64.zip
DEBUG[1769386435] $substitutions.$baseurl                       https://www.uderzo.it/main_products/space_sniffer/files
DEBUG[1769386435] $substitutions.$basename                      spacesniffer_2_1_0_21_x64.zip
DEBUG[1769386435] $substitutions.$underscoreVersion             2_1_0_21
DEBUG[1769386435] $substitutions.$cleanVersion                  21021
DEBUG[1769386435] $substitutions.$match1                        2.1.0.21
DEBUG[1769386435] $substitutions.$basenameNoExt                 spacesniffer_2_1_0_21_x64
DEBUG[1769386435] $substitutions.$majorVersion                  2
DEBUG[1769386435] $substitutions.$minorVersion                  1
DEBUG[1769386435] $hashfile_url = https://www.uderzo.it/main_products/space_sniffer/download_alt.html -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for spacesniffer_2_1_0_21_x64.zip in https://www.uderzo.it/main_products/space_sniffer/download_alt.html
DEBUG[1769386436] $regex = (?s)spacesniffer_2_1_0_21_x64\.zip.+?>([a-fA-F0-9]{40}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:80:9
Found: sha1:ea8a8de988958f49615a919219ffe5982eb2e8a9 using Extract Mode
Writing updated spacesniffer manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/spacesniffer
Installing 'spacesniffer' (2.1.0.21) [64bit] from 'Unofficial' bucket
Loading spacesniffer_2_1_0_21_x64.zip from cache.
Checking hash of spacesniffer_2_1_0_21_x64.zip... OK.
Extracting spacesniffer_2_1_0_21_x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\spacesniffer\current => D:\Software\Scoop\Local\apps\spacesniffer\2.1.0.21
Creating shortcut for SpaceSniffer (SpaceSniffer.exe)
Persisting SpaceSnifferConfig.xml
'spacesniffer' (2.1.0.21) was installed successfully!

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> Get-ChildItem -Path $(scoop prefix spacesniffer) -Filter '*.xml' | Select-Object -Property Length, LastWriteTime

Length LastWriteTime
------ -------------
     0 1/25/2026 7:19:59 PM

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> Get-ChildItem -Path $(scoop prefix spacesniffer) -Filter '*.xml' | Select-Object -Property Length, LastWriteTime

Length LastWriteTime
------ -------------
  5984 1/25/2026 7:20:59 PM

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> Get-ChildItem -Path $(scoop prefix spacesniffer) -Filter '*.xml' | Get-Item | ForEach-Object -MemberName LinkType
HardLink
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic configuration file initialization on installation to ensure proper setup.
  * Configuration file now persists across updates and reinstalls.

* **Chores**
  * Updated package version to 2.1.0.21.
  * Updated download URLs and package verification methods.
  * Restructured package manifest configuration for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->