### PR TITLE
gdscript-formatter: Add version 0.18.2

### DIFF
--- a/bucket/gdscript-formatter.json
+++ b/bucket/gdscript-formatter.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.18.2",
+    "description": "A fast code formatter for GDScript in Godot 4",
+    "homepage": "https://www.gdquest.com/library/gdscript_formatter/",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/GDQuest/GDScript-formatter"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/0.18.2/gdscript-formatter-0.18.2-windows-x86_64.exe.zip",
+            "hash": "4052d0588c903e0558ddf0732638547c26058706873eb0f3e3991ba9419cde9f",
+            "bin": "gdscript-formatter-0.18.2-windows-x86_64.exe"
+        },
+        "arm64": {
+            "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/0.18.2/gdscript-formatter-0.18.2-windows-aarch64.exe.zip",
+            "hash": "32a6813c2d7f2fa61e3cf8e290892504552cc5ff590a946a538ff175f8e4d766",
+            "bin": "gdscript-formatter-0.18.2-windows-aarch64.exe"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/GDQuest/GDScript-formatter"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip"
+            }
+        }
+    }
+}

--- a/bucket/gdscript-formatter.json
+++ b/bucket/gdscript-formatter.json
@@ -10,12 +10,22 @@
         "64bit": {
             "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/0.18.2/gdscript-formatter-0.18.2-windows-x86_64.exe.zip",
             "hash": "4052d0588c903e0558ddf0732638547c26058706873eb0f3e3991ba9419cde9f",
-            "bin": "gdscript-formatter-0.18.2-windows-x86_64.exe"
+            "bin": [
+                [
+                    "gdscript-formatter-0.18.2-windows-x86_64.exe",
+                    "gdscript-formatter"
+                ]
+            ]
         },
         "arm64": {
             "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/0.18.2/gdscript-formatter-0.18.2-windows-aarch64.exe.zip",
             "hash": "32a6813c2d7f2fa61e3cf8e290892504552cc5ff590a946a538ff175f8e4d766",
-            "bin": "gdscript-formatter-0.18.2-windows-aarch64.exe"
+            "bin": [
+                [
+                    "gdscript-formatter-0.18.2-windows-aarch64.exe",
+                    "gdscript-formatter"
+                ]
+            ]
         }
     },
     "checkver": {
@@ -24,10 +34,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip"
+                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip",
+                "bin": "gdscript-formatter-$version-windows-x86_64.exe"
             },
             "arm64": {
-                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip"
+                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip",
+                "bin": "gdscript-formatter-$version-windows-aarch64.exe"
             }
         }
     }

--- a/bucket/gdscript-formatter.json
+++ b/bucket/gdscript-formatter.json
@@ -1,45 +1,33 @@
 {
     "version": "0.18.2",
-    "description": "A fast code formatter for GDScript in Godot 4",
+    "description": "A fast code formatter for GDScript in Godot 4.",
     "homepage": "https://www.gdquest.com/library/gdscript_formatter/",
     "license": {
         "identifier": "MIT",
-        "url": "https://github.com/GDQuest/GDScript-formatter"
+        "url": "https://github.com/GDQuest/GDScript-formatter/blob/HEAD/LICENSE"
     },
     "architecture": {
         "64bit": {
             "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/0.18.2/gdscript-formatter-0.18.2-windows-x86_64.exe.zip",
-            "hash": "4052d0588c903e0558ddf0732638547c26058706873eb0f3e3991ba9419cde9f",
-            "bin": [
-                [
-                    "gdscript-formatter-0.18.2-windows-x86_64.exe",
-                    "gdscript-formatter"
-                ]
-            ]
+            "hash": "4052d0588c903e0558ddf0732638547c26058706873eb0f3e3991ba9419cde9f"
         },
         "arm64": {
             "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/0.18.2/gdscript-formatter-0.18.2-windows-aarch64.exe.zip",
-            "hash": "32a6813c2d7f2fa61e3cf8e290892504552cc5ff590a946a538ff175f8e4d766",
-            "bin": [
-                [
-                    "gdscript-formatter-0.18.2-windows-aarch64.exe",
-                    "gdscript-formatter"
-                ]
-            ]
+            "hash": "32a6813c2d7f2fa61e3cf8e290892504552cc5ff590a946a538ff175f8e4d766"
         }
     },
+    "pre_install": "Get-ChildItem -Path \"$dir\\gdscript-formatter*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'gdscript-formatter.exe'",
+    "bin": "gdscript-formatter.exe",
     "checkver": {
         "github": "https://github.com/GDQuest/GDScript-formatter"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip",
-                "bin": "gdscript-formatter-$version-windows-x86_64.exe"
+                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip"
             },
             "arm64": {
-                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip",
-                "bin": "gdscript-formatter-$version-windows-aarch64.exe"
+                "url": "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip"
             }
         }
     }

--- a/bucket/gdscript-formatter.json
+++ b/bucket/gdscript-formatter.json
@@ -16,7 +16,7 @@
             "hash": "32a6813c2d7f2fa61e3cf8e290892504552cc5ff590a946a538ff175f8e4d766"
         }
     },
-    "pre_install": "Get-ChildItem -Path \"$dir\\gdscript-formatter*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'gdscript-formatter.exe'",
+    "pre_install": "Get-Item -Path \"$dir\\gdscript-formatter*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'gdscript-formatter.exe'",
     "bin": "gdscript-formatter.exe",
     "checkver": {
         "github": "https://github.com/GDQuest/GDScript-formatter"


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Godot GDScript Formatter:

- https://github.com/GDQuest/GDScript-formatter
- https://www.gdquest.com/library/gdscript_formatter/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GDScript Formatter v0.18.2 is now available via Scoop for Windows, with x64 and arm64 builds, MIT-licensed and linked to its homepage. Installer includes architecture-specific packages and checksum-verified downloads, plus automatic update support via GitHub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->