### PR TITLE
miascii: Add version 0.3.5

### DIFF
--- a/bucket/miascii.json
+++ b/bucket/miascii.json
@@ -9,19 +9,27 @@
       "hash": "61b9642f67df54ac2df18c1f810d43842ad5a59c44fd693635e1ccff05085fcd"
     }
   },
-  "installer": {
-    "script": "Start-Process -FilePath \"$dir\\miascii-0.3.5-setup-x64.exe\" -ArgumentList \"/S\" -Wait"
-  },
-  "uninstaller": {
-    "script": "Start-Process -FilePath \"$env:LOCALAPPDATA\\miascii\\Uninstall miascii.exe\" -ArgumentList \"/S\" -Wait"
-  },
+  "pre_install": [
+    "Expand-7zipArchive \"$dir\\$fname\" \"$dir\" -Removal"
+  ],
+  "shortcuts": [
+    [
+      "miascii.exe",
+      "miascii"
+    ]
+  ],
   "checkver": {
     "github": "https://github.com/emireln/miascii"
   },
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://github.com/emireln/miascii/releases/download/v$version/miascii-$version-setup-x64.exe"
+        "url": "https://github.com/emireln/miascii/releases/download/v$version/miascii-$version-setup-x64.exe",
+        "hash": {
+          "url": "$baseurl/latest.yml",
+          "regex": "(?sm)miascii-$version-setup-x64\\.exe.*?sha512:\\s*([\\w+/=]+)",
+          "type": "sha512"
+        }
       }
     }
   }

--- a/bucket/miascii.json
+++ b/bucket/miascii.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.3.5",
+  "description": "text · image · video to ASCII — fully client-side. miascii turns anything into chunky, hand-crafted ASCII art — right in your browser or on your desktop. Convert text, images, and video to ASCII art with 8 themes, 12 languages, and 100% offline processing.",
+  "homepage": "https://github.com/emireln/miascii",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/emireln/miascii/releases/download/v0.3.5/miascii-0.3.5-setup-x64.exe",
+      "hash": "61b9642f67df54ac2df18c1f810d43842ad5a59c44fd693635e1ccff05085fcd"
+    }
+  },
+  "installer": {
+    "script": "Start-Process -FilePath \"$dir\\miascii-0.3.5-setup-x64.exe\" -ArgumentList \"/S\" -Wait"
+  },
+  "uninstaller": {
+    "script": "Start-Process -FilePath \"$env:LOCALAPPDATA\\miascii\\Uninstall miascii.exe\" -ArgumentList \"/S\" -Wait"
+  },
+  "checkver": {
+    "github": "https://github.com/emireln/miascii"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/emireln/miascii/releases/download/v$version/miascii-$version-setup-x64.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding miascii package version 0.3.5

miascii is a retro CRT-terminal app for converting text, images, and video into ASCII art. It runs entirely in your browser or as a standalone desktop app on Windows, macOS, and Linux. There is no server, no sign-up, and no uploads — everything happens on your device.

- Package: miascii
- Version: 0.3.5
- Publisher: emireln
- License: Apache-2.0
- Homepage: https://github.com/emireln/miascii

Features:
- Text to ASCII conversion with FIGlet fonts
- Image to ASCII conversion with density ramps
- Video to ASCII conversion with real-time processing
- 8 carefully tuned themes
- 12 language translations
- 100% offline processing
- No telemetry or analytics

This is the first submission of miascii to the scoop-extras repository.