### PR TITLE
locale-remulator: Add version 1.6.0

### DIFF
--- a/bucket/locale_remulator.json
+++ b/bucket/locale_remulator.json
@@ -12,11 +12,14 @@
     },
     "installer": {
         "script": [
-            " if (!(Test-Path \"$persist_dir\\LRConfig.xml\")) { ",
-            " $proc_tmp = Start-Process \"$dir\\LRProc.exe\" -PassThru ",
-            " Write-Host \"Running LRProc to generate LRConfig.xml, the msgbox will be terminated in 5s, please wait in patience! \" -ForegroundColor Green",
-            " Start-Sleep -Seconds 5 ",
-            " Stop-Process -Id $proc_tmp.Id -Force ",
+            "if (!(Test-Path \"$persist_dir\\LRConfig.xml\")) {",
+            "    $proc_tmp = Start-Process \"$dir\\LRProc.exe\" -PassThru",
+            "    Write-Host \"Running LRProc to generate $dir\\LRConfig.xml, so that it can be persisted later, please wait patiently!\" -ForegroundColor Green",
+            "    Start-Sleep -Seconds 5",
+            "    Stop-Process -Id $proc_tmp.Id -Force -ErrorAction SilentlyContinue",
+            "    if (!(Test-Path \"$dir\\LRConfig.xml\")) {",
+            "        Write-Host \"Warning: LRConfig.xml was not created.\" -ForegroundColor Yellow",
+            "    }",
             "}"
         ]
     },


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Extras/issues/16726

Relates to:
- https://github.com/ScoopInstaller/Extras/pull/16778
- https://github.com/ScoopInstaller/Extras/pull/11473

I believe it's better to persist the config file `LRConfig.xml` between installations, but simply creating an empty `LRConfig.xml` doesn't work, **'cause the program refuses to run at all using a empty config file.**

So there might be 2 ways:

- Manually create a full default config file, of which the content is below
- Run LRProc.exe once after it is extracted, and we got a default config file, then kill the process.

I took the latter one, since it is way easier to write the script.

```
<?xml version="1.0" encoding="utf-8"?>
<LRConfig>
  <Profiles Type="exe">
    <Profile Name="Run in Japanese" Guid="fb0c87bb-fa60-49f3-ba0d-3132699e285a">
      <Location>ja-JP</Location>
      <CodePage>932</CodePage>
      <LCID>1041</LCID>
      <TimeZone>Tokyo Standard Time</TimeZone>
      <Bias>540</Bias>
      <RunAsAdmin>false</RunAsAdmin>
      <HookIME>false</HookIME>
      <HookLCID>true</HookLCID>
    </Profile>
    <Profile Name="Run in Japanese (Admin)" Guid="db7b6986-f6e8-473d-9f0b-ff53a6cbc035">
      <Location>ja-JP</Location>
      <CodePage>932</CodePage>
      <LCID>1041</LCID>
      <TimeZone>Tokyo Standard Time</TimeZone>
      <Bias>540</Bias>
      <RunAsAdmin>true</RunAsAdmin>
      <HookIME>true</HookIME>
      <HookLCID>true</HookLCID>
    </Profile>
    <Profile Name="Run in Taiwan (Admin)" Guid="937df259-7cb9-4da2-be5a-3ec430b81393">
      <Location>zh-TW</Location>
      <CodePage>950</CodePage>
      <LCID>1028</LCID>
      <TimeZone>Taipei Standard Time</TimeZone>
      <Bias>480</Bias>
      <RunAsAdmin>true</RunAsAdmin>
      <HookIME>true</HookIME>
      <HookLCID>true</HookLCID>
    </Profile>
    <Profile Name="Run in Korean (Admin)" Guid="9596cb07-5bd2-45f8-b6dd-ec0752446b4b">
      <Location>ko-KR</Location>
      <CodePage>949</CodePage>
      <LCID>1042</LCID>
      <TimeZone>Korea Standard Time</TimeZone>
      <Bias>540</Bias>
      <RunAsAdmin>true</RunAsAdmin>
      <HookIME>true</HookIME>
      <HookLCID>true</HookLCID>
    </Profile>
  </Profiles>
</LRConfig>
```

Last but no least, LRProc.exe does accept CLI arguments.
```
LRProc.exe /?

---------------------------
Locale Remulator x64
---------------------------

Welcome to Locale Remulator x64 command line tool.

Usage: LRProc.exe GUID Path Args

GUID	Guid of the target profile (in LRConfig.xml).
Path	Full path of the target application.
Args	Additional arguments will be passed to the application.

You can also run LREditor to use this applicaction.
				
---------------------------
OK   
---------------------------
```


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Locale Remulator v1.6.0 package with automatic installer initialization on first install.
  * Included convenient shortcuts for Locale Remulator Installer and Editor applications.
  * Enabled automatic updates via GitHub releases integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->