### PR TITLE
velocity: Add version 0.4.0

### DIFF
--- a/bucket/velocity.json
+++ b/bucket/velocity.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.4.0",
+    "description": "Windows 11 push-to-talk dictation using Deepgram Voice AI.",
+    "homepage": "https://github.com/deepgram-devs/deepgram-demos-rust/tree/main/velocity",
+    "license": "ISC",
+    "notes": "Velocity runs from the system tray. On first launch, open the settings window to save your Deepgram API key.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/deepgram-devs/deepgram-demos-rust/releases/download/velocity-v0.4.0/velocity-0.4.0-windows-x64.zip",
+            "hash": "025c5e3ee686c8e6a6d68e253c50e250884e4a3a56091f860cdfccdbc51b0270"
+        }
+    },
+    "bin": "velocity.exe",
+    "shortcuts": [
+        [
+            "velocity.exe",
+            "Velocity",
+            "",
+            "deepgram-icon.ico"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/deepgram-devs/deepgram-demos-rust/releases",
+        "regex": "velocity-v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/deepgram-devs/deepgram-demos-rust/releases/download/velocity-v$version/velocity-$version-windows-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Velocity 0.4.0 to the Extras bucket. Closes #17678. Homepage: https://github.com/deepgram-devs/deepgram-demos-rust/tree/main/velocity. Release: https://github.com/deepgram-devs/deepgram-demos-rust/releases/tag/velocity-v0.4.0. Validation completed: manifest JSON parse succeeded; bin/checkver.ps1 velocity returned 0.4.0; bin/checkurls.ps1 velocity reported 1 okay and 0 failed; downloaded GitHub release ZIP hash matched the manifest hash 025c5e3ee686c8e6a6d68e253c50e250884e4a3a56091f860cdfccdbc51b0270; ZIP includes deepgram-icon.ico for the Start Menu shortcut.