### PR TITLE
dual-key-remap: Add manifest for v0.11

### DIFF
--- a/bucket/dual-key-remap.json
+++ b/bucket/dual-key-remap.json
@@ -1,0 +1,55 @@
+{
+    "version": "0.11",
+    "description": "Remap any key to any other two keys on Windows. Remap CapsLock to both Ctrl and Escape!",
+    "homepage": "https://github.com/ililim/dual-key-remap",
+    "license": "GPL-2.0-only",
+    "notes": [
+        "dual-key-remap requires Administrator privileges to remap keys in elevated windows.",
+        "",
+        "To start dual-key-remap automatically at logon (with admin rights), run:",
+        "  install-dual-key-startup",
+        "",
+        "To remove the startup task, run (as Admin):",
+        "  schtasks /delete /tn \"DualKeyRemap\" /f"
+    ],
+    "url": "https://github.com/ililim/dual-key-remap/releases/download/v0.11/dual-key-remap-v0.11.zip",
+    "hash": "3fb5da6fd608d3c1479df79736cb05a471e12c5ef9d93827c613e604af652ea7",
+    "installer": {
+        "script": [
+            "$startup_script = @'",
+            "#Requires -RunAsAdministrator",
+            "$scoopDir = (Get-Item \"$PSScriptRoot\").Target",
+            "if (-not $scoopDir) { $scoopDir = $PSScriptRoot }",
+            "$exe = Join-Path $scoopDir 'dual-key-remap.exe'",
+            "if (-not (Test-Path $exe)) {",
+            "    Write-Error \"Could not find dual-key-remap.exe at '$exe'\"",
+            "    exit 1",
+            "}",
+            "$action  = New-ScheduledTaskAction -Execute $exe -WorkingDirectory $scoopDir",
+            "$trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME",
+            "$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -RunLevel Highest -LogonType Interactive",
+            "$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit 0",
+            "Register-ScheduledTask -TaskName 'DualKeyRemap' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null",
+            "Write-Host 'Scheduled task \"DualKeyRemap\" registered successfully.' -ForegroundColor Green",
+            "Write-Host 'dual-key-remap will start automatically at logon with elevated privileges.'",
+            "if (-not (Get-Process -Name 'dual-key-remap' -ErrorAction SilentlyContinue)) {",
+            "    Start-Process -FilePath $exe -WorkingDirectory $scoopDir -Verb RunAs",
+            "    Write-Host 'dual-key-remap started.' -ForegroundColor Green",
+            "}",
+            "'@",
+            "$startup_script | Set-Content \"$dir\\install-dual-key-startup.ps1\" -Encoding UTF8"
+        ]
+    },
+    "bin": [
+        "dual-key-remap.exe",
+        [
+            "install-dual-key-startup.ps1",
+            "install-dual-key-startup"
+        ]
+    ],
+    "persist": "config.txt",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ililim/dual-key-remap/releases/download/v$version/dual-key-remap-v$version.zip"
+    }
+}

--- a/bucket/dual-key-remap.json
+++ b/bucket/dual-key-remap.json
@@ -18,8 +18,7 @@
         "script": [
             "$startup_script = @'",
             "#Requires -RunAsAdministrator",
-            "$scoopDir = (Get-Item \"$PSScriptRoot\").Target",
-            "if (-not $scoopDir) { $scoopDir = $PSScriptRoot }",
+            "$scoopDir = $PSScriptRoot",
             "$exe = Join-Path $scoopDir 'dual-key-remap.exe'",
             "if (-not (Test-Path $exe)) {",
             "    Write-Error \"Could not find dual-key-remap.exe at '$exe'\"",


### PR DESCRIPTION
Close [#17858](https://github.com/ScoopInstaller/Extras/issues/17858)


## New Manifest: dual-key-remap v0.11

**Homepage:** https://github.com/ililim/dual-key-remap
**License:** GPL-2.0-only
**Description:** Remap any key to any other two keys on Windows. Remap CapsLock to both Ctrl and Escape!

### Features
- `checkver` / `autoupdate` for automatic version tracking via GitHub releases
- `persist` for `config.txt` so user config survives updates
- Startup helper (`install-dual-key-startup`) that registers a Windows Scheduled Task at Highest RunLevel, pointing through the Scoop `current` symlink so it never breaks on update

### Checklist
- [x] Manifest is valid JSON
- [x] `checkver` / `autoupdate` configured
- [x] Hash matches release asset
- [x] License SPDX identifier used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the dual-key-remap application to the package manager, allowing users to install a Windows keyboard remapping tool that sets up automatic startup (scheduled task) and supports auto-update/version checks.
* **Chores**
  * Added a manifest to enable installation, startup registration, and update metadata for the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->