### PR TITLE
multipar: Fix pre_uninstall script

### DIFF
--- a/bucket/multipar.json
+++ b/bucket/multipar.json
@@ -33,7 +33,7 @@
             "MultiPar"
         ]
     ],
-    "pre_uninstall": "MultiPar.exe /clean",
+    "pre_uninstall": "Start-Process -FilePath \"$dir\\MultiPar.exe\" -ArgumentList '/clean' -Wait",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Yutaka-Sawada/MultiPar/releases/download/v$version/MultiPar$cleanVersion.zip",


### PR DESCRIPTION
Use `Start-Process -Wait` to make Scoop wait for the `pre_uninstall` script to complete before trying to remove MultiPar.exe

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #17313
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MultiPar uninstall process execution. The pre-uninstall cleanup command now uses an enhanced execution method that properly waits for the operation to complete before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->