### PR TITLE
czkawka-gui: Update to version 11.0.0, fix autoupdate

### DIFF
--- a/bucket/czkawka-gui.json
+++ b/bucket/czkawka-gui.json
@@ -1,17 +1,18 @@
 {
-    "version": "10.0.0",
+    "version": "11.0.0",
     "description": "Find duplicates, empty folders, similar images, unnecessary files, etc.",
     "homepage": "https://github.com/qarmin/czkawka",
-    "license": {
-        "identifier": "MIT, CC-BY-4.0, Unknown",
-        "url": "https://www.reshot.com/license/"
-    },
+    "license": "MIT|CC-BY-4.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qarmin/czkawka/releases/download/10.0.0/windows_czkawka_gui_gtk46.zip",
-            "hash": "6f575b1a553bb13ac3f3e29dc26e3381205d96031d3ab974ccfa40152be2866b"
+            "url": "https://github.com/qarmin/czkawka/releases/download/11.0.0/windows_czkawka_gui_gtk_412.zip",
+            "hash": "928e1c881068f01e415694277bcc5a90688054b8a3f720ce9de3a4796c244a4f"
         }
     },
+    "bin": [
+        "czkawka_cli.exe",
+        "czkawka_gui.exe"
+    ],
     "shortcuts": [
         [
             "czkawka_gui.exe",
@@ -22,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_czkawka_gui_gtk46.zip"
+                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_czkawka_gui_gtk_412.zip"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `czkawka-gui` to version **11.0.0**, fixes the download URL pattern for the new GTK 4.12 assets, and exposes the CLI binary.

### Changes

- **Cleanup License**: Simplify the `license` field to use standard SPDX identifiers (`MIT|CC-BY-4.0`) and removed the external URL.
- **Update** version to **11.0.0**.
- **Fix** asset URL pattern: The upstream release changed the suffix from `gtk46.zip` to `gtk_412.zip`.
- **Expose Binaries**: Add `bin` field to include both `czkawka_gui.exe` and `czkawka_cli.exe` in the user's path.

### Notes

- Upstream discontinued GTK 4.6 builds in version [11.0.0](https://github.com/qarmin/czkawka/releases/tag/11.0.0) and added the command-line options `--cache` and `--config` to `czkawka_gui.exe`.

> Added `--cache` and `--config CLI` options to open cache and config paths - https://github.com/qarmin/czkawka/pull/1745

> Windows prebuilt binaries now bundle libEGL and libGLES, which fixes issues running GTK 4.12 builds on some systems, GTK 4.6 builds are no longer provided

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App czkawka-gui -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
czkawka-gui: 11.0.0 (scoop version is 11.0.0)
Forcing autoupdate!
Autoupdating czkawka-gui
DEBUG[1771081041] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1771081041] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1771081041] $substitutions.$cleanVersion                  1100
DEBUG[1771081041] $substitutions.$url                           https://github.com/qarmin/czkawka/releases/download/11.0.0/windows_czkawka_gui_gtk_412.zip
DEBUG[1771081041] $substitutions.$underscoreVersion             11_0_0
DEBUG[1771081041] $substitutions.$dashVersion                   11-0-0
DEBUG[1771081041] $substitutions.$baseurl                       https://github.com/qarmin/czkawka/releases/download/11.0.0
DEBUG[1771081041] $substitutions.$buildVersion
DEBUG[1771081041] $substitutions.$basename                      windows_czkawka_gui_gtk_412.zip
DEBUG[1771081041] $substitutions.$matchTail
DEBUG[1771081041] $substitutions.$matchHead                     11.0.0
DEBUG[1771081041] $substitutions.$majorVersion                  11
DEBUG[1771081041] $substitutions.$preReleaseVersion             11.0.0
DEBUG[1771081041] $substitutions.$basenameNoExt                 windows_czkawka_gui_gtk_412
DEBUG[1771081041] $substitutions.$patchVersion                  0
DEBUG[1771081041] $substitutions.$version                       11.0.0
DEBUG[1771081041] $substitutions.$urlNoExt                      https://github.com/qarmin/czkawka/releases/download/11.0.0/windows_czkawka_gui_gtk_412
DEBUG[1771081041] $substitutions.$match1                        11.0.0
DEBUG[1771081041] $substitutions.$dotVersion                    11.0.0
DEBUG[1771081041] $substitutions.$minorVersion                  0
DEBUG[1771081041] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1771081043] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/qarmin/czkawka/releases/download/11.0.0/windows_czkawka_gui_gtk_412.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 928e1c881068f01e415694277bcc5a90688054b8a3f720ce9de3a4796c244a4f using Github Mode
Writing updated czkawka-gui manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated manifest to version 11.0.0
  * Simplified license field format to MIT|CC-BY-4.0
  * Updated download and auto-update URLs for the latest release
  * Added executable binary references for command-line and GUI versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->