### PR TITLE
solomd: Add version 0.1.9

### DIFF
--- a/bucket/solomd.json
+++ b/bucket/solomd.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.1.9",
+    "description": "A lightweight Markdown and plain text editor built with Tauri 2",
+    "homepage": "https://solomd.app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zhitongblog/solomd/releases/download/v0.1.9/SoloMD_0.1.9_x64-setup.exe#/setup.exe",
+            "hash": "2299fc3cd801fd47d8a2ec4aa3f4f4ce3431458cf336ef5289c28f01bffb3850"
+        }
+    },
+    "installer": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList '/S', \"/D=$dir\" -Wait"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\uninstall.exe\" -ArgumentList '/S' -Wait"
+        ]
+    },
+    "shortcuts": [
+        [
+            "SoloMD.exe",
+            "SoloMD"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/setup.exe",
+                "hash": {
+                    "url": "https://github.com/zhitongblog/solomd/releases/tag/v$version",
+                    "regex": "SoloMD_$version_x64-setup\\.exe.*?$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update SoloMD to v0.1.9. New feature: file-to-Markdown conversion (DOCX/PDF/XLSX/PPTX/HTML/CSV).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SoloMD version 0.1.9 package configuration with 64-bit installer, automated uninstaller scripts, desktop shortcut mapping, integrity verification, and GitHub-based automatic update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->