### PR TITLE
(chore): Move WebView2 from `notes` to `suggest`

### DIFF
--- a/bucket/project-graph.json
+++ b/bucket/project-graph.json
@@ -6,7 +6,9 @@
         "identifier": "Proprietary",
         "url": "https://graphif.dev/docs/app/misc/terms"
     },
-    "notes": "If the GUI does not work properly, you may install Microsoft Edge WebView2 Runtime (https://go.microsoft.com/fwlink/p/?LinkId=2124703) manually.",
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/graphif/project-graph/releases/download/v2.11.4/Project.Graph_2.11.4_x64-setup.exe#/dl.7z",

--- a/bucket/rclone-manager.json
+++ b/bucket/rclone-manager.json
@@ -3,10 +3,9 @@
     "description": "A powerful, cross-platform GUI for managing Rclone remotes with style and ease.",
     "homepage": "https://zarestia-dev.github.io/rclone-manager/",
     "license": "GPL-3.0-or-later",
-    "notes": [
-        "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
-        "If missing, install the Evergreen Runtime from Microsoft."
-    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/Zarestia-Dev/rclone-manager/releases/download/v0.2.2/RClone.Manager_0.2.2_x64-setup.exe#/dl.7z",

--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -3,10 +3,9 @@
     "description": "GUI for rclone & S3",
     "homepage": "https://rcloneui.com",
     "license": "Apache-2.0",
-    "notes": [
-        "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
-        "If missing, install the Evergreen Runtime from Microsoft."
-    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v3.5.0/Rclone.UI_x64.exe#/dl.7z",

--- a/bucket/seelen-ui.json
+++ b/bucket/seelen-ui.json
@@ -3,10 +3,9 @@
     "description": "Seelen UI is a fully customizable desktop environment for Windows 10/11.",
     "homepage": "https://seelen.io/apps/seelen-ui",
     "license": "AGPL-3.0-or-later",
-    "notes": [
-        "Seelen UI requires Microsoft Edge and the WebView runtime to function properly.",
-        "For more information, see: https://github.com/eythaann/Seelen-UI/?tab=readme-ov-file#installation"
-    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/eythaann/Seelen-UI/releases/download/v2.5.3/Seelen.UI_2.5.3_x64-setup.exe#/dl.7z",

--- a/bucket/squirreldisk.json
+++ b/bucket/squirreldisk.json
@@ -3,11 +3,9 @@
     "homepage": "https://www.squirreldisk.com/",
     "description": "A beautiful, super fast disk usage analysis tool. Built with rust.",
     "license": "AGPL-3.0",
-    "notes": [
-        "This app depends on MSEdgeWebview2 to function properly.",
-        "Click below to download the latest version of MSEdgeWebview2:",
-        "https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section"
-    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/adileo/squirreldisk/releases/download/v0.3.4/SquirrelDisk_0.3.4_x64_en-US.msi",


### PR DESCRIPTION
> https://github.com/ScoopInstaller/Scoop/issues/6378#issue-3106905535
> #### VCRedist / .NET Runtime related
> When they are suggested by manifest, it means that the app requires them. You can install them any way you want, not limited to Scoop

The same applies to Microsoft Edge WebView2.

- Relates to #17085
<!-- -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated dependency suggestion mechanism across multiple packages. Required dependencies like Microsoft Edge WebView2 are now presented through an improved system for clearer installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->