### PR TITLE
miniforge3: Add version 26.1.1-3

### DIFF
--- a/bucket/miniforge.json
+++ b/bucket/miniforge.json
@@ -1,6 +1,6 @@
 {
     "version": "26.1.1-3",
-    "description": "A conda-forge distribution",
+    "description": "Community-driven minimalistic conda installer using the conda-forge channel as default.",
     "homepage": "https://github.com/conda-forge/miniforge",
     "license": "BSD-3-Clause",
     "notes": [
@@ -19,6 +19,7 @@
     "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
     "installer": {
         "script": [
+            # Move the installer to the upper directory to avoid 'The installation directory is not empty' error",
             "Move-Item \"$dir\\$fname\" \"$dir\\..\\$fname\"",
             "Start-Process -Wait \"$dir\\..\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
             "Remove-Item \"$dir\\..\\$fname\""

--- a/bucket/miniforge.json
+++ b/bucket/miniforge.json
@@ -39,8 +39,10 @@
     "persist": "envs",
     "uninstaller": {
         "script": [
+            "# Workaround for https://github.com/ScoopInstaller/Scoop/issues/4075",
+            "# Remove junction point before executing the uninstaller, otherwise all envs will be removed by the uninstaller.",
+            "Invoke-ExternalCommand cmd -ArgumentList @('/c', 'rmdir', '/s', '/q', \"`\"$dir\\envs`\"\")",
             "Start-Process -Wait \"$dir\\Uninstall-Miniforge3.exe\" -ArgumentList '/S'",
-            "# Workaround for 'envs' being deleted by the uninstaller. This does not affect persist.",
             "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
         ]
     },

--- a/bucket/miniforge.json
+++ b/bucket/miniforge.json
@@ -1,0 +1,61 @@
+{
+    "version": "26.1.1-3",
+    "description": "A conda-forge distribution",
+    "homepage": "https://github.com/conda-forge/miniforge",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "* Known issue:",
+        "  - The App may fail to install when 'Long Paths' are not enabled, Check it by executing `scoop checkup`. (#11570)",
+        "------",
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\""
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/conda-forge/miniforge/releases/download/26.1.1-3/Miniforge3-26.1.1-3-Windows-x86_64.exe",
+            "hash": "4d987034d25684fbed0fe7c691227067e37f7443061e2732c3b726c0c5dd45c2"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "Move-Item \"$dir\\$fname\" \"$dir\\..\\$fname\"",
+            "Start-Process -Wait \"$dir\\..\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
+            "Remove-Item \"$dir\\..\\$fname\""
+        ]
+    },
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "persist": "envs",
+    "uninstaller": {
+        "script": [
+            "Start-Process -Wait \"$dir\\Uninstall-Miniforge3.exe\" -ArgumentList '/S'",
+            "# Workaround for 'envs' being deleted by the uninstaller. This does not affect persist.",
+            "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/conda-forge/miniforge",
+        "regex": "tag/([\\d.-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/conda-forge/miniforge/releases/download/$version/Miniforge3-$version-Windows-x86_64.exe",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/miniforge.json
+++ b/bucket/miniforge.json
@@ -19,7 +19,7 @@
     "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
     "installer": {
         "script": [
-            # Move the installer to the upper directory to avoid 'The installation directory is not empty' error",
+            "# Move the installer to the upper directory to avoid 'The installation directory is not empty' error",
             "Move-Item \"$dir\\$fname\" \"$dir\\..\\$fname\"",
             "Start-Process -Wait \"$dir\\..\\$fname\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\")",
             "Remove-Item \"$dir\\..\\$fname\""

--- a/bucket/miniforge3.json
+++ b/bucket/miniforge3.json
@@ -42,7 +42,7 @@
         "script": [
             "# Workaround for https://github.com/ScoopInstaller/Scoop/issues/4075",
             "# Remove junction point before executing the uninstaller, otherwise all envs will be removed by the uninstaller.",
-            "Invoke-ExternalCommand cmd -ArgumentList @('/c', 'rmdir', '/s', '/q', \"`\"$dir\\envs`\"\")",
+            "Invoke-ExternalCommand cmd -ArgumentList @('/c', 'rmdir', '/s', '/q', \"`\"$dir\\envs`\"\") | Out-Null",
             "Start-Process -Wait \"$dir\\Uninstall-Miniforge3.exe\" -ArgumentList '/S'",
             "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
         ]


### PR DESCRIPTION
- Closes #11983
- Supersedes #11986
- Supersedes #13918

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Miniforge3 (v26.1.1-3) Windows installer now available with Python runtime and conda package management
  * Automatic PATH configuration for streamlined command-line access to Python binaries
  * Persistent environment management capabilities with simplified installation workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->