### PR TITLE
inkwell: Add version 1.1

### DIFF
--- a/bucket/inkwell.json
+++ b/bucket/inkwell.json
@@ -1,9 +1,9 @@
 {
     "version": "1.1",
-    "description": "Lightweight Markdown editor with split view, live preview, themes, focus mode, and diff viewer",
+    "description": "Lightweight Markdown editor with split view, live preview, themes, focus mode, and diff viewer.",
     "homepage": "https://4worlds.gumroad.com/l/inkwell",
     "license": {
-        "identifier": "Freemium",
+        "identifier": "Shareware",
         "url": "https://github.com/4worlds4w-svg/inkwell/blob/main/LICENSE.md"
     },
     "architecture": {


### PR DESCRIPTION
Closes #17412

Lightweight Markdown editor with split view, live preview, themes, focus mode, and diff viewer.

- **Homepage**: https://github.com/4worlds4w-svg/inkwell
- **License**: Free + Pro (one-time purchase for PDF/HTML export)
- **Architecture**: 64-bit Windows

Checklist:
- [x] Manifest is valid JSON
- [x] Hash verified against release asset
- [x] `checkver` and `autoupdate` configured
- [x] Alphabetical placement in bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inkwell application (v1.1) is now available.
  * 64-bit binary distribution provided with downloadable release and SHA256 integrity verification.
  * Automatic update support via release-based updates.
  * Homepage and license information included.
  * Adds a desktop shortcut mapping for easy access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->