### PR TITLE
office-tool-plus: Update to version 11.0.27.0, drop 32bit support

### DIFF
--- a/bucket/office-tool-plus.json
+++ b/bucket/office-tool-plus.json
@@ -1,19 +1,16 @@
 {
     "version": "11.0.27.0",
     "description": "A powerful and useful tool for Office deployments",
-    "homepage": "https://www.officetool.plus/",
+    "homepage": "https://www.officetool.plus",
     "license": "GPL-3.0-or-later",
-    "suggest": {
-        ".NET Desktop Runtime LTS": "extras/windowsdesktop-runtime-lts"
-    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.0.27.0/Office_Tool_v11.0.27.0_x64.zip",
-            "hash": "3f2686aec273add2a65053bf17e76d65cf47e70f724795ce6cc51e7b5554e74a"
+            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.0.27.0/Office_Tool_with_runtime_v11.0.27.0_x64.7z",
+            "hash": "393e2433c7e237e9ef2f0ad737b83227a4578bed96f2868f9128204dc243a18b"
         },
         "arm64": {
-            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.0.27.0/Office_Tool_v11.0.27.0_arm64.zip",
-            "hash": "254b6e12c4df1b97aa34fb8cec90c0263765aaf6c8dfe45ae4fca621eaa1be82"
+            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.0.27.0/Office_Tool_with_runtime_v11.0.27.0_arm64.7z",
+            "hash": "cbc33f32e3277f15719e85d3a7a83e1e7a689473de0e7e21455d172693e8c935"
         }
     },
     "extract_dir": "Office Tool",
@@ -30,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_v$version_x64.zip"
+                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_with_runtime_v$version_x64.7z"
             },
             "arm64": {
-                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_v$version_arm64.zip"
+                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_with_runtime_v$version_arm64.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX

office-tool-plus: Update to Version [11.0.27.0](https://github.com/YerongAI/Office-Tool/releases/tag/v11.0.27.0)
Upgrade runtime from .NET 8 to .NET 10
The 32-bit version of Office Tool Plus has been deprecated

-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Software version upgraded to 11.0.27.0
  * Homepage URL updated to the new official site
  * Removed the "suggest" section from the package
  * 64‑bit and ARM64 builds refreshed with new packages and hashes
  * 32‑bit (x86) support removed
  * Autoupdate metadata cleaned to reflect current architectures only
<!-- end of auto-generated comment: release notes by coderabbit.ai -->