### PR TITLE
soulseekqt: Update to version 2026.4.30, drop 32bit support

### DIFF
--- a/bucket/soulseekqt.json
+++ b/bucket/soulseekqt.json
@@ -1,5 +1,5 @@
 {
-    "version": "2024.6.30",
+    "version": "2026.4.30",
     "description": "File sharing network.",
     "homepage": "https://www.slsknet.org/news/",
     "license": {
@@ -8,12 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30-64bit.exe",
-            "hash": "b2db0e41afe444ad597045d06df4d4672fa6cf2be8ce3474cd61e8118f3cd4d6"
-        },
-        "32bit": {
-            "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2024-6-30-32bit.exe",
-            "hash": "cce7d17ec1a1f22d973eeabb71aafed98996b56d9ce7b03583d6d0dd2a2a39af"
+            "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2026-4-30-64bit.exe",
+            "hash": "4ba32e37bbd804ee69a88af018c3b9b49dd1bf772b65ad7c268718d0ed93eb29"
         }
     },
     "innosetup": true,
@@ -33,9 +29,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-$dashVersion-64bit.exe"
-            },
-            "32bit": {
-                "url": "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-$dashVersion-32bit.exe"
             }
         }
     }


### PR DESCRIPTION
### Summary

Update `soulseekqt` to version **2026.4.30** and drop 32bit support.

### Changes

- Update version to **2026.4.30**
- Remove `32bit` architecture support from both the main manifest and `autoupdate` blocks
- Update `64bit` download URL and SHA256 hash
- Refine `autoupdate` configuration to reflect the architecture change

### Notes

- The upstream vendor appears to [have discontinued providing a 32-bit version for this release](https://www.slsknet.org/news/node/1). Unfortunately, I was unable to find any related information on the project's homepage or forum.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ soulseekqt ≢]
└─> .\bin\checkver.ps1 -App '.\bucket\soulseekqt.json' -f
soulseekqt: 2026.4.30 (scoop version is 2026.4.30)
Forcing autoupdate!
Autoupdating soulseekqt
DEBUG[1777720930] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1777720930] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1777720930] $substitutions.$matchTail                     
DEBUG[1777720930] $substitutions.$version                       2026.4.30
DEBUG[1777720930] $substitutions.$url                           https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2026-4-30-64bit.exe
DEBUG[1777720930] $substitutions.$basenameNoExt                 SoulseekQt-2026-4-30-64bit
DEBUG[1777720930] $substitutions.$majorVersion                  2026
DEBUG[1777720930] $substitutions.$dotVersion                    2026.4.30
DEBUG[1777720930] $substitutions.$urlNoExt                      https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-2026-4-30-64bit
DEBUG[1777720930] $substitutions.$matchHead                     2026.4.30
DEBUG[1777720930] $substitutions.$underscoreVersion             2026_4_30
DEBUG[1777720930] $substitutions.$match1                        2026
DEBUG[1777720930] $substitutions.$dashVersion                   2026-4-30
DEBUG[1777720930] $substitutions.$minorVersion                  4
DEBUG[1777720930] $substitutions.$preReleaseVersion             2026.4.30
DEBUG[1777720930] $substitutions.$match2                        4
DEBUG[1777720930] $substitutions.$baseurl                       https://f004.backblazeb2.com/file/SoulseekQt
DEBUG[1777720930] $substitutions.$cleanVersion                  2026430
DEBUG[1777720930] $substitutions.$match3                        30
DEBUG[1777720930] $substitutions.$buildVersion                  
DEBUG[1777720930] $substitutions.$basename                      SoulseekQt-2026-4-30-64bit.exe
DEBUG[1777720930] $substitutions.$patchVersion                  30
DEBUG[1777720930] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading SoulseekQt-2026-4-30-64bit.exe to compute hashes!
Loading SoulseekQt-2026-4-30-64bit.exe from cache
Computed hash: 4ba32e37bbd804ee69a88af018c3b9b49dd1bf772b65ad7c268718d0ed93eb29
Writing updated soulseekqt manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ soulseekqt ≢]
└─> scoop install Unofficial/soulseekqt
Installing 'soulseekqt' (2026.4.30) [64bit] from 'Unofficial' bucket
Loading SoulseekQt-2026-4-30-64bit.exe from cache.
Checking hash of SoulseekQt-2026-4-30-64bit.exe... OK.
Extracting SoulseekQt-2026-4-30-64bit.exe... Done.
Linking D:\Software\Scoop\Local\apps\soulseekqt\current => D:\Software\Scoop\Local\apps\soulseekqt\2026.4.30
Creating shim for 'SoulseekQt'.
Making D:\Software\Scoop\Local\shims\soulseekqt.exe a GUI binary.
Creating shortcut for SoulseekQt (SoulseekQt.exe)
'soulseekqt' (2026.4.30) was installed successfully!

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ soulseekqt ≢]
└─> scoop uninstall soulseekqt -p
Uninstalling 'soulseekqt' (2026.4.30).
Removing shim 'SoulseekQt.shim'.
Removing shim 'SoulseekQt.exe'.
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\SoulseekQt.lnk
Unlinking D:\Software\Scoop\Local\apps\soulseekqt\current
Removing persisted data.
'soulseekqt' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)