### PR TITLE
nekobox: Add version 5.10.38

### DIFF
--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -7,10 +7,12 @@
         "64bit": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows64.zip",
             "hash": "1541ae2c64a056bdfc4807085ea32b4ec150fdd2a951e446c8e9659ed338d17f"
-        },"32bit": {
+        },
+        "32bit": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows32.zip",
             "hash": "44fd068a867595585feea7235c21679ebb7f3f7a4f2a369672fadfc87b39f749"
-        },"arm64": {
+        },
+        "arm64": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows-arm64.zip",
             "hash": "3ea6c618e95745fb5ddae190c9bc80244093149ae1951295fff77c936559235f"
         }
@@ -26,9 +28,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows64.zip"
-            },"32bit": {
+            },
+            "32bit": {
                 "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows32.zip"
-            },"arm64": {
+            },
+            "arm64": {
                 "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows-arm64.zip"
             }
         }

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -1,20 +1,20 @@
 {
-    "version": "5.10.37",
+    "version": "5.10.38",
     "description": "A lightweight proxy client, empowered by sing-box and thrift.",
     "homepage": "https://github.com/qr243vbi/nekobox",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows64.zip",
-            "hash": "1541ae2c64a056bdfc4807085ea32b4ec150fdd2a951e446c8e9659ed338d17f"
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.38/nekobox-5.10.38-windows64.zip",
+            "hash": "ae8bc610b77bd196066035eb854684e63632181cd9e2e39d4239a254f4b9ad45"
         },
         "32bit": {
-            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows32.zip",
-            "hash": "44fd068a867595585feea7235c21679ebb7f3f7a4f2a369672fadfc87b39f749"
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.38/nekobox-5.10.38-windows32.zip",
+            "hash": "04dbbf64e14cd32c2d707cdcec64ca795d50bcd0d8289b759b005c864dcff125"
         },
         "arm64": {
-            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows-arm64.zip",
-            "hash": "3ea6c618e95745fb5ddae190c9bc80244093149ae1951295fff77c936559235f"
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.38/nekobox-5.10.38-windows-arm64.zip",
+            "hash": "31a5e51f69b8ab8343b9fbe1dee90d55e317c8df7a91e6001f213df7aaadf535"
         }
     },
     "shortcuts": [

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -2,7 +2,7 @@
     "version": "5.10.38",
     "description": "A lightweight proxy client, empowered by sing-box and thrift.",
     "homepage": "https://github.com/qr243vbi/nekobox",
-    "license": "GPL-3.0-only",
+    "license": "GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.38/nekobox-5.10.38-windows64.zip",

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -25,9 +25,7 @@
             "NekoBox"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/qr243vbi/nekobox"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -1,6 +1,6 @@
 {
     "version": "5.10.37",
-    "description": "NekoBox – A lightweight proxy client",
+    "description": "A lightweight proxy client, empowered by sing-box and thrift.",
     "homepage": "https://github.com/qr243vbi/nekobox",
     "license": "GPL-3.0-only",
     "architecture": {

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -2,7 +2,7 @@
     "version": "5.10.37",
     "description": "NekoBox – A lightweight proxy client",
     "homepage": "https://github.com/qr243vbi/nekobox",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows64.zip",

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -2,7 +2,7 @@
     "version": "5.10.38",
     "description": "A lightweight proxy client, empowered by sing-box and thrift.",
     "homepage": "https://github.com/qr243vbi/nekobox",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.38/nekobox-5.10.38-windows64.zip",
@@ -17,13 +17,16 @@
             "hash": "31a5e51f69b8ab8343b9fbe1dee90d55e317c8df7a91e6001f213df7aaadf535"
         }
     },
+    "extract_dir": "nekobox",
+    "bin": "nekobox_core.exe",
     "shortcuts": [
         [
-            "nekobox/nekobox.exe",
+            "nekobox.exe",
             "NekoBox"
         ]
     ],
     "checkver": "github",
+    "persist": "settings",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -15,10 +15,6 @@
             "hash": "3ea6c618e95745fb5ddae190c9bc80244093149ae1951295fff77c936559235f"
         }
     },
-    "bin": [
-        "nekobox/nekobox.exe",
-        "nekobox/nekobox_core.exe"
-    ],
     "shortcuts": [
         [
             "nekobox/nekobox.exe",

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -25,8 +25,8 @@
             "NekoBox"
         ]
     ],
-    "checkver": "github",
     "persist": "settings",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -7,10 +7,16 @@
         "64bit": {
             "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows64.zip",
             "hash": "1541ae2c64a056bdfc4807085ea32b4ec150fdd2a951e446c8e9659ed338d17f"
+        },"32bit": {
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows32.zip",
+            "hash": "44fd068a867595585feea7235c21679ebb7f3f7a4f2a369672fadfc87b39f749"
+        },"arm64": {
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows-arm64.zip",
+            "hash": "3ea6c618e95745fb5ddae190c9bc80244093149ae1951295fff77c936559235f"
         }
     },
     "bin": [
-        "nekobox/nekobox.exe"
+        "nekobox/nekobox.exe",
         "nekobox/nekobox_core.exe"
     ],
     "shortcuts": [
@@ -26,6 +32,10 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows64.zip"
+            },"32bit": {
+                "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows32.zip"
+            },"arm64": {
+                "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows-arm64.zip"
             }
         }
     }

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -1,0 +1,32 @@
+{
+    "version": "5.10.37",
+    "description": "NekoBox – A lightweight proxy client",
+    "homepage": "https://github.com/qr243vbi/nekobox",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.10.37/nekobox-5.10.37-windows64.zip",
+            "hash": "1541ae2c64a056bdfc4807085ea32b4ec150fdd2a951e446c8e9659ed338d17f"
+        }
+    },
+    "bin": [
+        "nekobox/nekobox.exe"
+        "nekobox/nekobox_core.exe"
+    ],
+    "shortcuts": [
+        [
+            "nekobox/nekobox.exe",
+            "NekoBox"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/qr243vbi/nekobox"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/qr243vbi/nekobox/releases/download/$version/nekobox-$version-windows64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17621

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NekoBox proxy client v5.10.38 is now available for Windows (64‑bit, 32‑bit, ARM64). Packages include integrity verification, architecture-specific download artifacts and update URLs tied to GitHub releases, automatic update checks, installation that extracts into the application directory and preserves user settings, and an installed "NekoBox" shortcut that launches the primary executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->