### PR TITLE
kiro: Add version 0.10.32

### DIFF
--- a/bucket/kiro.json
+++ b/bucket/kiro.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.10.32",
+    "description": "Amazon's agentic AI IDE and CLI",
+    "homepage": "https://kiro.dev/",
+    "license": "Proprietary",
+    "bin": "Kiro.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/0.10.32/kiro-ide-0.10.32-stable-win32-x64.exe",
+            "hash": "f071dce4e215ac1f6f6d01e7b497eb45f079e59555d8885f0b56b066440a48f4"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/$version/kiro-ide-$version-stable-win32-x64.exe"
+            }
+        }
+    },
+    "checkver": {
+        "url": "https://prod.download.desktop.kiro.dev/stable/metadata-win32-x64-user-stable.json",
+        "jsonpath": "$.currentRelease"
+    },
+    "installer": {
+        "args": [
+            "/SP-",
+            "/NORESTART",
+            "/SILENT",
+            "/CURRENTUSER",
+            "/DIR=$dir"
+        ]
+    },
+    "##": [
+        "The installer for Kiro IDE uses Inno Setup.",
+        "You can inspect the help options with either the /? or /HELP flags.",
+        "For online documentation, visit https://jrsoftware.org/ishelp/index.php?topic=setupcmdline"
+    ]
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

## Summary

Adding Amazon Kiro to the Extras bucket. Amazon released their own fork of Visual Studio Code some time ago, and recent versions have also been shipped to Windows. This manifest tries to define that process, though it isn't well-documented by Amazon.

One thing that is lacking is publisher hashes. The hash in this manifest was the one I got after install, courtesy of the excellent logging in Scoop, but otherwise I don't have any visibility into their official release cadence.

## Reason for Contribution

My employer uses Amazon Q Developer in VSCode, and recently started adopting Kiro, both as an IDE and CLI. However, while most of them are on MacOS, I'm one of the few on Windows. There are no formal instructions for installing it within our organization, but we have adopted Scoop for self-service utilities. So, rather than manually downloading and installing it, I decided to write a custom manifest and use Scoop to manage it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiro IDE (version 0.10.32) is now available for installation via Scoop package manager, with automatic update support enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->