### PR TITLE
zsh-patina: Add version 1.4.0

### DIFF
--- a/bucket/zsh-patina.json
+++ b/bucket/zsh-patina.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.4.0",
+    "description": "A blazingly fast Zsh plugin performing syntax highlighting of your command line while you type",
+    "homepage": "https://github.com/michel-kraemer/zsh-patina",
+    "license": "MIT",
+    "notes": "To use this plugin, add 'eval \"$(zsh-patina activate)\"' in your .zshrc. Zsh may be installed through msys2 or cygwin",
+    "suggest": {
+        "msys2": "main/msys2",
+        "cygwin": "main/cygwin"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/michel-kraemer/zsh-patina/releases/download/1.4.0/zsh-patina-v1.4.0-x86_64-pc-cygwin.zip",
+            "hash": "163043EC3B4494DF5562CECB07816FC4ABE0830277F070B68B60A4D63CCB56B3",
+            "extract_dir": "zsh-patina-v1.4.0-x86_64-pc-cygwin",
+            "env_add_path": "."
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/michel-kraemer/zsh-patina/releases/download/$version/zsh-patina-v$version-x86_64-pc-cygwin.zip",
+                "extract_dir": "zsh-patina-v$version-x86_64-pc-cygwin"
+            }
+        }
+    }
+}

--- a/bucket/zsh-patina.json
+++ b/bucket/zsh-patina.json
@@ -1,9 +1,9 @@
 {
     "version": "1.4.0",
-    "description": "A blazingly fast Zsh plugin performing syntax highlighting of your command line while you type",
+    "description": "A blazingly fast Zsh plugin performing syntax highlighting of your command line while you type.",
     "homepage": "https://github.com/michel-kraemer/zsh-patina",
     "license": "MIT",
-    "notes": "To use this plugin, add 'eval \"$(zsh-patina activate)\"' in your .zshrc. Zsh may be installed through msys2 or cygwin",
+    "notes": "To use this plugin, add 'eval \"$(zsh-patina activate)\"' in your .zshrc. Zsh may be installed through msys2 or cygwin.",
     "suggest": {
         "msys2": "main/msys2",
         "cygwin": "main/cygwin"
@@ -11,11 +11,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/michel-kraemer/zsh-patina/releases/download/1.4.0/zsh-patina-v1.4.0-x86_64-pc-cygwin.zip",
-            "hash": "163043EC3B4494DF5562CECB07816FC4ABE0830277F070B68B60A4D63CCB56B3",
-            "extract_dir": "zsh-patina-v1.4.0-x86_64-pc-cygwin",
-            "env_add_path": "."
+            "hash": "163043ec3b4494df5562cecb07816fc4abe0830277f070b68b60a4d63ccb56b3",
+            "extract_dir": "zsh-patina-v1.4.0-x86_64-pc-cygwin"
         }
     },
+    "env_add_path": ".",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds `zsh-patina`, a blazingly fast Zsh syntax highlighter.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #17596 

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Zsh plugin "zsh-patina" (v1.4.0).
  * Installer now fetches releases from GitHub and provides automatic updates.
  * Plugin is installed and made available on the command line for immediate use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->