### PR TITLE
registry-explorer: Update to version 2.1.0, fix checkver & autoupdate

### DIFF
--- a/bucket/registry-explorer.json
+++ b/bucket/registry-explorer.json
@@ -24,7 +24,7 @@
         "Bookmarks\\User"
     ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/EricZimmerman/ericzimmerman.github.io/master/index.md",
+        "url": "https://raw.githubusercontent.com/EricZimmerman/ericzimmerman.github.io/HEAD/index.md",
         "regex": "Registry Explorer[^[]+\\[([\\d.]+)[^)]+/(?<path>[^/]+)/RegistryExplorer"
     },
     "autoupdate": {


### PR DESCRIPTION
### Summary

Updates `registry-explorer` to version **2.1.0**, migrates the download source to the new official domain, and upgrades the target runtime to **.NET 9**.

### Changes

- **Update version to 2.1.0**: Bump version and updated hashes.
- **Migrate Download Source**: Update the base URL from `download.mikestammer.com` to `download.ericzimmermanstools.com`.
- **Refine Description**: Provide a more detailed description highlighting advanced search and locked file access.
- **Target .NET 9**: 
  - Update download paths to use the `net9` binaries.
  - Add a `suggest` field for `.NET Desktop Runtime 9.0`.
- **Improve Persistence**: Expand the `persist` field to include `Bookmarks\User` alongside the existing `Settings` directory.
- **Robust checkver & autoupdate**:
  - Refactor `checkver` regex to use a named capture group `path` (e.g., `net9`).
  - Update `autoupdate` to use `$matchPath`, ensuring future runtime version changes are handled automatically.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App registry-explorer -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
registry-explorer: 2.1.0 (scoop version is 2.1.0)
Forcing autoupdate!
Autoupdating registry-explorer
DEBUG[1774111485] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1774111485] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1774111485] $substitutions.$version                       2.1.0
DEBUG[1774111485] $substitutions.$minorVersion                  1
DEBUG[1774111485] $substitutions.$basenameNoExt                 RegistryExplorer
DEBUG[1774111485] $substitutions.$matchTail
DEBUG[1774111485] $substitutions.$patchVersion                  0
DEBUG[1774111485] $substitutions.$url                           https://download.ericzimmermanstools.com/net9/RegistryExplorer.zip
DEBUG[1774111485] $substitutions.$matchHead                     2.1.0
DEBUG[1774111485] $substitutions.$matchPath                     net9
DEBUG[1774111485] $substitutions.$cleanVersion                  210
DEBUG[1774111485] $substitutions.$preReleaseVersion             2.1.0
DEBUG[1774111485] $substitutions.$underscoreVersion             2_1_0
DEBUG[1774111485] $substitutions.$dotVersion                    2.1.0
DEBUG[1774111485] $substitutions.$baseurl                       https://download.ericzimmermanstools.com/net9
DEBUG[1774111485] $substitutions.$dashVersion                   2-1-0
DEBUG[1774111485] $substitutions.$majorVersion                  2
DEBUG[1774111485] $substitutions.$urlNoExt                      https://download.ericzimmermanstools.com/net9/RegistryExplorer
DEBUG[1774111485] $substitutions.$buildVersion
DEBUG[1774111485] $substitutions.$match1                        2.1.0
DEBUG[1774111485] $substitutions.$basename                      RegistryExplorer.zip
DEBUG[1774111485] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading RegistryExplorer.zip to compute hashes!
Loading RegistryExplorer.zip from cache
Computed hash: 5d0569fcf18adaf50dc7f8294204cf0335c4f81e78e5587bacd57f2685cab1a4
Writing updated registry-explorer manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/registry-explorer
Installing 'registry-explorer' (2.1.0) [64bit] from 'Unofficial' bucket
Loading RegistryExplorer.zip from cache.
Checking hash of RegistryExplorer.zip... OK.
Extracting RegistryExplorer.zip... Done.
Linking D:\Software\Scoop\Local\apps\registry-explorer\current => D:\Software\Scoop\Local\apps\registry-explorer\2.1.0
Creating shortcut for Registry Explorer (RegistryExplorer.exe)
Persisting Settings
Persisting Bookmarks\User
'registry-explorer' (2.1.0) was installed successfully!
'registry-explorer' suggests installing 'versions/windowsdesktop-runtime-9.0'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced search for improved discovery
  * Multi-hive support and access to locked registry files
  * Support targeting .NET Desktop Runtime 9.0

* **Improvements**
  * Expanded persistence to include settings and user bookmarks
  * 64-bit-specific download/update entries for more reliable updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->