### PR TITLE
kicad: Update to version 10.0.0-1, fix checkver & autoupdate

### DIFF
--- a/bucket/kicad.json
+++ b/bucket/kicad.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.0.0",
+    "version": "10.0.0-1",
     "description": "Electronics Design Automation Suite",
     "homepage": "https://www.kicad.org",
     "license": "GPL-3.0-only",
@@ -46,13 +46,13 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/KiCad/kicad-source-mirror/",
+        "github": "https://github.com/KiCad/kicad-source-mirror",
         "regex": "kicad-([\\d.]+(?:-\\d+)?)-x86_64\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/KiCad/kicad-source-mirror/releases/download/$majorVersion.$minorVersion.$patchVersion/kicad-$version-x86_64.exe#/dl.7z"
+                "url": "https://github.com/KiCad/kicad-source-mirror/releases/download/$matchHead/kicad-$version-x86_64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Previous file has been removed from github release page, new one has been added with `-1` suffix

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version updated to include a build suffix; Windows 64-bit installer filename and its verification checksum updated.
  * Release detection improved by adding a regex and normalizing the release URL.
  * Autoupdate download path adjusted to follow the release tag naming so updates resolve to the correct installer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->