### PR TITLE
primesieve@12.13: Add version 12.13

### DIFF
--- a/bucket/primesieve.json
+++ b/bucket/primesieve.json
@@ -17,7 +17,7 @@
     "checkver": {
         "url": "https://api.github.com/repos/kimwalisch/primesieve/releases",
         "jsonpath": "$..tag_name",
-        "regex": "v([\\d.]+)$"
+        "regex": "^v([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Worked on my machine.
```
PS C:\Users\Anth-Z790> scoop install anthony/primesieve
Installing 'primesieve' (12.13) [64bit] from 'anthony' bucket
proxy: https://github.com/kimwalisch/primesieve/releases/download/v12.13/primesieve-12.13-win-x64.zip
primesieve-12.13-win-x64.zip (297.3 KB) [=====================================================================] 100%
Checking hash of primesieve-12.13-win-x64.zip ... ok.
Extracting primesieve-12.13-win-x64.zip ... done.
Linking C:\scoop\apps\primesieve\current => C:\scoop\apps\primesieve\12.13
Creating shim for 'primesieve'.
'primesieve' (12.13) was installed successfully!
```
This CLI doesn't fit in the criteria of 150 forks, so I guess it belongs here

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package manifest for PrimeSieve (v12.13) to enable automated installation and autoupdate. Includes release metadata, integrity-checked downloads for 64-bit and ARM64, version checking against releases, and parameterized update URLs so installers can detect and fetch new releases automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->