### PR TITLE
solomd: Add version 1.1.0

### DIFF
--- a/bucket/solomd.json
+++ b/bucket/solomd.json
@@ -1,39 +1,28 @@
 {
-    "version": "0.1.8",
-    "description": "A lightweight Markdown and plain text editor built with Tauri 2",
+    "version": "1.1.0",
+    "description": "A lightweight Markdown and plain text editor built with Tauri 2.",
     "homepage": "https://solomd.app",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zhitongblog/solomd/releases/download/v0.1.8/SoloMD_0.1.8_x64-setup.exe#/setup.exe",
-            "hash": "868a9351eaf52b3cb204037ba592204d887950172ea7a982449b51ee81dd9e62"
+            "url": "https://github.com/zhitongblog/solomd/releases/download/v1.1.0/SoloMD_1.1.0_x64-setup.exe#/dl.7z",
+            "hash": "834d362515178c249e927ef9eb00531744b030d84f161ebde474fa82b8212aa5"
         }
     },
-    "installer": {
-        "script": [
-            "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList '/S', \"/D=$dir\" -Wait"
-        ]
-    },
-    "uninstaller": {
-        "script": [
-            "Start-Process -FilePath \"$dir\\uninstall.exe\" -ArgumentList '/S' -Wait"
-        ]
-    },
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Force -Recurse -ErrorAction Ignore",
     "shortcuts": [
         [
             "SoloMD.exe",
             "SoloMD"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/zhitongblog/solomd"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/setup.exe",
-                "hash": {
-                    "url": "https://github.com/zhitongblog/solomd/releases/tag/v$version",
-                    "regex": "SoloMD_$version_x64-setup\\.exe.*?$sha256"
-                }
+                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/dl.7z"
             }
         }
     }

--- a/bucket/solomd.json
+++ b/bucket/solomd.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.1.8",
+    "description": "A lightweight Markdown and plain text editor built with Tauri 2",
+    "homepage": "https://solomd.app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zhitongblog/solomd/releases/download/v0.1.8/SoloMD_0.1.8_x64-setup.exe#/setup.exe",
+            "hash": "868a9351eaf52b3cb204037ba592204d887950172ea7a982449b51ee81dd9e62"
+        }
+    },
+    "installer": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\setup.exe\" -ArgumentList '/S', \"/D=$dir\" -Wait"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Start-Process -FilePath \"$dir\\uninstall.exe\" -ArgumentList '/S' -Wait"
+        ]
+    },
+    "shortcuts": [
+        [
+            "SoloMD.exe",
+            "SoloMD"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zhitongblog/solomd/releases/download/v$version/SoloMD_$version_x64-setup.exe#/setup.exe",
+                "hash": {
+                    "url": "https://github.com/zhitongblog/solomd/releases/tag/v$version",
+                    "regex": "SoloMD_$version_x64-setup\\.exe.*?$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds SoloMD, a lightweight cross-platform Markdown + plain text editor built with Tauri 2.

- GitHub: https://github.com/zhitongblog/solomd (MIT)
- Website: https://solomd.app
- Installer: Wix MSI / NSIS setup from GitHub releases

The Windows build is signed (not EV, so first-run SmartScreen prompt may appear) and verified via the SHA256 in the manifest. Version bumps will follow each GitHub release.