### PR TITLE
audiveris: Add version 5.9.0

### DIFF
--- a/bucket/audiveris.json
+++ b/bucket/audiveris.json
@@ -1,16 +1,22 @@
 {
     "version": "5.9.0",
-    "description": "Optical Music Recognition",
-    "homepage": "https://github.com/Audiveris/audiveris",
+    "description": "An open source tool for optical music recognition (OMR).",
+    "homepage": "https://audiveris.github.io/audiveris/",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Audiveris/audiveris/releases/download/5.9.0/Audiveris-5.9.0-windowsConsole-x86_64.msi",
-            "hash": "sha256:7d0b3edcb581526b1a0a6f68fb494692774c14160abd8f1ff7c781dc1b35b560"
+            "hash": "7d0b3edcb581526b1a0a6f68fb494692774c14160abd8f1ff7c781dc1b35b560"
         }
     },
     "extract_dir": "Audiveris",
     "bin": "Audiveris.exe",
+    "shortcuts": [
+        [
+            "Audiveris.exe",
+            "Audiveris"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/Audiveris/audiveris"
     },


### PR DESCRIPTION
This is my first attempt to publish audiveris application on scoop Extras bucket.

Audiveris performs optical music recognition (OMR) on music scores.

Please tell me if something is missing.
Thanks in advance for your help,
/Hervé


<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for Audiveris 5.9.0 (Optical Music Recognition) on 64‑bit Windows with MSI installation, SHA‑256 verification, installation metadata, a desktop shortcut, and automatic update checks to enable seamless installation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->