### PR TITLE
tablacus-explorer: Update to version 26.2.2, fix checkver & autoupdate, use original binary names

### DIFF
--- a/bucket/tablacus-explorer.json
+++ b/bucket/tablacus-explorer.json
@@ -1,4 +1,8 @@
 {
+    "##": [
+        "Please avoid renaming the binaries, as this may cause compatibility issues.",
+        "Ensure you use the original filenames: 'TE64.exe' for 64-bit and 'TE32.exe' for 32-bit."
+    ],
     "version": "26.2.2",
     "description": "A tabbed file manager with Add-on support.",
     "homepage": "https://tablacus.github.io/explorer_en.html",
@@ -37,11 +41,11 @@
     },
     "persist": "config",
     "checkver": {
-        "url": "https://api.github.com/repos/tablacus/TablacusExplorer/releases/latest",
-        "jsonpath": "$..browser_download_url",
-        "regex": "download/([\\d.]+)/te(\\d{6})\\.zip"
+        "github": "https://github.com/tablacus/TablacusExplorer",
+        "jsonpath": "$.assets[?(@.name =~ /te.+zip/i)].browser_download_url",
+        "regex": "download/(?<version>[\\d.]+)/(?<filename>.*)\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/tablacus/TablacusExplorer/releases/download/$version/te$match2.zip"
+        "url": "https://github.com/tablacus/TablacusExplorer/releases/download/$version/$matchFilename.zip"
     }
 }


### PR DESCRIPTION
Revert https://github.com/ScoopInstaller/Extras/pull/16975/changes/c1346055b4c47ee05e5f3a77d10aeaebe0c44010
Relates to https://github.com/tablacus/TablacusExplorer/issues/899

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded application to version 26.2.2 and updated release download and checksum.
* **New Features**
  * Added advisory messages recommending preservation of original binary filenames.
* **Refactor**
  * Installer manifest reorganized so executables and shortcuts are defined per-architecture (64-bit and 32-bit); removed legacy installer steps.
  * Improved update detection and autoupdate handling with enhanced version-check configuration and filename-based update pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->