### PR TITLE
unigetui: Update to version 2026.1.0, add arm64 support, update URLs

### DIFF
--- a/bucket/unigetui.json
+++ b/bucket/unigetui.json
@@ -35,6 +35,9 @@
             "arm64": {
                 "url": "https://github.com/Devolutions/UniGetUI/releases/download/v$version/UniGetUI.arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
UniGetUI has changed ownership. [Announcement from the creator](https://github.com/devolutions/UniGetUI/discussions/4444)
URLs have been updated to reflect new versioning scheme and to point to the correct github page. 


- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 support for the package.

* **Documentation**
  * Updated product homepage and documentation URL.

* **Updates**
  * Version bumped to 2026.1.0.
  * 64-bit and ARM64 download sources and autoupdate paths switched to the new vendor release.
  * Verification hashes updated to match the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->