### PR TITLE
makemkv@1.18.3: Add shim for `makemkvcon64` (64bit only)

### DIFF
--- a/bucket/makemkv.json
+++ b/bucket/makemkv.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.18.1",
+    "version": "1.18.3",
     "description": "One-click solution to convert video that you own into a set of MKV files.",
     "homepage": "https://www.makemkv.com/",
     "license": "Shareware",
     "architecture": {
         "64bit": {
-            "url": "https://www.makemkv.com/download/Setup_MakeMKV_v1.18.1.exe#/dl.7z",
-            "hash": "97a5e8688c5f57f57396750f7139cab35b5349e6138d1b6e00c6a9b1fcdf1517"
+            "url": "https://www.makemkv.com/download/Setup_MakeMKV_v1.18.3.exe#/dl.7z",
+            "hash": "b0c329506e5128d1711b4edac5bee19c1b1b9e9e04d2f8aa94670d38dece5bce"
         }
     },
     "bin": [


### PR DESCRIPTION
The MakeMKV is implicitly a 64bit app, so architecture block and respective binary shims need to be added.

Closes #17514

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit 64-bit support so systems can install and run the 64-bit build alongside the standard build
  * Installer and updater now use architecture-aware download selection to fetch the correct files

* **Enhancements**
  * Desktop shortcut targets and executable selection updated to point to the appropriate 64-bit binaries
  * Auto-update flow now retrieves architecture-specific update packages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->