### PR TITLE
pdfgear: Update to version 2.1.15, add file associations

### DIFF
--- a/bucket/pdfgear.json
+++ b/bucket/pdfgear.json
@@ -1,26 +1,52 @@
 {
-    "version": "2.1.14",
-    "description": "Read, edit, convert, merge, and sign PDFs across devices for free, no registration required.",
+    "version": "2.1.15",
+    "description": "A free, cross-platform PDF application that allows you to read, edit, convert, and merge documents across devices without requiring registration.",
     "homepage": "https://www.pdfgear.com",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.pdfgear.com/end-user-license-agreement/"
     },
+    "notes": [
+        "To register file associations, please execute the following command:",
+        "reg import \"$dir\\install-associations.reg\""
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.14.exe",
-            "hash": "b668557a3874cc6d0775d1b4375b23908226f7af4f84515f3f4791b7d0809d13"
+            "url": "https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.15.exe",
+            "hash": "3a37578a08e0723b1bd101482c9e3cfa8f4add4f8854ec0187fc5cf2bfef9fe2"
         }
     },
     "innosetup": true,
+    "post_install": [
+        "$pdfgear_dir = $dir -replace '\\\\', '\\\\'",
+        "Get-ChildItem -Path \"$bucketsdir\\$bucket\\scripts\\$app\" -Filter '*.reg' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding utf8",
+        "    if ($global) { $content = $content -replace 'HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE' }",
+        "    $content -replace '{{pdfgear_dir}}', $pdfgear_dir | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding unicode",
+        "}"
+    ],
+    "bin": [
+        "pdfeditor.exe",
+        "PDFLauncher.exe",
+        "pdfconverter.exe"
+    ],
     "shortcuts": [
         [
             "PDFLauncher.exe",
             "PDFgear"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "if ($cmd -ne 'uninstall') { return }",
+            "Get-ChildItem -Path $dir -Filter 'un*.reg' -File | ForEach-Object -Process {",
+            "    $registry_file = '\"{0}\"' -f $_.FullName",
+            "    Start-Process -FilePath 'reg.exe' -ArgumentList @('import', $registry_file) -WindowStyle Hidden -Wait",
+            "}"
+        ]
+    },
     "checkver": {
-        "url": "https://www.pdfgear.com/pdfgear-for-windows",
+        "url": "https://www.pdfgear.com/js/jquery.common.js",
         "regex": "pdfgear_setup_v([\\d.]+)\\.exe"
     },
     "autoupdate": {

--- a/scripts/pdfgear/install-associations.reg
+++ b/scripts/pdfgear/install-associations.reg
@@ -1,0 +1,22 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.pdf\OpenWithProgIDs]
+"PdfGear.App.1"=hex(0):
+
+
+[HKEY_CURRENT_USER\Software\Classes\PdfGear.App.1]
+@="PDF Document"
+"AppUserModelID"="PDFgear.PDFgear"
+"FriendlyTypeName"="PDF Document"
+
+[HKEY_CURRENT_USER\Software\Classes\PdfGear.App.1\DefaultIcon]
+@="\"{{pdfgear_dir}}\\PDFLauncher.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\PdfGear.App.1\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\PdfGear.App.1\shell\open]
+"FriendlyAppName"="PDFgear"
+"Icon"="\"{{pdfgear_dir}}\\PDFLauncher.exe\",0"
+
+[HKEY_CURRENT_USER\Software\Classes\PdfGear.App.1\shell\open\command]
+@="\"{{pdfgear_dir}}\\PDFLauncher.exe\" \"%1\""

--- a/scripts/pdfgear/uninstall-associations.reg
+++ b/scripts/pdfgear/uninstall-associations.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.pdf\OpenWithProgIDs]
+"PdfGear.App.1"=-
+
+[-HKEY_CURRENT_USER\Software\Classes\PdfGear.App.1]


### PR DESCRIPTION
### Summary

Updates `pdfgear` to version **2.1.15** and introduces automated registry-based file association for `.pdf` documents.

### Changes

- Update version to **2.1.15**
- **Improve Manifest Accuracy**:
  - Add `notes` to guide users on manual registry import if needed.
  - Expand `bin` to include `pdfeditor.exe`, `PDFLauncher.exe`, and `pdfconverter.exe`.
  - Refine `description` for better clarity and SEO consistency.
- **File Association Support**:
  - Add `install-associations.reg` and `uninstall-associations.reg` templates.
  - Implement `post_install` logic to dynamically generate registry files with the correct installation path (`{{pdfgear_dir}}`).
  - Add `uninstaller` script to clean up registry entries upon uninstallation.
- **Robust `checkver`**:
  - Switch version detection URL to `https://www.pdfgear.com/js/jquery.common.js`, which provides a more consistent update string than the landing page.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ pdfgear ≡  1]
└─> .\bin\checkver.ps1 -App '.\bucket\pdfgear.json' -f
pdfgear: 2.1.15 (scoop version is 2.1.15)
Forcing autoupdate!
Autoupdating pdfgear
DEBUG[1777198630] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1777198630] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1777198630] $substitutions.$dotVersion                    2.1.15
DEBUG[1777198630] $substitutions.$matchHead                     2.1.15
DEBUG[1777198630] $substitutions.$url                           https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.15.exe
DEBUG[1777198630] $substitutions.$dashVersion                   2-1-15
DEBUG[1777198630] $substitutions.$basenameNoExt                 pdfgear_setup_v2.1.15
DEBUG[1777198630] $substitutions.$cleanVersion                  2115
DEBUG[1777198630] $substitutions.$patchVersion                  15
DEBUG[1777198630] $substitutions.$urlNoExt                      https://downloadfiles.pdfgear.com/releases/windows/pdfgear_setup_v2.1.15
DEBUG[1777198630] $substitutions.$matchTail                     
DEBUG[1777198630] $substitutions.$minorVersion                  1
DEBUG[1777198630] $substitutions.$baseurl                       https://downloadfiles.pdfgear.com/releases/windows
DEBUG[1777198630] $substitutions.$version                       2.1.15
DEBUG[1777198630] $substitutions.$underscoreVersion             2_1_15
DEBUG[1777198630] $substitutions.$buildVersion                  
DEBUG[1777198630] $substitutions.$preReleaseVersion             2.1.15
DEBUG[1777198630] $substitutions.$basename                      pdfgear_setup_v2.1.15.exe
DEBUG[1777198630] $substitutions.$majorVersion                  2
DEBUG[1777198630] $substitutions.$match1                        2.1.15
DEBUG[1777198630] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading pdfgear_setup_v2.1.15.exe to compute hashes!
Loading pdfgear_setup_v2.1.15.exe from cache
Computed hash: 3a37578a08e0723b1bd101482c9e3cfa8f4add4f8854ec0187fc5cf2bfef9fe2
Writing updated pdfgear manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ pdfgear ≡  1]
└─> scoop install Unofficial/pdfgear
Installing 'pdfgear' (2.1.15) [64bit] from 'Unofficial' bucket
Loading pdfgear_setup_v2.1.15.exe from cache.
Checking hash of pdfgear_setup_v2.1.15.exe... OK.
Extracting pdfgear_setup_v2.1.15.exe... Done.
Linking D:\Software\Scoop\Local\apps\pdfgear\current => D:\Software\Scoop\Local\apps\pdfgear\2.1.15
Creating shim for 'pdfeditor'.
Making D:\Software\Scoop\Local\shims\pdfeditor.exe a GUI binary.
Creating shim for 'PDFLauncher'.
Making D:\Software\Scoop\Local\shims\pdflauncher.exe a GUI binary.
Creating shim for 'pdfconverter'.
Making D:\Software\Scoop\Local\shims\pdfconverter.exe a GUI binary.
Creating shortcut for PDFgear (PDFLauncher.exe)
Running post_install script... Done.
'pdfgear' (2.1.15) was installed successfully!
Notes
-----
To register file associations, please execute the following command:
- `reg import "D:\Software\Scoop\Local\apps\pdfgear\current\install-associations.reg"`
-----

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ pdfgear ≡  1]
└─> reg import "D:\Software\Scoop\Local\apps\pdfgear\current\install-associations.reg"
The operation completed successfully.

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ pdfgear ≡  1]
└─> scoop uninstall pdfgear -p
Uninstalling 'pdfgear' (2.1.15).
Running uninstaller script... Done.
Removing shim 'pdfeditor.shim'.
Removing shim 'pdfeditor.exe'.
Removing shim 'PDFLauncher.shim'.
Removing shim 'PDFLauncher.exe'.
Removing shim 'pdfconverter.shim'.
Removing shim 'pdfconverter.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\PDFgear.lnk
Unlinking D:\Software\Scoop\Local\apps\pdfgear\current
Removing persisted data.
'pdfgear' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)