### PR TITLE
utpm: Update to version 0.3.0, fix autoupdate

### DIFF
--- a/bucket/utpm.json
+++ b/bucket/utpm.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/typst-community/utpm/releases/download/v0.3.0/utpm-x86_64-pc-windows-msvc.tar.gz",
-            "hash": "88337427c8d1f7228dbf873d80113c231a55070f9ebc4fa409b3dd36a3db34d5",
+            "hash": "88337427c8d1f7228dbf873d80113c231a55070f9ebc4fa409b3dd36a3db34d5"
         },
         "arm64": {
             "url": "https://github.com/typst-community/utpm/releases/download/v0.3.0/utpm-aarch64-pc-windows-msvc.tar.gz",
-            "hash": "d58aad50355f65c1eb8537f1e187dbe88ebe86f810e249a273c8fcca134abee4",
+            "hash": "d58aad50355f65c1eb8537f1e187dbe88ebe86f810e249a273c8fcca134abee4"
         }
     },
     "bin": "utpm.exe",


### PR DESCRIPTION
Fix manifest: removed extract_dir, changed archives from .zip to .tar.gz, update to version v0.3.0.

Closes #17575

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.0
  * Changed distribution artifact format from ZIP to TAR.GZ for both 64-bit and ARM64 architectures
  * Updated corresponding integrity checksums and package references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->