### PR TITLE
webview2: Update to version 147.0.3912.72, fix checkver

### DIFF
--- a/bucket/webview2.json
+++ b/bucket/webview2.json
@@ -1,5 +1,5 @@
 {
-    "version": "147.0.3912.60",
+    "version": "147.0.3912.72",
     "description": "Microsoft Edge WebView2 Runtime. Embed web content (HTML, CSS, and JavaScript) in your native applications with Microsoft Edge WebView2.",
     "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/webview2",
     "license": {
@@ -9,19 +9,19 @@
     "notes": "Overrides any natively installed Runtime through environment variable 'WEBVIEW2_BROWSER_EXECUTABLE_FOLDER'. This is architecture-specific: Applications must match the runtime architecture, for example install the 32-bit build (--arch 32bit) to support 32-bit applications.",
     "architecture": {
         "32bit": {
-            "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/ee8e85af-5861-403e-b65e-cf7ab88ebca5/Microsoft.WebView2.FixedVersionRuntime.147.0.3912.60.x86.cab#/dl.7z",
-            "hash": "8d00b69f233305af14c13ca5df6bef4dbddc964b1ff3ad0352bab6d3785a1474",
-            "extract_dir": "Microsoft.WebView2.FixedVersionRuntime.147.0.3912.60.x86"
+            "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/1848f931-7e0f-41d7-9483-2e8b41536887/Microsoft.WebView2.FixedVersionRuntime.147.0.3912.72.x86.cab#/dl.7z",
+            "hash": "1aafd81a79bd1d11021f2c3b23be1ae03b9cd5b247aad53982d0d12bf7aebe4f",
+            "extract_dir": "Microsoft.WebView2.FixedVersionRuntime.147.0.3912.72.x86"
         },
         "64bit": {
-            "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/ba2f21eb-9775-49e3-9a8b-7bfb2c924bfb/Microsoft.WebView2.FixedVersionRuntime.147.0.3912.60.x64.cab#/dl.7z",
-            "hash": "f79f5e8750e477a6118229e2eb61be4961143024cceb2369458ec98ddb6e6622",
-            "extract_dir": "Microsoft.WebView2.FixedVersionRuntime.147.0.3912.60.x64"
+            "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/4cd93908-3ce1-47db-aad9-37412e3d89be/Microsoft.WebView2.FixedVersionRuntime.147.0.3912.72.x64.cab#/dl.7z",
+            "hash": "6ceba673111c629d096465989bdefdda2ca249aa4834dbdabc815e40711a8828",
+            "extract_dir": "Microsoft.WebView2.FixedVersionRuntime.147.0.3912.72.x64"
         },
         "arm64": {
-            "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/95249428-9691-4d3c-8292-843d1cd5168c/Microsoft.WebView2.FixedVersionRuntime.147.0.3912.60.arm64.cab#/dl.7z",
-            "hash": "0341adb55234972688563e2a60866340f0169fd90b81fd52cc900a37ab5fa3f0",
-            "extract_dir": "Microsoft.WebView2.FixedVersionRuntime.147.0.3912.60.arm64"
+            "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/da2bd430-3408-4b2a-8470-3436f74729cb/Microsoft.WebView2.FixedVersionRuntime.147.0.3912.72.arm64.cab#/dl.7z",
+            "hash": "fc899d4b5d788e0da634da30306c517058e26c10deb3b319f70d3ae9630b3ae0",
+            "extract_dir": "Microsoft.WebView2.FixedVersionRuntime.147.0.3912.72.arm64"
         }
     },
     "env_set": {
@@ -30,6 +30,7 @@
     "checkver": {
         "url": "https://developer.microsoft.com/en-us/Microsoft-edge/webview2/",
         "script": [
+            "$page = $page -replace '\\\\u002F', '/'",
             "$page -match 'https://msedge\\.sf\\.dl\\.delivery\\.mp\\.microsoft\\.com/filestreamingservice/files/(?<folder>[0-9a-z-]+)/Microsoft\\.WebView2\\.FixedVersionRuntime\\.([0-9.]+)\\.x86\\.cab'",
             "$arch32 = $Matches.folder",
             "$page -match 'https://msedge\\.sf\\.dl\\.delivery\\.mp\\.microsoft\\.com/filestreamingservice/files/(?<folder>[0-9a-z-]+)/Microsoft\\.WebView2\\.FixedVersionRuntime\\.(?<version>[0-9.]+)\\.x64\\.cab'",


### PR DESCRIPTION
### Summary

Fixes #17649.

Microsoft's WebView2 page now serializes fixed-version runtime URLs with escaped slashes (`\u002F`), so the existing full-URL matches no longer find the current CAB links.

This normalizes the page content before applying the existing regexes, then updates the manifest to the current fixed runtime version.

### Testing

```powershell
.\bin\checkver.ps1 -App webview2 -Dir .\bucket
.\bin\checkurls.ps1 -App webview2 -Dir .\bucket
```

Results:

```text
webview2: 147.0.3912.72
[3][3][0] webview2
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)