### PR TITLE
tomcat: Update to version 11.0.18, drop 32bit support, fix checkver

### DIFF
--- a/bucket/tomcat.json
+++ b/bucket/tomcat.json
@@ -1,22 +1,18 @@
 {
-    "version": "10.1.52",
+    "version": "11.0.18",
     "description": "Implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies",
     "homepage": "https://tomcat.apache.org",
     "license": "Apache-2.0",
     "suggest": {
-        "JRE": "java/openjdk"
+        "JDK": "java/openjdk"
     },
     "architecture": {
         "64bit": {
-            "url": "https://dlcdn.apache.org/tomcat/tomcat-10/v10.1.52/bin/apache-tomcat-10.1.52-windows-x64.zip",
-            "hash": "sha512:88a0256b3e8aef997b2ba3a4ae621efe2b344e501e17be42d840309d862617f0eacf72b9ac67d2e098b015e7bdb4b92489dfad550e13173644d610ffe366492a"
-        },
-        "32bit": {
-            "url": "https://dlcdn.apache.org/tomcat/tomcat-10/v10.1.52/bin/apache-tomcat-10.1.52-windows-x86.zip",
-            "hash": "sha512:b1a0ec73f29e6f985cae6812eaf0730ea3a4222cc54dc9e413721c45f749b16df37dcaff2a5525f69648be5fd9aac35302461fcde871cf53cf42f00234820008"
+            "url": "https://archive.apache.org/dist/tomcat/tomcat-11/v11.0.18/bin/apache-tomcat-11.0.18-windows-x64.zip",
+            "hash": "sha512:ec0f53a87ee109ae1c4c34592c39791f0b590148ce2c4a9584decb56c2aaa7178bba5e94e6ce2dc4a22995fb15a2e3aacc62623ed79b8eae78109421b5366ba2"
         }
     },
-    "extract_dir": "apache-tomcat-10.1.52",
+    "extract_dir": "apache-tomcat-11.0.18",
     "bin": "bin\\catalina.bat",
     "env_set": {
         "CATALINA_HOME": "$dir",
@@ -27,16 +23,13 @@
         "webapps"
     ],
     "checkver": {
-        "url": "https://dlcdn.apache.org/tomcat/tomcat-10/?C=M;O=D",
+        "url": "https://archive.apache.org/dist/tomcat/tomcat-11/?C=M;O=D",
         "regex": "v([\\d.]+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dlcdn.apache.org/tomcat/tomcat-$majorVersion/v$version/bin/apache-tomcat-$version-windows-x64.zip"
-            },
-            "32bit": {
-                "url": "https://dlcdn.apache.org/tomcat/tomcat-$majorVersion/v$version/bin/apache-tomcat-$version-windows-x86.zip"
+                "url": "https://archive.apache.org/dist/tomcat/tomcat-$majorVersion/v$version/bin/apache-tomcat-$version-windows-x64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
## tomcat@11.0.18: Upgrade to 11.0.18 and drop 32-bit support

<!--
Relates and closes #17218
-->

This pull request updates the `tomcat.json` manifest to upgrade Apache Tomcat from version 10.1.52 to 11.0.18 and removes support for 32-bit Windows builds. The changes ensure the manifest now references the latest stable Tomcat release and simplifies the architecture support.

**Version upgrade and download updates:**
* Updated the `version` field to `11.0.18` and changed all relevant download URLs, hashes, and extraction directories to reference Tomcat 11.0.18 for 64-bit Windows
* Updated the `checkver` URL to point to the Tomcat 11 directory for version checking

**Architecture support changes:**
* Removed all configuration and download links for 32-bit Windows builds, making the manifest 64-bit only

- [x] Use conventional PR title: `tomcat@11.0.18: Upgrade to 11.0.18 and drop 32-bit support`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Tomcat from 10.1.52 to 11.0.18 and updated Windows x64 download URL and checksum.
  * Removed 32-bit Windows support.
  * Switched suggested runtime from JRE to JDK.
  * Updated version-check and auto-update sources to use Tomcat 11 archive paths and a generalized extract directory pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->