### PR TITLE
android-studio: Update to version 2025.3.2.6, fix checkver & autoupdate

### DIFF
--- a/bucket/android-studio.json
+++ b/bucket/android-studio.json
@@ -4,7 +4,7 @@
     "homepage": "https://developer.android.com/studio",
     "license": {
         "identifier": "Freeware",
-        "url": "https://developer.android.com/studio/terms.html"
+        "url": "https://developer.android.com/studio/terms"
     },
     "suggest": {
         "Android SDK": "main/android-clt"
@@ -22,11 +22,11 @@
         }
     },
     "extract_dir": "android-studio",
-    "checkver": "/ide-zips/([\\d.]+)/android-studio-(.+)-windows\\.zip",
+    "checkver": "/ide-zips/(?<version>[\\d.]+)/(?<filename>android-studio.*windows\\.zip)",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://edgedl.me.gvt1.com/android/studio/ide-zips/$version/android-studio-$match2-windows.zip",
+                "url": "https://edgedl.me.gvt1.com/android/studio/ide-zips/$version/$matchFilename",
                 "hash": {
                     "url": "https://developer.android.com/studio",
                     "regex": "(?sm)$basename.*?$sha256"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Fix download links and hash values

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android Studio to version 2025.3.2.6.
  * Updated license URL to the canonical terms page.
  * Switched download endpoint and filename for the 64-bit Windows package.
  * Updated the 64-bit package checksum.
  * Improved update detection pattern and autoupdate download URL to match new release layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->