### PR TITLE
subloader: Add version 1.7.0

### DIFF
--- a/bucket/subloader.json
+++ b/bucket/subloader.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.7.0",
+    "description": "Subloader enables you to quickly find and download subtitles for your video files using OpenSubtitles API.",
+    "homepage": "https://github.com/Valyreon/Subloader",
+    "license": "MIT-Modern-Variant",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Valyreon/Subloader/releases/download/v1.7.0/scoop.zip",
+            "hash": "a0ad188706b219d26992557d861c9ae7ed8b5c6499b6d12aa6f0c4b425e854f4"
+        }
+    },
+    "post_install": "powershell -NoProfile -Command \"& '$dir\\add_to_openwith_menu.ps1'\"",
+    "bin": "subloader-cli.exe",
+    "shortcuts": [
+        [
+            "subload.exe",
+            "Subloader"
+        ]
+    ],
+    "pre_uninstall": "powershell -NoProfile -Command \"reg.exe import '$dir\\clean_registry.reg'\"",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Valyreon/Subloader/releases/download/v$version/scoop.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/subloader.json
+++ b/bucket/subloader.json
@@ -9,10 +9,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Valyreon/Subloader/releases/download/v1.7.0/scoop.zip",
-            "hash": "a0ad188706b219d26992557d861c9ae7ed8b5c6499b6d12aa6f0c4b425e854f4"
+            "hash": "dcf162b6c1c6d5b20e46a3e69a9eb0ba5a18d040681bc2c11a5cdb71b2eda977"
         }
     },
-    "post_install": "powershell -NoProfile -Command \"& '$dir\\add_to_openwith_menu.ps1'\"",
+    "post_install": ". \"$dir\\create_registry.ps1\"",
     "bin": "subloader-cli.exe",
     "shortcuts": [
         [
@@ -20,7 +20,7 @@
             "Subloader"
         ]
     ],
-    "pre_uninstall": "powershell -NoProfile -Command \"reg.exe import '$dir\\clean_registry.reg'\"",
+    "pre_uninstall": ". \"$dir\\clean_registry.ps1\"",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/subloader.json
+++ b/bucket/subloader.json
@@ -2,7 +2,10 @@
     "version": "1.7.0",
     "description": "Subloader enables you to quickly find and download subtitles for your video files using OpenSubtitles API.",
     "homepage": "https://github.com/Valyreon/Subloader",
-    "license": "MIT-Modern-Variant",
+    "license": "MIT",
+    "suggest": {
+        ".NET 10 Runtime": "dotnet/runtime"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/Valyreon/Subloader/releases/download/v1.7.0/scoop.zip",

--- a/bucket/subloader.json
+++ b/bucket/subloader.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/Valyreon/Subloader",
     "license": "MIT",
     "suggest": {
-        ".NET 10 Runtime": "dotnet/runtime"
+        ".NET Desktop Runtime 10.0": "versions/windowsdesktop-runtime-10.0"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
# Subloader v1.7.0

Closes #17681 

Hi, would like to contribute to Scoop package manager and add my app for downloading subtitles.
Project page: [Subloader GitHub](https://github.com/Valyreon/Subloader)

I have been maintaining this app since 2018. It has more than 100 stars and regular users, here are the stats:
<img width="980" height="851" alt="image" src="https://github.com/user-attachments/assets/ccbd4c5b-4bbe-474d-a0ab-de797f1c523f" />
Upper graph shows number of subtitles downloaded per day and lower graph the number of users that login to Opensubtitles API using the app every day, although anonymous usage is also possible.

The app has both GUI and CLI version. CLI version enables you to search and batch download subtitles for entire directories. All functionalities you can find described on the project page and wiki.

Post-install script adds associations to mkv, mp4 and avi files and adds a "Find subtitles" context menu to those files. 
Pre-uninstall script removed these associations. Configs are stored in %appdata%.

I have actually maintained a scoop app manifest in my repository for quite some time and was using it but would like to add it to a scoop bucket because I use scoop regularly, and it will be more accesible.

---
### Install Test
<img width="1046" height="230" alt="image" src="https://github.com/user-attachments/assets/e73d1064-a384-45ee-8b1e-717a718681ab" />

### Uninstall Test
<img width="840" height="134" alt="image" src="https://github.com/user-attachments/assets/0dbcf5f1-62fd-43e1-8fb1-1fd699b51ff7" />

### Checkver Test
<img width="1018" height="120" alt="image" src="https://github.com/user-attachments/assets/79ea116e-9d38-4068-b90b-fc4ed465f5bf" />


---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
