### PR TITLE
notepad--@3.6.4: Update checkver to avoid pre-release versions

### DIFF
--- a/bucket/notepad--.json
+++ b/bucket/notepad--.json
@@ -18,7 +18,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/cxasm/notepad--",
+        "url": "https://api.github.com/repos/cxasm/notepad--/releases/latest",
+        "jsonpath": "$.tag_name",
         "regex": "notepad-v([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Notepad-- has been added to the bucket (https://github.com/ScoopInstaller/Extras/pull/17426). Because the developer of Notepad-- uses unconventional tag format, `checkver.url` and `checkver.regex` need to be manually customized. The previous version of manifest may include its pre-release versions. This pr updates the checkver to avoid these pre-release versions.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version checking configuration to use explicit GitHub Releases API parameters for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->