### PR TITLE
ffstudio: Add version 0.2.7

### DIFF
--- a/bucket/ffstudio.json
+++ b/bucket/ffstudio.json
@@ -1,7 +1,7 @@
 {
     "version": "0.2.7",
-    "description": "Graphical User Interface for FFmpeg with powerful features",
-    "homepage": "https://ffstudio.app/",
+    "description": "Graphical User Interface for FFmpeg with powerful features.",
+    "homepage": "https://ffstudio.app",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
@@ -17,6 +17,15 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/Draver93/ff-studio"
+        "url": "https://api.github.com/repos/Draver93/ff-studio/releases/latest",
+        "jsonpath": "$..assets[?(@.browser_download_url =~ /FFStudio_.*\\.msi/i)].browser_download_url",
+        "regex": "download/v(?<version>[\\d.]+)/FFStudio_0.2.7_x64_en-US-(?<commit>[a-f0-9]+)\\.msi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Draver93/ff-studio/releases/download/v$version/FFStudio_0.2.7_x64_en-US-$matchCommit.msi"
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #17562
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added package configuration for FFStudio v0.2.7.
  * Includes 64‑bit installer download and integrity verification.
  * Sets installation directory and creates a FFStudio application shortcut.
  * Enables automatic update/version checking and URL generation for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->