### PR TITLE
effekseer: Update to version 1.7.3.0, fix checkver, drop 32-bit version

### DIFF
--- a/bucket/effekseer.json
+++ b/bucket/effekseer.json
@@ -1,16 +1,12 @@
 {
-    "version": "170e",
-    "homepage": "https://effekseer.github.io/",
+    "version": "1.7.3.0",
+    "homepage": "https://effekseer.github.io/en/index.html",
     "description": "An open source tool that allows easy creation of beautiful particle effects for games and movies. ",
     "license": "MIT",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/effekseer/Effekseer/releases/download/170e/Effekseer170eWin_x86.zip",
-            "hash": "f7b4221a9249b71a231b731ef8882e60d06baa41a4548b46367421ee486b1de4"
-        },
         "64bit": {
-            "url": "https://github.com/effekseer/Effekseer/releases/download/170e/Effekseer170eWin.zip",
-            "hash": "e5430a9e263737aedf2f8e0de1095de9b8158e541a6304b456e2c194a8acb77e"
+            "url": "https://github.com/effekseer/Effekseer/releases/download/1.7.3.0/Effekseer1.7.3.0Win.zip",
+            "hash": "155212c5ec4d365eb1a4a5cbe25a03cfc59893723ec6680e462de4f49e605b69"
         }
     },
     "installer": {
@@ -35,18 +31,16 @@
         ]
     ],
     "persist": [
-        "Tool\\config.network.xml",
-        "Tool\\scripts"
+        "Tool\\scripts",
+        "Tool\\config.network.xml"
     ],
     "checkver": {
-        "github": "https://github.com/effekseer/Effekseer",
-        "regex": "tag/([\\w]+)"
+        "url": "https://api.github.com/repos/effekseer/Effekseer/releases",
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /Win\\.zip/i)].browser_download_url",
+        "regex": "(?i)download/([\\w.]+)/Effekseer"
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/effekseer/Effekseer/releases/download/$version/Effekseer$versionWin_x86.zip"
-            },
             "64bit": {
                 "url": "https://github.com/effekseer/Effekseer/releases/download/$version/Effekseer$versionWin.zip"
             }


### PR DESCRIPTION
### Summary

Updates `effekseer` to version **1.7.3.0**, refines the versioning scheme, and modernizes the update logic.

### Related issues or pull requests

- Closes #17373 

### Changes

- **Update Homepage**: Point to the English index page for better accessibility.
- **Update version to 1.7.3.0**: Migrate from the old alphanumeric versioning (e.g., `170e`) to the standard semantic versioning used in recent releases.
- **Drop 32-bit Support**: Remove the `32bit` architecture from `architecture` and `autoupdate` as the upstream no longer provides 32-bit binaries for the latest versions.
- **Modernize checkver**:
  - Switch from the basic GitHub helper to the GitHub API.
  - Implement `jsonpath` to filter for stable releases and specifically target the `Win.zip` asset.
  - Improve `regex` to ensure accurate version extraction from the download URL.

### Notes

- Not all released versions provide corresponding packages, such as version [1.7.2.0](https://github.com/effekseer/Effekseer/releases/tag/1.7.2.0). Therefore, `jsonpath` filtering is required.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App effekseer -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
effekseer: 1.7.3.0 (scoop version is 1.7.3.0)
Forcing autoupdate!
Autoupdating effekseer
DEBUG[1773034042] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1773034042] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1773034042] $substitutions.$url                           https://github.com/effekseer/Effekseer/releases/download/1.7.3.0/Effekseer1.7.3.0Win.zip
DEBUG[1773034042] $substitutions.$cleanVersion                  1730
DEBUG[1773034042] $substitutions.$basenameNoExt                 Effekseer1.7.3.0Win
DEBUG[1773034042] $substitutions.$majorVersion                  1
DEBUG[1773034042] $substitutions.$underscoreVersion             1_7_3_0
DEBUG[1773034042] $substitutions.$buildVersion                  0
DEBUG[1773034042] $substitutions.$preReleaseVersion             1.7.3.0
DEBUG[1773034042] $substitutions.$match1                        1.7.3.0
DEBUG[1773034042] $substitutions.$version                       1.7.3.0
DEBUG[1773034042] $substitutions.$urlNoExt                      https://github.com/effekseer/Effekseer/releases/download/1.7.3.0/Effekseer1.7.3.0Win
DEBUG[1773034042] $substitutions.$minorVersion                  7
DEBUG[1773034042] $substitutions.$dashVersion                   1-7-3-0
DEBUG[1773034042] $substitutions.$basename                      Effekseer1.7.3.0Win.zip
DEBUG[1773034042] $substitutions.$matchHead                     1.7.3
DEBUG[1773034042] $substitutions.$patchVersion                  3
DEBUG[1773034042] $substitutions.$matchTail                     .0
DEBUG[1773034042] $substitutions.$baseurl                       https://github.com/effekseer/Effekseer/releases/download/1.7.3.0
DEBUG[1773034042] $substitutions.$dotVersion                    1.7.3.0
DEBUG[1773034042] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1773034044] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/effekseer/Effekseer/releases/download/1.7.3.0/Effekseer1.7.3.0Win.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 155212c5ec4d365eb1a4a5cbe25a03cfc59893723ec6680e462de4f49e605b69 using Github Mode
Writing updated effekseer manifest

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package to version 1.7.3.0
  * Removed 32-bit architecture support; 64-bit only
  * Updated homepage reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->