### PR TITLE
agentop: Add version 0.1.1

### DIFF
--- a/bucket/agentop.json
+++ b/bucket/agentop.json
@@ -5,34 +5,27 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_x86_64.zip",
+            "url": "https://github.com/mohitmishra786/agentop/releases/download/v0.1.1/agentop_0.1.1_windows_x86_64.zip",
             "hash": "b1c3c06f9665ecadf722c093a1db3c2514689f3d97d7d5898f6e83ea5123a3e7"
         },
         "arm64": {
-            "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_arm64.zip",
+            "url": "https://github.com/mohitmishra786/agentop/releases/download/v0.1.1/agentop_0.1.1_windows_arm64.zip",
             "hash": "97c5e4afb1ec5906a19034d56c5533307ca139f59e2cd25321a115dacc2b7a73"
         }
     },
     "bin": "agentop.exe",
-    "checkver": {
-        "github": "https://github.com/mohitmishra786/agentop"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_x86_64.zip",
-                "hash": {
-                    "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/checksums.txt",
-                    "find": "([a-fA-F0-9]{64})\\s+agentop_$version_windows_x86_64\\.zip"
-                }
+                "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_x86_64.zip"
             },
             "arm64": {
-                "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_arm64.zip",
-                "hash": {
-                    "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/checksums.txt",
-                    "find": "([a-fA-F0-9]{64})\\s+agentop_$version_windows_arm64\\.zip"
-                }
+                "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/agentop.json
+++ b/bucket/agentop.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.1.1",
+    "description": "Terminal dashboard for AI coding assistant sessions - token usage, cost, and cache efficiency",
+    "homepage": "https://github.com/mohitmishra786/agentop",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_x86_64.zip",
+            "hash": "b1c3c06f9665ecadf722c093a1db3c2514689f3d97d7d5898f6e83ea5123a3e7"
+        },
+        "arm64": {
+            "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_arm64.zip",
+            "hash": "97c5e4afb1ec5906a19034d56c5533307ca139f59e2cd25321a115dacc2b7a73"
+        }
+    },
+    "bin": "agentop.exe",
+    "checkver": {
+        "github": "https://github.com/mohitmishra786/agentop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_x86_64.zip",
+                "hash": {
+                    "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/checksums.txt",
+                    "find": "([a-fA-F0-9]{64})\\s+agentop_$version_windows_x86_64\\.zip"
+                }
+            },
+            "arm64": {
+                "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/agentop_$version_windows_arm64.zip",
+                "hash": {
+                    "url": "https://github.com/mohitmishra786/agentop/releases/download/v$version/checksums.txt",
+                    "find": "([a-fA-F0-9]{64})\\s+agentop_$version_windows_arm64\\.zip"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17599

## What is agentop?

A terminal dashboard for Claude Code (AI coding assistant) sessions. It reads local JSONL session files from `~/.claude/projects/` and shows token usage, cost, and cache efficiency in a clean duf-style grid table.

## Why Extras?

- CLI tool, pure Go binary, MIT licensed
- Pre-built Windows x86_64 and arm64 binaries on GitHub Releases
- No runtime dependencies, no install wizard
- Checkver + autoupdate wired to `checksums.txt` so hashes auto-update

## Manifest notes

- `bin`: single `agentop.exe`, no shortcuts needed (CLI only)
- `architecture`: 64bit + arm64 (no 32-bit release)
- `autoupdate`: pulls hashes from `checksums.txt` in each release
- `checkver`: tracks latest GitHub release tag

## Checklist

- [x] Manifest follows field order from contributing guide
- [x] 4-space indentation
- [x] MIT is a valid SPDX identifier
- [x] `checkver` configured
- [x] `autoupdate` configured with hash lookup from checksums.txt
- [x] No `shortcuts` (CLI app)
- [x] Issue created first (#17599)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a downloadable Windows package for agentop (v0.1.1) with official releases available for both 64-bit and ARM64 systems. The release supports automatic version checking and in-place updates from official releases, making installation and keeping the app up to date smoother for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->