### PR TITLE
bitwarden-secrets-manager-cli: Add version 2.0.0

### DIFF
--- a/bucket/bitwarden-secrets-cli.json
+++ b/bucket/bitwarden-secrets-cli.json
@@ -1,0 +1,24 @@
+{
+    "version": "2.0.0",
+    "description": "The Bitwarden Secrets Manager command-line interface (CLI) is a powerful tool for retrieving and injecting your secrets. The CLI can be used to organize your vault with create, delete, edit, and list your secrets and projects.",
+    "homepage": "https://bitwarden.com/products/secrets-manager/",
+    "license": "Bitwarden SDK",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bitwarden/sdk-sm/releases/download/bws-v2.0.0/bws-x86_64-pc-windows-msvc-2.0.0.zip",
+            "hash": "4284944f3b0c7b97a4d4105c715cd814c744ceff0405481a213937955e31d866"
+        }
+    },
+    "bin": "bws.exe",
+    "checkver": {
+        "url": "https://github.com/bitwarden/sdk-sm/releases.atom",
+        "regex": "\\/bws-v([\\d.]+)<\\/id>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bitwarden/sdk-sm/releases/download/bws-v$version/bws-x86_64-pc-windows-msvc-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17458

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package manifest to enable distribution of the Bitwarden Secrets Manager CLI for Windows x64, providing easier installation, automated update checks, and verified downloads with integrity checks to ensure users receive authentic releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->