### PR TITLE
pdf-xchange-editor: Fix persistence

### DIFF
--- a/bucket/pdf-xchange-editor.json
+++ b/bucket/pdf-xchange-editor.json
@@ -18,8 +18,10 @@
     },
     "pre_install": [
         "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
-        "ensure $persist_dir | Out-Null",
         "'History', 'Settings' | ForEach-Object {",
+        "    if (Test-Path -Path \"$persist_dir\\$_.dat\" -PathType Container) {",
+        "        Remove-Item -Path \"$persist_dir\\$_.dat\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "    }",
         "    if (Test-Path -Path \"$persist_dir\\$_.dat\" -PathType Leaf) {",
         "        Copy-Item -Path \"$persist_dir\\$_.dat\" -Destination $dir -Force",
         "    }",
@@ -34,6 +36,7 @@
     ],
     "pre_uninstall": [
         "# Hard links are not applicable here because the application creates a new file instead of modifying the existing one in place.",
+        "ensure $persist_dir | Out-Null",
         "'History', 'Settings' | ForEach-Object {",
         "    if (Test-Path -Path \"$dir\\$_.dat\" -PathType Leaf) {",
         "        Copy-Item -Path \"$dir\\$_.dat\" -Destination $persist_dir -Force",


### PR DESCRIPTION
### Summary

Refactors the persistence logic for `pdf-xchange-editor` by replacing the native `persist` field with manual copy-based logic in `pre_install` and `pre_uninstall`.

### Related issues or pull requests

- Relates to d81bb8054a55c48f437b775dfa250ade3e9b55f5 
- Closes #17293 

### Changes

- **Remove native `persist` field**: Deleted `History.dat` and `Settings.dat` from the `persist` array to prevent filesystem link breakage.
- **Refine `pre_install`**: 
  - Add `ensure $persist_dir` to guarantee the persistence directory exists.
  - Implement a loop to copy `History.dat` and `Settings.dat` from the persist directory to the application directory if they exist.
- **Refine `pre_uninstall`**: 
  - Implement a loop to back up the current data files back to the persist directory before the application is removed.
- **Code Quality**: Improve PowerShell syntax with explicit parameters (`-Path`, `-Destination`, `-PathType Leaf`) and clearer comments.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ ~]
└─> scoop install Unofficial/pdf-xchange-editor
Installing 'pdf-xchange-editor' (10.8.4.409) [64bit] from 'Unofficial' bucket
Loading PDFXEdit10_Portable_x64.zip from cache.
Checking hash of PDFXEdit10_Portable_x64.zip... OK.
Extracting PDFXEdit10_Portable_x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\pdf-xchange-editor\current => D:\Software\Scoop\Local\apps\pdf-xchange-editor\10.8.4.409
Creating shim for 'PDFXEdit'.
Making D:\Software\Scoop\Local\shims\pdfxedit.exe a GUI binary.
Creating shortcut for PDF-XChange Editor (PDFXEdit.exe)
'pdf-xchange-editor' (10.8.4.409) was installed successfully!

┏[ ~]
└─> Test-Path -Path "$(scoop prefix pdf-xchange-editor)\Settings.dat" -PathType Leaf
False

# Modify some settings after launching the application, then close it.

┏[ ~]
└─> Get-Item -Path "$(scoop prefix pdf-xchange-editor)\Settings.dat" | Select-Object -Property CreationTime, LastAccessTime, LastWriteTime

CreationTime          LastAccessTime        LastWriteTime
------------          --------------        -------------
2/26/2026 10:37:21 AM 2/26/2026 10:37:21 AM 2/26/2026 10:37:21 AM

┏[ ~]
└─> scoop update pdf-xchange-editor -f
pdf-xchange-editor: 10.8.4.409 -> 10.8.4.409
Updating one outdated app:
Updating 'pdf-xchange-editor' (10.8.4.409 -> 10.8.4.409)
Downloading new version
Loading PDFXEdit10_Portable_x64.zip from cache.
Checking hash of PDFXEdit10_Portable_x64.zip... OK.
Running pre_uninstall script... Done.
Uninstalling 'pdf-xchange-editor' (10.8.4.409)
Removing shim 'PDFXEdit.shim'.
Removing shim 'PDFXEdit.exe'.
Unlinking D:\Software\Scoop\Local\apps\pdf-xchange-editor\current
Installing 'pdf-xchange-editor' (10.8.4.409) [64bit] from 'Unofficial' bucket
Loading PDFXEdit10_Portable_x64.zip from cache.
Extracting PDFXEdit10_Portable_x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\pdf-xchange-editor\current => D:\Software\Scoop\Local\apps\pdf-xchange-editor\10.8.4.409
Creating shim for 'PDFXEdit'.
Making D:\Software\Scoop\Local\shims\pdfxedit.exe a GUI binary.
Creating shortcut for PDF-XChange Editor (PDFXEdit.exe)
'pdf-xchange-editor' (10.8.4.409) was installed successfully!

┏[ ~]
└─> Get-Item -Path "$(scoop prefix pdf-xchange-editor)\Settings.dat" | Select-Object -Property CreationTime, LastAccessTime, LastWriteTime

CreationTime          LastAccessTime        LastWriteTime
------------          --------------        -------------
2/26/2026 10:39:01 AM 2/26/2026 10:39:01 AM 2/26/2026 10:37:21 AM

┏[ ~]
└─> scoop uninstall pdf-xchange-editor
Uninstalling 'pdf-xchange-editor' (10.8.4.409).
Running pre_uninstall script... Done.
Removing shim 'PDFXEdit.shim'.
Removing shim 'PDFXEdit.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\PDF-XChange Editor.lnk
Unlinking D:\Software\Scoop\Local\apps\pdf-xchange-editor\current
Removing older version (_10.8.4.409.old).
'pdf-xchange-editor' was uninstalled.

┏[ ~]
└─> scoop install Unofficial/pdf-xchange-editor
Installing 'pdf-xchange-editor' (10.8.4.409) [64bit] from 'Unofficial' bucket
Loading PDFXEdit10_Portable_x64.zip from cache.
Checking hash of PDFXEdit10_Portable_x64.zip... OK.
Extracting PDFXEdit10_Portable_x64.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\pdf-xchange-editor\current => D:\Software\Scoop\Local\apps\pdf-xchange-editor\10.8.4.409
Creating shim for 'PDFXEdit'.
Making D:\Software\Scoop\Local\shims\pdfxedit.exe a GUI binary.
Creating shortcut for PDF-XChange Editor (PDFXEdit.exe)
'pdf-xchange-editor' (10.8.4.409) was installed successfully!

# Close the application after launching it.

┏[ ~]
└─> Get-Item -Path "$(scoop prefix pdf-xchange-editor)\Settings.dat" | Select-Object -Property CreationTime, LastAccessTime, LastWriteTime

CreationTime          LastAccessTime        LastWriteTime
------------          --------------        -------------
2/26/2026 10:40:26 AM 2/26/2026 10:40:26 AM 2/26/2026 10:39:31 AM

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined persistence handling for PDF XChange Editor: installation now ensures the persistence area is prepared, removes legacy per-item files, and restores persisted settings and history when present.
  * Uninstall now reliably preserves and returns persisted settings and history via a generalized check instead of explicit per-file listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->