### PR TITLE
solomd: Add version 0.1.8

### DIFF
--- a/bucket/solomd.json
+++ b/bucket/solomd.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.1.8",
+    "description": "A lightweight Markdown and plain text editor built with Tauri 2",
+    "homepage": "https://solomd.app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zhitongblog/solomd/releases/download/v0.1.8/SoloMD_0.1.8_x64-setup.exe#/setup.exe",
+            "hash": "868a9351eaf52b3cb204037ba592204d887950172ea7a982449b51ee81dd9e62"
+        }
+    },
+    "installer": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList '/S', \"/D=$dir\" -Wait"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\uninstall.exe\" -ArgumentList '/S' -Wait"
+        ]
+    },
+    "shortcuts": [
+        [
+            "SoloMD.exe",
+            "SoloMD"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/setup.exe",
+                "hash": {
+                    "url": "https://github.com/zhitongblog/solomd/releases/tag/v$version",
+                    "regex": "SoloMD_$version_x64-setup\\.exe.*?$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## New App: SoloMD

**Homepage:** https://solomd.app
**License:** MIT
**Installer:** NSIS (x64)

A lightweight, open-source Markdown + plain text editor built with Tauri 2.
~15 MB installed. Live Preview, Vim mode, 8 themes, KaTeX math, Mermaid
diagrams, Clean AI Artifacts, export to PDF/DOCX/HTML/PNG.

**GitHub:** https://github.com/zhitongblog/solomd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package configuration for SoloMD v0.1.8 including installation settings, startup shortcuts, and automatic update configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->