### PR TITLE
powertoys: Change checkver to github, fix autoupdate

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -76,11 +76,7 @@
             "PowerToys"
         ]
     ],
-    "checkver": {
-        "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
-        "jsonpath": "$[0].assets[*].browser_download_url",
-        "regex": "/releases/download/(?<tag>[\\w.]+)/PowerToysUserSetup-([\\d.]+)-x64\\.exe"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The powertoys manifest is not autoupdaing to 0.99.1 which is released 3 days ago, in which the scoop manifest shows that it is still on 0.99.0. This PR changes the checkver to the conventional GitHub method which is `"checkver": "github",`. It is confirmed to fix the bug and would be able to autoupdate to 0.99.1. Actually, don't know why the powertoys manifest is using a checkver in a manual manner in the case that it is a GitHub repo: 
```json
"checkver": {
        "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
        "jsonpath": "$[0].assets[*].browser_download_url",
        "regex": "/releases/download/(?<tag>[\\w.]+)/PowerToysUserSetup-([\\d.]+)-x64\\.exe"
    },
```
If this was done deliberately, please ignore this PR.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #17743

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
