### PR TITLE
wsl2-distro-manager: Update to version 1.11.0

### DIFF
--- a/bucket/wsl2-distro-manager.json
+++ b/bucket/wsl2-distro-manager.json
@@ -2,7 +2,7 @@
   "version": "1.11.0",
   "description": "GUI manager for Windows Subsystem for Linux distributions",
   "homepage": "https://github.com/bostrot/wsl2-distro-manager",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "architecture": {
     "64bit": {
       "url": "https://github.com/bostrot/wsl2-distro-manager/releases/download/v1.11.0/wsl2-distro-manager-v1.11.0.zip",


### PR DESCRIPTION
Automated Scoop manifest update for `wsl2-distro-manager`.

- Version: `1.11.0`
- Source: GitHub release `v1.11.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped WSL2 Distro Manager to version 1.11.0.
  * Updated license from GPL-3.0-or-later to GPL-3.0.
  * Improved auto-update configuration for streamlined update URL handling.
  * Added explicit executable entry and updated app shortcut label to “WSL2 Distro Manager.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->