### PR TITLE
azurestorageexplorer: Fix download & autoupdate URLs

### DIFF
--- a/bucket/azurestorageexplorer.json
+++ b/bucket/azurestorageexplorer.json
@@ -5,11 +5,11 @@
     "license": "CC-BY-4.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/1.41.1/StorageExplorer-windows-x64.exe",
+            "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.41.1/StorageExplorer-windows-x64.exe",
             "hash": "8fddc37e3032dae43875325af0da75fb69153cdef66602061cd409ca8e6fad42"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/1.41.1/StorageExplorer-windows-arm64.exe",
+            "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.41.1/StorageExplorer-windows-arm64.exe",
             "hash": "d84a31ac16c3d5a709ded4b6520b09635420547db084ac50a3d7b14a4cd6f857"
         }
     },
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/$version/StorageExplorer-windows-x64.exe"
+                "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-x64.exe"
             },
             "arm64": {
-                "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/$version/StorageExplorer-windows-arm64.exe"
+                "url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v$version/StorageExplorer-windows-arm64.exe"
             }
         }
     }


### PR DESCRIPTION
Closes #17354
Relates to https://github.com/microsoft/AzureStorageExplorer/issues/8963

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated download and auto-update URLs to consistently include a "v" prefix in version paths for both 64-bit and arm64 releases, ensuring uniform download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->