### PR TITLE
hekasoft-backup-restore: Update to version 1.0.0, fix checkver & autodate

### DIFF
--- a/bucket/hekasoft-backup-restore.json
+++ b/bucket/hekasoft-backup-restore.json
@@ -1,14 +1,26 @@
 {
-    "version": "0.99.1",
+    "version": "1.0.0",
     "description": "Hekasoft Backup & Restore provides a reliable solution for backing up, restoring, and migrating browser profiles. It also allows you to optimize profile data by removing unnecessary files.",
     "homepage": "https://hekasoft.com/hekasoft-backup-restore/",
     "license": {
         "identifier": "Freeware",
         "url": "https://hekasoft.com/eula/"
     },
-    "url": "https://www.fosshub.com/Hekasoft-Backup-Restore.html/backup_restore_0991-portable.zip",
-    "hash": "44af16a0229bc99fc7afa5924a9f219cd1758c6f06112c9957d64c3d8454a6b6",
-    "extract_dir": "backup_restore_0991",
+    "architecture": {
+        "64bit": {
+            "url": "https://hekasoft.com/hbr-portable.zip",
+            "hash": "a91f2ae5af62eb6029118b098d0a90ef4cf055eea4bcab8ede197686ee1766a1"
+        }
+    },
+    "pre_install": [
+        "# Use a script to extract files since the extract_dir changes frequently.",
+        "$items = Get-ChildItem -Path $dir | Select-Object -First 3",
+        "if ($items.Count -eq 1 -and $items.PSIsContainer) {",
+        "    $inner_dir = $items | ForEach-Object -MemberName FullName",
+        "    Move-Item -Path \"$inner_dir\\*\" -Destination $dir -Force",
+        "    Remove-Item -Path $inner_dir -Recurse -Force -ErrorAction SilentlyContinue",
+        "}"
+    ],
     "shortcuts": [
         [
             "hbr.exe",
@@ -16,11 +28,14 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.fosshub.com/Hekasoft-Backup-Restore.html",
-        "regex": "\"softwareVersion\">([\\d.]+)<"
+        "url": "https://hekasoft.com/hekasoft-backup-restore/",
+        "regex": "Current Version.+?([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/Hekasoft-Backup-Restore.html/backup_restore_$cleanVersion-portable.zip",
-        "extract_dir": "backup_restore_$cleanVersion"
+        "architecture": {
+            "64bit": {
+                "url": "https://hekasoft.com/hbr-portable.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
### Summary

Updates `hekasoft-backup-restore` to version **1.0.0**, migrates the download source to the official website, and implements a more robust extraction logic.

### Changes

- Update version to **1.0.0**
- **Source Migration**: Change URL and `checkver` from FossHub to `hekasoft.com`.
- **Architecture Support**: Restructure manifest to use `architecture` block (64bit).
- **Dynamic Extraction**: Add a `pre_install` script to automatically detect and flatten nested subdirectories, replacing the rigid `extract_dir` property.
- **Auto-update**: Update `autoupdate` configuration to align with the new official download URL structure.

### Notes

- Remove the specific `extract_dir` dependency as it frequently changed between minor versions.
- This release is 64-bit.

  ```powershell
  ┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ hekasoft-backup-restore ≡]
  └─> diec "$(scoop prefix hekasoft-backup-restore)\hbr.exe"
  PE64
      Linker: Microsoft Linker
      Compiler: VB.NET
      Library: Newton Json
      Library: .NET Framework(v4.8, CLR v4.0.30319)

  ```


### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ hekasoft-backup-restore ≢  ~1]
└─> .\bin\checkver.ps1 -App '.\bucket\hekasoft-backup-restore.json' -f
hekasoft-backup-restore: 1.0.0 (scoop version is 1.0.0)
Forcing autoupdate!
Autoupdating hekasoft-backup-restore
DEBUG[1777722121] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1777722121] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1777722121] $substitutions.$matchTail                     
DEBUG[1777722121] $substitutions.$preReleaseVersion             1.0.0
DEBUG[1777722121] $substitutions.$url                           https://hekasoft.com/hbr-portable.zip
DEBUG[1777722121] $substitutions.$basenameNoExt                 hbr-portable
DEBUG[1777722121] $substitutions.$cleanVersion                  100
DEBUG[1777722121] $substitutions.$dotVersion                    1.0.0
DEBUG[1777722121] $substitutions.$urlNoExt                      https://hekasoft.com/hbr-portable
DEBUG[1777722121] $substitutions.$matchHead                     1.0.0
DEBUG[1777722121] $substitutions.$underscoreVersion             1_0_0
DEBUG[1777722121] $substitutions.$match1                        1.0.0
DEBUG[1777722121] $substitutions.$dashVersion                   1-0-0
DEBUG[1777722121] $substitutions.$baseurl                       https://hekasoft.com
DEBUG[1777722121] $substitutions.$minorVersion                  0
DEBUG[1777722121] $substitutions.$basename                      hbr-portable.zip
DEBUG[1777722121] $substitutions.$majorVersion                  1
DEBUG[1777722121] $substitutions.$buildVersion                  
DEBUG[1777722121] $substitutions.$version                       1.0.0
DEBUG[1777722121] $substitutions.$patchVersion                  0
DEBUG[1777722121] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading hbr-portable.zip to compute hashes!
Loading hbr-portable.zip from cache
Computed hash: a91f2ae5af62eb6029118b098d0a90ef4cf055eea4bcab8ede197686ee1766a1
Writing updated hekasoft-backup-restore manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ hekasoft-backup-restore ≢  ~1]
└─> scoop install Unofficial/hekasoft-backup-restore
Installing 'hekasoft-backup-restore' (1.0.0) [64bit] from 'Unofficial' bucket
Loading hbr-portable.zip from cache.
Checking hash of hbr-portable.zip... OK.
Extracting hbr-portable.zip... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\hekasoft-backup-restore\current => D:\Software\Scoop\Local\apps\hekasoft-backup-restore\1.0.0
Creating shortcut for Hekasoft Backup and Restore (hbr.exe)
'hekasoft-backup-restore' (1.0.0) was installed successfully!

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ hekasoft-backup-restore ≢  ~1]
└─> scoop uninstall hekasoft-backup-restore -p
Uninstalling 'hekasoft-backup-restore' (1.0.0).
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Hekasoft Backup and Restore.lnk
Unlinking D:\Software\Scoop\Local\apps\hekasoft-backup-restore\current
Removing persisted data.
'hekasoft-backup-restore' was uninstalled.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)