### PR TITLE
paint.net-plugin-pyrochild@2020-11-21: Change download URL to archive.org

### DIFF
--- a/bucket/paint.net-plugin-pyrochild.json
+++ b/bucket/paint.net-plugin-pyrochild.json
@@ -4,7 +4,7 @@
     "homepage": "https://forums.getpaint.net/topic/7291-pyrochild-plugins",
     "license": "MIT",
     "depends": "paint.net",
-    "url": "https://forums.getpaint.net/applications/core/interface/file/attachment.php?id=18335#/dl.zip",
+    "url": "https://web.archive.org/web/20240409113833if_/https://content-restricted.invisioncic.com/r125076/monthly_2020_11/pyrochild.2020-11-21_zip.fcab871e681c758ff38f832e2d05956e?response-content-disposition=attachment;%20filename=pyrochild.2020-11-21.zip&Expires=1712663913&Key-Pair-Id=K186TDY4WHSHHJ&Signature=jrCXSFGEuqMvSYdmDfqmzfo1LuAeoWS7NyoKwgqn8Y2KW0ttto~PSJkGtWpAAuOLKsDfORtdv7oxc0z1h9a3I8qfUXZMEsVd~Mzc7ntAECM5lsGdUvE2Se3MErQUS836mOGeZDb5QN~qjOf9e7L1XxxY7lRYK9HUM2zkCj-R2h-7o3n7hEhB5oWD9JZ-PlPh1ii1F5Vtae3PXvcYx-4R0-B32pZFQ5UiW7Cj6xgnMgPTAiuk3LrBlljMph8U2pEI3FXgfIVryGN1le5zXe94D0lOgSsq0iMGH3Ajd6a891DDofbPbJ6e3-WRUQMXSPqggM2Y6Dp-xNYQ3bQPr1w-Fw__#/dl.zip",
     "hash": "88261fd6eb2ebf89924aab93083d9890ef43bdb468bf6e342e355494423cf6f5",
     "pre_install": [
         "$pluginFolder = Join-Path (appdir 'paint.net' $global) 'current\\Effects'",


### PR DESCRIPTION
Closes #17390

* Change download URL to archive.org.

The original URL still works ( <https://forums.getpaint.net/applications/core/interface/file/attachment.php?id=18335> ) when testing from the browser. Maybe it blocks non-browsers? 🤔

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin manifest URL source to enhance reliability and ensure continued access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->