### PR TITLE
fluent-search: Update to version 1.0.1.4, fix checkver & autoupdate

### DIFF
--- a/bucket/fluent-search.json
+++ b/bucket/fluent-search.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/adirh3/Fluent-Search/releases/download/1.0.1.4/fluent-search-portable-x64.zip",
             "hash": "56b9c2f3f9a5fcfa163c31b462df3a9f3989ffcc3797baf3ea897d9730f88f8b"
+        },
+        "arm64": {
+            "url": "https://github.com/adirh3/Fluent-Search/releases/download/1.0.1.4/fluent-search-portable-arm64.zip",
+            "hash": "10d3d4e207a5de01619bf06228e1569c8c8128f7bb9de7fe7f2c3c1f99b06e34"
         }
     },
     "pre_install": "if([environment]::OSVersion.Version.Major -lt 10) { error 'This app requires Windows 10 or 11'; break }",
@@ -27,6 +31,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/adirh3/Fluent-Search/releases/download/$version/fluent-search-portable-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/adirh3/Fluent-Search/releases/download/$version/fluent-search-portable-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #17571

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

- update `fluent-search` stable manifest from `1.0.0` to `1.0.1.4`
- switch stable download/autoupdate to the versioned GitHub release asset
- replace the old blog-based version check with GitHub stable release detection
- add `fluent-search-nightly` manifest for Nightly portable builds

## Verification

- JSON parses correctly for both manifests
- `checkver.ps1 bucket/fluent-search.json` returns `1.0.1.4`
- `checkver.ps1 bucket/fluent-search-nightly.json` returns `1.1.1.6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 architecture support.

* **Chores**
  * Bumped version to 1.0.1.4.
  * Improved package distribution and version detection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->