### PR TITLE
powertoys: Refactor installation & uninstallation logic

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -2,13 +2,20 @@
     "version": "0.99.0",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/microsoft/PowerToys/blob/HEAD/LICENSE"
+    },
     "notes": [
-        "Add PowerToys context menu option by running:",
+        "To register the context menu entry, please execute the following command:",
         "Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
         "",
         "If an error occurs when updating or uninstalling, execute the following command then retry:",
-        "`Stop-Process -Name 'explorer'`"
+        "`Stop-Process -Name 'explorer'`",
+        "",
+        "Please note that the related logic has been changed.",
+        "The context menu must be re-registered once, even if it was previously registered.",
+        "No further action is required if this message appears again."
     ],
     "architecture": {
         "64bit": {
@@ -22,64 +29,62 @@
     },
     "installer": {
         "script": [
-            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\.tmp\"",
-            "Get-ChildItem \"$dir\\.tmp\\AttachedContainer\\PowerToysUserSetup*.msi\" | Rename-Item -NewName 'PowerToysSetup.msi' -Force",
-            "$ver = ([xml](Get-Content -Raw \"$dir\\.tmp\\UX\\manifest.xml\" -Encoding utf8)).BurnManifest.EngineVersion",
-            "if (($null -ne $ver) -and ($ver -like \"5.*\")) {",
-            "    Expand-MsiArchive \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup.msi\" \"$dir\" -ExtractDir 'LocalApp\\PowerToys'",
+            "Expand-DarkArchive -Path \"$dir\\$fname\" -DestinationPath \"$dir\\tmp\" -Removal",
+            "$installer_file = Get-ChildItem -Path \"$dir\\tmp\\AttachedContainer\" -Filter 'PowerToys*.msi' -File |",
+            "        Select-Object -ExpandProperty FullName -First 1",
+            "if (-not $installer_file) { abort \"`nDeployment Failed: MSI package not found in extraction buffer.\" }",
+            "[xml]$xml = Get-Content -Path \"$dir\\tmp\\UX\\manifest.xml\" -Encoding utf8",
+            "$engine_version = $xml.BurnManifest.EngineVersion",
+            "if ($null -ne $engine_version -and [version]$engine_version -ge [version]::new(5, 0)) {",
+            "    Expand-MsiArchive -Path $installer_file -DestinationPath $dir -ExtractDir 'LocalApp\\PowerToys'",
             "} else {",
-            "    Expand-MsiArchive \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup.msi\" \"$dir\" -ExtractDir 'PowerToys'",
+            "    Expand-MsiArchive -Path $installer_file -DestinationPath $dir -ExtractDir 'PowerToys'",
             "}",
-            "Remove-Item \"$dir\\.tmp\", \"$dir\\$fname\" -Force -Recurse"
+            "Remove-Item -Path \"$dir\\tmp\" -Recurse -Force -ErrorAction SilentlyContinue"
         ]
     },
     "post_install": [
-        "'install-context', 'uninstall-context' | ForEach-Object {",
-        "    if (Test-Path \"$bucketsdir\\$bucket\\scripts\\$app\\$_.ps1\") {",
-        "        $content = Get-Content \"$bucketsdir\\$bucket\\scripts\\$app\\$_.ps1\"",
-        "        $content = $content.Replace('{{scoop_dir}}', $original_dir)",
-        "        if ($global) {",
-        "            $content = $content.Replace('{{install_scope}}', 'perMachine')",
-        "            $content = $content.Replace('{{registry_scope}}', 'HKLM')",
-        "        }",
-        "        $content = $content.Replace('{{install_scope}}', 'perUser')",
-        "        $content = $content.Replace('{{registry_scope}}', 'HKCU')",
-        "        $content | Set-Content -Path \"$dir\\$_.ps1\"",
-        "    }",
+        "$install_scope, $registry_hive = if ($global) { 'perMachine', 'HKLM' } else { 'perUser', 'HKCU' }",
+        "Get-ChildItem -Path \"$bucketsdir\\$bucket\\scripts\\$app\" -Filter '*.ps1' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding utf8",
+        "    $content = $content -Replace '{{install_scope}}', $install_scope",
+        "    $content = $content -Replace '{{registry_hive}}', $registry_hive",
+        "    $content -Replace '{{powertoys_dir}}', $original_dir | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding utf8",
         "}",
-        "$regpath = 'HKCU:\\Software\\Classes\\powertoys'",
-        "if ($global) {",
-        "    $regpath = $regpath.Replace('HKCU', 'HKLM')",
-        "}",
-        "if (Test-Path -Path $regpath) {",
-        "    Remove-Item -Path $regpath -Recurse -Force | Out-Null",
+        "$registry_path = \"${registry_hive}:\\Software\\Classes\\powertoys\"",
+        "if (-not (Test-Path -Path $registry_path)) { return }",
+        "$default_value = Get-ItemProperty -Path $registry_path | ForEach-Object -MemberName '(default)'",
+        "if ($null -ne $default_value -and $default_value -eq 'Context menu registration status check') {",
         "    Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
         "}"
     ],
-    "uninstaller": {
-        "script": [
-            "$regpath = 'HKCU:\\Software\\Classes\\powertoys'",
-            "if ($global) {",
-            "    $regpath = $regpath.Replace('HKCU', 'HKLM')",
-            "}",
-            "if (Test-Path -Path $regpath) {",
-            "    Invoke-Expression -Command \"& `\"$dir\\uninstall-context.ps1`\"\"",
-            "    if ($cmd -ne 'uninstall') {",
-            "        New-Item -Path $regpath -Force | Out-Null",
-            "    }",
-            "}"
-        ]
-    },
     "shortcuts": [
         [
             "PowerToys.exe",
             "PowerToys"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "$registry_hive = if ($global) { 'HKLM' } else { 'HKCU' }",
+            "$registry_path = \"${registry_hive}:\\Software\\Classes\\powertoys\"",
+            "if (-not (Test-Path -Path $registry_path)) { return }",
+            "$default_value = Get-ItemProperty -Path $registry_path | ForEach-Object -MemberName '(default)'",
+            "if ($default_value -ne 'URL:PowerToys custom internal URI protocol') { return }",
+            "Invoke-Expression -Command \"& `\"$dir\\uninstall-context.ps1`\"\"",
+            "if ($cmd -eq 'uninstall') {",
+            "    $remove_list = @($registry_path, 'HKCU:\\Software\\Classes\\powertoys')",
+            "    $remove_list | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue",
+            "} else {",
+            "    $default_value = 'Context menu registration status check'",
+            "    Set-ItemProperty -Path $registry_path -Name '(default)' -Value $default_value -Force",
+            "}"
+        ]
+    },
     "checkver": {
         "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
-        "jsonpath": "$[0].assets[*].browser_download_url",
-        "regex": "/releases/download/(?<tag>[\\w.]+)/PowerToysUserSetup-([\\d.]+)-x64\\.exe"
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /PowerToysUser/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/PowerToysUserSetup-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -92,7 +97,7 @@
         },
         "hash": {
             "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
-            "regex": "(?sm)$basename.*?>$sha256<"
+            "regex": "(?s)$basename.+?$sha256"
         }
     }
 }

--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.99.0",
+    "version": "0.99.1",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": {
@@ -19,12 +19,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.99.0/PowerToysUserSetup-0.99.0-x64.exe",
-            "hash": "1e3586a2ecd454b86fe61c44b003e0027fcc24dcb5135958b73d04a58285618c"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.99.1/PowerToysUserSetup-0.99.1-x64.exe",
+            "hash": "cad34aa632251cfb9bda1d6fe70e0bd5c150ac6fec7afb0ba179df90413430cd"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.99.0/PowerToysUserSetup-0.99.0-arm64.exe",
-            "hash": "2bca2a1edb0077faf752dde95c8d02a0a7a70f8e5128f43ea58432bbbe4e3c62"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.99.1/PowerToysUserSetup-0.99.1-arm64.exe",
+            "hash": "7bd4c3e66d64339c40dd42ec58de8f25e2b81ecd90c45f0ad95247024f508705"
         }
     },
     "installer": {
@@ -82,7 +82,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
+        "github": "https://api.github.com/repos/microsoft/PowerToys/releases",
         "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /PowerToysUser/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>[^/]+)/PowerToysUserSetup-([\\d.]+)"
     },

--- a/scripts/powertoys/install-context.ps1
+++ b/scripts/powertoys/install-context.ps1
@@ -1,112 +1,116 @@
-$regPath = '{{registry_scope}}:\Software\Classes\powertoys'
-New-Item -Path $regPath -Value 'URL:PowerToys custom internal URI protocol' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'InstallScope' -Value '{{install_scope}}' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'URL Protocol' -Value '' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\powertoys'
+if (-not (Test-Path -Path $registry_path)) {
+    New-Item -Path $registry_path -Value 'URL:PowerToys custom internal URI protocol' -Force | Out-Null
+} else {
+    Set-ItemProperty -Path $registry_path -Name '(default)' -Value 'URL:PowerToys custom internal URI protocol' -Force
+}
+Set-ItemProperty -Path $registry_path -Name 'InstallScope' -Value '{{install_scope}}' -Force | Out-Null
+Set-ItemProperty -Path $registry_path -Name 'URL Protocol' -Value '' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\powertoys\components'
-New-Item -Path $regPath -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'BugReportTool_exe' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'License_rtf' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'Module_KeyboardManager_Editor' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'Module_KeyboardManager_Engine' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'Module_VideoConference' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'Module_VideoConferenceIcons' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'Notice_md' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'StylesReportTool_exe' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'WebcamReportTool_exe' -Value '' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'WinUI3AppsMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG' -Value '' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\powertoys\components'
+New-Item -Path $registry_path -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'BugReportTool_exe' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'License_rtf' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'Module_KeyboardManager_Editor' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'Module_KeyboardManager_Engine' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'Module_VideoConference' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'Module_VideoConferenceIcons' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'Notice_md' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'StylesReportTool_exe' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'WebcamReportTool_exe' -Value '' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'WinUI3AppsMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG' -Value '' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\powertoys\DefaultIcon'
-New-Item -Path $regPath -Value 'PowerToys.exe' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\powertoys\DefaultIcon'
+New-Item -Path $registry_path -Value 'PowerToys.exe' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\powertoys\shell\open\command'
-New-Item -Path $regPath -Value '"{{scoop_dir}}\PowerToys.exe" "%1"' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\powertoys\shell\open\command'
+New-Item -Path $registry_path -Value '"{{powertoys_dir}}\PowerToys.exe" "%1"' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}'
-New-Item -Path $regPath -Value 'PowerRename Shell Extension' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'ContextMenuOptIn' -Value '' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}'
+New-Item -Path $registry_path -Value 'PowerRename Shell Extension' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'ContextMenuOptIn' -Value '' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}\InprocServer32'
-New-Item -Path $regPath -Value '{{scoop_dir}}\WinUI3Apps\PowerToys.PowerRenameExt.dll' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}\InprocServer32'
+New-Item -Path $registry_path -Value '{{powertoys_dir}}\WinUI3Apps\PowerToys.PowerRenameExt.dll' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\PowerRenameExt'
-New-Item -Path $regPath -Value '{0440049F-D1DC-4E46-B27B-98393D79486B}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\PowerRenameExt'
+New-Item -Path $registry_path -Value '{0440049F-D1DC-4E46-B27B-98393D79486B}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\Directory\background\ShellEx\ContextMenuHandlers\PowerRenameExt'
-New-Item -Path $regPath -Value '{0440049F-D1DC-4E46-B27B-98393D79486B}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\Directory\background\ShellEx\ContextMenuHandlers\PowerRenameExt'
+New-Item -Path $registry_path -Value '{0440049F-D1DC-4E46-B27B-98393D79486B}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{51B4D7E5-7568-4234-B4BB-47FB3C016A69}\InprocServer32'
-New-Item -Path $regPath -Value '{{scoop_dir}}\PowerToys.ImageResizerExt.dll' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{51B4D7E5-7568-4234-B4BB-47FB3C016A69}\InprocServer32'
+New-Item -Path $registry_path -Value '{{powertoys_dir}}\PowerToys.ImageResizerExt.dll' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\Directory\ShellEx\DragDropHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\Directory\ShellEx\DragDropHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.bmp\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.bmp\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.dib\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.dib\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.gif\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.gif\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jfif\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jfif\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jpe\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jpe\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jpeg\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jpeg\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jpg\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jpg\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jxr\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jxr\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.png\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.png\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.rle\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.rle\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.tif\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.tif\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.tiff\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.tiff\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.wdp\ShellEx\ContextMenuHandlers\ImageResizer'
-New-Item -Path $regPath -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.wdp\ShellEx\ContextMenuHandlers\ImageResizer'
+New-Item -Path $registry_path -Value '{51B4D7E5-7568-4234-B4BB-47FB3C016A69}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}'
-New-Item -Path $regPath -Value 'File Locksmith Shell Extension' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'ContextMenuOptIn' -Value '' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}'
+New-Item -Path $registry_path -Value 'File Locksmith Shell Extension' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'ContextMenuOptIn' -Value '' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}\InprocServer32'
-New-Item -Path $regPath -Value '{{scoop_dir}}\WinUI3Apps\PowerToys.FileLocksmithExt.dll' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}\InprocServer32'
+New-Item -Path $registry_path -Value '{{powertoys_dir}}\WinUI3Apps\PowerToys.FileLocksmithExt.dll' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\FileLocksmithExt'
-New-Item -Path $regPath -Value '{84D68575-E186-46AD-B0CB-BAEB45EE29C0}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\FileLocksmithExt'
+New-Item -Path $registry_path -Value '{84D68575-E186-46AD-B0CB-BAEB45EE29C0}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\Drive\ShellEx\ContextMenuHandlers\FileLocksmithExt'
-New-Item -Path $regPath -Value '{84D68575-E186-46AD-B0CB-BAEB45EE29C0}' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\Drive\ShellEx\ContextMenuHandlers\FileLocksmithExt'
+New-Item -Path $registry_path -Value '{84D68575-E186-46AD-B0CB-BAEB45EE29C0}' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}'
-New-Item -Path $regPath -Value 'PowerToys Toast Notifications Background Activator' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}'
+New-Item -Path $registry_path -Value 'PowerToys Toast Notifications Background Activator' -Force | Out-Null
 
-$regPath = '{{registry_scope}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}\LocalServer32'
-New-Item -Path $regPath -Value '{{scoop_dir}}\PowerToys.exe -ToastActivated' -Force | Out-Null
-New-ItemProperty -Path $regPath -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
+$registry_path = '{{registry_hive}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}\LocalServer32'
+New-Item -Path $registry_path -Value '{{powertoys_dir}}\PowerToys.exe -ToastActivated' -Force | Out-Null
+New-ItemProperty -Path $registry_path -Name 'ThreadingModel' -Value 'Apartment' -Force | Out-Null
 
-if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell 3>$null }
+if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell *> $null }
 
-Add-AppxPackage -Path '{{scoop_dir}}\WinUI3Apps\ImageResizerContextMenuPackage.msix' -ExternalLocation '{{scoop_dir}}\WinUI3Apps' | Out-Null
+Add-AppxPackage -Path '{{powertoys_dir}}\WinUI3Apps\ImageResizerContextMenuPackage.msix' -ExternalLocation '{{powertoys_dir}}\WinUI3Apps' | Out-Null
 
-Add-AppxPackage -Path '{{scoop_dir}}\WinUI3Apps\PowerRenameContextMenuPackage.msix' -ExternalLocation '{{scoop_dir}}\WinUI3Apps' | Out-Null
+Add-AppxPackage -Path '{{powertoys_dir}}\WinUI3Apps\PowerRenameContextMenuPackage.msix' -ExternalLocation '{{powertoys_dir}}\WinUI3Apps' | Out-Null
 
-Get-ChildItem '{{scoop_dir}}\WinUI3Apps\CmdPal\Microsoft.CmdPal.UI_*.msix' | ForEach-Object { Add-AppxPackage -Path $_.FullName | Out-Null }
+Get-ChildItem '{{powertoys_dir}}\WinUI3Apps\CmdPal\Microsoft.CmdPal.UI_*.msix' | ForEach-Object { Add-AppxPackage -Path $_.FullName | Out-Null }

--- a/scripts/powertoys/uninstall-context.ps1
+++ b/scripts/powertoys/uninstall-context.ps1
@@ -1,48 +1,38 @@
 @(
-    '{{registry_scope}}:\Software\Classes\powertoys\shell\open\command'
-    '{{registry_scope}}:\Software\Classes\powertoys\DefaultIcon'
-    '{{registry_scope}}:\Software\Classes\powertoys\components'
-    '{{registry_scope}}:\Software\Classes\powertoys'
-    '{{registry_scope}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}\InprocServer32'
-    '{{registry_scope}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}'
-    '{{registry_scope}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\PowerRenameExt'
-    '{{registry_scope}}:\Software\Classes\Directory\background\ShellEx\ContextMenuHandlers\PowerRenameExt'
-    '{{registry_scope}}:\Software\Classes\CLSID\{51B4D7E5-7568-4234-B4BB-47FB3C016A69}\InprocServer32'
-    '{{registry_scope}}:\Software\Classes\Directory\ShellEx\DragDropHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.bmp\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.dib\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.gif\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jfif\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jpe\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jpeg\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jpg\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.jxr\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.png\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.rle\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.tif\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.tiff\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\SystemFileAssociations\.wdp\ShellEx\ContextMenuHandlers\ImageResizer'
-    '{{registry_scope}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}\InprocServer32'
-    '{{registry_scope}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}'
-    '{{registry_scope}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\FileLocksmithExt'
-    '{{registry_scope}}:\Software\Classes\Drive\ShellEx\ContextMenuHandlers\FileLocksmithExt'
-    '{{registry_scope}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}\LocalServer32'
-    '{{registry_scope}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}'
+    '{{registry_hive}}:\Software\Classes\powertoys\shell'
+    '{{registry_hive}}:\Software\Classes\powertoys\components'
+    '{{registry_hive}}:\Software\Classes\powertoys\DefaultIcon'
+    '{{registry_hive}}:\Software\Classes\CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}'
+    '{{registry_hive}}:\Software\Classes\CLSID\{51B4D7E5-7568-4234-B4BB-47FB3C016A69}'
+    '{{registry_hive}}:\Software\Classes\CLSID\{84D68575-E186-46AD-B0CB-BAEB45EE29C0}'
+    '{{registry_hive}}:\Software\Classes\CLSID\{DD5CACDA-7C2E-4997-A62A-04A597B58F76}'
+    '{{registry_hive}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\PowerRenameExt'
+    '{{registry_hive}}:\Software\Classes\AllFileSystemObjects\ShellEx\ContextMenuHandlers\FileLocksmithExt'
+    '{{registry_hive}}:\Software\Classes\Directory\background\ShellEx\ContextMenuHandlers\PowerRenameExt'
+    '{{registry_hive}}:\Software\Classes\Directory\ShellEx\DragDropHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\Drive\ShellEx\ContextMenuHandlers\FileLocksmithExt'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.bmp\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.dib\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.gif\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jfif\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jpe\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jpeg\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jpg\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.jxr\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.png\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.rle\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.tif\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.tiff\ShellEx\ContextMenuHandlers\ImageResizer'
+    '{{registry_hive}}:\Software\Classes\SystemFileAssociations\.wdp\ShellEx\ContextMenuHandlers\ImageResizer'
 ) | ForEach-Object {
-    if (Test-Path $_) {
-        Remove-Item $_ -Recurse -Force | Out-Null
+    if (Test-Path -Path $_) {
+        Remove-Item -Path $_ -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
 
-if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell 3>$null }
+if ($PSVersionTable.PSVersion.Major -ge 6) { Import-Module Appx -UseWindowsPowershell *> $null }
 
-@(
-    'ImageResizerContextMenu'
-    'PowerRenameContextMenu'
-    'CommandPalette'
-) | ForEach-Object {
-    $likeName = $_
-    Get-AppxPackage |
-    Where-Object { $_.PackageFullName -like "*$likeName*" } |
-    Remove-AppxPackage | Out-Null
+@('CommandPalette', 'PowerRenameContextMenu', 'ImageResizerContextMenu') | ForEach-Object {
+    $name_filter = $_
+    Get-AppxPackage | Where-Object { $_.PackageFullName -like "*$name_filter*" } | Remove-AppxPackage | Out-Null
 }


### PR DESCRIPTION
### Summary

Refactors the `powertoys` manifest and associated scripts to improve installation reliability, shell extension (context menu) management, and registry state validation.

### Related issues or pull requests

- Relates to #17051 

### Changes

- **Refine** `license` field with explicit SPDX identifier and source URL.
- **Refactor** `installer` logic to use `[version]` type checking and improved `Expand-DarkArchive` parameters.
- **Improve** `post_install` and `uninstaller` scripts with robust registry value validation (checking for specific protocol strings/status markers) before performing actions.
- **Standardize** script templates by renaming internal variables (e.g., `{{scoop_dir}}` to `{{powertoys_dir}}`) and using UTF-8 encoding for file operations.
- ~~**Add** automatic `explorer` restart and sleep delay in the `uninstaller` to ensure shell extensions are properly released.~~
- **Update** `checkver` to use repository ID, filter out pre-releases, and utilize a more precise regex for asset detection.
- **Enhance** `autoupdate` regex to handle diverse HTML structures on the release page.

### Notes

- **Context Menu Re-registration**: Due to logic changes in how the context menu is tracked in the registry, users are required to re-run the registration command even if it was previously enabled.
- Reasons for changing the context menu registration status check:
  - Regardless of whether the installation is global, PowerToys may use `HKCU:\Software\Classes\powertoys` to create values such as `AllowDataDiagnostics` and `DataDiagnosticsViewEnabled`.
  - If the logic only checks whether `$registry_path` exists
    - These values may be removed, resulting in partial configuration loss.
    - In addition, if a user has installed the machine-wide version of PowerToys and then installs PowerToys again via `scoop install powertoys`, the context menu will always be registered, which may cause confusion for users who are only testing the manifest.

### Testing

> [!Note]
> Since I have already installed the machine-wide version of PowerToys via winget, the following tests do not include the context menu registration component in order to avoid unnecessary complications.

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App powertoys -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
powertoys: 0.98.1 (scoop version is 0.98.1)
Forcing autoupdate!
Autoupdating powertoys
DEBUG[1769632121] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1769632121] $substitutions.$cleanVersion                  0971
DEBUG[1769632121] $substitutions.$majorVersion                  0
DEBUG[1769632121] $substitutions.$match1                        0.98.1
DEBUG[1769632121] $substitutions.$underscoreVersion             0_97_1
DEBUG[1769632121] $substitutions.$matchHead                     0.98.1
DEBUG[1769632121] $substitutions.$patchVersion                  1
DEBUG[1769632121] $substitutions.$basenameNoExt                 PowerToysUserSetup-0.98.1-arm64
DEBUG[1769632121] $substitutions.$matchTail
DEBUG[1769632121] $substitutions.$urlNoExt                      https://github.com/microsoft/PowerToys/releases/download/v0.98.1/PowerToysUserSetup-0.98.1-arm64
DEBUG[1769632121] $substitutions.$baseurl                       https://github.com/microsoft/PowerToys/releases/download/v0.98.1
DEBUG[1769632121] $substitutions.$dashVersion                   0-97-1
DEBUG[1769632121] $substitutions.$preReleaseVersion             0.98.1
DEBUG[1769632121] $substitutions.$basename                      PowerToysUserSetup-0.98.1-arm64.exe
DEBUG[1769632121] $substitutions.$dotVersion                    0.98.1
DEBUG[1769632121] $substitutions.$minorVersion                  97
DEBUG[1769632121] $substitutions.$matchTag                      v0.98.1
DEBUG[1769632121] $substitutions.$url                           https://github.com/microsoft/PowerToys/releases/download/v0.98.1/PowerToysUserSetup-0.98.1-arm64.exe
DEBUG[1769632121] $substitutions.$version                       0.98.1
DEBUG[1769632121] $substitutions.$buildVersion
DEBUG[1769632121] $hashfile_url = https://github.com/microsoft/PowerToys/releases/tag/v0.98.1 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for PowerToysUserSetup-0.98.1-arm64.exe in https://github.com/microsoft/PowerToys/releases/tag/v0.98.1
DEBUG[1769632121] $regex = (?s)PowerToysUserSetup-0\.97\.1-arm64\.exe.+?([a-fA-F0-9]{64}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:80:9
Found: b16a1aee649c82da4062b7bd2adbe68a9928cd5ff567bfa9098c0d70ee3653a5 using Extract Mode
Writing updated powertoys manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/powertoys
Installing 'powertoys' (0.98.1) [64bit] from 'Unofficial' bucket
Loading PowerToysUserSetup-0.98.1-x64.exe from cache.
Checking hash of PowerToysUserSetup-0.98.1-x64.exe... OK.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\powertoys\current => D:\Software\Scoop\Local\apps\powertoys\0.98.1
Creating shortcut for PowerToys (PowerToys.exe)
Running post_install script... Done.
'powertoys' (0.98.1) was installed successfully!
Notes
-----
To register the context menu entry, please execute the following command:
Invoke-Expression -Command "& `"D:\Software\Scoop\Local\apps\powertoys\current\install-context.ps1`""

If an error occurs when updating or uninstalling, execute the following command then retry:
`Stop-Process -Name 'explorer'`

Please note that the related logic has been changed.
The context menu must be re-registered once, even if it was previously registered.
No further action is required if this message appears again.
-----

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop update powertoys -f
powertoys: 0.98.1 -> 0.98.1
Updating one outdated app:
Updating 'powertoys' (0.98.1 -> 0.98.1)
Downloading new version
Loading PowerToysUserSetup-0.98.1-x64.exe from cache.
Checking hash of PowerToysUserSetup-0.98.1-x64.exe... OK.
Uninstalling 'powertoys' (0.98.1)
Running uninstaller script... Done.
Unlinking D:\Software\Scoop\Local\apps\powertoys\current
Installing 'powertoys' (0.98.1) [64bit] from Unofficial/powertoys.json'
Loading PowerToysUserSetup-0.98.1-x64.exe from cache.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\powertoys\current => D:\Software\Scoop\Local\apps\powertoys\0.98.1
Creating shortcut for PowerToys (PowerToys.exe)
Running post_install script... Done.
'powertoys' (0.98.1) was installed successfully!
Notes
-----
To register the context menu entry, please execute the following command:
Invoke-Expression -Command "& `"D:\Software\Scoop\Local\apps\powertoys\current\install-context.ps1`""

If an error occurs when updating or uninstalling, execute the following command then retry:
`Stop-Process -Name 'explorer'`

Please note that the related logic has been changed.
The context menu must be re-registered once, even if it was previously registered.
No further action is required if this message appears again.
-----

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop uninstall powertoys -p
Uninstalling 'powertoys' (0.98.1).
Running uninstaller script... Done.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\PowerToys.lnk
Unlinking D:\Software\Scoop\Local\apps\powertoys\current
Removing older version (_0.98.1.old).
Removing persisted data.
'powertoys' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formal uninstaller with improved, context-aware cleanup.

* **Bug Fixes**
  * Improved installation and update handling with more robust archive extraction, asset detection, and version-aware extraction behavior.
  * Consolidated post-install configuration to reliably set installation scope and registry context.
  * Refined registry and context-menu cleanup logic for uninstall scenarios.

* **Chores**
  * License declaration updated to include identifier and reference URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->