### PR TITLE
mwbtoggle: Add version 2.3.1

### DIFF
--- a/bucket/mwbtoggle.json
+++ b/bucket/mwbtoggle.json
@@ -1,0 +1,26 @@
+{
+    "version": "2.3.1",
+    "description": "Toggle Mouse Without Borders clipboard & file sharing on/off — stop MWB from intercepting local copy/paste.",
+    "homepage": "https://github.com/itsnateai/MousewithoutBordersToggle",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/itsnateai/MousewithoutBordersToggle/releases/download/v2.3.1/MWBToggle.exe#/MWBToggle.exe",
+            "hash": "a0bdb71e0519550d01546ed316e39439ee0d47f5e37f8ef572329db5b6bea59a"
+        }
+    },
+    "shortcuts": [
+        [
+            "MWBToggle.exe",
+            "MWBToggle"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/itsnateai/MousewithoutBordersToggle/releases/download/v$version/MWBToggle.exe#/MWBToggle.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17544

- [x] Use conventional PR title: `mwbtoggle: Add mwbtoggle 2.3.1`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

---

System tray toggle for Mouse Without Borders clipboard and file sharing. Hotkey (`Ctrl+Alt+C`, configurable) or tray click to enable/disable MWB's clipboard interception and file transfer without disconnecting.

Single portable .exe, .NET 8, MIT licensed.

- `checkver` and `autoupdate` configured
- Hash verified against GitHub release asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package manifest for MousewithoutBordersToggle (v2.3.1) with automatic update support enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->