### PR TITLE
vpxtool: Add version 0.24.15

### DIFF
--- a/bucket/vpxtool.json
+++ b/bucket/vpxtool.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.24.15",
+    "description": "Terminal based frontend and utilities for Visual Pinball",
+    "homepage": "https://github.com/francisdb/vpxtool",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/francisdb/vpxtool/releases/download/v0.24.15/vpxtool-Windows-x86_64-v0.24.15.zip#/vpxtool.zip",
+            "hash": "a1de90c02b175d84afb7f6843f61c9d29ca078df76c6dcd9d491ec44105fcbc7"
+        }
+    },
+    "bin": "vpxtool.exe",
+    "checkver": {
+        "github": "https://github.com/francisdb/vpxtool"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/francisdb/vpxtool/releases/download/v$version/vpxtool-Windows-x86_64-v$version.zip#/vpxtool.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [vpxtool](https://github.com/francisdb/vpxtool).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17190 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a package manifest for VPX Tool version 0.24.15, enabling installation and automated updates through the Scoop package manager for Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->