### PR TITLE
goneovim: Update to version 0.6.17, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/goneovim.json
+++ b/bucket/goneovim.json
@@ -1,15 +1,26 @@
 {
-    "version": "0.6.16",
+    "version": "0.6.17",
     "description": "Neovim GUI which uses a Golang Qt backend",
     "homepage": "https://github.com/akiyosi/goneovim",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/akiyosi/goneovim/blob/HEAD/LICENSE"
+    },
+    "suggest": {
+        "Neovim": "main/neovim"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/akiyosi/goneovim/releases/download/v0.6.16/goneovim-v0.6.16-windows.zip",
-            "hash": "456182a9a08c0ded34b241fe60aef5dab06b07b08b3703eebe54aa76ee06fc2f"
+            "url": "https://github.com/akiyosi/goneovim/releases/download/v0.6.17/goneovim-v0.6.17-windows-x86_64.zip",
+            "hash": "d7401c2e33c4dffc7dccf65cfb5fc7d8537dffc4ddc35a75feb6566f2fdcfe38",
+            "extract_dir": "goneovim-v0.6.17-windows-x86_64"
+        },
+        "arm64": {
+            "url": "https://github.com/akiyosi/goneovim/releases/download/v0.6.17/goneovim-v0.6.17-windows-arm64.zip",
+            "hash": "713d3cf487cb287df0337f314688325ccd455ab30df5c4717ad404f34058a0ee",
+            "extract_dir": "goneovim-v0.6.17-windows-arm64"
         }
     },
-    "extract_dir": "goneovim-v0.6.16-windows",
     "bin": "goneovim.exe",
     "shortcuts": [
         [
@@ -17,16 +28,17 @@
             "Goneovim"
         ]
     ],
-    "suggest": {
-        "Neovim": "neovim"
-    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/akiyosi/goneovim/releases/download/v$version/goneovim-v$version-windows.zip"
+                "url": "https://github.com/akiyosi/goneovim/releases/download/v$version/goneovim-v$version-windows-x86_64.zip",
+                "extract_dir": "goneovim-v$version-windows-x86_64"
+            },
+            "arm64": {
+                "url": "https://github.com/akiyosi/goneovim/releases/download/v$version/goneovim-v$version-windows-arm64.zip",
+                "extract_dir": "goneovim-v$version-windows-arm64"
             }
-        },
-        "extract_dir": "goneovim-v$version-windows"
+        }
     }
 }


### PR DESCRIPTION
### Summary

Updates `goneovim` to version **0.6.17**, adds support for the **ARM64** architecture, and refines manifest metadata for better maintainability.

### Changes

- **Update version to 0.6.17**: Bump version and updated hashes for all architectures.
- **Improve license field**: Migrate to a structured object with SPDX identifier `MIT` and a direct link to the license file.
- **Refine suggestions**: Update the `suggest` field for Neovim to point explicitly to `main/neovim`.
- **Add arm64 support**: Introduce `arm64` architecture block with its respective download URL and extraction path.
- **Update 64-bit binaries**: 
  - Update the `64bit` URL to match the new upstream naming convention (appended `-x86_64`).
  - Move `extract_dir` from the root level to architecture-specific blocks, as the zip structure now varies between `x86_64` and `arm64`.
- **Sync autoupdate**: Update the `autoupdate` logic to reflect the new architecture-specific directory structure and file naming.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App goneovim -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
goneovim: 0.6.17 (scoop version is 0.6.17)
Forcing autoupdate!
Autoupdating goneovim
DEBUG[1774113070] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1774113070] $substitutions.$basenameNoExt                 goneovim-v0.6.17-windows-arm64
DEBUG[1774113070] $substitutions.$buildVersion
DEBUG[1774113070] $substitutions.$match1                        0.6.17
DEBUG[1774113070] $substitutions.$matchTail
DEBUG[1774113070] $substitutions.$basename                      goneovim-v0.6.17-windows-arm64.zip
DEBUG[1774113070] $substitutions.$urlNoExt                      https://github.com/akiyosi/goneovim/releases/download/v0.6.17/goneovim-v0.6.17-windows-arm64
DEBUG[1774113070] $substitutions.$underscoreVersion             0_6_17
DEBUG[1774113070] $substitutions.$preReleaseVersion             0.6.17
DEBUG[1774113070] $substitutions.$majorVersion                  0
DEBUG[1774113070] $substitutions.$patchVersion                  17
DEBUG[1774113070] $substitutions.$cleanVersion                  0617
DEBUG[1774113070] $substitutions.$url                           https://github.com/akiyosi/goneovim/releases/download/v0.6.17/goneovim-v0.6.17-windows-arm64.zip
DEBUG[1774113070] $substitutions.$dashVersion                   0-6-17
DEBUG[1774113070] $substitutions.$minorVersion                  6
DEBUG[1774113070] $substitutions.$version                       0.6.17
DEBUG[1774113070] $substitutions.$matchHead                     0.6.17
DEBUG[1774113070] $substitutions.$dotVersion                    0.6.17
DEBUG[1774113070] $substitutions.$baseurl                       https://github.com/akiyosi/goneovim/releases/download/v0.6.17
DEBUG[1774113070] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1774113071] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/akiyosi/goneovim/releases/download/v0.6.17/goneovim-v0.6.17-windows-arm64.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 713d3cf487cb287df0337f314688325ccd455ab30df5c4717ad404f34058a0ee using Github Mode
Writing updated goneovim manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/goneovim --arch 64bit
Installing 'goneovim' (0.6.17) [64bit] from 'Unofficial' bucket
Loading goneovim-v0.6.17-windows-x86_64.zip from cache.
Checking hash of goneovim-v0.6.17-windows-x86_64.zip... OK.
Extracting goneovim-v0.6.17-windows-x86_64.zip... Done.
Linking D:\Software\Scoop\Local\apps\goneovim\current => D:\Software\Scoop\Local\apps\goneovim\0.6.17
Creating shim for 'goneovim'.
Making D:\Software\Scoop\Local\shims\goneovim.exe a GUI binary.
Creating shortcut for Goneovim (goneovim.exe)
'goneovim' (0.6.17) was installed successfully!
'goneovim' suggests installing 'main/neovim'.

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/goneovim --arch arm64
Installing 'goneovim' (0.6.17) [arm64] from 'Unofficial' bucket
Loading goneovim-v0.6.17-windows-arm64.zip from cache.
Checking hash of goneovim-v0.6.17-windows-arm64.zip... OK.
Extracting goneovim-v0.6.17-windows-arm64.zip... Done.
Linking D:\Software\Scoop\Local\apps\goneovim\current => D:\Software\Scoop\Local\apps\goneovim\0.6.17
Creating shim for 'goneovim'.
Making D:\Software\Scoop\Local\shims\goneovim.exe a GUI binary.
Creating shortcut for Goneovim (goneovim.exe)
'goneovim' (0.6.17) was installed successfully!
'goneovim' suggests installing 'main/neovim'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Version 0.6.17 released with improved Windows platform support
  * Added native ARM64 architecture support for Windows installations
  * License information now includes direct reference URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->