### PR TITLE
cinny: Update license, suggest `webview2`

### DIFF
--- a/bucket/cinny.json
+++ b/bucket/cinny.json
@@ -3,14 +3,10 @@
     "homepage": "https://cinny.in/",
     "description": "A simple, elegant and secure Matrix client protected by e2ee with the power of open source.",
     "license": "AGPL-3.0-only",
-    "notes": [
-        "Settings are stored in the ~\\AppData\\Local\\in.cinny.app directory.",
-        "This app depends on MSEdgeWebview2 to function properly.",
-        "Click below to download the latest version of MSEdgeWebview2:",
-        "https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section",
-        "or run `scoop install extras/webview2`"
-    ],
-    "depends": "webview2",
+    "notes": "Settings are stored in the ~\\AppData\\Local\\in.cinny.app directory.",
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/cinnyapp/cinny-desktop/releases/download/v4.10.5/Cinny_desktop-x86_64.msi",


### PR DESCRIPTION
Updated license to [AGPL-3.0-only](https://github.com/cinnyapp/cinny-desktop/pull/142) and added notes about MSEdgeWebview2 dependency.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project license updated to AGPL-3.0-only.
  * Declared a new dependency on WebView2 required for the app.

* **Documentation**
  * Expanded user-facing notes: settings location, WebView2 requirement, official download link, and an alternative install command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->