### PR TITLE
solomd: Add version 0.1.12

### DIFF
--- a/bucket/solomd.json
+++ b/bucket/solomd.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.1.12",
+    "description": "A lightweight Markdown and plain text editor built with Tauri 2",
+    "homepage": "https://solomd.app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zhitongblog/solomd/releases/download/v0.1.12/SoloMD_0.1.12_x64-setup.exe#/setup.exe",
+            "hash": "fc3b489821c74ac6340d73e2a1dd3ec86447524305d7c21f3a86214ad8aa5f9e"
+        }
+    },
+    "installer": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList '/S', \"/D=$dir\" -Wait"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\uninstall.exe\" -ArgumentList '/S' -Wait"
+        ]
+    },
+    "shortcuts": [
+        [
+            "SoloMD.exe",
+            "SoloMD"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/setup.exe",
+                "hash": {
+                    "url": "https://github.com/zhitongblog/solomd/releases/tag/v$version",
+                    "regex": "SoloMD_$version_x64-setup\\.exe.*?$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update SoloMD to v0.1.12. Release notes: https://github.com/zhitongblog/solomd/releases/tag/v0.1.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Solomd version 0.1.12 is now available for package manager installation with automatic version checking and seamless updates. Silent installation and uninstallation processes run without user interaction or prompts. Desktop shortcuts are automatically created for quick application access. Updates are detected and applied directly from GitHub release sources without manual intervention required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->