### PR TITLE
mousejiggler: Update to version 3.0.0, enable checkver & autoupdate

### DIFF
--- a/bucket/mousejiggler.json
+++ b/bucket/mousejiggler.json
@@ -5,16 +5,13 @@
     "license": "MS-PL",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/arkane-systems/mousejiggler/releases/download/3.0.0/MouseJiggler-mainline-x64.zip",
-            "hash": "389bc7e4166aeb9c3b43380fad9dd3e4e65ddd0de5e6f25f296c9d3bcc5bcc16"
+            "url": "https://github.com/arkane-systems/mousejiggler/releases/download/3.0.0/MouseJiggler-standalone-x64.zip",
+            "hash": "7b4d95659b3777789e7cfaff62e60f095e06ad6d321dd61c65dd87f792339953"
         },
         "arm64": {
-            "url": "https://github.com/arkane-systems/mousejiggler/releases/download/3.0.0/MouseJiggler-mainline-arm64.zip",
-            "hash": "fb99bdd93eb364c7f84be9297276ecd2c73efcab7565cfa536d4a3832cfb2447"
+            "url": "https://github.com/arkane-systems/mousejiggler/releases/download/3.0.0/MouseJiggler-standalone-arm64.zip",
+            "hash": "e989104df9e26804a7eb24bae9ba52038d8eccb06f01ee6bd63b98120e58433f"
         }
-    },
-    "suggest": {
-        ".NET10": "versions/dotnet10-sdk"
     },
     "bin": "MouseJiggler.exe",
     "shortcuts": [
@@ -29,10 +26,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/arkane-systems/mousejiggler/releases/download/$version/MouseJiggler-mainline-x64.zip"
+                "url": "https://github.com/arkane-systems/mousejiggler/releases/download/$version/MouseJiggler-standalone-x64.zip"
             },
             "arm64": {
-                "url": "https://github.com/arkane-systems/mousejiggler/releases/download/$version/MouseJiggler-mainline-arm64.zip"
+                "url": "https://github.com/arkane-systems/mousejiggler/releases/download/$version/MouseJiggler-standalone-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
Upstream my changes regarding mousejiggler from https://github.com/Vinfall/sb/blob/main/bucket/mousejiggler.json.
Despite the URL change, it's still from the same developer instead of another active fork.
3.0.0 now requires .NET10 instead of .NET6 and I suggest `version/dotnet10-sdk` instead of `main/dotnet-sdk` or `main/dotnet-sdk-lts` so we don't have to manually update it later when .NET11 released.

Supersedes #5541

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-architecture support for 64‑bit and ARM64.
  * Automatic version checks and architecture-specific autoupdates.
  * Upgraded release to version 3.0.0.

* **Chores**
  * Updated application binary and shortcut names to "MouseJiggler" and homepage to Arkane Systems.
  * Cleaned up package manifest and simplified description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->