### PR TITLE
ghostwriter: Fix deprecated URLs, suggest vcredist2022

### DIFF
--- a/bucket/ghostwriter.json
+++ b/bucket/ghostwriter.json
@@ -1,11 +1,11 @@
 {
     "version": "2.1.6",
     "description": "Distraction-free Markdown editor",
-    "homepage": "https://wereturtle.github.io/ghostwriter/",
+    "homepage": "https://ghostwriter.kde.org/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wereturtle/ghostwriter/releases/download/2.1.6/ghostwriter_2.1.6_win64_portable.zip",
+            "url": "https://github.com/KDE/ghostwriter/releases/download/2.1.6/ghostwriter_2.1.6_win64_portable.zip",
             "hash": "f3b3408f12a01d05c5ad360147949e3a15c7df8ed7eefa8d2a408b90b27d14f5"
         }
     },
@@ -18,12 +18,12 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://github.com/wereturtle/ghostwriter"
+        "github": "https://github.com/KDE/ghostwriter"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/wereturtle/ghostwriter/releases/download/$version/ghostwriter_$version_win64_portable.zip"
+                "url": "https://github.com/KDE/ghostwriter/releases/download/$version/ghostwriter_$version_win64_portable.zip"
             }
         }
     }

--- a/bucket/ghostwriter.json
+++ b/bucket/ghostwriter.json
@@ -3,6 +3,9 @@
     "description": "Distraction-free Markdown editor",
     "homepage": "https://ghostwriter.kde.org/",
     "license": "GPL-3.0-only",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/KDE/ghostwriter/releases/download/2.1.6/ghostwriter_2.1.6_win64_portable.zip",


### PR DESCRIPTION
Fix deprecated URLs - Now a KDE project.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
