### PR TITLE
perry: Add version 0.5.386

### DIFF
--- a/bucket/perry.json
+++ b/bucket/perry.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.5.345",
+    "version": "0.5.386",
     "description": "Native TypeScript compiler — compiles .ts directly to native executables via LLVM.",
     "homepage": "https://github.com/PerryTS/perry",
     "license": "MIT",
@@ -15,8 +15,8 @@
     "depends": "main/llvm",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PerryTS/perry/releases/download/v0.5.345/perry-windows-x86_64.zip",
-            "hash": "f2dd12e3aa32e80df782422d8e8858f0be1fc9b44bd27f780bf4e908fe6dc20e"
+            "url": "https://github.com/PerryTS/perry/releases/download/v0.5.386/perry-windows-x86_64.zip",
+            "hash": "8c833333ac5ee4279087b6fda1e1b3b01386da0cfe7d61467d3cb27147d284f4"
         }
     },
     "bin": "perry.exe",

--- a/bucket/perry.json
+++ b/bucket/perry.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.5.345",
+    "description": "Native TypeScript compiler — compiles .ts directly to native executables via LLVM.",
+    "homepage": "https://github.com/PerryTS/perry",
+    "license": "MIT",
+    "notes": [
+        "Perry shells out to clang for the IR -> object step. The 'main/llvm'",
+        "dependency installs the official MSVC-default LLVM, which Perry needs",
+        "for Windows-native object emission. If you have multiple clangs on PATH,",
+        "set PERRY_LLVM_CLANG to the full path of an MSVC-default clang.exe.",
+        "",
+        "Verify with: perry doctor",
+        "First compile: perry compile hello.ts -o hello.exe"
+    ],
+    "depends": "main/llvm",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PerryTS/perry/releases/download/v0.5.345/perry-windows-x86_64.zip",
+            "hash": "f2dd12e3aa32e80df782422d8e8858f0be1fc9b44bd27f780bf4e908fe6dc20e"
+        }
+    },
+    "bin": "perry.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PerryTS/perry/releases/download/v$version/perry-windows-x86_64.zip",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes ScoopInstaller/Main#7908

Adds a Scoop manifest for [Perry](https://github.com/PerryTS/perry) — native TypeScript compiler that compiles `.ts` directly to native executables via LLVM. MIT, 1924 ★, 354 patch releases since 2026-01-19.

Maintainer @z-Fng greenlit the request in ScoopInstaller/Main#7908 ("Feel free to make a PR for this.").

### Manifest highlights

- `depends: "main/llvm"` — Perry shells out to clang for IR→object emission. Pulling the official MSVC-default LLVM as a hard dep means the install works end-to-end out of the box; without it, users with MinGW-flavored clang on PATH hit a `LNK2019: __main` link error (a class of bug we just patched upstream in v0.5.353, but the dep makes it impossible to hit at all).
- `checkver: "github"` — uses the standard shortcut.
- `autoupdate.architecture.64bit.hash.url: "$url.sha256"` — the Perry release workflow now uploads `.sha256` sidecars next to every archive, so future bumps resolve hashes by URL with no manual intervention or full-archive re-download.
- `extract_dir` omitted — the release zip is flat (perry.exe + 3 .lib files + xwin.exe at root).

### Verified end-to-end

Tested locally on Windows 11 x64:

```
> scoop install <fork>/perry
... pulls 7zip + LLVM 22.1.4 + perry-windows-x86_64.zip (111 MB)
... hash check passes
... shim created at ~/scoop/shims/perry.exe
> perry --version
perry 0.5.345
> perry doctor
[OK] perry version: 0.5.345
[OK] clang (LLVM codegen): clang version 22.1.3
[OK] runtime library: ~/scoop/apps/perry/current/perry_runtime.lib
> perry compile smoke.ts -o smoke.exe && ./smoke.exe
hello from scoop-installed perry
> scoop uninstall perry
... cleanly removes shim + install dir
```

Same manifest is also live in Perry's own bucket at https://github.com/PerryTS/perry/tree/main/bucket as `perry-ts/perry`.

---

- [x] Use conventional PR title: `perry: Add version 0.5.345`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
