### PR TITLE
dngrep@4.7.10.0: Fix extract_dir, add arm64 support

### DIFF
--- a/bucket/dngrep.json
+++ b/bucket/dngrep.json
@@ -7,17 +7,17 @@
         "64bit": {
             "url": "https://github.com/dnGrep/dnGrep/releases/download/v4.7.10.0/dnGREP.4.7.10.x64.msi",
             "hash": "e19c8eaedb21b2a0fe1c7245e31b9727aad50f89ef1bd47792b2934a40470b47",
-            "extract_dir":"PFiles64\\dnGrep"
+            "extract_dir": "PFiles64\\dnGrep"
         },
         "32bit": {
             "url": "https://github.com/dnGrep/dnGrep/releases/download/v4.7.10.0/dnGREP.4.7.10.x86.msi",
             "hash": "e7aa89df02c0baae10f02fd0dc5c0d7debe53e7c633479366240f0ceda6c9d47",
-            "extract_dir":"PFiles\\dnGrep"
+            "extract_dir": "PFiles\\dnGrep"
         },
         "arm64": {
             "url": "https://github.com/dnGrep/dnGrep/releases/download/v4.7.10.0/dnGREP.4.7.10.ARM64.msi",
             "hash": "21d91242efd13760a1b0e6fcf90328d748b25b7a6b1774001fb2b27c96bc32da",
-            "extract_dir":"PFiles64\\dnGrep"
+            "extract_dir": "PFiles64\\dnGrep"
         }
     },
     "pre_install": [


### PR DESCRIPTION
- Specified `extract_dir` on a per-architecture basis as x64 and x86 now have different extract dirs.
- Remove manual hash check so that Scoop's Github Mode hash check can be used.
- Add arm64 support.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17387 
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 support with dedicated download, integrity info, and install layout.
  * Per-architecture extraction directories for 64-bit and 32-bit installs.

* **Chores**
  * Simplified update metadata: autoupdate now includes per-architecture URLs; removed outdated top-level/regex lookup entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->