### PR TITLE
grepwin: Fix portability

### DIFF
--- a/bucket/grepwin.json
+++ b/bucket/grepwin.json
@@ -3,7 +3,7 @@
     "description": "Regular expression search and replace tool for Windows.",
     "homepage": "https://tools.stefankueng.com/grepWin.html",
     "license": "GPL-3.0-only",
-    "notes": "Run '$dir\\install-context.reg' to add grepWin to right-click context menu.",
+    "notes": "Execute reg import '$dir\\install-context.reg' to add grepWin to right-click context menu.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/stefankueng/grepWin/releases/download/2.1.12/grepWin-x64-2.1.12_portable.zip",
@@ -31,14 +31,20 @@
         "        }",
         "    }",
         "    $content | Set-Content -Path \"$dir\\$_\" -Encoding ascii",
-        "}"
+        "}",
+        "",
+        "Rename-Item \"$dir\\grepWin.exe\" -NewName 'grepWin_portable.exe' -ErrorAction Ignore"
     ],
-    "bin": "grepWin.exe",
+    "bin": [
+        [
+            "grepWin_portable.exe",
+            "grepWin"
+        ]
+    ],
     "shortcuts": [
         [
-            "grepWin.exe",
-            "grepWin",
-            "/portable"
+            "grepWin_portable.exe",
+            "grepWin"
         ]
     ],
     "persist": "grepwin.ini",

--- a/bucket/grepwin.json
+++ b/bucket/grepwin.json
@@ -15,15 +15,13 @@
         }
     },
     "pre_install": [
-        "Get-ChildItem \"$dir\\grepWin*.exe\" | Rename-Item -NewName 'grepWin.exe'",
+        "Get-ChildItem \"$dir\\grepWin*.exe\" | Rename-Item -NewName 'grepWin_portable.exe'",
         "if (-not (Test-Path \"$persist_dir\\grepwin.ini\")) {",
         "    Set-Content \"$dir\\grepwin.ini\" (@('[global]', '[Software\\grepWin\\History]') -join \"`r`n\") -Encoding ASCII",
-        "}",
-        "",
-        "Rename-Item \"$dir\\grepWin.exe\" -NewName 'grepWin_portable.exe' -ErrorAction Ignore"
+        "}"
     ],
     "post_install": [
-        "$app_path = \"$dir\\grepWin.exe\".Replace('\\', '\\\\')",
+        "$app_path = \"$dir\\grepWin_portable.exe\".Replace('\\', '\\\\')",
         "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\extras\\scripts\\grepwin\\$_\") {",
         "        $content = Get-Content \"$bucketsdir\\extras\\scripts\\grepwin\\$_\"",

--- a/bucket/grepwin.json
+++ b/bucket/grepwin.json
@@ -3,7 +3,7 @@
     "description": "Regular expression search and replace tool for Windows.",
     "homepage": "https://tools.stefankueng.com/grepWin.html",
     "license": "GPL-3.0-only",
-    "notes": "Execute reg import '$dir\\install-context.reg' to add grepWin to right-click context menu.",
+    "notes": "Execute \"reg import '$dir\\install-context.reg'\" to add grepWin to right-click context menu.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/stefankueng/grepWin/releases/download/2.1.12/grepWin-x64-2.1.12_portable.zip",
@@ -18,7 +18,9 @@
         "Get-ChildItem \"$dir\\grepWin*.exe\" | Rename-Item -NewName 'grepWin.exe'",
         "if (-not (Test-Path \"$persist_dir\\grepwin.ini\")) {",
         "    Set-Content \"$dir\\grepwin.ini\" (@('[global]', '[Software\\grepWin\\History]') -join \"`r`n\") -Encoding ASCII",
-        "}"
+        "}",
+        "",
+        "Rename-Item \"$dir\\grepWin.exe\" -NewName 'grepWin_portable.exe' -ErrorAction Ignore"
     ],
     "post_install": [
         "$app_path = \"$dir\\grepWin.exe\".Replace('\\', '\\\\')",
@@ -31,9 +33,7 @@
         "        }",
         "    }",
         "    $content | Set-Content -Path \"$dir\\$_\" -Encoding ascii",
-        "}",
-        "",
-        "Rename-Item \"$dir\\grepWin.exe\" -NewName 'grepWin_portable.exe' -ErrorAction Ignore"
+        "}"
     ],
     "bin": [
         [

--- a/bucket/grepwin.json
+++ b/bucket/grepwin.json
@@ -24,6 +24,7 @@
         "}"
     ],
     "post_install": [
+        "# keep the 'portable' suffix to ensure it runs in portable mode.",
         "$app_path = \"$dir\\grepWin_portable.exe\".Replace('\\', '\\\\')",
         "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\extras\\scripts\\grepwin\\$_\") {",
@@ -34,6 +35,17 @@
         "        }",
         "    }",
         "    $content | Set-Content -Path \"$dir\\$_\" -Encoding ascii",
+        "}",
+        "# Workaround for https://github.com/ScoopInstaller/Extras/pull/17697 (Remove this workaround after 2027-01-01)",
+        "if ($cmd -eq 'update') {",
+        "    $regPath = 'HKCU:\\Software\\Classes\\*\\shell\\grepWin\\command'",
+        "    if ($global) {",
+        "        $regPath = $regPath -replace '^HKCU', 'HKLM'",
+        "    }",
+        "    $regValue = Get-ItemProperty -LiteralPath $regPath -ErrorAction Ignore",
+        "    if ($regValue -and $regValue.'(default)' -match \"^$([regex]::Escape($(appdir $app $global)))\") {",
+        "        reg import \"$dir\\install-context.reg\" *> $null",
+        "    }",
         "}"
     ],
     "bin": [
@@ -49,7 +61,7 @@
         ]
     ],
     "persist": "grepwin.ini",
-    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
+    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" *> $null }",
     "checkver": {
         "github": "https://github.com/stefankueng/grepWin"
     },

--- a/bucket/grepwin.json
+++ b/bucket/grepwin.json
@@ -3,7 +3,10 @@
     "description": "Regular expression search and replace tool for Windows.",
     "homepage": "https://tools.stefankueng.com/grepWin.html",
     "license": "GPL-3.0-only",
-    "notes": "Execute \"reg import '$dir\\install-context.reg'\" to add grepWin to right-click context menu.",
+    "notes": [
+        "To add grepWin to right-click context menu, run:",
+        "reg import \"$dir\\install-context.reg\""
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/stefankueng/grepWin/releases/download/2.1.12/grepWin-x64-2.1.12_portable.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
To properly handle portability, by renaming the executable to `grepWin_portable.exe`, the alternative solution would have been to add the argument to the “script” registry key, but that would not have covered the case where the executable is launched directly
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #17696 
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
