### PR TITLE
bandcamp-downloader: Add version 1.5.2

### DIFF
--- a/bucket/bandcamp-downloader.json
+++ b/bucket/bandcamp-downloader.json
@@ -1,10 +1,19 @@
 {
-    "homepage": "https://github.com/Otiel/BandcampDownloader",
-    "description": "A Windows app used to download albums from Bandcamp.",
-    "license": "MIT",
     "version": "1.5.2",
-    "url": "https://github.com/Otiel/BandcampDownloader/releases/download/v1.5.2/BandcampDownloader.zip",
-    "hash": "c7a1711fc1041d07e5b8bd8367a23bf23220e7a10d6439d4233817794c3682ac",
+    "description": "A Windows app used to download albums from Bandcamp.",
+    "homepage": "https://github.com/Otiel/BandcampDownloader",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Otiel/BandcampDownloader/releases/download/v1.5.2/BandcampDownloader.zip",
+            "hash": "c7a1711fc1041d07e5b8bd8367a23bf23220e7a10d6439d4233817794c3682ac"
+        }
+    },
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\BandcampDownloader.ini\")) {",
+        "    Set-Content -Path \"$dir\\BandcampDownloader.ini\" -Value 'CheckForUpdates=false' -Encoding Ascii",
+        "}"
+    ],
     "shortcuts": [
         [
             "BandcampDownloader.exe",
@@ -12,9 +21,12 @@
         ]
     ],
     "persist": "BandcampDownloader.ini",
-    "pre_install": "if(!(Test-Path \"$persist_dir\\BandcampDownloader.ini\")) { New-Item \"$dir\\BandcampDownloader.ini\" | Out-Null }",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Otiel/BandcampDownloader/releases/download/v$version/BandcampDownloader.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Otiel/BandcampDownloader/releases/download/v$version/BandcampDownloader.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Closes #17453 


- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Windows installer for Bandcamp Downloader v1.5.2 with automatic update support from releases.
  * Installer preserves user settings between installs and ensures a default configuration file is created if missing.
  * Added Start Menu shortcut and streamlined launch integration for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->