### PR TITLE
telegram@6.7.1: Fix hash

### DIFF
--- a/bucket/telegram.json
+++ b/bucket/telegram.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v6.7.1/tportable-x64.6.7.1.zip",
-            "hash": "72e9f279a4bb73596894147a7d131d16896ad77ac7d27b1e786091d3f8e32584"
+            "hash": "317ea71c277f07526d19e15887f13e3e2deb69ca5c85cb63f01d2f73e44e654b"
         },
         "32bit": {
             "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v6.7.1/tportable.6.7.1.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

This commit fixes broken telegram installation for the x64 bit version, Telegram 6.7.1 release was broken itself

First release contained corrupted zip archive:
https://github.com/telegramdesktop/tdesktop/issues/30503

Second update had missing app icon and digital signature:
https://github.com/telegramdesktop/tdesktop/issues/30515

This was resolved, so I'm updating hash for the [v 6.7.1](https://github.com/telegramdesktop/tdesktop/releases/tag/v6.7.1) 64bit portable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package hash for 64-bit architecture downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->