### PR TITLE
beebeep@5.8.6: Fix download & autoupdate URLs

### DIFF
--- a/bucket/beebeep.json
+++ b/bucket/beebeep.json
@@ -6,7 +6,7 @@
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
-    "url": "https://sourceforge.net/project/beebeep/Windows/beebeep-5.8.6-32bit-portable.zip",
+    "url": "https://sourceforge.net/projects/beebeep/files/Windows/beebeep-5.8.6-32bit-portable.zip/download",
     "hash": "sha1:545d8a1024d3081c59fd14d8401cf23198f79b4e",
     "extract_dir": "beebeep-5.8.6-32bit-portable",
     "shortcuts": [
@@ -20,7 +20,7 @@
         "regex": "beebeep-([\\d.]+)-32bit-portable"
     },
     "autoupdate": {
-        "url": "https://sourceforge.net/project/beebeep/Windows/beebeep-$version-32bit-portable.zip",
+        "url": "https://sourceforge.net/projects/beebeep/files/Windows/beebeep-$version-32bit-portable.zip/download",
         "extract_dir": "beebeep-$version-32bit-portable"
     }
 }


### PR DESCRIPTION
This PR fixes the installer url of Beebeep

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
