### PR TITLE
sshpass: Add version 1.10.0

### DIFF
--- a/bucket/sshpass.json
+++ b/bucket/sshpass.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.10.0",
+  "description": "Non-interactive SSH password authentication tool - native Win64 port using ConPTY",
+  "homepage": "https://github.com/sharpninja/sshpass-win64",
+  "license": "GPL-2.0-only",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/sharpninja/sshpass-win64/releases/download/v1.10.0/sshpass-win64-1.10.0.zip",
+      "hash": "5F3913CA790B1311A8C08EE1802C4C6EAC2A3062A662288A63AC49DDA04EEF3F"
+    }
+  },
+  "bin": "sshpass.exe",
+  "checkver": {
+    "github": "https://github.com/sharpninja/sshpass-win64"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/sharpninja/sshpass-win64/releases/download/v$version/sshpass-win64-$version.zip"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## New/Updated App Submission

**App name:** sshpass
**Version:** 1.10.0
**Homepage:** https://github.com/sharpninja/sshpass-win64
**Description:** Non-interactive SSH password authentication tool - native Win64 port using ConPTY

This is a native Windows 64-bit port of the Linux `sshpass` utility, using the Windows ConPTY API instead of Unix PTY.

---
*Automated submission from [sshpass-win64](https://github.com/sharpninja/sshpass-win64) CI/CD pipeline.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * sshpass v1.10.0 is now available as a native Windows 64-bit package, enabling password-based SSH automation on Windows.
  * Packaged release includes metadata, download integrity checks (SHA-256), and built-in autoupdate support for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->