### PR TITLE
colormix-screensaver: Add version 1.0.0

### DIFF
--- a/bucket/colormix-screensaver.json
+++ b/bucket/colormix-screensaver.json
@@ -6,12 +6,6 @@
     "url": "https://www.saversplanet.com/download/colormix.exe",
     "hash": "62DFF06EC2D8A4F80A682752D31FF835B7545D2F497254C64AC908E91D736349",
     "innosetup": true,
-    "bin": [
-        [
-            "Color Mix.scr",
-            "colormix"
-        ]
-    ],
     "shortcuts": [
         [
             "Color Mix.scr",


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Added new freeware screensaver from SaversPlanet.
Manifest validated and tested locally.

Manifest:
- Name: Color Mix Screensaver
- Version: 1.0.0
- License: Freeware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Color Mix Screensaver as an installable package with a desktop shortcut and bundled icon.
* **Chores**
  * Installer removes leftover ancillary files (shortcut/URL, readme, license) from the install folder after setup.
* **Notes**
  * Automatic version detection or auto-update is not included for this package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->