### PR TITLE
yaw: Add manifest for v0.9.51

### DIFF
--- a/bucket/yaw.json
+++ b/bucket/yaw.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.9.51",
+    "description": "A modern terminal with built-in connection management and AI assistance.",
+    "homepage": "https://yaw.sh",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://yaw.sh"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://yaw.sh/downloads/yaw-win32-x64-0.9.51.zip",
+            "hash": "222bd494e77d82163fd89a17356fc80c35e65d99f1429b7c54090922909e4b04"
+        }
+    },
+    "bin": "yaw.exe",
+    "shortcuts": [
+        [
+            "yaw.exe",
+            "yaw"
+        ]
+    ],
+    "checkver": {
+        "url": "https://yaw.sh/version.json",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://yaw.sh/downloads/yaw-win32-x64-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add manifest for [yaw](https://yaw.sh) — a modern terminal with built-in connection management and AI assistance.

- **Homepage**: https://yaw.sh
- **License**: Proprietary
- **Architecture**: 64-bit
- **Download**: Zip archive from yaw.sh
- **Autoupdate**: Configured via version.json endpoint

## Checklist

- [x] Manifest is valid JSON
- [x] URL returns 200
- [x] Hash matches download
- [x] `checkver` configured for autoupdate
- [x] `autoupdate` configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Yaw application now available for Windows with automatic version checking and update capabilities built-in for seamless software maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->