### PR TITLE
obs-studio@32.1.0: Fix `url`

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -9,7 +9,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-32.1.0-Windows-x64.zip",
+            "url": "https://github.com/obsproject/obs-studio/releases/download/32.1.0/OBS-Studio-32.1.0-Windows-x64.zip",
             "hash": "7c742f250dc1355ca4a7ccfbcd07a1b63f53ea46f4e052bce2426d8d324ee90d",
             "shortcuts": [
                 [
@@ -19,7 +19,7 @@
             ]
         },
         "arm64": {
-            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-32.1.0-Windows-arm64.zip",
+            "url": "https://github.com/obsproject/obs-studio/releases/download/32.1.0/OBS-Studio-32.1.0-Windows-arm64.zip",
             "hash": "af0ce32dc3c9beb443545fa5b356a4094b3bdbcb70936019c4c5198505dc19ee",
             "shortcuts": [
                 [
@@ -56,10 +56,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Windows-x64.zip"
+                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Windows-x64.zip"
             },
             "arm64": {
-                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Windows-arm64.zip"
+                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

There is a delay between GitHub releases and Fastly CDN mirrors (currently it's 404):

<img width="779" height="214" alt="image" src="https://github.com/user-attachments/assets/93a5c914-8765-44e4-854a-045bb9773f73" />

cc: @HUMORCE

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated download URLs for 64-bit and ARM64 builds to GitHub Releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->