### PR TITLE
yacreader: Update to version 10.0.0.260501214, Fix `autoupdate`

### DIFF
--- a/bucket/yacreader.json
+++ b/bucket/yacreader.json
@@ -1,16 +1,16 @@
 {
-    "version": "9.16.3.26010361",
+    "version": "10.0.0.260501214",
     "description": "A comic reader and manager",
     "homepage": "https://www.yacreader.com",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/YACReader/yacreader/releases/download/9.16.3/YACReader-v9.16.3.26010361-winx64-7z.exe",
-            "hash": "e1c70d35ff1cffd17c67a1fab162176d1fb705accbdc5be549072fd03b0ab976"
+            "url": "https://github.com/YACReader/yacreader/releases/download/10.0.0/YACReader-v10.0.0.260501214-winx64-7z-qt6.exe",
+            "hash": "945b57496bb436c27b0ae017aa72c4aab006c0af94931f029603f9d3798df4da"
         },
-        "32bit": {
-            "url": "https://github.com/YACReader/yacreader/releases/download/9.16.3/YACReader-v9.16.3.26010361-winx86-7z.exe",
-            "hash": "36d7026cfd94184ecae214aafcdabe273073be9fa49a478b3465a5e86806b153"
+        "arm64": {
+            "url": "https://github.com/YACReader/yacreader/releases/download/10.0.0/YACReader-v10.0.0.260501214-winarm64-7z-qt6.exe",
+            "hash": "7a75fbcc5bad4ded8891ea12410785a0b6f0781a302800d09e75064bc8aee692"
         }
     },
     "innosetup": true,
@@ -30,16 +30,17 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/YACReader/yacreader",
-        "regex": "YACReader-v([\\d.]+)-winx86-7z"
+        "url": "https://api.github.com/repos/YACReader/yacreader/releases/latest",
+        "jsonpath": "$..browser_download_url",
+        "regex": "YACReader-v([\\d.]+)-winx64-7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/YACReader/yacreader/releases/download/$matchHead/YACReader-v$version-winx64-7z.exe"
+                "url": "https://github.com/YACReader/yacreader/releases/download/$matchHead/YACReader-v$version-winx64-7z-qt6.exe"
             },
-            "32bit": {
-                "url": "https://github.com/YACReader/yacreader/releases/download/$matchHead/YACReader-v$version-winx86-7z.exe"
+            "arm64": {
+                "url": "https://github.com/YACReader/yacreader/releases/download/$matchHead/YACReader-v$version-winarm64-7z-qt6.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Qt5 builds are dropped in 10.0.0
- Remove 32bit arch, add arm64

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
