### PR TITLE
freecad: Update to version 1.1.0, fix checkver & autoupdate

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -12,18 +12,7 @@
             "hash": "040a6971614e7ad0455b4080b13144f9c6b2e154904d9fd443fd8dd357927cab"
         }
     },
-    "pre_install": [
-        "$current_depth = 0",
-        "while ($current_depth -lt 5) {",
-        "    $items = Get-ChildItem -Path $dir | Select-Object -First 3",
-        "    if ($items.Count -eq 1 -and $items.PSIsContainer) {",
-        "        $inner_dir = $items | ForEach-Object -MemberName FullName",
-        "        Move-Item -Path \"$inner_dir\\*\" -Destination $dir -Force",
-        "        Remove-Item -Path $inner_dir -Recurse -Force -ErrorAction SilentlyContinue",
-        "        $current_depth++",
-        "    } else { break }",
-        "}"
-    ],
+    "pre_install": "pushd $dir ; mv */* . ; rm FreeCAD_* ; popd",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
### Summary

Updates `freecad` to version **1.1.0**, modernizes the license field, and implements a robust directory flattening logic in `pre_install`.

### Changes

- **Update version to 1.1.0**: Bump version and update hashes for the x64 architecture.
- **Modernize License**: Update to `LGPL-2.1-or-later` and move to a structured object with a direct link to the license file.
- **Robust `pre_install`**: 
  - Replace the `mv */* .` command with a PowerShell `while` loop that automatically detects and flattens nested top-level directories (up to 5 levels).
  - This ensures successful installation even if the upstream ZIP structure changes or contains unexpected wrappers.
- **Enhance checkver**:
  - Switch to the GitHub API with `jsonpath` to target `.7z` Windows assets.
  - Improve `regex` using named capture groups (`tag` and `name`) to handle both standard and "conda" naming conventions.
- **Refine autoupdate**:
  - Integrate named groups (`$matchTag`, `$matchName`) for more reliable URL construction.

### Notes

- Upstream has moved to [LGPL-2.1](https://github.com/FreeCAD/FreeCAD/commit/01da3ddd35fdeebdfd5a2b4a5ad63c1389cfbc29) for recent releases, which is reflected in the updated `license` field.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App freecad -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
freecad: 1.1.0 (scoop version is 1.1.0)
Forcing autoupdate!
Autoupdating freecad
DEBUG[1774688065] [$updatedProperties] = [hash url] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1774688065] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1774688065] $substitutions.$patchVersion                  0
DEBUG[1774688065] $substitutions.$url                           https://github.com/FreeCAD/FreeCAD/releases/download/1.1.0/FreeCAD_1.1.0-Windows-x86_64-py311.7z
DEBUG[1774688065] $substitutions.$urlNoExt                      https://github.com/FreeCAD/FreeCAD/releases/download/1.1.0/FreeCAD_1.1.0-Windows-x86_64-py311
DEBUG[1774688065] $substitutions.$matchName                     FreeCAD_1.1.0-Windows-x86_64-py311.7z
DEBUG[1774688065] $substitutions.$underscoreVersion             1_1_0
DEBUG[1774688065] $substitutions.$basename                      FreeCAD_1.1.0-Windows-x86_64-py311.7z
DEBUG[1774688065] $substitutions.$buildVersion
DEBUG[1774688065] $substitutions.$match1                        1.1.0
DEBUG[1774688065] $substitutions.$version                       1.1.0
DEBUG[1774688065] $substitutions.$majorVersion                  1
DEBUG[1774688065] $substitutions.$dotVersion                    1.1.0
DEBUG[1774688065] $substitutions.$basenameNoExt                 FreeCAD_1.1.0-Windows-x86_64-py311
DEBUG[1774688065] $substitutions.$minorVersion                  1
DEBUG[1774688065] $substitutions.$matchTail
DEBUG[1774688065] $substitutions.$matchHead                     1.1.0
DEBUG[1774688065] $substitutions.$preReleaseVersion             1.1.0
DEBUG[1774688065] $substitutions.$dashVersion                   1-1-0
DEBUG[1774688065] $substitutions.$cleanVersion                  110
DEBUG[1774688065] $substitutions.$matchTag                      1.1.0
DEBUG[1774688065] $substitutions.$baseurl                       https://github.com/FreeCAD/FreeCAD/releases/download/1.1.0
DEBUG[1774688065] $hashfile_url = https://github.com/FreeCAD/FreeCAD/releases/download/1.1.0/FreeCAD_1.1.0-Windows-x86_64-py311.7z-SHA256.txt -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for FreeCAD_1.1.0-Windows-x86_64-py311.7z in https://github.com/FreeCAD/FreeCAD/releases/download/1.1.0/FreeCAD_1.1.0-Windows-x86_64-py311.7z-SHA256.txt
DEBUG[1774688065] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*FreeCAD_1\.1\.0-Windows-x86_64-py311\.7z(?:\s|$)|FreeCAD_1\.1\.0-Windows-x86_64-py311\.7z[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: 040a6971614e7ad0455b4080b13144f9c6b2e154904d9fd443fd8dd357927cab using Extract Mode
Writing updated freecad manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/freecad.json
Installing 'freecad' (1.1.0) [64bit] from 'Unofficial' bucket
Loading FreeCAD_1.1.0-Windows-x86_64-py311.7z from cache.
Checking hash of FreeCAD_1.1.0-Windows-x86_64-py311.7z... OK.
Extracting FreeCAD_1.1.0-Windows-x86_64-py311.7z... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\freecad\current => D:\Software\Scoop\Local\apps\freecad\1.1.0
Creating shim for 'FreeCADCmd'.
Creating shortcut for FreeCAD (FreeCAD.exe)
'freecad' (1.1.0) was installed successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated FreeCAD to version 1.1.0
  * Clarified license information with a link to the official LICENSE
  * Updated Windows installer download and checksum for the new release
  * Improved automatic update detection and download selection for Windows assets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->