### PR TITLE
dbeaver: Update to version 25.3.5, add arm64 support, fix autoupdate

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -14,6 +14,10 @@
         "64bit": {
             "url": "https://dbeaver.io/files/25.3.5/dbeaver-ce-25.3.5-windows-x86_64.zip",
             "hash": "20b44004e28cd8e369d65fe8c28713a1c4c9f5e700d8cbe095a71f9035612f6f"
+        },
+        "arm64": {
+            "url": "https://dbeaver.io/files/25.3.5/dbeaver-ce-25.3.5-windows-aarch64.zip",
+            "hash": "0ff731fd8d0639b3f4ca74d94af667f6dafba28ecd9cbb7dcf52024ea5eb0cf5"
         }
     },
     "extract_dir": "dbeaver",
@@ -34,6 +38,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://dbeaver.io/files/$version/dbeaver-ce-$version-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://dbeaver.io/files/$version/dbeaver-ce-$version-windows-aarch64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
The dbeaver download path has changed, please see https://dbeaver.io/files/ for versions 25.3.4 vs 25.3.5

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official Windows ARM64 (aarch64) build availability.

* **Chores**
  * Version bumped to 25.3.5.
  * Updated 64-bit Windows download links and verification checksums.
  * Updated autoupdate URL patterns for 64-bit Windows packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->