### PR TITLE
pastebar: Add version 0.7.0

### DIFF
--- a/bucket/pastebar.json
+++ b/bucket/pastebar.json
@@ -1,0 +1,36 @@
+{
+    "version": "0.7.0",
+    "description": "Limitless, Free Clipboard Manager for Mac and Windows",
+    "homepage": "https://www.pastebar.app/",
+    "license": "CC-BY-NC-SA-4.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PasteBar/PasteBarApp/releases/download/v0.7.0/PasteBar_0.7.0_x64-portable.zip",
+            "hash": "ed661b9734c4d35d7223437f026359d25d22be6bec0e567882745809005cb9a9"
+        },
+        "arm64": {
+            "url": "https://github.com/PasteBar/PasteBarApp/releases/download/v0.7.0/PasteBar_0.7.0_arm64-portable.zip",
+            "hash": "e514999c9f71d5110e7b52fb02afbb6f2f158b18ac98cc8bc3b9ed4c8de19bc6"
+        }
+    },
+    "bin": "PasteBar.exe",
+    "shortcuts": [
+        [
+            "PasteBar.exe",
+            "PasteBar"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/PasteBar/PasteBarApp"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PasteBar/PasteBarApp/releases/download/v$version/PasteBar_$version_x64-portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/PasteBar/PasteBarApp/releases/download/v$version/PasteBar_$version_arm64-portable.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
My first contribution to Scoop project.
Add PasteBar. A great Clipboard Manager.

Closes #17137

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows package-manager manifest to simplify distribution and installation for PasteBar.
  * Enables portable downloads with integrity verification for safer installs.
  * Adds automatic version checks and seamless updates sourced from GitHub releases.
  * Creates a single desktop/start menu shortcut for easy launching and upgrade handling.
  * Supports 64-bit and ARM64 Windows builds and publishes versioned releases (v0.7.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->