### PR TITLE
librehardwaremonitor: Persist user data

### DIFF
--- a/bucket/librehardwaremonitor.json
+++ b/bucket/librehardwaremonitor.json
@@ -11,21 +11,11 @@
     },
     "pre_install": [
         "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
-        "# Please keep the file list the same in both pre_install and pre_uninstall scripts.",
         "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
-        "   if (!(Test-Path \"$persist_dir\\\")) {",
-        "       New-Item -Type Directory -Path \"$persist_dir\\\" -ErrorAction Ignore | Out-Null",
-        "   }",
-        "   if (Test-Path \"$persist_dir\\$_\") {",
-        "       Copy-Item -Path \"$persist_dir\\$_\" -Destination \"$dir\\\" -Force",
-        "   }",
+        "    if (Test-Path -Path \"$persist_dir\\$_\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination \"$dir\\$_\" -Force",
+        "    }",
         "}"
-    ],
-    "bin": [
-        [
-            "LibreHardwareMonitor.exe",
-            "lhm"
-        ]
     ],
     "shortcuts": [
         [
@@ -35,11 +25,11 @@
     ],
     "pre_uninstall": [
         "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
-        "# Please keep the file list the same in both pre_install and pre_uninstall scripts.",
         "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
-        "   if (Test-Path -Path \"$dir\\$_\") {",
-        "       Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\\" -Force",
-        "   }",
+        "    if (Test-Path -Path \"$dir\\$_\" -PathType Leaf) {",
+        "        ensure $persist_dir | Out-Null",
+        "        Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\$_\" -Force",
+        "    }",
         "}"
     ],
     "checkver": "github",

--- a/bucket/librehardwaremonitor.json
+++ b/bucket/librehardwaremonitor.json
@@ -17,7 +17,7 @@
         "       New-Item -Type Directory -Path \"$persist_dir\\\" -ErrorAction Ignore | Out-Null",
         "   }",
         "   if (Test-Path \"$persist_dir\\$_\") {",
-        "       Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
+        "       Copy-Item -Path \"$persist_dir\\$_\" -Destination \"$dir\\\" -Force",
         "   }",
         "}"
     ],
@@ -38,7 +38,7 @@
         "# Please keep the file list the same in both pre_install and pre_uninstall scripts.",
         "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
         "   if (Test-Path -Path \"$dir\\$_\") {",
-        "       Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\$_\" -Force",
+        "       Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\\" -Force",
         "   }",
         "}"
     ],

--- a/bucket/librehardwaremonitor.json
+++ b/bucket/librehardwaremonitor.json
@@ -13,7 +13,7 @@
         "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
         "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
         "    if (Test-Path -Path \"$persist_dir\\$_\" -PathType Leaf) {",
-        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination \"$dir\\$_\" -Force",
+        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination $dir -Force",
         "    }",
         "}"
     ],
@@ -28,7 +28,7 @@
         "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
         "    if (Test-Path -Path \"$dir\\$_\" -PathType Leaf) {",
         "        ensure $persist_dir | Out-Null",
-        "        Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\$_\" -Force",
+        "        Copy-Item -Path \"$dir\\$_\" -Destination $persist_dir -Force",
         "    }",
         "}"
     ],

--- a/bucket/librehardwaremonitor.json
+++ b/bucket/librehardwaremonitor.json
@@ -9,11 +9,38 @@
             "hash": "086d9f1b5a99e643edc2cfaaac16051685b551e4c5ac0b32a57c58c0e529c001"
         }
     },
+    "pre_install": [
+        "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
+        "# Please keep the file list the same in both pre_install and pre_uninstall scripts.",
+        "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
+        "   if (!(Test-Path \"$persist_dir\\\")) {",
+        "       New-Item -Type Directory -Path \"$persist_dir\\\" -ErrorAction Ignore | Out-Null",
+        "   }",
+        "   if (Test-Path \"$persist_dir\\$_\") {",
+        "       Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -Force",
+        "   }",
+        "}"
+    ],
+    "bin": [
+        [
+            "LibreHardwareMonitor.exe",
+            "lhm"
+        ]
+    ],
     "shortcuts": [
         [
             "LibreHardwareMonitor.exe",
             "Libre Hardware Monitor"
         ]
+    ],
+    "pre_uninstall": [
+        "# Hardlinks cannot work properly here, as this app would create a new file instead of writing directly.",
+        "# Please keep the file list the same in both pre_install and pre_uninstall scripts.",
+        "'LibreHardwareMonitor.config', 'LibreHardwareMonitorLog*.csv' | ForEach-Object {",
+        "   if (Test-Path -Path \"$dir\\$_\") {",
+        "       Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\$_\" -Force",
+        "   }",
+        "}"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Persist mechanism fixed
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #17663 
<!--
Closes #XXXX
or
Relates to #XXXX
-->
(I've also already prepared a manifest for the Net10 version of the app, but I'm not sure whether to submit a pull request for this repo or for `versions`)
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application configuration and log files are now automatically preserved during installation and uninstallation to prevent accidental data loss.
  * User settings and historical monitoring data are intelligently managed through automatic backup before uninstall and restoration after reinstall.
  * Your preferences and data history remain intact across software updates and complete application reinstallations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->