### PR TITLE
aix: Add version 1.0.4

### DIFF
--- a/bucket/aix.json
+++ b/bucket/aix.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0.4",
+    "description": "CLI to switch Anthropic-compatible API providers and tokens for Claude Code",
+    "homepage": "https://github.com/h4ck4life/aix-go",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/h4ck4life/aix-go/releases/download/v1.0.4/aix_1.0.4_windows_amd64.zip",
+            "hash": "c58022a46b532334ae4b317fbaf34605e34bf39e8192b66086ddca9192bf1f4a"
+        },
+        "arm64": {
+            "url": "https://github.com/h4ck4life/aix-go/releases/download/v1.0.4/aix_1.0.4_windows_arm64.zip",
+            "hash": "7df2d82a23d6499e66a5fd36f4c9b14db6cb768b05a494f6bb9b61805da86d38"
+        }
+    },
+    "bin": "aix.exe",
+    "checkver": {
+        "github": "https://github.com/h4ck4life/aix-go"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/h4ck4life/aix-go/releases/download/v$version/aix_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/h4ck4life/aix-go/releases/download/v$version/aix_$version_windows_arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [aix](https://github.com/h4ck4life/aix-go), a CLI tool for switching between Anthropic-compatible API providers and tokens for Claude Code.