### PR TITLE
syncthingtray: Switch upstream to `itsnateai/synctray`

### DIFF
--- a/bucket/syncthingtray.json
+++ b/bucket/syncthingtray.json
@@ -1,58 +1,25 @@
 {
-    "version": "2.0.9",
-    "description": "Tray application for Syncthing",
-    "homepage": "https://github.com/Martchus/syncthingtray",
-    "license": {
-        "identifier": "GPL-2.0-only,...",
-        "url": "https://github.com/Martchus/syncthingtray/blob/master/LICENSES-windows-distribution.md"
-    },
+    "version": "2.1.3",
+    "description": "Lightweight system tray manager for Syncthing on Windows.",
+    "homepage": "https://github.com/itsnateai/synctray",
+    "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Martchus/syncthingtray/releases/download/v2.0.9/syncthingtray-2.0.9-x86_64-w64-mingw32.exe.zip",
-            "hash": "d71665143271d081ebc8974773df5001181be26bcda4fd2909d676dcac3b0050"
-        },
-        "32bit": {
-            "url": "https://github.com/Martchus/syncthingtray/releases/download/v2.0.9/syncthingtray-qt5-2.0.9-i686-w64-mingw32.exe.zip",
-            "hash": "9294b94c2f32cc1d75968ac97277bdecaed355d5bd9b7dc1b1b8fc6ac92a5be1"
-        },
-        "arm64": {
-            "url": "https://github.com/Martchus/syncthingtray/releases/download/v2.0.9/syncthingtray-2.0.9-aarch64-w64-mingw32.exe.zip",
-            "hash": "e1c048c8e8409a676c882d34846172a5f11ae419aaaaca55e35c0873bedbd3e4"
+            "url": "https://github.com/itsnateai/synctray/releases/download/v2.1.3/SyncthingTray.exe#/SyncthingTray.exe",
+            "hash": "d0ff68967a95185e4db937715ab73479b65ada97f6f39ab99c8e3782adb17ee3"
         }
     },
-    "pre_install": [
-        "Move-Item \"$dir\\syncthingtray-*-mingw32.exe\" \"$dir\\syncthingtray.exe\"",
-        "Move-Item \"$dir\\syncthingtray-*-mingw32-cli.exe\" \"$dir\\syncthingtray-cli.exe\""
-    ],
-    "##": "syncthingtray.ini will recreate by syncthingtray.exe",
-    "post_install": [
-        "$config = \"syncthingtray.ini\"",
-        "ensure $persist_dir",
-        "if (!(Test-Path \"$persist_dir\\$config\")) { New-Item \"$persist_dir\\$config\" -ItemType File | Out-Null }",
-        "move-item \"$persist_dir\\$config\" \"$dir\""
-    ],
-    "pre_uninstall": [
-        "ensure $persist_dir",
-        "move-item \"$dir\\syncthingtray.ini\" \"$persist_dir\""
-    ],
-    "bin": "syncthingtray-cli.exe",
     "shortcuts": [
         [
-            "syncthingtray.exe",
-            "Syncthing Tray"
+            "SyncthingTray.exe",
+            "SyncthingTray"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingtray-$version-x86_64-w64-mingw32.exe.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingtray-qt5-$version-i686-w64-mingw32.exe.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/Martchus/syncthingtray/releases/download/v$version/syncthingtray-$version-aarch64-w64-mingw32.exe.zip"
+                "url": "https://github.com/itsnateai/synctray/releases/download/v$version/SyncthingTray.exe#/SyncthingTray.exe"
             }
         }
     }


### PR DESCRIPTION
## Description

Add [SyncthingTray](https://github.com/itsnateai/synctray) — a lightweight system tray manager for Syncthing on Windows.

- Single portable .exe, no installer needed
- Quick-access rescan, configurable click actions, sound notifications
- .NET 8, MIT licensed

## Checklist

- [x] Manifest is valid JSON
- [x] `checkver` and `autoupdate` configured
- [x] Hash verified against release asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Syncthing Tray to version 2.1.3 with MIT licensing
  * Streamlined to 64-bit Windows support only (32-bit and ARM64 support removed)
  * Application binaries updated and legacy CLI tool removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->