### PR TITLE
installerclean: Add version 1.5.0

### DIFF
--- a/bucket/installerclean.json
+++ b/bucket/installerclean.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.5.0",
+    "description": "Open source tool to safely clean orphaned Windows Installer files and reclaim disk space.",
+    "homepage": "https://github.com/no-faff/InstallerClean",
+    "license": "MIT",
+    "notes": "Requires administrator privileges to access C:\\Windows\\Installer.",
+    "url": "https://github.com/no-faff/InstallerClean/releases/download/v1.5.0/InstallerClean-portable.exe",
+    "hash": "58d8b445e5446fe00f03d2eb1dbf9a4cbaf18cf6c8ae8203f6081ded5a2c7e98",
+    "bin": "InstallerClean-portable.exe",
+    "shortcuts": [
+        ["InstallerClean-portable.exe", "InstallerClean"]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/no-faff/InstallerClean/releases/download/v$version/InstallerClean-portable.exe",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
**New package** - InstallerClean 1.5.0

Open source tool to safely clean orphaned Windows Installer files and reclaim disk space. Modern replacement for PatchCleaner (which was last updated in 2016).

- Homepage: https://github.com/no-faff/InstallerClean
- Licence: MIT
- Binary: portable single-file exe, 76 MB, bundles .NET 8 runtime
- VirusTotal (setup variant, same codebase): 0/70

Manifest uses the portable exe. Requires admin to run (accesses C:\\Windows\\Installer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for InstallerClean v1.5.0 portable Windows executable.
  * Enabled automatic version checking and updates from GitHub releases.
  * Configured desktop shortcut for convenient access to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->