### PR TITLE
solomd: Add version 0.1.11

### DIFF
--- a/bucket/solomd.json
+++ b/bucket/solomd.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.1.11",
+    "description": "A lightweight Markdown and plain text editor built with Tauri 2",
+    "homepage": "https://solomd.app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zhitongblog/solomd/releases/download/v0.1.11/SoloMD_0.1.11_x64-setup.exe#/setup.exe",
+            "hash": "d5dfe145c22db2adde6ce3ac6f89790e17f24a4b53b72c326cfc6cf843aeee14"
+        }
+    },
+    "installer": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList '/S', \"/D=$dir\" -Wait"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\uninstall.exe\" -ArgumentList '/S' -Wait"
+        ]
+    },
+    "shortcuts": [
+        [
+            "SoloMD.exe",
+            "SoloMD"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/setup.exe",
+                "hash": {
+                    "url": "https://github.com/zhitongblog/solomd/releases/tag/v$version",
+                    "regex": "SoloMD_$version_x64-setup\\.exe.*?$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update SoloMD to v0.1.11. Release notes: https://github.com/zhitongblog/solomd/releases/tag/v0.1.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing SoloMD (Tauri 2) with 64-bit installer, silent install/uninstall flow, and desktop/start‑menu shortcut creation.
  * Enabled automatic version checking and autoupdate via GitHub with downloadable 64-bit releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->