### PR TITLE
utpm: Add version 0.2.0

### DIFF
--- a/bucket/utpm.json
+++ b/bucket/utpm.json
@@ -1,20 +1,21 @@
 {
     "version": "0.2.0",
-    "description": "UTPM is a powerful command-line package manager for Typst. Create, manage, and share Typst packages with ease — whether for local development or publishing to Typst Universe.",
+    "description": "A package manager for local and remote Typst packages.",
     "homepage": "https://github.com/typst-community/utpm",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/typst-community/utpm/releases/download/v0.2.0/utpm-x86_64-pc-windows-msvc.zip",
             "hash": "c1f93c77406bc7d754c48ed78f19ac662ea3bb022106dfe40541144fccf6f8aa",
-            "bin": "utpm-x86_64-pc-windows-msvc/utpm.exe"
+            "extract_dir": "utpm-x86_64-pc-windows-msvc"
         },
         "arm64": {
             "url": "https://github.com/typst-community/utpm/releases/download/v0.2.0/utpm-aarch64-pc-windows-msvc.zip",
             "hash": "3bed9ebe2cfbef41e1a555f37f4162dfb05dfc06faeaadf18f6b8a7c68ea48aa",
-            "bin": "utpm-aarch64-pc-windows-msvc/utpm.exe"
+            "extract_dir": "utpm-aarch64-pc-windows-msvc"
         }
     },
+    "bin": "utpm.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Added utpm manifest.

Closes #17142 

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added official UTPM v0.2.0 Windows package manifest enabling 64‑bit and ARM64 distributions. Includes release metadata (description, homepage, license), architecture‑specific download links and SHA‑256 checksums, executable extraction path, integrated GitHub version checking, and autoupdate configuration to simplify installation and keep users on current releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->