### PR TITLE
aida64business: Add version 8.25.8200

### DIFF
--- a/bucket/aida64business.json
+++ b/bucket/aida64business.json
@@ -1,7 +1,7 @@
 {
     "version": "8.25.8200",
     "description": "System information, diagnostics, and auditing application",
-    "homepage": "https://www.aida64.com",
+    "homepage": "https://www.aida64.com/products/aida64-business",
     "license": {
         "identifier": "Shareware",
         "url": "https://www.aida64.com/licensing"
@@ -28,11 +28,11 @@
     "shortcuts": [
         [
             "aida64.exe",
-            "AIDA64"
+            "AIDA64 Business"
         ]
     ],
     "checkver": {
-        "url": "https://www.aida64.com/downloads/latesta64xe",
+        "url": "https://www.aida64.com/downloads/latesta64be",
         "regex": "Version:\\s+([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
Closes #17271

The manifest is basically the same as the extreme version, where the major difference is the following line so that the binary also gets its own shim.
`    "bin": "aida64.exe",`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AIDA64 Business is now available for installation with full package manifest support.
  * Installer creates default configuration and auxiliary files when missing.
  * Preserves user data and configuration across installs and updates.
  * Adds automatic update checks with templated update URLs.
  * Adds a convenient start shortcut for quick access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->