### PR TITLE
archi@5.8.0: Fix download URL, fix checkver & autoupdate

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -18,8 +18,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.archimatetool.com/download/",
-        "regex": "Archi-Win64-([\\d.]+)\\.zip"
+        "url": "https://api.github.com/repos/archimatetool/archi.io/releases",
+        "regex": "download/(?<tag>[^/]+)/Archi-Win64-(?<version>[\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Download references for Archi packages from https://www.archimatetool.com/download/ has changed to point directly GitHub releases.

Closes #17494

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched artifact download and auto-update sources to GitHub Releases for more reliable distribution.
  * Integrity verification remains unchanged (existing checksums preserved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->