### PR TITLE
keepassprotectedkeystore: Add version 1.4.0

### DIFF
--- a/bucket/keepass-plugin-keepassprotectedkeystore.json
+++ b/bucket/keepass-plugin-keepassprotectedkeystore.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.4.0",
+    "description": "Plugin for KeePass 2.x that uses the computer's Trusted Platform Module (TPM) hardware to create protected key stores.",
+    "homepage": "https://github.com/CSquared167/KeePassProtectedKeyStore",
+    "license": "MIT",
+    "depends": "extras/keepass",
+    "url": "https://github.com/CSquared167/KeePassProtectedKeyStore/releases/download/v1.4.0/KeePassProtectedKeyStore.zip",
+    "hash": "fedc795c6d915ba33a790d1748477b4b1d79b904f66652ba461394232f443f71",
+    "installer": {
+        "script": "Copy-Item \"$dir\\KeePassProtectedKeyStore.dll\" \"$(appdir keepass $global)\\current\\Plugins\" -Force"
+    },
+    "uninstaller": {
+        "script": "Remove-Item \"$(appdir keepass $global)\\current\\Plugins\\KeePassProtectedKeyStore.dll\" -Force -ErrorAction SilentlyContinue"
+    },
+    "post_uninstall": [
+        "if ($purge) {",
+        "    Remove-Item \"$env:LOCALAPPDATA\\CSquared167\\KeePassProtectedKeyStore\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "}"
+    ],
+    "checkver": {
+        "github": "https://github.com/CSquared167/KeePassProtectedKeyStore"
+    },
+    "autoupdate": {
+        "url": "https://github.com/CSquared167/KeePassProtectedKeyStore/releases/download/v$version/KeePassProtectedKeyStore.zip"
+    }
+}


### PR DESCRIPTION
Adds `keepass-plugin-keepassprotectedkeystore`, a plugin for KeePass 2.x that uses the computer's Trusted Platform Module (TPM) hardware to create protected key stores.

I had a headache deciding what to do with user data. The plugin stores stuff in hardcoded AppData/Local/..., so I've tried to make a Junction, or to copy files back and forth with `$persist_dir` during `pre_[un]install`. But ultimately, I think just clearing AppData when `$purge`d does the same behavior.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KeePassProtectedKeyStore plugin (v1.4.0) is now available via Scoop for easy installation.
  * Installer and uninstaller flows add or remove the plugin from your KeePass plugins folder.
  * Automatic update support for future releases ensures the plugin stays current.
  * Optional post-uninstall purge can remove related local application data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->