### PR TITLE
ifrextractor-rs: Update to version 1.6.1, fix autoupdate

### DIFF
--- a/bucket/ifrextractor-rs.json
+++ b/bucket/ifrextractor-rs.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/LongSoft/IFRExtractor-RS",
     "license": "BSD-2-Clause",
     "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v1.6.1/ifrextractor_1.6.1_windows.zip",
-    "hash": "446502aecaa323ec175f535fd2e7dc6062e1c635fdec630148c2b10625c56819",
+    "hash": "3a0d93ecd3a4cb092d210c499d125ffd782982311f5f8dc40a8b180b58c4ffe7",
     "bin": "ifrextractor.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/ifrextractor-rs.json
+++ b/bucket/ifrextractor-rs.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Rust utility to extract UEFI IFR data into human-readable text",
     "homepage": "https://github.com/LongSoft/IFRExtractor-RS",
     "license": "BSD-2-Clause",
-    "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v1.6.0/ifrextractor_1.6.0_win32.zip",
+    "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v1.6.1/ifrextractor_1.6.1_windows.zip",
     "hash": "446502aecaa323ec175f535fd2e7dc6062e1c635fdec630148c2b10625c56819",
     "bin": "ifrextractor.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v$version/ifrextractor_$version_win32.zip"
+        "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v$version/ifrextractor_$version_windows.zip"
     }
 }

--- a/bucket/ifrextractor-rs.json
+++ b/bucket/ifrextractor-rs.json
@@ -3,11 +3,22 @@
     "description": "Rust utility to extract UEFI IFR data into human-readable text",
     "homepage": "https://github.com/LongSoft/IFRExtractor-RS",
     "license": "BSD-2-Clause",
-    "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v1.6.1/ifrextractor_1.6.1_windows.zip",
-    "hash": "3a0d93ecd3a4cb092d210c499d125ffd782982311f5f8dc40a8b180b58c4ffe7",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v1.6.1/ifrextractor_1.6.1_windows.zip",
+            "hash": "3a0d93ecd3a4cb092d210c499d125ffd782982311f5f8dc40a8b180b58c4ffe7"
+        }
+    },
     "bin": "ifrextractor.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v$version/ifrextractor_$version_windows.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/LongSoft/IFRExtractor-RS/releases/download/v$version/ifrextractor_$version_windows.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/LongSoft/IFRExtractor-RS/issues/35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to version 1.6.1.
  * Updated primary download URL and archive checksum to match the new Windows release.
  * Adjusted autoupdate template to use the 64‑bit Windows archive naming and architecture-specific download.
  * Added a suggestion referencing the Visual C++ Redistributable (vcredist2022).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->