### PR TITLE
idea: Update to version 2025.3.3-253.31033.145, switch to unified version

### DIFF
--- a/bucket/idea-ultimate.json
+++ b/bucket/idea-ultimate.json
@@ -1,20 +1,25 @@
 {
+    "##": "Deprecate this manifest after 2026-06-01.",
     "version": "2025.3.3-253.31033.145",
-    "description": "Cross-Platform IDE for Java by JetBrains.",
+    "description": "Cross-Platform IDE for Java by JetBrains. (Deprecated, please use `extras/idea` instead)",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
         "identifier": "Proprietary",
-        "url": "https://www.jetbrains.com/store/license.html"
+        "url": "https://www.jetbrains.com/legal/docs/toolbox/license/"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIU-2025.3.3.win.zip",
-    "hash": "ab46608bb649804e347194137ff7a9761b959d571d511dc48c9cfcbe4e4f56eb",
-    "extract_to": "IDE",
-    "pre_install": "Get-ChildItem \"$persist_dir\\IDE\\bin\\idea*.exe.vmoptions\" -ErrorAction SilentlyContinue | Copy-Item -Destination \"$dir\\IDE\\bin\"",
-    "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" \"$dir\" \"$persist_dir\""
+    "notes": [
+        "IDEA Community Edition and Ultimate Edition have now been merged into a unified product.",
+        "See: https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/",
+        "The unified `extras/idea` manifest now replaces all IDEA variants.",
+        "This manifest is deprecated and scheduled for removal on 2026-06-01. Please use `extras/idea` instead."
+    ],
+    "suggest": {
+        "IDEA": "extras/idea"
     },
     "architecture": {
         "64bit": {
+            "url": "https://download.jetbrains.com/idea/idea-2025.3.3.win.zip",
+            "hash": "ab46608bb649804e347194137ff7a9761b959d571d511dc48c9cfcbe4e4f56eb",
             "bin": [
                 [
                     "IDE\\bin\\idea64.exe",
@@ -24,32 +29,51 @@
             "shortcuts": [
                 [
                     "IDE\\bin\\idea64.exe",
-                    "JetBrains\\IDEA Ultimate"
+                    "JetBrains\\IDEA"
                 ]
             ]
         },
-        "32bit": {
-            "bin": "IDE\\bin\\idea.exe",
+        "arm64": {
+            "url": "https://download.jetbrains.com/idea/idea-2025.3.3-aarch64.win.zip",
+            "hash": "a2386ba5c5102da9514c00afd0be3c9b16d255e54083c8a11985943b8899a4a8",
+            "bin": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "idea"
+                ]
+            ],
             "shortcuts": [
                 [
-                    "IDE\\bin\\idea.exe",
-                    "JetBrains\\IDEA Ultimate"
+                    "IDE\\bin\\idea64.exe",
+                    "JetBrains\\IDEA"
                 ]
             ]
         }
     },
+    "extract_to": "IDE",
+    "installer": {
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" \"$dir\" \"$persist_dir\""
+    },
     "persist": [
         "IDE\\bin\\idea.properties",
+        "IDE\\bin\\idea64.exe.vmoptions",
+        "IDE\\bin\\jetbrains_client64.exe.vmoptions",
         "profile"
     ],
-    "pre_uninstall": "Get-ChildItem \"$dir\\IDE\\bin\\idea*.exe.vmoptions\" -ErrorAction SilentlyContinue | Copy-Item -Destination \"$persist_dir\\IDE\\bin\"",
     "checkver": {
         "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&platform=zip&type=release",
         "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIU-$matchVer.win.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/idea/idea-$matchVer.win.zip"
+            },
+            "arm64": {
+                "url": "https://download.jetbrains.com/idea/idea-$matchVer-aarch64.win.zip"
+            }
+        },
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea.json
+++ b/bucket/idea.json
@@ -1,19 +1,20 @@
 {
-    "version": "2025.2.6.1-252.28539.33",
-    "description": "Cross-Platform IDE for Java by JetBrains (Community edition).",
+    "version": "2025.3.3-253.31033.145",
+    "description": "Cross-Platform IDE for Java by JetBrains.",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
-        "identifier": "Apache-2.0",
-        "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/legal/docs/toolbox/license/"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.6.1.win.zip",
-    "hash": "7fa549bcbcf65de2678b34c7fc75c250e11c37ba3a409274fc7dd9d9743b6504",
-    "extract_to": "IDE",
-    "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
-    },
+    "notes": [
+        "IDEA Community Edition and Ultimate Edition have now been merged into a unified product.",
+        "IDEA Community 2025.2 is the last standalone version available to existing users only.",
+        "For more information, see: https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/"
+    ],
     "architecture": {
         "64bit": {
+            "url": "https://download.jetbrains.com/idea/idea-2025.3.3.win.zip",
+            "hash": "ab46608bb649804e347194137ff7a9761b959d571d511dc48c9cfcbe4e4f56eb",
             "bin": [
                 [
                     "IDE\\bin\\idea64.exe",
@@ -27,29 +28,47 @@
                 ]
             ]
         },
-        "32bit": {
-            "bin": "IDE\\bin\\idea.exe",
+        "arm64": {
+            "url": "https://download.jetbrains.com/idea/idea-2025.3.3-aarch64.win.zip",
+            "hash": "a2386ba5c5102da9514c00afd0be3c9b16d255e54083c8a11985943b8899a4a8",
+            "bin": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "idea"
+                ]
+            ],
             "shortcuts": [
                 [
-                    "IDE\\bin\\idea.exe",
+                    "IDE\\bin\\idea64.exe",
                     "JetBrains\\IDEA"
                 ]
             ]
         }
     },
+    "extract_to": "IDE",
+    "installer": {
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" \"$dir\" \"$persist_dir\""
+    },
     "persist": [
         "IDE\\bin\\idea.properties",
-        "IDE\\bin\\idea.exe.vmoptions",
         "IDE\\bin\\idea64.exe.vmoptions",
+        "IDE\\bin\\jetbrains_client64.exe.vmoptions",
         "profile"
     ],
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&platform=zip&type=release",
+        "url": "https://data.services.jetbrains.com/products/releases?code=II&latest=true&platform=zip&type=release",
         "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIC-$matchVer.win.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/idea/idea-$matchVer.win.zip"
+            },
+            "arm64": {
+                "url": "https://download.jetbrains.com/idea/idea-$matchVer-aarch64.win.zip"
+            }
+        },
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
### Changes
This PR makes the following changes to `idea(-ultimate)`:
- Update `idea` to version 2025.3.3-253.31033.145.
- Switch to unified version, add deprecation notes.
- Drop 32bit support, add arm64 support.
- Persist more config files.
- Update license URLs.

### Motivation
- https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/
  > As we [announced](https://blog.jetbrains.com/idea/2025/07/intellij-idea-unified-distribution-plan/) back in July, starting from this release (2025.3), there is one IntelliJ IDEA, replacing the separate IntelliJ IDEA Community Edition and IntelliJ IDEA Ultimate to keep things simple and convenient. All the functionality of the Community Edition remains free for non-commercial and commercial use. We’re also adding [even more free features](https://www.jetbrains.com/products/compare/?product=idea&product=idea-ult), and fallback licensing stays unchanged.
- Closes #17150

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support for modern processors.

* **Deprecations & Removals**
  * Removed 32-bit architecture support.
  * IDEA Ultimate manifest deprecated; users directed to use extras/idea instead.

* **Updates**
  * IDEA Community Edition updated to version 2025.3.3.
  * Updated licensing information and legal URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->