### PR TITLE
insomnia: Add version 1.2.0

### DIFF
--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -1,33 +1,31 @@
 {
-    "version": "12.4.0",
-    "description": "HTTP and GraphQL client",
-    "homepage": "https://insomnia.rest",
-    "license": "Apache-2.0",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/Kong/insomnia/releases/download/core%4012.4.0/insomnia-12.4.0-full.nupkg",
-            "hash": "sha1:df4aaf419b2838dde84138a84ca6a3195aed7900"
-        }
-    },
-    "extract_dir": "lib\\net45",
-    "shortcuts": [
-        [
-            "Insomnia.exe",
-            "Insomnia"
-        ]
-    ],
-    "checkver": {
-        "url": "https://api.github.com/repos/Kong/insomnia/releases",
-        "regex": "\"core@([\\d.]+)\""
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/Kong/insomnia/releases/download/core%40$version/insomnia-$version-full.nupkg"
-            }
-        },
-        "hash": {
-            "url": "$baseurl/RELEASES"
-        }
+  "version": "1.2.0",
+  "description": "Keep your PC awake when it matters — hook-based AI integration, app watching, manual toggle.",
+  "homepage": "https://stanley-projects.github.io/Insomnia",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/stanley-projects/Insomnia/releases/download/v1.2.0/Insomnia.Setup.1.2.0.exe",
+      "hash": "902254DF88D12BAE8C83062BAC8EF9722A3E06B141400A953FF46663354770ED"
     }
+  },
+  "installer": {
+    "script": "Start-Process \"$dir\$fname\" '/S' -Wait"
+  },
+  "uninstaller": {
+    "script": "Start-Process \"$env:LOCALAPPDATA\Programs\insomnia-app\Uninstall Insomnia.exe\" '/S' -Wait"
+  },
+  "shortcuts": [
+    ["$env:LOCALAPPDATA\Programs\insomnia-app\Insomnia.exe", "Insomnia"]
+  ],
+  "checkver": {
+    "github": "https://github.com/stanley-projects/Insomnia"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/stanley-projects/Insomnia/releases/download/v$version/Insomnia.Setup.$version.exe"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## New package: Insomnia v1.2.0

**Description:** Keep your PC awake when it matters — lightweight Windows tray app.

**Homepage:** https://stanley-projects.github.io/Insomnia  
**License:** MIT  
**Repo:** https://github.com/stanley-projects/Insomnia

Prevents Windows from sleeping via:
- Hook-based Claude Code integration (awake only while Claude is actively working)
- Process-based app watching (Cursor, Aider, Ollama, etc.)
- Manual toggle

NSIS silent installer. Tested on Windows 10/11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata and distribution configuration.
  * License changed to MIT.
  * Modified installation and update delivery mechanism.
  * Updated installation paths and shortcut configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->