### PR TITLE
vibesdj: Add version 0.11.1

### DIFF
--- a/bucket/vibesdj.json
+++ b/bucket/vibesdj.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.10.3",
+    "version": "0.11.1",
     "description": "DJ library organizer that sorts tracks by mood, energy, and technique",
     "homepage": "https://vibesdj.io/",
     "license": {
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/benmdg/vibes-releases/releases/download/v0.10.3/Vibes_0.10.3_x64-setup.exe",
-            "hash": "3ad3b3032fc193cf09d0a250bf4b0a835b0851e5bd96807cb90b6f48b868e2ee"
+            "url": "https://github.com/benmdg/vibes-releases/releases/download/v0.11.1/Vibes_0.11.1_x64-setup.exe",
+            "hash": "56ae82bd352d9f473fa289f69c1bca998f6ba75f8d93921ab8c811a9180606ea"
         }
     },
     "installer": {

--- a/bucket/vibesdj.json
+++ b/bucket/vibesdj.json
@@ -1,0 +1,45 @@
+{
+    "version": "0.10.3",
+    "description": "DJ library organizer that sorts tracks by mood, energy, and technique",
+    "homepage": "https://vibesdj.io/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://vibesdj.io/terms"
+    },
+    "notes": [
+        "Vibes is commercial software. See https://vibesdj.io/ for licensing.",
+        "The app is installed per-user via the bundled NSIS installer and auto-updates."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/benmdg/vibes-releases/releases/download/v0.10.3/Vibes_0.10.3_x64-setup.exe",
+            "hash": "3ad3b3032fc193cf09d0a250bf4b0a835b0851e5bd96807cb90b6f48b868e2ee"
+        }
+    },
+    "installer": {
+        "script": [
+            "$installer = Get-ChildItem \"$dir\" -Filter 'Vibes_*_x64-setup.exe' | Select-Object -First 1",
+            "if (-not $installer) { error 'Installer not found in package dir.'; break }",
+            "Invoke-ExternalCommand $installer.FullName -ArgumentList @('/S') -RunAs | Out-Null",
+            "Remove-Item $installer.FullName -Force"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$uninstaller = Join-Path $env:LOCALAPPDATA 'Vibes\\uninstall.exe'",
+            "if (Test-Path $uninstaller) {",
+            "    Invoke-ExternalCommand $uninstaller -ArgumentList @('/S') -RunAs | Out-Null",
+            "}"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/benmdg/vibes-releases"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/benmdg/vibes-releases/releases/download/v$version/Vibes_$version_x64-setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Vibes — a DJ library organizer — to the Extras bucket.

Closes #17659

- **Homepage:** https://vibesdj.io/
- **Source (public releases mirror):** https://github.com/benmdg/vibes-releases
- **License:** Commercial (Proprietary)
- **Platform:** Windows 10+ (x64)
- **Installer:** NSIS (silent `/S` supported)
- **Latest version:** 0.11.1

## What Vibes is

Vibes is a native desktop DJ library organizer. Users sort and prepare tracks by mood, energy, and technique, then export prepped crates back to Rekordbox, Serato DJ, Engine DJ, or Lexicon DJ. Built with Tauri (small native app, not Electron).

## Update history

- Originally submitted for v0.10.3
- Bumped to v0.11.1 (v0.10.3 release was rotated off the public mirror)

## Checklist

- [x] Manifest JSON is valid
- [x] `checkver` + `autoupdate` configured for future bumps
- [x] `installer` script runs the NSIS installer silently
- [x] `uninstaller` script removes the app via its own uninstaller
- [x] SHA256 verified against the real v0.11.1 installer on GitHub Releases
- [x] Package-request issue filed (#17659) per CONTRIBUTING