### PR TITLE
kakaotalk: Add 64bit support

### DIFF
--- a/bucket/kakaotalk.json
+++ b/bucket/kakaotalk.json
@@ -3,8 +3,16 @@
     "description": "An easy, no-cost messenger that transcends standard chat.",
     "homepage": "https://www.kakaocorp.com/service/KakaoTalk",
     "license": "Unknown",
-    "url": "http://app.pc.kakao.com/talk/win32/KakaoTalk_Setup.exe#/dl.7z",
-    "hash": "df09fbcc0b075b75f583093a97bb384e951c9ad02c245bd1d79f7608ae9a6b63",
+    "architecture": {
+        "64bit": {
+            "url": "https://lk.kakaocdn.net/talkpc/talk/win32/x64/KakaoTalk_Setup.exe#/dl.7z",
+            "hash": "165e03160d9a1adb9a97f880219db361b9734088d248d3c0cea3f55b1c2117f7"
+        },
+        "32bit": {
+            "url": "https://lk.kakaocdn.net/talkpc/talk/win32/KakaoTalk_Setup.exe#/dl.7z",
+            "hash": "df09fbcc0b075b75f583093a97bb384e951c9ad02c245bd1d79f7608ae9a6b63"
+        }
+    },
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\unisntall*\" -Recurse",
     "shortcuts": [
         [
@@ -17,6 +25,13 @@
         "regex": "kakaotalk_([\\d.]+)_full\\.pak"
     },
     "autoupdate": {
-        "url": "http://app.pc.kakao.com/talk/win32/KakaoTalk_Setup.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://lk.kakaocdn.net/talkpc/talk/win32/x64/KakaoTalk_Setup.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://lk.kakaocdn.net/talkpc/talk/win32/KakaoTalk_Setup.exe#/dl.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
Add 64-bit architecture support and update download URLs from `app.pc.kakao.com` to `lk.kakaocdn.net`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for both 64-bit and 32-bit architecture-specific installers
  * Enhanced download security by switching to encrypted connections
  * Updated to use an improved content delivery network for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->