### PR TITLE
Add quickshare v1.0.2527.0

### DIFF
--- a/bucket/quickshare.json
+++ b/bucket/quickshare.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.0.2527.0",
+    "description": "Quick Share from Google lets you quickly and easily share files and links with nearby Android devices and Windows PCs.",
+    "homepage": "https://www.android.com/phones/quick-share/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://policies.google.com/terms"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dl.google.com/release2/Nearby/o2jg3mmmruq4r5vmifvettngce_1.0.2527.0/better_together.msi#/dl.msi",
+            "hash": "615c5760ce1c556f19ba40ac0a2ccc706a8639f30ea42f66478608cd0d68581a"
+        }
+    },
+    "installer": {
+        "args": [
+            "/quiet",
+            "/norestart"
+        ]
+    },
+    "shortcuts": [
+        [
+            "$env:ProgramFiles\\Google\\Quick Share\\QuickShare.exe",
+            "Quick Share"
+        ]
+    ],
+    "checkver": {
+        "url": "https://community.chocolatey.org/packages/quick-share",
+        "regex": "Downloads of v\\s+([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dl.google.com/release2/Nearby/o2jg3mmmruq4r5vmifvettngce_$underscoreVersion/better_together.msi#/dl.msi"
+            }
+        }
+    },
+    "notes": [
+        "Quick Share from Google installs to %ProgramFiles%\\Google\\Quick Share\\.",
+        "Package request issue: https://github.com/ScoopInstaller/Extras/issues/XXXXX"
+    ]
+}


### PR DESCRIPTION
Add Scoop manifest for Quick Share from Google.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Quick Share from Google application version 1.0.2527.0 with automated installation configuration, including version checking and update management support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->