### PR TITLE
aida64business: Add version 8.25.8200

### DIFF
--- a/bucket/aida64business.json
+++ b/bucket/aida64business.json
@@ -6,8 +6,19 @@
         "identifier": "Shareware",
         "url": "https://www.aida64.com/licensing"
     },
-    "url": "https://download.aida64.com/aida64business825.zip",
-    "hash": "03cb63dbd707896f7c1c221c0e1c0b50ab7a55c7bb8ead865f90932f73b87b5a",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.aida64.com/aida64business825.zip",
+            "hash": "03cb63dbd707896f7c1c221c0e1c0b50ab7a55c7bb8ead865f90932f73b87b5a"
+        }
+    },
+    "bin": "aida64.exe",
+    "shortcuts": [
+        [
+            "aida64.exe",
+            "AIDA64 Business"
+        ]
+    ],
     "pre_install": [
         "$FILE = 'aida64.ini'",
         "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
@@ -24,18 +35,15 @@
         "pkey.txt",
         "aida64.ini"
     ],
-    "bin": "aida64.exe",
-    "shortcuts": [
-        [
-            "aida64.exe",
-            "AIDA64 Business"
-        ]
-    ],
     "checkver": {
         "url": "https://www.aida64.com/downloads/latesta64be",
         "regex": "AIDA64 Business\\s+([0-9]+\\.[0-9]+\\.[0-9]+)"
     },
     "autoupdate": {
-        "url": "https://download.aida64.com/aida64business$majorVersion$minorVersion.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://download.aida64.com/aida64business$majorVersion$minorVersion.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #17271

The manifest is basically the same as the extreme version, where the major difference is the following line so that the binary also gets its own shim.
`    "bin": "aida64.exe",`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AIDA64 Business can be installed and managed via the package system with automatic version detection and autoupdates.
  * Installer creates missing configuration, license/key, and auxiliary files during setup.
  * Application settings and user files are preserved across installs and updates.
  * Desktop shortcut and executable are configured automatically during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->