### PR TITLE
fastflowlm: Add version 0.9.33

### DIFF
--- a/bucket/fastflowlm.json
+++ b/bucket/fastflowlm.json
@@ -2,7 +2,10 @@
     "version": "0.9.33",
     "description": "Run LLMs on AMD Ryzen AI NPUs in minutes. Purpose-built and deeply optimized for AMD XDNA2 NPUs.",
     "homepage": "https://fastflowlm.com",
-    "license": "Proprietary",
+    "license": {
+        "identifier": "MIT,Proprietary",
+        "url": "https://github.com/FastFlowLM/FastFlowLM/blob/main/TERMS.md"
+    },
     "url": "https://github.com/FastFlowLM/FastFlowLM/releases/download/v0.9.33/flm-setup.exe",
     "hash": "sha256:90870cdfe7d82a416160b5c4523ffa822792ac33966b1177a35490450102e3bf",
     "innosetup": true,
@@ -11,7 +14,11 @@
         "github": "https://github.com/FastFlowLM/FastFlowLM"
     },
     "autoupdate": {
-        "url": "https://github.com/FastFlowLM/FastFlowLM/releases/download/v$version/flm-setup.exe"
+        "url": "https://github.com/FastFlowLM/FastFlowLM/releases/download/v$version/flm-setup.exe",
+        "hash": {
+            "url": "https://api.github.com/repos/FastFlowLM/FastFlowLM/releases/tags/v$version",
+            "jsonpath": "$.assets[?(@.name=='flm-setup.exe')].digest"
+        }
     },
     "notes": [
         "IMPORTANT REQUIREMENTS:",


### PR DESCRIPTION
fastflowlm: Add version 0.9.33

- [x] Use conventional PR title: `fastflowlm@0.9.33: Add new manifest`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

### Description
Add `fastflowlm` version 0.9.33. This is a lightweight LLM tool.

### Verification
I have tested this manifest locally using:
`scoop install bucket/fastflowlm.json`
The installation was successful and the binary is correctly shimmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Windows installer package for the app, including a bundled executable and user-facing setup/quick-start notes.
  * Enables automatic update checks with published release metadata and download verification.

* **Chores**
  * Includes license and documentation links surfaced to users during install and in the quick-start guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->