### PR TITLE
screenoff@2.1: Use archived link, remove checkver & autoupdate

### DIFF
--- a/bucket/screenoff.json
+++ b/bucket/screenoff.json
@@ -4,7 +4,7 @@
     "description": "[Archived] Turn off Windows laptop monitor screen in a click, without putting it to Sleep.",
     "homepage": "https://www.thewindowsclub.com/screenoff-turn-off-windows-laptop-screen",
     "license": "Freeware",
-    "url": "https://web.archive.org/web/20220519202920/https://www.thewindowsclub.com/downloads/Scrof.zip",
+    "url": "https://web.archive.org/web/20220519202920if_/https://www.thewindowsclub.com/downloads/Scrof.zip",
     "hash": "3c459278dd005b0e334d66a794b7904e73789d4720b13109c1dadbe1e2156fce",
     "extract_dir": "ScreenOff 2.1",
     "pre_install": "Move-Item \"$dir\\ScreenOff*.exe\" \"$dir\\ScreenOff.exe\"",


### PR DESCRIPTION
The screenoff website is blocking the scoop user agent. This change switches the download to archive.org. It adds a maintainer note "##" and adds the `[Archived]` tag to the description.

Closes https://github.com/ScoopInstaller/Extras/issues/16014
Relates to https://github.com/ScoopInstaller/Extras/issues/16379

### Tests:
- ✅Hash remains the same when downloading through browser
- ✅Virustotal 0/67
- ✅Installs fine
- ⚠️Screen does not turn off in my VM, but I guess that might be VM related

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Application marked as archived in metadata and description updated to indicate archival status.
  * Download URL switched to an archived (Internet Archive) link.
  * Automatic update checking and auto-update configuration removed, leaving only the primary manifest fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->