### PR TITLE
worktrunk: Add version 0.23.1

### DIFF
--- a/bucket/worktrunk.json
+++ b/bucket/worktrunk.json
@@ -9,9 +9,7 @@
             "hash": "e9577875c4e96196ba105d927f0a1312fdb59095e07824ed7f1f813c4f6e4458"
         }
     },
-    "bin": [
-        "git-wt.exe"
-    ],
+    "bin": "git-wt.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for WorkTrunk CLI v0.23.1 (Windows 64-bit), enabling one-step installation and automated updates via the package manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->