### PR TITLE
plezy: Add version 1.23.0

### DIFF
--- a/bucket/plezy.json
+++ b/bucket/plezy.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.23.0",
+    "description": "Modern Plex client built with Flutter.",
+    "homepage": "https://plezy.app",
+    "license": "GPL-3.0-only",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/edde746/plezy/releases/download/1.23.0/plezy-windows-x64-portable.7z",
+            "hash": "49af08856aa21ae689d27b51615c6377dfc0e7b54d092a7565e7837d60e75a10"
+        },
+        "arm64": {
+            "url": "https://github.com/edde746/plezy/releases/download/1.23.0/plezy-windows-arm64-portable.7z",
+            "hash": "4fd8c8020fc3c14d25694157dfd10de2545f0b93eca4faa2bc510d4dea36eb75"
+        }
+    },
+    "shortcuts": [
+        [
+            "plezy.exe",
+            "Plezy"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/edde746/plezy"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/edde746/plezy/releases/download/$version/plezy-windows-x64-portable.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/edde746/plezy/releases/download/$version/plezy-windows-arm64-portable.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Closes #17318
- Relates to https://github.com/ScoopInstaller/Scoop/issues/6589

<!---->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Plezy Windows portable releases with automatic updates enabled for version 1.23.0
  * Now available for both 64-bit and ARM64 architectures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->