### PR TITLE
driverstoreexplorer: Update to version 1.0.26, fix autoupdate

### DIFF
--- a/bucket/driverstoreexplorer.json
+++ b/bucket/driverstoreexplorer.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.12.152",
+    "version": "1.0.26",
     "description": "A GUI tool to manage Windows driver store",
     "homepage": "https://github.com/lostindark/DriverStoreExplorer",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/lostindark/DriverStoreExplorer/releases/download/v0.12.152/DriverStoreExplorer.v0.12.152.zip",
-    "hash": "3d7364a4f0afd6a373717933395f36b47cafda633d417141b6056a4c2d10a241",
+    "url": "https://github.com/lostindark/DriverStoreExplorer/releases/download/v1.0.26/DriverStoreExplorer-v1.0.26.zip",
+    "hash": "89a5ed17bf7c08c869294af2202f5f9b34050f81c2feeaa6cd694970da8e931f",
     "bin": "Rapr.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Fix autoupdate url as `DriverStoreExplorer.v$version.zip` is changed to `DriverStoreExplorer-v$version.zip` in according to the upstream repository.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17510

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the autoupdate/installer metadata so the app can detect and download the v1.0.26 release correctly.
  * Updated the release download references and filename pattern to match the v1.0.26 artifact, improving update reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->