### PR TITLE
lazyssh: Add version 0.3.0

### DIFF
--- a/bucket/lazyssh.json
+++ b/bucket/lazyssh.json
@@ -1,25 +1,30 @@
 {
-  "version": "0.3.0",
-  "description": "A terminal-based SSH manager inspired by lazydocker and k9s - Written in go",
-  "homepage": "https://github.com/adembc/lazyssh",
-  "license": "Apache-2.0",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/Adembc/lazyssh/releases/download/v0.3.0/lazyssh_windows_x86_64.zip",
-      "hash": "ca4353a910e453deb5de68c95d83aa8738ff0e52c4bff919f6d74dc27560a1df"
-    }
-  },
-  "bin": "lazyssh.exe",
-  "shortcuts": [["lazyssh.exe", "LazySSH"]],
-  "checkver": {
-    "url": "https://api.github.com/repos/Adembc/lazyssh/releases/latest",
-    "regex": "tag/v([\\d.]+)"
-  },
-  "autoupdate": {
+    "version": "0.3.0",
+    "description": "A terminal-based SSH manager inspired by lazydocker and k9s - Written in go",
+    "homepage": "https://github.com/adembc/lazyssh",
+    "license": "Apache-2.0",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/Adembc/lazyssh/releases/download/v$version/lazyssh_windows_x86_64.zip"
-      }
+        "64bit": {
+            "url": "https://github.com/Adembc/lazyssh/releases/download/v0.3.0/lazyssh_windows_x86_64.zip",
+            "hash": "ca4353a910e453deb5de68c95d83aa8738ff0e52c4bff919f6d74dc27560a1df"
+        }
+    },
+    "bin": "lazyssh.exe",
+    "shortcuts": [
+        [
+            "lazyssh.exe",
+            "LazySSH"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/Adembc/lazyssh/releases/latest",
+        "regex": "tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Adembc/lazyssh/releases/download/v$version/lazyssh_windows_x86_64.zip"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows installation manifest for LazySSH v0.3.0, enabling installation via Scoop, creating a desktop shortcut/alias, and supporting automated update checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->