### PR TITLE
ropy: Add version 0.4.3

### DIFF
--- a/ropy.json
+++ b/ropy.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.4.3",
+    "description": "A clipboard manager built with Rust and GPUI",
+    "homepage": "https://github.com/StudentWeis/ropy",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/StudentWeis/ropy/releases/download/0.4.3/ropy-x86_64-pc-windows-msvc.zip",
+            "hash": "sha256:02b5b373da3dfe4380a30fd08c118dbc6dee18f5fe2fa09a7dd2f1ce97dc3099"
+        }
+    },
+    "shortcuts": [
+        [
+            "ropy.exe",
+            "Ropy"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/StudentWeis/ropy/releases",
+        "regex": "releases/tag/([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/StudentWeis/ropy/releases/download/$version/ropy-x86_64-pc-windows-msvc.zip",
+                "hash": {
+                    "url": "https://github.com/StudentWeis/ropy/releases/download/$version/ropy-x86_64-pc-windows-msvc.zip.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17566

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ropy clipboard manager (version 0.4.3) with automatic update detection and installation for Windows 64-bit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->