### PR TITLE
aegisub: Persist `config.json`

### DIFF
--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -2,7 +2,13 @@
     "version": "3.4.2",
     "description": "Cross-platform advanced subtitle editor",
     "homepage": "https://www.aegisub.org/",
-    "license": "https://github.com/TypesettingTools/Aegisub/blob/master/LICENCE",
+    "license": {
+        "identifier": "BSD-3-Clause,MIT,BSDL,MPL-1.1",
+        "url": "https://github.com/TypesettingTools/Aegisub/blob/master/LICENCE"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/TypesettingTools/Aegisub/releases/download/v3.4.2/Aegisub-3.4.2-portable.zip",
@@ -10,7 +16,14 @@
         }
     },
     "extract_dir": "aegisub-portable",
-    "pre_install": "Copy-Item \"$persist_dir\\config.json\" \"$dir\" -ErrorAction SilentlyContinue",
+    "pre_install": [
+        "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
+        "'config.json' | ForEach-Object {",
+        "    if (Test-Path -LiteralPath \"$persist_dir\\$_\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination \"$dir\\$_\" -Force",
+        "    }",
+        "}"
+    ],
     "shortcuts": [
         [
             "aegisub.exe",
@@ -25,8 +38,12 @@
     ],
     "pre_uninstall": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "ensure \"$persist_dir\" | Out-Null",
-        "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction SilentlyContinue"
+        "'config.json' | ForEach-Object {",
+        "    if (Test-Path -LiteralPath \"$dir\\$_\" -PathType Leaf) {",
+        "        ensure $persist_dir | Out-Null",
+        "        Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\$_\" -Force",
+        "    }",
+        "}"
     ],
     "checkver": {
         "github": "https://github.com/TypesettingTools/Aegisub"

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -10,6 +10,7 @@
         }
     },
     "extract_dir": "aegisub-portable",
+    "pre_install": "Copy-Item \"$persist_dir\\config.json\" \"$dir\" -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "aegisub.exe",
@@ -20,8 +21,12 @@
         "autoback",
         "autosave",
         "catalog",
-        "config",
-        "config.json"
+        "config"
+    ],
+    "pre_uninstall": [
+        "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
+        "ensure \"$persist_dir\" | Out-Null",
+        "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction SilentlyContinue"
     ],
     "checkver": {
         "github": "https://github.com/TypesettingTools/Aegisub"

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -20,7 +20,8 @@
         "autoback",
         "autosave",
         "catalog",
-        "config"
+        "config",
+        "config.json"
     ],
     "checkver": {
         "github": "https://github.com/TypesettingTools/Aegisub"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
# Summary
Aegisub uses config.json to store misc settings. The manifest needs to persist this for most settings to carry over versions. We do not need to create the file ourselves as the portable zip comes with a pre-configured config.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
