### PR TITLE
gitbutler: Update to version 0.19.7, fix checkver, add shim for `but`

### DIFF
--- a/bucket/gitbutler.json
+++ b/bucket/gitbutler.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.19.5",
+    "version": "0.19.7",
     "description": "A Git client for simultaneous branches on top of your existing workflow.",
     "homepage": "https://gitbutler.com/",
     "license": "FSL-1.1-MIT",
     "architecture": {
         "64bit": {
-            "url": "https://releases.gitbutler.com/releases/release/0.19.5-2897/windows/x86_64/GitButler_0.19.5_x64_en-US.msi",
-            "hash": "a5c2dcaa02827747a886e6c24db84ef4cd71caa895963cad495db18aff24867d",
+            "url": "https://releases.gitbutler.com/releases/release/0.19.7-2956/windows/x86_64/GitButler_0.19.7_x64_en-US.msi",
+            "hash": "110679ec8d4d8d3220769d6e4b644fa6050976bceebf38d02c8bcbcbb54897e9",
             "extract_dir": "PFiles/GitButler"
         }
     },
@@ -18,8 +18,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://app.gitbutler.com/downloads",
-        "regex": "releases/release/([\\d.-]+)-(?<Build>[\\d]+)"
+        "url": "https://app.gitbutler.com/api/downloads?limit=1&channel=release",
+        "regex": "releases/release/([\\d.-]+)-(?<Build>[\\d]+)/windows"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

GitBuler already have a CLI, See https://blog.gitbutler.com/but-cli


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package release from 0.19.5 to 0.19.7 and updated Windows installer download and checksum.
  * Added configuration to expose the command-line executable (but.exe).
  * Improved version-check/update metadata endpoint and matching to better detect Windows releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->