### PR TITLE
cdburnerxp@4.5.8.7128: Switch to sourceforge

### DIFF
--- a/bucket/cdburnerxp.json
+++ b/bucket/cdburnerxp.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.fosshub.com/CDBurnerXP.html/CDBurnerXP-x64-4.5.8.7128.zip",
+            "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-x64-4.5.8.7128.zip/download",
             "hash": "9d45a76026b3d1dff9397fcda2dd81c60af8a2d105103f6e021a581e9b492d8f"
         },
         "32bit": {
-            "url": "https://www.fosshub.com/CDBurnerXP.html/CDBurnerXP-4.5.8.7128.zip",
+            "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-4.5.8.7128.zip/download",
             "hash": "c3759753ba9301d3b48bf4823c146b41ca6eb103bcab2f7cd943bee85e624647"
         }
     },
@@ -38,16 +38,16 @@
         "UserSettings.ini"
     ],
     "checkver": {
-        "url": "https://www.fosshub.com/CDBurnerXP.html",
-        "regex": "\"softwareVersion\">([\\d.]+)<"
+        "sourceforge": "cdburnerxp",
+        "regex": "CDBurnerXP-x64-([\\d.]+).zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.fosshub.com/CDBurnerXP.html/CDBurnerXP-x64-$version.zip"
+                "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-x64-$version.zip/download"
             },
             "32bit": {
-                "url": "https://www.fosshub.com/CDBurnerXP.html/CDBurnerXP-$version.zip"
+                "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-$version.zip/download"
             }
         }
     }

--- a/bucket/cdburnerxp.json
+++ b/bucket/cdburnerxp.json
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-x64-4.5.8.7128.zip/download",
-            "hash": "9d45a76026b3d1dff9397fcda2dd81c60af8a2d105103f6e021a581e9b492d8f"
+            "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-x64-4.5.8.7128.zip",
+            "hash": "sha1:43c1acec3d891fc24dbc841202e7cc00ffcc9769"
         },
         "32bit": {
-            "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-4.5.8.7128.zip/download",
-            "hash": "c3759753ba9301d3b48bf4823c146b41ca6eb103bcab2f7cd943bee85e624647"
+            "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-4.5.8.7128.zip",
+            "hash": "sha1:1e1acd637eee12b238cfb496dbbe92cb06708488"
         }
     },
     "pre_install": [
@@ -44,10 +44,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-x64-$version.zip/download"
+                "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-x64-$version.zip"
             },
             "32bit": {
-                "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-$version.zip/download"
+                "url": "https://sourceforge.net/projects/cdburnerxp/files/CDBurnerXP-$version.zip"
             }
         }
     }

--- a/bucket/cdburnerxp.json
+++ b/bucket/cdburnerxp.json
@@ -39,7 +39,7 @@
     ],
     "checkver": {
         "sourceforge": "cdburnerxp",
-        "regex": "CDBurnerXP-x64-([\\d.]+).zip"
+        "regex": "CDBurnerXP-x64-([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This PR fixes the cdburnderxp installer URL and checkver script.

Why I did these changes is because of the installer url not working by using the checkurls script it shows that this manifest installer url is unreachable.

Test: 
<img width="1089" height="362" alt="image" src="https://github.com/user-attachments/assets/42a28fad-e4e5-435a-8fe3-9e7e2e4da455" />

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
