### PR TITLE
backrest: Add restic dependency

### DIFF
--- a/bucket/backrest.json
+++ b/bucket/backrest.json
@@ -3,6 +3,7 @@
     "description": "Web UI and orchestrator for restic backup.",
     "homepage": "https://github.com/garethgeorge/backrest",
     "license": "GPL-3.0-only",
+    "depends": "restic",
     "architecture": {
         "64bit": {
             "url": "https://github.com/garethgeorge/backrest/releases/download/v1.12.0/backrest_Windows_x86_64.zip",
@@ -19,9 +20,6 @@
             "backrest.exe",
             "Backrest"
         ]
-    ],
-    "depends": [
-        "restic"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
On windows, restic is not installed by when running backrest for the first time.
Added the required dependency.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a runtime dependency declaration for restic in the package manifest, ensuring restic is installed and available at runtime. This change updates the package metadata to include restic as a required dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->