### PR TITLE
inno-setup@6.7.1: Switch to GitHub releases

### DIFF
--- a/bucket/inno-setup.json
+++ b/bucket/inno-setup.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/jrsoftware/issrc/releases/download/is-6_7_1/innosetup-6.7.1.exe",
     "hash": "4d11e8050b6185e0d49bd9e8cc661a7a59f44959a621d31d11033124c4e8a7b0",
     "innosetup": true,
-    "post_install": "Invoke-WebRequest -Uri 'https://www.jrsoftware.org/download.php/iscrypt.dll' -OutFile \"$dir\\ISCrypt.dll\"",
     "bin": "iscc.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
The inno-setup manifest was using an older download URL which referred to the official website. This URL was only in HTTP and is anyway not valid anymore.

This PR updates the manifest to download the package from GitHub releases. It also updates the autoupdate accordingly.
In addition, I updated the other URLs to HTTPS, and removed the post install task for the encryption DLL as this one is not used since inno-setup 6.4.

Note that the manifest will probably need to be updated again with the release of 7.0.0 as it will introduce a new package for 64-bit architecture.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded package description and updated homepage and license links to use HTTPS.
  * Migrated primary download source to GitHub Releases (HTTPS).
  * Removed the post-installation step.
  * Updated version-check and auto-update endpoints to HTTPS.
  * Added hash-based verification for auto-updates to validate downloaded artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->