### PR TITLE
matlab-mpm: Add version 2026.3

### DIFF
--- a/bucket/matlab-mpm.json
+++ b/bucket/matlab-mpm.json
@@ -14,7 +14,7 @@
   },
   "bin": "matlab-mpm.exe",
   "checkver": {
-    "url": "https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md",
+    "url": "https://raw.githubusercontent.com/mathworks-ref-arch/matlab-dockerfile/refs/heads/main/MPM.md",
     "regex": "\\d{4}\\.\\d{1,2}(\\.\\d+)?(\\.\\d+)?(?= - )"
   },
   "autoupdate": {

--- a/bucket/matlab-mpm.json
+++ b/bucket/matlab-mpm.json
@@ -1,0 +1,27 @@
+{
+  "version": "2026.3",
+  "description": "MATLAB Package Manager",
+  "homepage": "https://www.mathworks.com/help/install/ug/get-mpm-os-command-line.html",
+  "license": "Proprietary",
+  "architecture": {
+    "64bit": {
+      "url": "https://www.mathworks.com/mpm/win64/mpm",
+      "hash": "1BE2C7ABA0032FF73DD7656864E607254B24D1F49AF8BD94E70947246D2979BB"
+    }
+  },
+  "installer": {
+    "script": ["Rename-Item \"$dir\\mpm\" \"$dir\\matlab-mpm.exe\""]
+  },
+  "bin": "matlab-mpm.exe",
+  "checkver": {
+    "url": "https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md",
+    "regex": "\\d{4}\\.\\d{1,2}(\\.\\d+)?(\\.\\d+)?(?= - )"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://www.mathworks.com/mpm/win64/mpm"
+      }
+    }
+  }
+}


### PR DESCRIPTION
matlab-mpm is the [MATLAB Package Manager](https://www.mathworks.com/help/install/ug/get-mpm-os-command-line.html).

Since:
- the exe file downloaded by scoop from the immutable link https://www.mathworks.com/mpm/win64/mpm is named `mpm`, without the exe extension
- `mpm` has a name collision with `mpm` set by the TeX distribution miktex
- `matlab-mcp-server` is already on scoop (Main) and starts with the prefix `matlab-`

I decided to name the package `matlab-mpm` instead of `mpm`. I put a script installer line of code to rename the app.
Hope it is all ok.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
