### PR TITLE
bulk-crap-uninstaller: Update to version 6.1.0.1

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,11 +1,11 @@
 {
-    "version": "6.1.0",
+    "version": "6.1.0.1",
     "description": "Bulk program uninstaller with advanced automation",
     "homepage": "https://www.bcuninstaller.com/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v6.1/BCUninstaller_6.1.0_portable.zip",
+            "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v6.1/BCUninstaller_6.1.0.1_portable.zip",
             "hash": "sha1:728ff01424fb2a035ccf3b51f2134ac535818668",
             "extract_dir": "win-x64"
         }


### PR DESCRIPTION
The upstream release `v6.1` renamed the portable zip from `BCUninstaller_6.1.0_portable.zip` to `BCUninstaller_6.1.0.1_portable.zip`, causing a 404 download error.

This PR updates `version` and `url` to match the actual asset filename. The hash remains unchanged (file content is identical).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 6.1.0.1
  * Updated 64-bit download URL to reflect the new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->