### PR TITLE
super-productivity@17.1.7: Fix download & autoupdate URLs

### DIFF
--- a/bucket/super-productivity.json
+++ b/bucket/super-productivity.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/super-productivity/super-productivity/releases/download/v17.1.7/superProductivity-x64.exe#/dl.7z",
-            "hash": "sha512:894906af07129222d3de21b7b0e9ac40fdc7831a92945bb15dfc2dcca30e534bdd5091e7256db931e9d8f050965126f0f4040fa7b79219359be48deffbf923b1",
+            "hash": "7f85830e6eb80ca1a52abe4cd9f6ec17af3a729100865f506d94f1c554b0d002",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Force -Recurse"
@@ -14,7 +14,7 @@
         },
         "arm64": {
             "url": "https://github.com/super-productivity/super-productivity/releases/download/v17.1.7/superProductivity-arm64.exe#/dl.7z",
-            "hash": "sha512:9e51f4c970c0259367d8ceaa28125c9ae9d185ac09259d7ca9140fb23733dd2840273a07030b1d8286bbb0292f5a9b4d1ba3c62c80e1fddbd139e02ca5e03cf9",
+            "hash": "ae52f2bad03988009166fdb63ae2747a2c2deb607fa13fa0520db42539976971",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Force -Recurse"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17203 


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated 64‑bit and arm64 installer download and autoupdate links to new locations and refreshed SHA‑512 checksums.
  * Removed the autoupdate hash lookup block for both architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->