### PR TITLE
gpg4win@5.0.2: Update `arch`

### DIFF
--- a/bucket/gpg4win.json
+++ b/bucket/gpg4win.json
@@ -3,8 +3,12 @@
     "description": "GNU Privacy Guard for Windows is encryption software for files and emails.",
     "homepage": "https://www.gpg4win.org",
     "license": "GPL-2.0-or-later",
-    "url": "https://files.gpg4win.org/gpg4win-5.0.2.exe",
-    "hash": "11864cdc6dedd58c5448ab1c0868886e56bdad96972bc06dcd44b80f9e527051",
+    "architecture": {
+        "64bit": {
+            "url": "https://files.gpg4win.org/gpg4win-5.0.2.exe",
+            "hash": "11864cdc6dedd58c5448ab1c0868886e56bdad96972bc06dcd44b80f9e527051"
+        }
+    },
     "post_install": [
         "Start-Process \"$dir\\$fname\" -ArgumentList @('/S', \"/D=$dir\\Gpg4win\") -WindowStyle Hidden -Wait",
         "Remove-Item \"$dir\\$fname\""
@@ -15,7 +19,11 @@
         "regex": "Download Gpg4win ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://files.gpg4win.org/gpg4win-$version.exe",
+        "architecture": {
+            "64bit": {
+                "url": "https://files.gpg4win.org/gpg4win-$version.exe"
+            }
+        },
         "hash": {
             "url": "https://gpg4win.org/package-integrity.html"
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://www.gpg4win.org/version5.html
> Be aware that Gpg4win is now built natively for 64-Bit Windows. This changes the path to the installation directory and Registry keys. If 3rd party software on your system uses gpg, you might have to update the path to the gpg binary in it's configuration.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized installer configuration structure for improved data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->