### PR TITLE
aegisub-arch1t3cht: Update to version 02-01, fix checkver & autoupdate

### DIFF
--- a/bucket/aegisub-arch1t3cht.json
+++ b/bucket/aegisub-arch1t3cht.json
@@ -1,5 +1,5 @@
 {
-    "version": "12",
+    "version": "02-01",
     "description": "Cross-platform advanced subtitle editor, with new feature branches. Read the README on the feature branch.",
     "homepage": "https://github.com/arch1t3cht/Aegisub",
     "license": {
@@ -11,8 +11,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/arch1t3cht/Aegisub/releases/download/feature_12/Windows.MSVC.Release.wx.master.-.portable.zip",
-            "hash": "0d242ae0333f1e9aa9ff734274d06d22fe4b4763717255c6b78af1af109672ef"
+            "url": "https://github.com/arch1t3cht/Aegisub/releases/download/migration02-01/Windows.MSVC.Release.-.portable.zip",
+            "hash": "f1855e1476daa6b10364791afb79cdcc941f66279e66df642c4aa68641b00744"
         }
     },
     "pre_install": [
@@ -43,17 +43,18 @@
     "persist": [
         "autoback",
         "autosave",
+        "catalog",
         "config"
     ],
     "checkver": {
-        "github": "https://github.com/arch1t3cht/Aegisub",
+        "url": "https://api.github.com/repos/arch1t3cht/Aegisub/releases/latest",
         "jsonpath": "$.tag_name",
-        "regex": "^feature_([0-9]+)$"
+        "regex": "^migration([0-9]+-[0-9]+)$"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/arch1t3cht/Aegisub/releases/download/feature_$version/Windows.MSVC.Release.wx.master.-.portable.zip"
+                "url": "https://github.com/arch1t3cht/Aegisub/releases/download/migration$version/Windows.MSVC.Release.-.portable.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
# Summary
The aegisub-arch1t3cht fork has switched to a new version format (migration releases) which are currently being used to migrate users to upstream. This PR fixes the checkver so these new releases are properly caught. Additionally, it applies the same fix as #17576 to persist the catalog folder.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
-->
Relates to #17576

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
