### PR TITLE
kopiorapido(-gui): Add version 2026.1.13

### DIFF
--- a/bucket/kopiorapido-gui.json
+++ b/bucket/kopiorapido-gui.json
@@ -1,0 +1,35 @@
+{
+    "version": "2026.1.13",
+    "description": "High-performance file copying application with a modern GUI.",
+    "homepage": "https://kopiorapido.com",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v2026.1.13/kopiorapido-gui-windows-x64-2026.1.13.zip",
+            "hash": "fe9a9001d7a2462f47aa0576a0b6bea50fb8293b343a0ee57a8ebc5bb9d633df"
+        },
+        "arm64": {
+            "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v2026.1.13/kopiorapido-gui-windows-arm64-2026.1.13.zip",
+            "hash": "b8ee456760b9b8709f48cd9287d8be462ef3680bfefa217501a48ed7237ee8c6"
+        }
+    },
+    "shortcuts": [
+        [
+            "KopioRapido.exe",
+            "KopioRapido"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/KredoKodo/KopioRapido-releases"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v$version/kopiorapido-gui-windows-x64-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v$version/kopiorapido-gui-windows-arm64-$version.zip"
+            }
+        }
+    }
+}

--- a/bucket/kopiorapido.json
+++ b/bucket/kopiorapido.json
@@ -1,0 +1,30 @@
+{
+    "version": "2026.1.13",
+    "description": "High-performance file copying CLI with intelligent transfer optimization.",
+    "homepage": "https://kopiorapido.com",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v2026.1.13/kopiorapido-cli-windows-x64-2026.1.13.zip",
+            "hash": "41dc9c3e38db94a1b8320739ff671130e70efd31573d333bddbaf7602b9a1e81"
+        },
+        "arm64": {
+            "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v2026.1.13/kopiorapido-cli-windows-arm64-2026.1.13.zip",
+            "hash": "c5bb32541deaad7ab1a11cbd4c5230cc53bdcccccb7bf856c4090b8e3c5cf8bc"
+        }
+    },
+    "bin": "kp.exe",
+    "checkver": {
+        "github": "https://github.com/KredoKodo/KopioRapido-releases"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v$version/kopiorapido-cli-windows-x64-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/KredoKodo/KopioRapido-releases/releases/download/v$version/kopiorapido-cli-windows-arm64-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] Use conventional PR title: <manifest-name[@version]|chore>: <general summary of the pull request>
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Adding the official KopioRapido CLI and GUI clients.
Version: 2026.1.13
Homepage: https://kopiorapido.com
Releases: https://github.com/KredoKodo/KopioRapido-releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KopioRapido GUI application now available for Windows (64-bit and ARM64 architectures)
  * KopioRapido CLI tool now available with command-line interface support
  * Automatic update checking enabled for both applications
  * Version 2026.1.13 released

<!-- end of auto-generated comment: release notes by coderabbit.ai -->