### PR TITLE
zedis: Update to version 0.2.3, add arm64 support, fix autoupdate

### DIFF
--- a/bucket/zedis.json
+++ b/bucket/zedis.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/vicanso/zedis/releases/download/v0.2.3/zedis-windows-x86_64.zip",
             "hash": "8d2f7120bfbcf7d2c94dba8dde5dbaf181331c85a8176f0e17a46677a818110a"
+        },
+        "arm64": {
+            "url": "https://github.com/vicanso/zedis/releases/download/v0.2.3/zedis-windows-aarch64.zip",
+            "hash": "de3583d8c6871d1ae21ef3356d7c25e2110dccbd6b9fba5701beacca173ad757"
         }
     },
     "shortcuts": [
@@ -20,6 +24,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/vicanso/zedis/releases/download/v$version/zedis-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/vicanso/zedis/releases/download/v$version/zedis-windows-aarch64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped manifest to v0.2.3.
  * Updated 64-bit Windows installer reference and checksum to the new v0.2.3 artifact.
  * Adjusted autoupdate pattern to the new 64-bit Windows artifact naming.
  * Added native ARM64 Windows installer reference and checksum for v0.2.3.
  * Added ARM64 autoupdate entry for the new artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->