### PR TITLE
bundletool: Add version 1.18.3

### DIFF
--- a/bucket/bundletool.json
+++ b/bucket/bundletool.json
@@ -8,7 +8,7 @@
     },
     "url": "https://github.com/google/bundletool/releases/download/1.18.3/bundletool-all-1.18.3.jar#/bundletool.jar",
     "hash": "a099cfa1543f55593bc2ed16a70a7c67fe54b1747bb7301f37fdfd6d91028e29",
-    "pre_install": "Set-Content \"$dir\\bundletool.bat\" '@start javaw.exe -jar \"%~dp0bundletool.jar\"' -Encoding Ascii",
+    "pre_install": "Set-Content \"$dir\\bundletool.bat\" '@java.exe -jar \"%~dp0bundletool.jar\" %*' -Encoding Ascii",
     "bin": "bundletool.jar",
     "shortcuts": [
         [


### PR DESCRIPTION
Added the bundletool, this is a tool to manipulate Android App Bundles and Android SDK Bundles.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `bundletool: Add bundletool.json configuration for bundletool 1.18.3`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * bundletool (v1.18.3) is now available via the package distribution platform with an executable shim and desktop shortcut for easy access.
  * Installer suggests installing a Java runtime when required.

* **Chores**
  * Automatic version checking and autoupdate configured to keep bundletool installations current via GitHub releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->