### PR TITLE
linqpad: Update download URL

### DIFF
--- a/bucket/linqpad.json
+++ b/bucket/linqpad.json
@@ -11,7 +11,7 @@
         ".NET SDK 9": "versions/dotnet9-sdk",
         ".NET SDK 10": "versions/dotnet10-sdk"
     },
-    "url": "https://linqpad.azureedge.net/public/LINQPad9.zip?cache=9.6.6.5942606",
+    "url": "https://cdn.linqpad.net/public/LINQPad9.zip?cache=9.6.6.5942606",
     "hash": "b9de0746d2974378343242f2febb67f1c883032fefdff5dbf2c7e5a418bccb62",
     "architecture": {
         "64bit": {
@@ -79,7 +79,7 @@
         "regex": "\\.zip\\?cache=(?<ver>(?<version>\\d+\\.\\d+\\.\\d+)[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://linqpad.azureedge.net/public/LINQPad$majorVersion.zip?cache=$matchVer",
+        "url": "https://cdn.linqpad.net/public/LINQPad$majorVersion.zip?cache=$matchVer",
         "architecture": {
             "64bit": {
                 "bin": [


### PR DESCRIPTION
Update download URI to canonical CDN prior to the impending shutdown of azureedge.net.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated content delivery network endpoints for LINQPad package downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->