### PR TITLE
jackett: Relocate process termination logic to uninstaller script

### DIFF
--- a/bucket/jackett.json
+++ b/bucket/jackett.json
@@ -2,21 +2,27 @@
     "version": "0.24.1779",
     "description": "API Support for your favorite torrent trackers",
     "homepage": "https://github.com/Jackett/Jackett",
-    "license": "GPL-2.0-or-later",
+    "license": {
+        "identifier": "GPL-2.0-or-later",
+        "url": "https://github.com/Jackett/Jackett/blob/HEAD/LICENSE"
+    },
     "url": "https://github.com/Jackett/Jackett/releases/download/v0.24.1779/Jackett.Binaries.Windows.zip",
     "hash": "d827869ece5a92e755838d7842da05bfd241a3b4a9f9b8748d1458db617705af",
     "extract_dir": "Jackett",
-    "pre_uninstall": [
-        "'JacketTray', 'JacketConsole', 'JacketService' | ForEach-Object {",
-        "    Stop-Process -Name $_ -ErrorAction SilentlyContinue",
-        "}"
-    ],
     "shortcuts": [
         [
             "JackettTray.exe",
             "Jackett"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "'JackettTray', 'JackettConsole', 'JackettService' | ForEach-Object {",
+            "    Stop-Process -Name $_ -Force -ErrorAction SilentlyContinue",
+            "}",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Jackett/Jackett/releases/download/v$version/Jackett.Binaries.Windows.zip"


### PR DESCRIPTION
### Summary

Refactors the `license` field for better metadata accuracy and migrates the process cleanup logic to a dedicated `uninstaller` script with enhanced reliability.

### Related issues or pull requests

- Relates to #17051 

### Changes

- Improve `license` field by using a structured object with `identifier` and `url`
- Migrate `pre_uninstall` logic to `uninstaller` script

### Notes

- The program names in the pre_uninstall script are incorrect, moving them to the uninstaller script would not have any effect either.

https://github.com/ScoopInstaller/Extras/blob/bf68502ccb9f09970cc01f3f1b3ba61808906af4/bucket/jackett.json#L9-L13

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)