### PR TITLE
tutanota: Add note about TLS 1.3 workaround

### DIFF
--- a/bucket/tutanota.json
+++ b/bucket/tutanota.json
@@ -17,7 +17,7 @@
             "Tuta Mail"
         ]
     ],
-    "notes": "If download fails with TLS 1.3 error on Windows 10, install aria2-openssl and configure: `scoop install aria2-openssl; scoop config aria2-path \"$env:USERPROFILE\\scoop\\apps\\aria2-openssl\\current\\aria2c.exe\"`",
+    "notes": "If download fails with SSL/TLS error on Windows 10, retry without aria2: `scoop install tutanota -a`. An OpenSSL-linked aria2 build is also being prepared in the Versions bucket for future use.",
     "checkver": {
         "url": "https://github.com/tutao/tutanota/tags",
         "regex": "tutanota-desktop-release-([\\d.]+)"

--- a/bucket/tutanota.json
+++ b/bucket/tutanota.json
@@ -17,6 +17,7 @@
             "Tuta Mail"
         ]
     ],
+    "notes": "If download fails with TLS 1.3 error on Windows 10, install aria2-openssl and configure: `scoop install aria2-openssl; scoop config aria2-path \"$env:USERPROFILE\\scoop\\apps\\aria2-openssl\\current\\aria2c.exe\"`",
     "checkver": {
         "url": "https://github.com/tutao/tutanota/tags",
         "regex": "tutanota-desktop-release-([\\d.]+)"


### PR DESCRIPTION
## Summary
Add a note to the `tutanota` manifest explaining the TLS 1.3 download issue on older Windows systems and an immediate workaround that works today.

## Details
Tuta download endpoints require TLS 1.3. On Windows 10 and some older Windows Server versions, the default `aria2` setup can fail when using Schannel.

This note points users to the immediate workaround that already works:

```powershell
scoop install tutanota -a
```

Relates to ScoopInstaller/Extras#17010.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
