### PR TITLE
notepad4: Fix persistence

### DIFF
--- a/bucket/notepad4.json
+++ b/bucket/notepad4.json
@@ -30,8 +30,14 @@
     ],
     "pre_install": [
         "'Notepad4.ini', 'matepath.ini', 'Notepad4 DarkTheme.ini' | ForEach-Object {",
-        "    if (-not (Test-Path -Path \"$persist_dir\\$_\")) {",
-        "        Copy-Item -Path \"$dir\\$_-default\" -Destination \"$dir\\$_\"",
+        "    $persistPath = Join-Path $persist_dir $_",
+        "    $defaultPath = Join-Path $dir \"$_-default\"",
+        "    $targetPath = Join-Path $dir $_",
+        "    if (Test-Path -LiteralPath $persistPath -PathType Container) {",
+        "        Remove-Item -LiteralPath $persistPath -Recurse -Force",
+        "    }",
+        "    if (-not (Test-Path -LiteralPath $persistPath -PathType Leaf) -and (Test-Path -LiteralPath $defaultPath -PathType Leaf)) {",
+        "        Copy-Item -LiteralPath $defaultPath -Destination $targetPath",
         "    }",
         "}"
     ],


### PR DESCRIPTION
This PR fixes two critical issues with the Notepad4 manifest:

1. **Folder creation bug**: Added `pre_install` hooks to copy the bundled `.ini-default` configuration files to their proper `.ini` names. This not only prevents Scoop from mistakenly creating folders for `Notepad4.ini`, `matepath.ini`, and `Notepad4 DarkTheme.ini` during a fresh installation, but also ensures the application initializes correctly with the author's intended default settings.
2. **Missing configuration**: Added `Notepad4 DarkTheme.ini` to the `persist` array so users won't lose their dark theme settings after running `scoop update`.

Closes https://github.com/ScoopInstaller/Extras/issues/17321
<!--->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure the app creates and initializes missing configuration files on first run so default settings are available.
  * Persist dark theme settings alongside existing preferences so theme choice is retained across updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->