### PR TITLE
potplayer: Update to version 260422, fix checkver & autoupdate

### DIFF
--- a/bucket/potplayer.json
+++ b/bucket/potplayer.json
@@ -1,14 +1,14 @@
 {
-    "version": "260401",
-    "description": "Highly customizable media player",
-    "homepage": "https://potplayer.daum.net",
+    "version": "260422",
+    "description": "A versatile multimedia player offering robust playback capabilities with broad support for numerous video codecs and formats.",
+    "homepage": "https://potplayer.tv",
     "license": {
         "identifier": "Freeware",
-        "url": "https://potplayer.daum.net/publicRelation"
+        "url": "https://potplayer.tv/publicRelation"
     },
     "architecture": {
         "64bit": {
-            "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/260401/PotPlayerSetup64.exe#/dl.7z",
+            "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64.exe#/dl.7z",
             "hash": "3a656da25ed1f5dd8954066bc83dad2d6d7194779edc51a41abf7a45b50c2a93",
             "shortcuts": [
                 [
@@ -22,7 +22,7 @@
             ]
         },
         "32bit": {
-            "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/260401/PotPlayerSetup.exe#/dl.7z",
+            "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup.exe#/dl.7z",
             "hash": "ec8c54cdc61b64bdd8982aec818f5758de7f0c2d53029c26e4d91d9f986b4e7e",
             "shortcuts": [
                 [
@@ -81,16 +81,24 @@
         "PotPlayerMini64.ini"
     ],
     "checkver": {
-        "url": "https://t1.daumcdn.net/potplayer/PotPlayer/v4/Update2/UpdateEng.html",
-        "regex": "\\[(\\d+)\\]"
+        "script": [
+            "$download_url = 'https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64.exe#/dl.7z'",
+            "$download_path = cache_path $app 'unknown' $download_url",
+            "Invoke-WebRequest -Uri $download_url -OutFile $download_path -UseBasicParsing",
+            "$version_info = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($download_path)",
+            "$version = $version_info.FileVersion -replace '\\.', '' -replace '0$', ''",
+            "Move-Item -Path $download_path -Destination (cache_path $app $version $download_url) -Force",
+            "Write-Output $version"
+        ],
+        "regex": "(\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/$version/PotPlayerSetup64.exe#/dl.7z"
+                "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/$version/PotPlayerSetup.exe#/dl.7z"
+                "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `potplayer` to version **260422** and refactors the `checkver` logic to ensure accurate version detection.

### Related issues or pull requests

- Relates to #17654 
- Relates to #17634 
- Relates to #17089 
- ...

### Changes

- Update version to **260422**
- Refine the `description` for better clarity.
- **Domain Migration**: Update `homepage` and `license` URLs from `daum.net` to the newer `potplayer.tv` domain.
- **Robust `checkver` Implementation**: 
    - Replace the HTML-based regex with a PowerShell script that downloads the latest installer to the cache.
    - Use `[System.Diagnostics.FileVersionInfo]` to extract the actual file version, ensuring the manifest matches the binary exactly.
- **URL Standardization**: Switche architecture URLs and `autoupdate` to use the `/Version/Latest/` path

### Notes

- The official `UpdateEng.html` page may lag behind the actual release version, and the download link for the actual version is bound to the link associated with the latest version on the `UpdateEng.html` page. Therefore, `$version` cannot be used in the autoupdate URL.

  ```powershell
  ┏[ D:\Software\Scoop\Local\buckets\Unofficial][ master ≡  ~1  1]
  └─> .\bin\checkver.ps1 -App 'D:\Software\Scoop\Local\buckets\Unofficial\bucket\d\Daum\potplayer.json' -f
  potplayer: 26.04.22 (scoop version is 260401) autoupdate available
  Forcing autoupdate!
  Autoupdating potplayer
  DEBUG[1777119811] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
  DEBUG[1777119811] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
  DEBUG[1777119811] $substitutions.$patchVersion                  22
  DEBUG[1777119811] $substitutions.$cleanVersion                  260422
  DEBUG[1777119811] $substitutions.$matchHead                     26.04.22
  DEBUG[1777119811] $substitutions.$majorVersion                  26
  DEBUG[1777119811] $substitutions.$matchTail
  DEBUG[1777119811] $substitutions.$preReleaseVersion             26.04.22
  DEBUG[1777119811] $substitutions.$urlNoExt                      https://t1.daumcdn.net/potplayer/PotPlayer/Version/260422/PotPlayerSetup
  DEBUG[1777119811] $substitutions.$buildVersion
  DEBUG[1777119811] $substitutions.$dotVersion                    26.04.22
  DEBUG[1777119811] $substitutions.$minorVersion                  04
  DEBUG[1777119811] $substitutions.$url                           https://t1.daumcdn.net/potplayer/PotPlayer/Version/260422/PotPlayerSetup.exe
  DEBUG[1777119811] $substitutions.$dashVersion                   26-04-22
  DEBUG[1777119811] $substitutions.$version                       26.04.22
  DEBUG[1777119811] $substitutions.$underscoreVersion             26_04_22
  DEBUG[1777119811] $substitutions.$baseurl                       https://t1.daumcdn.net/potplayer/PotPlayer/Version/260422
  DEBUG[1777119811] $substitutions.$basename                      PotPlayerSetup.exe
  DEBUG[1777119811] $substitutions.$match1                        26.04.22
  DEBUG[1777119811] $substitutions.$basenameNoExt                 PotPlayerSetup
  DEBUG[1777119811] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
  Downloading PotPlayerSetup.exe to compute hashes!
  The remote server returned an error: (404) Not Found.
  URL https://t1.daumcdn.net/potplayer/PotPlayer/Version/260422/PotPlayerSetup.exe is not valid
  ERROR Could not update potplayer, hash for PotPlayerSetup.exe failed!
  
  ```

- Using `Latest` in the autoupdate URL cannot completely eliminate hash check failures, but it can reduce the frequency of such issues.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ potplayer ≢  ~1  1]
└─> .\bin\checkver.ps1 -App '.\bucket\potplayer.json' -f
potplayer: 260422 (scoop version is 260422)                                                                             
Forcing autoupdate!
Autoupdating potplayer
DEBUG[1777122160] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1777122160] $substitutions.$minorVersion                  
DEBUG[1777122160] $substitutions.$match1                        260422
DEBUG[1777122160] $substitutions.$urlNoExt                      https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64
DEBUG[1777122160] $substitutions.$majorVersion                  260422
DEBUG[1777122160] $substitutions.$version                       260422
DEBUG[1777122160] $substitutions.$dotVersion                    260422
DEBUG[1777122160] $substitutions.$buildVersion                  
DEBUG[1777122160] $substitutions.$baseurl                       https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest
DEBUG[1777122160] $substitutions.$basename                      PotPlayerSetup64.exe
DEBUG[1777122160] $substitutions.$preReleaseVersion             260422
DEBUG[1777122160] $substitutions.$patchVersion                  
DEBUG[1777122160] $substitutions.$basenameNoExt                 PotPlayerSetup64
DEBUG[1777122160] $substitutions.$cleanVersion                  260422
DEBUG[1777122160] $substitutions.$dashVersion                   260422
DEBUG[1777122160] $substitutions.$url                           https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64.exe
DEBUG[1777122160] $substitutions.$underscoreVersion             260422
DEBUG[1777122160] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading PotPlayerSetup64.exe to compute hashes!
Loading PotPlayerSetup64.exe from cache
Computed hash: 3a656da25ed1f5dd8954066bc83dad2d6d7194779edc51a41abf7a45b50c2a93
Writing updated potplayer manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)