### PR TITLE
iotop-w: Add version 1.0.3

### DIFF
--- a/bucket/iotop-w.json
+++ b/bucket/iotop-w.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.3",
+    "description": "An iotop-like command line application for Windows, written in Go.",
+    "homepage": "https://github.com/gsmitheidw/iotop-w",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gsmitheidw/iotop-w/releases/download/1.0.3/iotop-w.exe",
+            "hash": "9104133e3ce258f1f5b3450e2a207fc3123392e75d126c0e73bb877fd4a2f7b6"
+        }
+    },
+    "bin": "iotop-w.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gsmitheidw/iotop-w/releases/download/$version/iotop-w.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
# iotop-w 
iotop-w is a portable single binary application (terminal user interface) for disk i/o monitoring in Windows command line. 
It is written in golang and I am the author. It is open source licenced with MIT. 

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Windows package manifest for iotop-w (v1.0.3), enabling installation via Scoop package manager for 64-bit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->