### PR TITLE
mambaforge: Update to version 26.1.1-3, fix autoupdate

### DIFF
--- a/bucket/mambaforge.json
+++ b/bucket/mambaforge.json
@@ -39,7 +39,7 @@
     "persist": "envs",
     "uninstaller": {
         "script": [
-            "Start-Process -Wait \"$dir\\Uninstall-Mambaforge.exe\" -ArgumentList '/S'",
+            "Start-Process -Wait \"$dir\\Uninstall-Miniforge3.exe\" -ArgumentList '/S'",
             "# Workaround for 'envs' being deleted by the uninstaller. This does not affect persist.",
             "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
         ]

--- a/bucket/mambaforge.json
+++ b/bucket/mambaforge.json
@@ -1,5 +1,5 @@
 {
-    "version": "24.11.0-0",
+    "version": "26.1.1-3",
     "description": "A conda-forge distribution",
     "homepage": "https://github.com/conda-forge/miniforge",
     "license": "BSD-3-Clause",
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/conda-forge/miniforge/releases/download/24.11.0-0/Mambaforge-24.11.0-0-Windows-x86_64.exe",
-            "hash": "5bb092e9fa1bed273ab0493303c2afdd4ab7f441b525652ed1b339f0499a603b"
+            "url": "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Windows-x86_64.exe",
+            "hash": "4d987034d25684fbed0fe7c691227067e37f7443061e2732c3b726c0c5dd45c2"
         }
     },
     "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
@@ -51,7 +51,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/conda-forge/miniforge/releases/download/$version/Mambaforge-$version-Windows-x86_64.exe",
+                "url": "https://github.com/conda-forge/miniforge/releases/download/$version/Miniforge3-$version-Windows-x86_64.exe",
                 "hash": {
                     "url": "$url.sha256"
                 }


### PR DESCRIPTION
It is outdated.

The package named `miniforge` now. Should I to create a new `miniforge.json` instead of directly renaming this manifest?

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Mambaforge package version from 24.11.0-0 to 26.1.1-3.
  * Switched Windows installer variant from Mambaforge to Miniforge3.
  * Updated Windows 64-bit installer download URL, installer filename, and corresponding security hash.
  * Adjusted Windows uninstaller name to match the new Miniforge3 installer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->