### PR TITLE
spek-x: Add version 0.9.4

### DIFF
--- a/bucket/spek-x.json
+++ b/bucket/spek-x.json
@@ -1,8 +1,8 @@
 {
     "version": "0.9.4",
-    "description": "Acoustic spectrum analyser (Spek-X fork)",
+    "description": "Acoustic spectrum analyser (fork of Spek).",
     "homepage": "https://github.com/MikeWang000000/spek-X",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/MikeWang000000/spek-X/releases/download/v0.9.4/spek-x-0.9.4-windows-x86_64.zip",


### PR DESCRIPTION
Closes #17327

Adds `spek-x` (fork of `spek` with updated FFmpeg and Windows arm64 builds) to Extras.

- Upstream: https://github.com/MikeWang000000/spek-X
- Uses official upstream release assets for Windows 64bit + arm64.
- Exposes CLI shim as `spek-x` (upstream binary is `spek.exe`) to avoid clashing with existing `spek`.
- Includes `checkver: github` and `autoupdate`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows package support for Spek-X (v0.9.4), available for 64‑bit and ARM64.
  * Includes executable mapping and a user-friendly desktop shortcut for easier launch.
  * Bundles package metadata (description, homepage, license) for clearer discovery.
  * Automatic update configuration via versioned release URLs so installations can receive updates automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->