### PR TITLE
ddu@18.1.4.2: Fix download & autoupdate URLs

### DIFF
--- a/bucket/ddu.json
+++ b/bucket/ddu.json
@@ -6,12 +6,10 @@
         "identifier": "Freeware",
         "url": "https://github.com/Wagnard/display-drivers-uninstaller/blob/WPF/LICENSE.md"
     },
-    "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v18.1.4.2.exe",
+    "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v18.1.4.2.exe#/dl.7z",
     "hash": "edd9a06a164d01bcdf578926047a785ed7aa7bee0f847e7235bacfe5bb25679c",
-    "pre_install": [
-        "Expand-7zipArchive \"$dir\\*DDU*.exe\" -DestinationPath \"$dir\" -ExtractDir \"DDU v$version\" -Removal",
-        "Copy-Item \"$persist_dir\\settings\\Settings.xml\" \"$dir\\settings\" -ErrorAction SilentlyContinue"
-    ],
+    "extract_dir": "DDU v18.1.4.2",
+    "pre_install": "Copy-Item \"$persist_dir\\settings\\Settings.xml\" \"$dir\\settings\" -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "Display Driver Uninstaller.exe",
@@ -28,6 +26,7 @@
         "regex": "Display Driver Uninstaller \\(DDU\\) (\\d+(?:\\.\\d+){3})"
     },
     "autoupdate": {
-        "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v$version.exe"
+        "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v$version.exe#/dl.7z",
+        "extract_dir": "DDU v$version"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17213
Relates to #14806

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched distribution to the official DDU executable hosted on the vendor site.
  * Updated integrity/hash to match the new executable.
  * Simplified pre-install to preserve user settings and removed multi-step extraction/cleanup.
  * Introduced a dedicated extraction directory for installs and autoupdate.
  * Updated autoupdate source to the vendor-hosted executable URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->