### PR TITLE
positron: Support version-specific hash extraction, add arm64 support

### DIFF
--- a/bucket/positron.json
+++ b/bucket/positron.json
@@ -10,11 +10,15 @@
     "architecture": {
         "64bit": {
             "url": "https://cdn.posit.co/positron/releases/win/x86_64/Positron-2026.03.0-212-UserSetup-x64.exe",
-            "hash": "c83da819444a7c1cb6231795e3597b2dd85738ec48e323f830a543c41d3ed169",
-            "extract_dir": "{code_GetDestDir}"
+            "hash": "c83da819444a7c1cb6231795e3597b2dd85738ec48e323f830a543c41d3ed169"
+        },
+        "arm64": {
+            "url": "https://cdn.posit.co/positron/releases/win/arm64/Positron-2026.03.0-212-UserSetup-arm64.exe",
+            "hash": "d100e76016b83f109f06bce7a85dfb553c54fd93bfe68addc2b465d83923ff88"
         }
     },
     "innosetup": true,
+    "extract_dir": "{code_GetDestDir}",
     "bin": "bin/positron.cmd",
     "shortcuts": [
         [
@@ -29,12 +33,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn.posit.co/positron/releases/win/x86_64/Positron-$version-UserSetup-x64.exe",
-                "hash": {
-                    "url": "https://cdn.posit.co/positron/releases/checksums/positron-$version-checksums.json",
-                    "jsonpath": "$['Positron-$version-UserSetup-x64.exe']"
-                }
+                "url": "https://cdn.posit.co/positron/releases/win/x86_64/Positron-$version-UserSetup-x64.exe"
+            },
+            "arm64": {
+                "url": "https://cdn.posit.co/positron/releases/win/arm64/Positron-$version-UserSetup-arm64.exe"
             }
+        },
+        "hash": {
+            "url": "https://cdn.posit.co/positron/releases/checksums/positron-$version-checksums.json",
+            "jsonpath": "$.['$basename']"
         }
     }
 }


### PR DESCRIPTION
Switches to a different hash json file to fix hash-extraction of older versions.

Relates to https://github.com/ScoopInstaller/Extras/issues/17238

### Tests
<details>
<summary>installing older versions</summary>

```powershell
PS C:\Users\WDAGUtilityAccount\Desktop> scoop install positron@2026.02.1-5
WARN  Given version (2026.02.1-5) does not match manifest (2026.03.0-212)
WARN  Attempting to generate manifest for 'positron' (2026.02.1-5)
Autoupdating positron
DEBUG[1773490400.72404] [$updatedProperties] = [url hash] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1773490400.74106] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1773490400.74106] $substitutions.$basename                      Positron-2026.02.1-5-UserSetup-x64.exe                                                                                                   
DEBUG[1773490400.74106] $substitutions.$preReleaseVersion             5                                                                                                                                        
DEBUG[1773490400.74106] $substitutions.$baseurl                       https://cdn.posit.co/positron/releases/win/x86_64                                                                                        
DEBUG[1773490400.74106] $substitutions.$url                           https://cdn.posit.co/positron/releases/win/x86_64/Positron-2026.02.1-5-UserSetup-x64.exe                                                 
DEBUG[1773490400.74106] $substitutions.$dashVersion                   2026-02-1-5                                                                                                                              
DEBUG[1773490400.74106] $substitutions.$underscoreVersion             2026_02_1_5                                                                                                                              
DEBUG[1773490400.74106] $substitutions.$urlNoExt                      https://cdn.posit.co/positron/releases/win/x86_64/Positron-2026.02.1-5-UserSetup-x64                                                     
DEBUG[1773490400.74106] $substitutions.$minorVersion                  02                                                                                                                                       
DEBUG[1773490400.74106] $substitutions.$patchVersion                  1                                                                                                                                        
DEBUG[1773490400.74106] $substitutions.$basenameNoExt                 Positron-2026.02.1-5-UserSetup-x64                                                                                                       
DEBUG[1773490400.74106] $substitutions.$dotVersion                    2026.02.1.5                                                                                                                              
DEBUG[1773490400.74106] $substitutions.$matchTail                     -5                                                                                                                                       
DEBUG[1773490400.74106] $substitutions.$buildVersion                                                                                                                                                           
DEBUG[1773490400.74106] $substitutions.$majorVersion                  2026                                                                                                                                     
DEBUG[1773490400.74106] $substitutions.$cleanVersion                  20260215                                                                                                                                 
DEBUG[1773490400.74106] $substitutions.$matchHead                     2026.02.1                                                                                                                                
DEBUG[1773490400.74106] $substitutions.$version                       2026.02.1-5                                                                                                                              
DEBUG[1773490400.77063] $hashfile_url = https://cdn.posit.co/positron/releases/checksums/positron-2026.02.1-5-checksums.json -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Positron-2026.02.1-5-UserSetup-x64.exe in https://cdn.posit.co/positron/releases/checksums/positron-2026.02.1-5-checksums.json
DEBUG[1773490401.22071] $jsonpath = $['Positron-$version-UserSetup-x64.exe'] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 2a355c4143e0f2a9a9d7aa67ddb5984c782bf3937fc5f56d8c79cf8a79d41f59 using Json Mode
Writing updated positron manifest
WARN  Purging previous failed installation of positron.
ERROR 'positron' isn't installed correctly.
Removing older version (2026.03.0-212).
'positron' was uninstalled.
Installing 'positron' (2026.02.1-5) [64bit] from 'C:\Users\WDAGUtilityAccount\scoop\workspace\positron.json'
Positron-2026.02.1-5-UserSetup-x64.exe (316.4 MB) [==================================================================================================================================================] 100%
Checking hash of Positron-2026.02.1-5-UserSetup-x64.exe ... ok.
Extracting Positron-2026.02.1-5-UserSetup-x64.exe ... done.
Linking ~\scoop\apps\positron\current => ~\scoop\apps\positron\2026.02.1-5
Creating shim for 'positron'.
Creating shortcut for Positron (Positron.exe)
'positron' (2026.02.1-5) was installed successfully!
'positron' suggests installing 'python'.
'positron' suggests installing 'r'.
PS C:\Users\WDAGUtilityAccount\Desktop> scoop install positron@2026.02.0-139
WARN  Given version (2026.02.0-139) does not match manifest (2026.02.1-5)
WARN  Attempting to generate manifest for 'positron' (2026.02.0-139)
Autoupdating positron
DEBUG[1773490579.68467] [$updatedProperties] = [url hash] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1773490579.68968] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1773490579.68968] $substitutions.$basename                      Positron-2026.02.0-139-UserSetup-x64.exe                                                                                                 
DEBUG[1773490579.68968] $substitutions.$preReleaseVersion             139                                                                                                                                      
DEBUG[1773490579.68968] $substitutions.$baseurl                       https://cdn.posit.co/positron/releases/win/x86_64                                                                                        
DEBUG[1773490579.68968] $substitutions.$url                           https://cdn.posit.co/positron/releases/win/x86_64/Positron-2026.02.0-139-UserSetup-x64.exe                                               
DEBUG[1773490579.68968] $substitutions.$dashVersion                   2026-02-0-139                                                                                                                            
DEBUG[1773490579.68968] $substitutions.$underscoreVersion             2026_02_0_139                                                                                                                            
DEBUG[1773490579.68968] $substitutions.$urlNoExt                      https://cdn.posit.co/positron/releases/win/x86_64/Positron-2026.02.0-139-UserSetup-x64                                                   
DEBUG[1773490579.68968] $substitutions.$minorVersion                  02                                                                                                                                       
DEBUG[1773490579.68968] $substitutions.$patchVersion                  0                                                                                                                                        
DEBUG[1773490579.68968] $substitutions.$basenameNoExt                 Positron-2026.02.0-139-UserSetup-x64                                                                                                     
DEBUG[1773490579.68968] $substitutions.$dotVersion                    2026.02.0.139                                                                                                                            
DEBUG[1773490579.68968] $substitutions.$matchTail                     -139                                                                                                                                     
DEBUG[1773490579.68968] $substitutions.$buildVersion                                                                                                                                                           
DEBUG[1773490579.68968] $substitutions.$majorVersion                  2026                                                                                                                                     
DEBUG[1773490579.68968] $substitutions.$cleanVersion                  2026020139                                                                                                                               
DEBUG[1773490579.68968] $substitutions.$matchHead                     2026.02.0                                                                                                                                
DEBUG[1773490579.68968] $substitutions.$version                       2026.02.0-139                                                                                                                            
DEBUG[1773490579.73877] $hashfile_url = https://cdn.posit.co/positron/releases/checksums/positron-2026.02.0-139-checksums.json -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for Positron-2026.02.0-139-UserSetup-x64.exe in https://cdn.posit.co/positron/releases/checksums/positron-2026.02.0-139-checksums.json
DEBUG[1773490580.17604] $jsonpath = $['Positron-$version-UserSetup-x64.exe'] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 7f86c03f8c662946768a38f2ad85fbb2735bd553b3b83d17eb1b63e69e7065b4 using Json Mode
Writing updated positron manifest
Installing 'positron' (2026.02.0-139) [64bit] from 'C:\Users\WDAGUtilityAccount\scoop\workspace\positron.json'
Positron-2026.02.0-139-UserSetup-x64.exe (316.4 MB) [================================================================================================================================================] 100%
Checking hash of Positron-2026.02.0-139-UserSetup-x64.exe ... ok.
Extracting Positron-2026.02.0-139-UserSetup-x64.exe ... done.
Linking ~\scoop\apps\positron\current => ~\scoop\apps\positron\2026.02.0-139
Creating shim for 'positron'.
Creating shortcut for Positron (Positron.exe)
'positron' (2026.02.0-139) was installed successfully!
'positron' suggests installing 'python'.
'positron' suggests installing 'r'.
```</details>


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native arm64 builds for Windows.

* **Chores**
  * Centralized update checksum verification to a single external checksums source for all architectures.
  * Standardized installation extraction location across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->