### PR TITLE
windows11-context-menu-manager: Add version 1.0.1

### DIFF
--- a/bucket/windows11-context-menu-manager.json
+++ b/bucket/windows11-context-menu-manager.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0.1",
+    "description": "Windows 11 Context Menu Manager is a simple tool that allows you to disable unwanted entries in Windows 11 Explorer new right-click context menu.",
+    "homepage": "https://github.com/branhill/windows-11-context-menu-manager",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/branhill/windows-11-context-menu-manager/releases/download/v1.0.1/release_win-x64.zip",
+            "hash": "147015346f27d182248f6aa76679abead297de096f76f83fafcd844a592e29aa"
+        },
+        "arm64": {
+            "url": "https://github.com/branhill/windows-11-context-menu-manager/releases/download/v1.0.1/release_win-arm64.zip",
+            "hash": "715b91419559e0aa1bd3b28b6c6fb0b43e50133c1d324e83472b05eb36975b11"
+        }
+    },
+    "shortcuts": [
+        [
+            "Windows11ContextMenuManager.exe",
+            "Windows 11 Context Menu Manager"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/branhill/windows-11-context-menu-manager/releases/download/v$version/release_win-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/branhill/windows-11-context-menu-manager/releases/download/v$version/release_win-arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "",
+            "regex": ""
+        }
+    }
+}

--- a/bucket/windows11-context-menu-manager.json
+++ b/bucket/windows11-context-menu-manager.json
@@ -28,10 +28,6 @@
             "arm64": {
                 "url": "https://github.com/branhill/windows-11-context-menu-manager/releases/download/v$version/release_win-arm64.zip"
             }
-        },
-        "hash": {
-            "url": "",
-            "regex": ""
         }
     }
 }


### PR DESCRIPTION
Adds version 1.0.1 of the Windows 11 Context Menu Manager

Closes https://github.com/ScoopInstaller/Extras/issues/17645

It is a simple one-binary GUI tool without installation procedure.

✅ Tested install on x64
✅ no x32 supported
✅ Tested install for arm64, but did not run the binary
✅ [Virustotal x64 Score 0/91](https://www.virustotal.com/gui/url/1dab8aa86434efceff5cbae111fe842c74ec55a8da2be5eca259f169a501b0a6/details)
✅ [Virustotal arm64 Score 0/91](https://www.virustotal.com/gui/url/3137fb06d0b7b411f450daefafdeb33bfc3916680da945823b4262a313fc0c30)
✅ Checkver
✅ Autoupdate
✅ formatjson.ps1
✅ tabwidth 4 spaces
✅ License checked with https://tools.spdx.org/app/check_license/
✅ App does not seem to create any files that would need to be persisted
✅ No CLI, so not added to BIN
✅ GUI only, so added to shortcut
✅ Test your manifest by installing, uninstalling, checking functionality, persistence etc.



- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
