### PR TITLE
recoll: Add version 1.43.13

### DIFF
--- a/bucket/recoll.json
+++ b/bucket/recoll.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.43.13",
+    "description": "Free desktop full-text search tool. Indexes and searches PDF, Word, email and hundreds of file formats.",
+    "homepage": "https://github.com/alarmz/recoll",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/alarmz/recoll/releases/download/1.43.13-1/recoll-1.43.13-1-win64-setup.exe#/setup.exe",
+            "hash": "164f705d4fc3692895c6cd116bd580f2b76e22ac0739b793c9ede61c1298b375"
+        }
+    },
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "recoll.exe",
+            "Recoll"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/alarmz/recoll/releases/download/$version-1/recoll-$version-1-win64-setup.exe#/setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Submission Type
- [x] New manifest
- [ ] Manifest update
- [ ] Manifest removal

## Description
Adds a new manifest for **Recoll** (version 1.43.13), a free desktop full-text search tool that indexes and searches PDF, Word, email, and hundreds of other file formats.

- Homepage: https://github.com/alarmz/recoll
- License: GPL-2.0-or-later
- Installer: Inno Setup (`innosetup: true`)
- 64-bit only
- Creates a Start Menu shortcut for `recoll.exe`

## Validation
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] The manifest follows existing conventions in this bucket
- [x] `checkver` and `autoupdate` are configured against the GitHub releases