### PR TITLE
synctray: Add version 2.1.3

### DIFF
--- a/bucket/synctray.json
+++ b/bucket/synctray.json
@@ -1,0 +1,26 @@
+{
+    "version": "2.1.3",
+    "description": "Lightweight system tray monitor for Syncthing on Windows — rescan, notifications, configurable click actions.",
+    "homepage": "https://github.com/itsnateai/synctray",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/itsnateai/synctray/releases/download/v2.1.3/SyncthingTray.exe#/SyncthingTray.exe",
+            "hash": "d0ff68967a95185e4db937715ab73479b65ada97f6f39ab99c8e3782adb17ee3"
+        }
+    },
+    "shortcuts": [
+        [
+            "SyncthingTray.exe",
+            "SyncthingTray"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/itsnateai/synctray/releases/download/v$version/SyncthingTray.exe#/SyncthingTray.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17543

- [x] Use conventional PR title: `synctray: Add synctray 2.1.3`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

---

Lightweight system tray monitor for Syncthing on Windows. Single portable .exe (~200 KB), .NET 8, MIT licensed.

Different from the existing `syncthingtray` package (Martchus/Qt) — this is a minimal alternative with rescan, notifications, and configurable click actions.

- `checkver` and `autoupdate` configured
- Hash verified against GitHub release asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now available as a Windows 64-bit package (version 2.1.3) with automated update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->