### PR TITLE
forkgram@6.7.3: Add 32bit support

### DIFF
--- a/bucket/forkgram.json
+++ b/bucket/forkgram.json
@@ -1,18 +1,18 @@
 {
     "version": "6.7.3",
-    "description": "Fork of Telegram Desktop with quality-of-life enhancements",
+    "description": "Fork of Telegram Desktop with quality-of-life enhancements.",
     "homepage": "https://t.me/forkgram",
     "license": {
         "identifier": "GPL-3.0-openssl-exception",
-        "url": "https://github.com/Forkgram/tdesktop/blob/dev/LICENSE"
+        "url": "https://github.com/forkgram/tdesktop/blob/dev/LICENSE"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Forkgram/tdesktop/releases/download/v6.7.3/Telegram.zip",
+            "url": "https://github.com/forkgram/tdesktop/releases/download/v6.7.3/Telegram.zip",
             "hash": "1a6001d314f562ec1efda358910e30d2d32539cf9fd43d8e265c02cdaf7d4c14"
         },
         "32bit": {
-            "url": "https://github.com/Forkgram/tdesktop/releases/download/v6.7.3/Telegram_x86.zip",
+            "url": "https://github.com/forkgram/tdesktop/releases/download/v6.7.3/Telegram_x86.zip",
             "hash": "fee944a38e1bbd4f2aa8c3267ff91379c029de3b9f5346ee7df0ebcb0209fe4f"
         }
     },
@@ -33,15 +33,15 @@
     ],
     "persist": "tdata",
     "checkver": {
-        "github": "https://github.com/Forkgram/tdesktop"
+        "github": "https://github.com/forkgram/tdesktop"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Forkgram/tdesktop/releases/download/v$version/Telegram.zip"
+                "url": "https://github.com/forkgram/tdesktop/releases/download/v$version/Telegram.zip"
             },
             "32bit": {
-                "url": "https://github.com/Forkgram/tdesktop/releases/download/v$version/Telegram_x86.zip"
+                "url": "https://github.com/forkgram/tdesktop/releases/download/v$version/Telegram_x86.zip"
             }
         }
     }


### PR DESCRIPTION
Add 32-bit architecture support and per-architecture autoupdate URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application description to reflect quality-of-life enhancements.
  * Restructured download and auto-update configuration to provide separate 64-bit and 32-bit versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->