### PR TITLE
capsnumtray: Add version 2.1.0

### DIFF
--- a/bucket/capsnumtray.json
+++ b/bucket/capsnumtray.json
@@ -1,0 +1,26 @@
+{
+    "version": "2.1.0",
+    "description": "Caps Lock, Num Lock, and Scroll Lock tray indicators for Windows.",
+    "homepage": "https://github.com/itsnateai/CaplockNumlock",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/itsnateai/CaplockNumlock/releases/download/v2.1.0/CapsNumTray.exe#/CapsNumTray.exe",
+            "hash": "1695c6ba8d31588c7a497ea0b7fbaf3e5a6d682096aabe3518650543a5c64594"
+        }
+    },
+    "shortcuts": [
+        [
+            "CapsNumTray.exe",
+            "CapsNumTray"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/itsnateai/CaplockNumlock/releases/download/v$version/CapsNumTray.exe#/CapsNumTray.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add [CapsNumTray](https://github.com/itsnateai/CaplockNumlock) — Caps Lock, Num Lock, and Scroll Lock tray indicators for Windows.

- Single portable .exe, no installer needed
- Independent tray icons per key, left-click toggle
- .NET 8, MIT licensed

## Checklist

- [x] Manifest is valid JSON
- [x] `checkver` and `autoupdate` configured
- [x] Hash verified against release asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CapsNumTray Windows tray indicator application (v2.1.0) is now available for installation
  * Includes automatic update checking from GitHub releases for seamless version management
  * MIT licensed open-source project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->