### PR TITLE
mpc-qt: Update to version 26.01, fix autoupdate

### DIFF
--- a/bucket/mpc-qt.json
+++ b/bucket/mpc-qt.json
@@ -1,7 +1,7 @@
 {
     "version": "26.01",
     "description": "A clone of Media Player Classic reimplemented in Qt.",
-    "homepage": "https://github.com/mpc-qt/mpc-qt",
+    "homepage": "https://mpc-qt.github.io",
     "license": "GPL-2.0-only",
     "suggest": {
         "yt-dlp": "yt-dlp"
@@ -20,7 +20,9 @@
             "MPC QT"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/mpc-qt/mpc-qt"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
### Summary

Updates `mpc-qt` to version **26.01** and simplifies the manifest by aligning with the new upstream release naming convention.

### Changes

- Update version to **26.01**
- Add `extract_dir` field to handle the nested folder structure in the new release archive
- Simplify `autoupdate` URL logic by switching from `$cleanVersion` to `$version`, as upstream now uses dotted version strings in asset names

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App mpc-qt -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket' -f
mpc-qt: 26.01 (scoop version is 26.01)
Forcing autoupdate!
Autoupdating mpc-qt
DEBUG[1775310658] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1775310658] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1775310658] $substitutions.$cleanVersion                  2601
DEBUG[1775310658] $substitutions.$buildVersion
DEBUG[1775310658] $substitutions.$basename                      mpc-qt-win-x64-26.01.zip
DEBUG[1775310658] $substitutions.$minorVersion                  01
DEBUG[1775310658] $substitutions.$patchVersion
DEBUG[1775310658] $substitutions.$dashVersion                   26-01
DEBUG[1775310658] $substitutions.$version                       26.01
DEBUG[1775310658] $substitutions.$dotVersion                    26.01
DEBUG[1775310658] $substitutions.$underscoreVersion             26_01
DEBUG[1775310658] $substitutions.$majorVersion                  26
DEBUG[1775310658] $substitutions.$preReleaseVersion             26.01
DEBUG[1775310658] $substitutions.$matchTail
DEBUG[1775310658] $substitutions.$url                           https://github.com/mpc-qt/mpc-qt/releases/download/v26.01/mpc-qt-win-x64-26.01.zip
DEBUG[1775310658] $substitutions.$match1                        26.01
DEBUG[1775310658] $substitutions.$urlNoExt                      https://github.com/mpc-qt/mpc-qt/releases/download/v26.01/mpc-qt-win-x64-26.01
DEBUG[1775310658] $substitutions.$baseurl                       https://github.com/mpc-qt/mpc-qt/releases/download/v26.01
DEBUG[1775310658] $substitutions.$basenameNoExt                 mpc-qt-win-x64-26.01
DEBUG[1775310658] $substitutions.$matchHead                     26.01
DEBUG[1775310658] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1775310659] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/mpc-qt/mpc-qt/releases/download/v26.01/mpc-qt-win-x64-26.01.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 5ac479a8ba69ba838e4e02b2abaa3496d9d35d52b690ecae0f9276330044e0bf using Github Mode
Writing updated mpc-qt manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/mpc-qt
Installing 'mpc-qt' (26.01) [64bit] from 'Unofficial' bucket
Loading mpc-qt-win-x64-26.01.zip from cache.
Checking hash of mpc-qt-win-x64-26.01.zip... OK.
Extracting mpc-qt-win-x64-26.01.zip... Done.
Linking D:\Software\Scoop\Local\apps\mpc-qt\current => D:\Software\Scoop\Local\apps\mpc-qt\26.01
Creating shim for 'mpc-qt'.
Making D:\Software\Scoop\Local\shims\mpc-qt.exe a GUI binary.
Creating shortcut for MPC QT (mpc-qt.exe)
'mpc-qt' (26.01) was installed successfully!
'mpc-qt' suggests installing 'yt-dlp'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated MPC-QT to version 26.01 with a new download URL and verification hash.
  * Improved 64‑bit installation by setting a dedicated extraction directory.
  * Updated project homepage link and release-check configuration to the official site.
  * Adjusted autoupdate archive naming to use the full version token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->