### PR TITLE
qtranslate@6.9.0: Use archived link

### DIFF
--- a/bucket/qtranslate.json
+++ b/bucket/qtranslate.json
@@ -7,7 +7,7 @@
         "identifier": "Freeware",
         "url": "https://web.archive.org/web/20221213180640/https://quest-app.appspot.com/license"
     },
-    "notes": "If you encounter 'Program initialization error', follow the instructions on 'https://quest-app.appspot.com/faq'.",
+    "notes": "If you encounter 'Program initialization error', follow the instructions on 'https://web.archive.org/web/20220821155706/https://quest-app.appspot.com/faq'.",
     "url": "https://web.archive.org/web/20220424164118if_/https://qtranslate2.appspot.com/QTranslate.6.9.0.zip",
     "hash": "md5:b235d430d195e0821a4dfd0309faaaa0",
     "extract_dir": "QTranslate.6.9.0",


### PR DESCRIPTION
Uses WayBackMachine for links and archives manifest.

Closes: https://github.com/ScoopInstaller/Extras/issues/7945

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked the utility as archived/deprecated and updated its description to indicate archival status.
  * Replaced the active autoupdate outage notice with a deprecation message.
  * Updated homepage, license, FAQ/notes, and download links to archived copies; version and other runtime entries remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->