### PR TITLE
audmes@2025.04.05: Fix download & autoupdate URLs

### DIFF
--- a/bucket/audmes.json
+++ b/bucket/audmes.json
@@ -20,6 +20,6 @@
         "regex": "(?<pathVersion>[\\d-]+)/AudMeS-(?<version>[\\d.]+)-win32\\.zip"
     },
     "autoupdate": {
-        "url": "https://sourceforge.net/projects/audmes/files/audmes-win32%20binary/$matchPathversion/AudMeS-$version-win32.zip/download"
+        "url": "https://sourceforge.net/projects/audmes/files/audmes-win32%20binary/$matchPathVersion/AudMeS-$version-win32.zip/download"
     }
 }

--- a/bucket/audmes.json
+++ b/bucket/audmes.json
@@ -3,7 +3,7 @@
     "description": "AUDio MEasurement System - PC based Oscilloscope and Spectrum analyzer using sound card",
     "homepage": "https://sourceforge.net/projects/audmes/",
     "license": "GPL-2.0-or-later",
-    "url": "https://downloads.sourceforge.net/projects/audmes/files/audmes-win32%20binary/2025-04-05/AudMeS-2025.04.05-win32.zip",
+    "url": "https://sourceforge.net/projects/audmes/files/audmes-win32%20binary/2025-04-05/AudMeS-2025.04.05-win32.zip/download",
     "hash": "sha1:c8ae2bf82c744a21174241abaf0189fd5e83ecbd",
     "pre_install": [
         "Move-Item \"$dir\\AudMeS-*-win32\\*\" \"$dir\\\" | Out-Null",
@@ -20,6 +20,6 @@
         "regex": "(?<pathVersion>[\\d-]+)/AudMeS-(?<version>[\\d.]+)-win32\\.zip"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/projects/audmes/files/audmes-win32%20binary/$matchPathversion/AudMeS-$version-win32.zip"
+        "url": "https://sourceforge.net/projects/audmes/files/audmes-win32%20binary/$matchPathversion/AudMeS-$version-win32.zip/download"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR fixes the installer url of audmes
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
