### PR TITLE
grepwin: Fix typo in context menu

### DIFF
--- a/scripts/grepwin/install-context.reg
+++ b/scripts/grepwin/install-context.reg
@@ -1,7 +1,7 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Classes\*\shell\grepWin]
-@="search with grepWin"
+@="Search with grepWin"
 "Icon"="$app_path,-107"
 
 [HKEY_CURRENT_USER\Software\Classes\*\shell\grepWin\command]
@@ -9,14 +9,14 @@ Windows Registry Editor Version 5.00
 
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\shell\grepWin]
-@="search with grepWin"
+@="Search with grepWin"
 "Icon"="$app_path,-107"
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\shell\grepWin\command]
 @="$app_path /searchpath:\"%1\""
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\grepWin]
-@="search with grepWin"
+@="Search with grepWin"
 "Icon"="$app_path,-107"
 
 ; %v – For verbs that are none implies all. If there is no parameter passed this is the working directory.
@@ -24,21 +24,21 @@ Windows Registry Editor Version 5.00
 @="$app_path /searchpath:\"%V\""
 
 [HKEY_CURRENT_USER\Software\Classes\Drive\shell\grepWin]
-@="search with grepWin"
+@="Search with grepWin"
 "Icon"="$app_path,-107"
 
 [HKEY_CURRENT_USER\Software\Classes\Drive\shell\grepWin\command]
 @="$app_path /searchpath:\"%1\""
 
 [HKEY_CURRENT_USER\Software\Classes\Folder\shell\grepWin]
-@="search with grepWin"
+@="Search with grepWin"
 "Icon"="$app_path,-107"
 
 [HKEY_CURRENT_USER\Software\Classes\Folder\shell\grepWin\command]
 @="$app_path /searchpath:\"%1\""
 
 [HKEY_CURRENT_USER\Software\Classes\LibraryFolder\Background\shell\grepWin]
-@="search with grepWin"
+@="Search with grepWin"
 "Icon"="$app_path,-107"
 
 [HKEY_CURRENT_USER\Software\Classes\LibraryFolder\Background\shell\grepWin\command]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixed a typo in the “reg” script used by the grepwin manifest to add entries to the context menu
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Relates to #17697
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
