### PR TITLE
librecad: Update to version 2.2.1.4, fix checkver & autoupdate

### DIFF
--- a/bucket/librecad.json
+++ b/bucket/librecad.json
@@ -1,18 +1,41 @@
 {
-    "version": "2.2.1.2",
+    "version": "2.2.1.4",
     "description": "Cross-platform 2D CAD program.",
-    "homepage": "https://librecad.org/",
-    "license": "GPL-2.0-only",
+    "homepage": "https://librecad.org",
+    "license": {
+        "identifier": "GPL-2.0-only",
+        "url": "https://github.com/LibreCAD/LibreCAD/blob/HEAD/LICENSE"
+    },
+    "notes": [
+        "To register file associations, please execute the following command:",
+        "reg import \"$dir\\install-associations.reg\""
+    ],
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.2/LibreCAD-v2.2.1.2-win64.exe#/dl.7z",
-            "hash": "fbc072ff0e59a9175563821b69fb791a3e8f8d97f60d10984ae4f7da6ca406b8"
+            "url": "https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.4/LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe#/dl.7z",
+            "hash": "c6e1ddfa67c24539f3bbb41f5614f6f0d9a30da4c94bfff1c4305ddb9fde5f76"
         },
         "32bit": {
-            "url": "https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.2/LibreCAD-v2.2.1.2.exe#/dl.7z",
-            "hash": "738176ac82516866b37cd90843b8d318825c63c6fd28f2c21a06b87f432e9df2"
+            "url": "https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.4/LibreCAD-v2.2.1.3-12-gd1ca469c9-msvc.exe#/dl.7z",
+            "hash": "8547c4e7f8ce74a7c8bdf9b4b0e01546173cc097ee77a02781312d5ff3e8c45a"
         }
     },
+    "pre_install": [
+        "'$*', 'Uninst*', 'vc_redist*' | ForEach-Object {",
+        "    Remove-Item -Path \"$dir\\$_\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "}"
+    ],
+    "post_install": [
+        "$librecad_dir = $dir -replace '\\\\', '\\\\'",
+        "Get-ChildItem -Path \"$bucketsdir\\$bucket\\scripts\\$app\" -Filter '*.reg' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding utf8",
+        "    if ($global) { $content = $content -replace 'HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE' }",
+        "    $content -replace '{{librecad_dir}}', $librecad_dir | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding unicode",
+        "}"
+    ],
     "bin": "LibreCAD.exe",
     "shortcuts": [
         [
@@ -20,21 +43,29 @@
             "LibreCAD"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "if ($cmd -eq 'uninstall') {",
+            "    Get-ChildItem -Path $dir -Filter 'un*.reg' -File | ForEach-Object {",
+            "        $registry_file = '\"{0}\"' -f $_.FullName",
+            "        Start-Process -FilePath 'reg.exe' -ArgumentList @('import', $registry_file) -WindowStyle Hidden -Wait",
+            "    }",
+            "}"
+        ]
+    },
     "checkver": {
-        "github": "https://github.com/LibreCAD/LibreCAD"
+        "url": "https://api.github.com/repos/LibreCAD/LibreCAD/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /win/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>v?([\\d.]+))/LibreCAD-(?<string>v?[\\d.-]+[+-]g\\w+)?-win"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/LibreCAD/LibreCAD/releases/download/v$version/LibreCAD-v$version-win64.exe#/dl.7z"
+                "url": "https://github.com/LibreCAD/LibreCAD/releases/download/$matchTag/LibreCAD-$matchString-win64-msvc.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/LibreCAD/LibreCAD/releases/download/v$version/LibreCAD-v$version.exe#/dl.7z"
+                "url": "https://github.com/LibreCAD/LibreCAD/releases/download/$matchTag/LibreCAD-$matchString-msvc.exe#/dl.7z"
             }
-        },
-        "hash": {
-            "url": "https://github.com/LibreCAD/LibreCAD/releases/tag/v$version",
-            "regex": "$sha256<\\/td>\\s*<td>$basename"
         }
     }
 }

--- a/scripts/librecad/install-associations.reg
+++ b/scripts/librecad/install-associations.reg
@@ -1,0 +1,20 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.dxf\OpenWithProgIDs]
+"LibreCAD.dxf"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\LibreCAD.dxf]
+@="DXF File"
+"FriendlyTypeName"="DXF File"
+
+[HKEY_CURRENT_USER\Software\Classes\LibreCAD.dxf\DefaultIcon]
+@="\"{{librecad_dir}}\\LibreCAD.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\LibreCAD.dxf\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\LibreCAD.dxf\shell\open]
+"Icon"="\"{{librecad_dir}}\\LibreCAD.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\LibreCAD.dxf\shell\open\command]
+@="\"{{librecad_dir}}\\LibreCAD.exe\" \"%1\""

--- a/scripts/librecad/uninstall-associations.reg
+++ b/scripts/librecad/uninstall-associations.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.dxf\OpenWithProgIDs]
+"LibreCAD.dxf"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\LibreCAD.dxf]


### PR DESCRIPTION
### Summary

Updates `librecad` to version **2.2.1.4** and introduces automated registry-based file association for `.dxf` files.

### Changes

- Update version to **2.2.1.4**
- Improve `license` field with structured SPDX identifier and URL
- Add `notes` to guide users on how to manually register file associations
- Add `suggest` for `vcredist2022` as a recommended dependency
- Implement `pre_install` script to clean up residual installer files (`$*`, `Uninst*`, `vc_redist*`)
- Introduce `post_install` and `uninstaller` scripts:
  - Dynamically generate `.reg` files by replacing `{{librecad_dir}}` placeholders with the actual installation path.
  - Support global installation by switching registry hives from `HKCU` to `HKLM`.
  - Handle uninstallation by importing the corresponding cleanup registry file.
- Update `checkver` to use GitHub API with complex regex to handle MSVC-based asset naming conventions and version tags.
- Update `autoupdate` to align with the new asset URL patterns using `$matchTag` and `$matchString`.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App librecad -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
librecad: 2.2.1.4 (scoop version is 2.2.1.4)
Forcing autoupdate!
Autoupdating librecad
DEBUG[1775309734] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1775309734] $substitutions.$matchTag                      v2.2.1.4
DEBUG[1775309734] $substitutions.$cleanVersion                  2214
DEBUG[1775309734] $substitutions.$buildVersion                  4
DEBUG[1775309734] $substitutions.$majorVersion                  2
DEBUG[1775309734] $substitutions.$minorVersion                  2
DEBUG[1775309734] $substitutions.$patchVersion                  1
DEBUG[1775309734] $substitutions.$basename                      LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe
DEBUG[1775309734] $substitutions.$dashVersion                   2-2-1-4
DEBUG[1775309734] $substitutions.$version                       2.2.1.4
DEBUG[1775309734] $substitutions.$dotVersion                    2.2.1.4
DEBUG[1775309734] $substitutions.$url                           https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.4/LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe
DEBUG[1775309734] $substitutions.$match1                        2.2.1.4
DEBUG[1775309734] $substitutions.$preReleaseVersion             2.2.1.4
DEBUG[1775309734] $substitutions.$matchTail                     .4
DEBUG[1775309734] $substitutions.$urlNoExt                      https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.4/LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc
DEBUG[1775309734] $substitutions.$underscoreVersion             2_2_1_4
DEBUG[1775309734] $substitutions.$matchString                   v2.2.1.3-12-gd1ca469c9
DEBUG[1775309734] $substitutions.$baseurl                       https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.4
DEBUG[1775309734] $substitutions.$basenameNoExt                 LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc
DEBUG[1775309734] $substitutions.$matchHead                     2.2.1
DEBUG[1775309734] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1775309736] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/LibreCAD/LibreCAD/releases/download/v2.2.1.4/LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: c6e1ddfa67c24539f3bbb41f5614f6f0d9a30da4c94bfff1c4305ddb9fde5f76 using Github Mode
Writing updated librecad manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/librecad
Installing 'librecad' (2.2.1.4) [64bit] from 'Unofficial' bucket
Loading LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe from cache.
Checking hash of LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe... OK.
Extracting LibreCAD-v2.2.1.3-12-gd1ca469c9-win64-msvc.exe... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\librecad\current => D:\Software\Scoop\Local\apps\librecad\2.2.1.4
Creating shim for 'LibreCAD'.
Making D:\Software\Scoop\Local\shims\librecad.exe a GUI binary.
Creating shortcut for LibreCAD (LibreCAD.exe)
Running post_install script... Done.
'librecad' (2.2.1.4) was installed successfully!
Notes
-----
To register file associations, please execute the following command:
reg import "D:\Software\Scoop\Local\apps\librecad\current\install-associations.reg"
-----
'librecad' suggests installing 'extras/vcredist2022'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LibreCAD now associates with .dxf files on Windows, allowing users to open them directly with the application.

* **Chores**
  * Updated to version 2.2.1.4.
  * Added Visual C++ 2022 redistributable as a required dependency.
  * Improved Windows installer artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->