### PR TITLE
miro-pdf: Add version 0.7.3

### DIFF
--- a/bucket/miro-pdf.json
+++ b/bucket/miro-pdf.json
@@ -1,14 +1,12 @@
 {
     "version": "0.7.3",
-    "description": "A native pdf viewer for Windows, macOS and Linux (Wayland/X11) with configurable keybindings.",
+    "description": "A native pdf viewer with configurable keybindings.",
     "homepage": "https://github.com/vincent-uden/miro",
     "license": "AGPL-3.0-only",
-    "notes": [
-        "User data is located at ~/.config/miro-pdf/ (or .config/miro-pdf/ in the home directory of your operating system).",
-        "",
-        "The configuration file specifically should be placed in or is located at ~/.config/miro-pdf/miro.conf.",
-        ""
-    ],
+    "notes": "For configuration guide, please refer to: https://github.com/vincent-uden/miro#configuration",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/vincent-uden/miro/releases/download/v0.7.3/miro-pdf.exe",


### PR DESCRIPTION
Adding the manifest for Miro, for which I have verified that auto-updating works on my local machine with checkver.ps1. Note that while the name of the software is Miro, Miro-PDF is the clearer identifier that is used for installation and the name of the executable.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17230

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows 64-bit installer manifest for miro-pdf (v0.7.3) to enable easy installation. Includes package metadata, runtime dependency indication, download location and checksum, a Start Menu shortcut, and autoupdate/GitHub-based version checks. No runtime code or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->