### PR TITLE
kiro: Add version 0.10.32

### DIFF
--- a/bucket/kiro.json
+++ b/bucket/kiro.json
@@ -1,8 +1,11 @@
 {
     "version": "0.10.32",
-    "description": "AI IDE for prototype to production",
+    "description": "An agentic IDE developed by AWS for structured, spec-driven AI development from prototype to production.",
     "homepage": "https://kiro.dev",
-    "license": "Proprietary",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://kiro.dev/license/"
+    },
     "architecture": {
         "64bit": {
             "url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/0.10.32/kiro-ide-0.10.32-stable-win32-x64.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17316

Relates to #17296

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kiro is now available via the Scoop package manager for Windows (x64) as an installable package (initial release v0.10.32).
  * Installer provides a desktop/Start shortcut and command shim, and supports automatic update checks for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->