### PR TITLE
rssguard@5.0.2: Update persist folder name

### DIFF
--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -19,7 +19,7 @@
             "RSS Guard"
         ]
     ],
-    "persist": "data4",
+    "persist": "data5",
     "checkver": {
         "url": "https://api.github.com/repositories/23906078/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /^rssguard-([\\d.]+)-([\\w]+)-win10.7z$/)].name",


### PR DESCRIPTION
According to the [docs](https://rssguard.readthedocs.io/en/stable/features/userdata.html#:~:text=subfolder%20data5), the data folder in portable mode now is called data5, after the release of version 5.0.0.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->