### PR TITLE
cefflashbrowser@1.1.7: Remove `extract_dir`

### DIFF
--- a/bucket/cefflashbrowser.json
+++ b/bucket/cefflashbrowser.json
@@ -16,7 +16,6 @@
             "hash": "cdb5b4750be0fd52d5320caf8ace450b0d8da77fc17864943a778ba6bcfcdc9a"
         }
     },
-    "extract_dir": "Release",
     "bin": "CefFlashBrowser.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Fix #17506 .
The `extracted_dir` isn't `Release`, but `.` .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration file to streamline installation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->