### PR TITLE
bulk-crap-uninstaller: Update to version 6.0.0, fix arch & checkver

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,16 +1,13 @@
 {
-    "version": "5.9.0",
+    "version": "6.0.0",
     "description": "Bulk program uninstaller with advanced automation",
     "homepage": "https://www.bcuninstaller.com/",
     "license": "Apache-2.0",
-    "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.9/BCUninstaller_5.9.0_portable.zip",
-    "hash": "sha1:ce8ad309eda40e523d7d285aade8d2b3c0a2596a",
     "architecture": {
         "64bit": {
+            "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v6.0/BCUninstaller_6.0.0_portable-x64.zip",
+            "hash": "sha1:b12ac2619fa65876a4c6c0ec2ff2a2befabab56f",
             "extract_dir": "win-x64"
-        },
-        "32bit": {
-            "extract_dir": "win-x86"
         }
     },
     "pre_install": [
@@ -37,10 +34,14 @@
     "checkver": {
         "url": "https://api.github.com/repositories/64677873/releases/latest",
         "jsonpath": "$..browser_download_url",
-        "regex": "download/v(?<tag>[\\d.]+)/BCUninstaller_([\\d.]+)_portable.zip"
+        "regex": "download/v(?<tag>[\\d.]+)/BCUninstaller_([\\d.]+)_portable(?:-[\\w]+)?\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$matchTag/BCUninstaller_$version_portable.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$matchTag/BCUninstaller_$version_portable-x64.zip"
+            }
+        },
         "hash": {
             "url": "https://sourceforge.net/projects/bulk-crap-uninstaller/files/v$matchTag/",
             "regex": "$basename.*?\"sha1\":\"$sha1"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Notes from https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/tag/v6.0
> Since there are now no supported x86 versions of Windows, the releases will no longer include x86 builds.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated 64-bit architecture support.

* **Chores**
  * Version updated to 6.0.0.
  * Removed 32-bit system support.
  * Streamlined distribution and update delivery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->