### PR TITLE
rabbitmq: Remove `rabbitmq-echopid.bat`

### DIFF
--- a/bucket/rabbitmq.json
+++ b/bucket/rabbitmq.json
@@ -11,7 +11,6 @@
         "sbin\\rabbitmqctl.bat",
         "sbin\\rabbitmq-defaults.bat",
         "sbin\\rabbitmq-diagnostics.bat",
-        "sbin\\rabbitmq-echopid.bat",
         "sbin\\rabbitmq-env.bat",
         "sbin\\rabbitmq-plugins.bat",
         "sbin\\rabbitmq-queues.bat",


### PR DESCRIPTION
That command was removed upstream by @lukebakken (moi) in this PR:

https://github.com/rabbitmq/rabbitmq-server/pull/15190

Remove it from the scoop shims

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
