### PR TITLE
mpv-git@20260224: Add arm64 support

### DIFF
--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -18,6 +18,10 @@
         "32bit": {
             "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260224/mpv-i686-20260224-git-4620834.7z",
             "hash": "bf9150bf5e90b17a48a999ee35a3a84b4a7079cc021ca13388071ca8c3b42daa"
+        },
+        "arm64": {
+            "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260224/mpv-aarch64-20260224-git-4620834.7z",
+            "hash": "df90fde6c00de8d7688f3b8970a90fb59cd606270b0393e499b95153c0d988ec"
         }
     },
     "pre_install": "Remove-Item \"$dir\\updater.bat\"",
@@ -41,6 +45,9 @@
             },
             "32bit": {
                 "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-i686-$version-git-$matchCommit.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-aarch64-$version-git-$matchCommit.7z"
             }
         }
     }


### PR DESCRIPTION

The modified manifest are tested to work on my WoA laptop.

```
PS C:\Users\Anthony-Air14sQ> scoop install anthony/mpv-git
Installing 'mpv-git' (20260224) [arm64] from 'anthony' bucket
proxy: https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260224/mpv-aarch64-20260224-git-4620834.7z
mpv-aarch64-20260224-git-4620834.7z (24.2 MB) [===============================================================] 100%
Checking hash of mpv-aarch64-20260224-git-4620834.7z ... ok.
Extracting mpv-aarch64-20260224-git-4620834.7z ... done.
Running pre_install script...done.
Linking ~\scoop\apps\mpv-git\current => ~\scoop\apps\mpv-git\20260224
Creating shortcut for mpv (mpv.exe)
Adding ~\scoop\apps\mpv-git\current to your path.
Persisting portable_config
'mpv-git' (20260224) was installed successfully!
Notes
-----
To set and unset file type associations and AutoPlay handlers, run
'C:\Users\Anthony-Air14sQ\scoop\apps\mpv-git\current\installer\mpv-install.bat' and
'C:\Users\Anthony-Air14sQ\scoop\apps\mpv-git\current\installer\mpv-uninstall.bat' as administrator, respectively.
You can use Icaros ('nonportable/icaros-np') to enable thumbnails for all media types.

```
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ARM64 architecture support with automatic updates enabled for compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->