### PR TITLE
cmakefmt: Add version 0.2.0

### DIFF
--- a/bucket/cmakefmt.json
+++ b/bucket/cmakefmt.json
@@ -1,29 +1,29 @@
 {
-  "version": "0.2.0",
-  "description": "A fast, correct CMake formatter",
-  "homepage": "https://cmakefmt.dev",
-  "license": "MIT OR Apache-2.0",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/cmakefmt/cmakefmt/releases/download/v0.2.0/cmakefmt-0.2.0-x86_64-pc-windows-msvc.zip",
-      "hash": "eb1cf93df9ffc96290a9f526f7dcb02774f10fe102262aebab277f681520acea",
-      "extract_dir": "cmakefmt-0.2.0-x86_64-pc-windows-msvc"
-    }
-  },
-  "bin": "cmakefmt.exe",
-  "checkver": {
-    "github": "https://github.com/cmakefmt/cmakefmt"
-  },
-  "autoupdate": {
+    "version": "0.2.0",
+    "description": "A fast, correct CMake formatter",
+    "homepage": "https://cmakefmt.dev",
+    "license": "MIT OR Apache-2.0",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/cmakefmt/cmakefmt/releases/download/v$version/cmakefmt-$version-x86_64-pc-windows-msvc.zip",
-        "hash": {
-          "url": "https://github.com/cmakefmt/cmakefmt/releases/download/v$version/SHA256SUMS",
-          "regex": "([a-f0-9]{64})\\s+cmakefmt-$version-x86_64-pc-windows-msvc.zip"
-        },
-        "extract_dir": "cmakefmt-$version-x86_64-pc-windows-msvc"
-      }
+        "64bit": {
+            "url": "https://github.com/cmakefmt/cmakefmt/releases/download/v0.2.0/cmakefmt-0.2.0-x86_64-pc-windows-msvc.zip",
+            "hash": "eb1cf93df9ffc96290a9f526f7dcb02774f10fe102262aebab277f681520acea",
+            "extract_dir": "cmakefmt-0.2.0-x86_64-pc-windows-msvc"
+        }
+    },
+    "bin": "cmakefmt.exe",
+    "checkver": {
+        "github": "https://github.com/cmakefmt/cmakefmt"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cmakefmt/cmakefmt/releases/download/v$version/cmakefmt-$version-x86_64-pc-windows-msvc.zip",
+                "hash": {
+                    "url": "https://github.com/cmakefmt/cmakefmt/releases/download/v$version/SHA256SUMS",
+                    "regex": "([a-f0-9]{64})\\s+cmakefmt-$version-x86_64-pc-windows-msvc.zip"
+                },
+                "extract_dir": "cmakefmt-$version-x86_64-pc-windows-msvc"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
## Description

Adds [cmakefmt](https://cmakefmt.dev) — a fast, correct, configurable CMake formatter written in Rust.

- Homepage: https://cmakefmt.dev
- Repository: https://github.com/cmakefmt/cmakefmt
- License: MIT OR Apache-2.0

## Manifest

The manifest includes an `autoupdate` block that pulls hashes from `SHA256SUMS` in GitHub Releases, so future updates should be automatic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a package manifest for the cmakefmt code formatter (v0.2.0) targeting 64-bit Windows.
  * Includes formatter metadata, release artifact and expected checksum for integrity verification.
  * Enables automatic version detection and update handling via upstream GitHub releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->