### PR TITLE
opera(-gx): Refactor installer script

### DIFF
--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -18,17 +18,23 @@
     },
     "installer": {
         "script": [
-            "Expand-7zipArchive -Path \"$dir\\$fname\" -DestinationPath $dir -Removal",
             "$version, 'autoupdate' | ForEach-Object { ensure \"$dir\\$_\" | Out-Null }",
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -Switches '-x!*_list -xr!unins*' -Removal",
             "Move-Item -Path \"$dir\\opera_autoupdate*\" -Destination \"$dir\\autoupdate\" -Force",
-            "Remove-Item -Path \"$dir\\*\" -Include '*_list' -Force -ErrorAction SilentlyContinue",
             "$exclude_list = @('Assets', $version, 'autoupdate', 'Resources.pri', 'opera.visualelementsmanifest.xml')",
-            "Get-ChildItem -Path $dir | Where-Object { $exclude_list -notcontains $_.Name } | ForEach-Object {",
-            "    Move-Item -Path $_.FullName -Destination \"$dir\\$version\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "Move-Item -Path \"$dir\\*\" -Destination \"$dir\\$version\" -Exclude $exclude_list -Force -ErrorAction SilentlyContinue",
+            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir -Force",
+            "$consent_settings = [ordered]@{",
+            "    'consent-given' = $true; 'general-interests' = $false",
+            "    'general-location' = $false; 'personalized-ads' = $false; 'personalized-content' = $false",
             "}",
-            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir",
-            "$cfg = @{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 5",
-            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -Encoding ascii"
+            "$cfg = [ordered]@{",
+            "    'autoupdate' = $false; 'consent' = $consent_settings",
+            "    'enable-crash-reporting' = $false; 'enable_stats' = $false",
+            "    'import_browser_data' = $false; 'run-at-startup' = $false",
+            "    'show_eula_window_on_first_run' = $false; 'show_onboarding_overlay' = $false; 'single_profile' = $true",
+            "} | ConvertTo-Json -Depth 5 -Compress",
+            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -NoNewline -Encoding utf8"
         ]
     },
     "shortcuts": [

--- a/bucket/opera-gx.json
+++ b/bucket/opera-gx.json
@@ -24,16 +24,7 @@
             "$exclude_list = @('Assets', $version, 'autoupdate', 'Resources.pri', 'opera.visualelementsmanifest.xml')",
             "Move-Item -Path \"$dir\\*\" -Destination \"$dir\\$version\" -Exclude $exclude_list -Force -ErrorAction SilentlyContinue",
             "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir -Force",
-            "$consent_settings = [ordered]@{",
-            "    'consent-given' = $true; 'general-interests' = $false",
-            "    'general-location' = $false; 'personalized-ads' = $false; 'personalized-content' = $false",
-            "}",
-            "$cfg = [ordered]@{",
-            "    'autoupdate' = $false; 'consent' = $consent_settings",
-            "    'enable-crash-reporting' = $false; 'enable_stats' = $false",
-            "    'import_browser_data' = $false; 'run-at-startup' = $false",
-            "    'show_eula_window_on_first_run' = $false; 'show_onboarding_overlay' = $false; 'single_profile' = $true",
-            "} | ConvertTo-Json -Depth 5 -Compress",
+            "$cfg = @{ 'autoupdate' = $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 5 -Compress",
             "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -NoNewline -Encoding utf8"
         ]
     },

--- a/bucket/opera.json
+++ b/bucket/opera.json
@@ -28,16 +28,7 @@
             "$exclude_list = @('Assets', $version, 'autoupdate', 'Resources.pri', 'opera.visualelementsmanifest.xml')",
             "Move-Item -Path \"$dir\\*\" -Destination \"$dir\\$version\" -Exclude $exclude_list -Force -ErrorAction SilentlyContinue",
             "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir -Force",
-            "$consent_settings = [ordered]@{",
-            "    'consent-given' = $true; 'general-interests' = $false",
-            "    'general-location' = $false; 'personalized-ads' = $false; 'personalized-content' = $false",
-            "}",
-            "$cfg = [ordered]@{",
-            "    'autoupdate' = $false; 'consent' = $consent_settings",
-            "    'enable-crash-reporting' = $false; 'enable_stats' = $false",
-            "    'import_browser_data' = $false; 'run-at-startup' = $false",
-            "    'show_eula_window_on_first_run' = $false; 'show_onboarding_overlay' = $false; 'single_profile' = $true",
-            "} | ConvertTo-Json -Depth 5 -Compress",
+            "$cfg = @{ 'autoupdate' = $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 5 -Compress",
             "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -NoNewline -Encoding utf8"
         ]
     },

--- a/bucket/opera.json
+++ b/bucket/opera.json
@@ -22,17 +22,23 @@
     },
     "installer": {
         "script": [
-            "Expand-7zipArchive -Path \"$dir\\$fname\" -DestinationPath $dir -Removal",
             "$version, 'autoupdate' | ForEach-Object { ensure \"$dir\\$_\" | Out-Null }",
+            "Expand-7zipArchive -Path \"$dir\\$fname\" -Switches '-x!*_list -xr!unins*' -Removal",
             "Move-Item -Path \"$dir\\opera_autoupdate*\" -Destination \"$dir\\autoupdate\" -Force",
-            "Remove-Item -Path \"$dir\\*\" -Include '*_list' -Force -ErrorAction SilentlyContinue",
             "$exclude_list = @('Assets', $version, 'autoupdate', 'Resources.pri', 'opera.visualelementsmanifest.xml')",
-            "Get-ChildItem -Path $dir | Where-Object { $exclude_list -notcontains $_.Name } | ForEach-Object {",
-            "    Move-Item -Path $_.FullName -Destination \"$dir\\$version\\$($_.Name)\" -Force -ErrorAction SilentlyContinue",
+            "Move-Item -Path \"$dir\\*\" -Destination \"$dir\\$version\" -Exclude $exclude_list -Force -ErrorAction SilentlyContinue",
+            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir -Force",
+            "$consent_settings = [ordered]@{",
+            "    'consent-given' = $true; 'general-interests' = $false",
+            "    'general-location' = $false; 'personalized-ads' = $false; 'personalized-content' = $false",
             "}",
-            "Copy-Item -Path \"$dir\\$version\\opera.exe\" -Destination $dir",
-            "$cfg = @{ 'autoupdate'= $false; 'enable_stats' = $false; 'single_profile' = $true } | ConvertTo-Json -Depth 5",
-            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -Encoding ascii"
+            "$cfg = [ordered]@{",
+            "    'autoupdate' = $false; 'consent' = $consent_settings",
+            "    'enable-crash-reporting' = $false; 'enable_stats' = $false",
+            "    'import_browser_data' = $false; 'run-at-startup' = $false",
+            "    'show_eula_window_on_first_run' = $false; 'show_onboarding_overlay' = $false; 'single_profile' = $true",
+            "} | ConvertTo-Json -Depth 5 -Compress",
+            "Set-Content -Path \"$dir\\installer_prefs.json\" -Value $cfg -NoNewline -Encoding utf8"
         ]
     },
     "shortcuts": [


### PR DESCRIPTION
### Summary

Refactors the installer scripts for `opera` and `opera-gx` to improve extraction efficiency, simplify file organization.

### Related issues or pull requests

- Relates to #16558 

### Changes

- **Extraction**: Update `Expand-7zipArchive` with `-Switches` to exclude `*_list` and `unins*` files directly during extraction, reducing disk I/O and cleanup steps.
- **File Organization**: Simplify the logic for moving version-specific files into the `$version` directory using the `-Exclude` parameter in `Move-Item`.
- **Compatibility**: Change `installer_prefs.json` encoding to `utf8` and apply `-Compress` to the JSON output for better alignment with Chromium-based installer expectations.

### Notes

- Initially, since the `$version` directory did not exist before moving the files, the `localization` directory was renamed to `$version`, which led to a series of subsequent issues. When implementing #16558, I did not recognize this, resulting in [an inefficient approach](https://github.com/ScoopInstaller/Extras/blob/c9127b9fe4d90e3cb9d984ad4542e47d83de77b8/bucket/opera.json#L29-L32). This change resolves the issue more comprehensively.
https://github.com/ScoopInstaller/Extras/blob/18f2e0e2de235909148b0984443468dce4080f0a/bucket/opera.json#L22-L26

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ ~]
└─> scoop install Unofficial/opera
Installing 'opera' (131.0.5877.5) [64bit] from 'Unofficial' bucket
Loading Opera_131.0.5877.5_Setup_x64.exe from cache.
Checking hash of Opera_131.0.5877.5_Setup_x64.exe... OK.
Running installer script... Done.
Linking D:\Software\Scoop\Local\apps\opera\current => D:\Software\Scoop\Local\apps\opera\131.0.5877.5
Creating shortcut for Opera (opera.exe)
Persisting profile
'opera' (131.0.5877.5) was installed successfully!

┏[ ~]
└─> Get-ChildItem -Path "$(scoop prefix opera)\131.0.5877.5" -Filter '*.pak' -File

        Directory: D:\Software\Scoop\Local\apps\opera\current\131.0.5877.5


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---         4/28/2026   4:05 AM           2923   headless_command_resources.pak
-a---         4/28/2026   4:05 AM        1371286   opera_100_percent.pak
-a---         4/28/2026   4:05 AM        1548340   opera_125_percent.pak
-a---         4/28/2026   4:05 AM        1814401   opera_150_percent.pak
-a---         4/28/2026   4:05 AM        2652126   opera_200_percent.pak
-a---         4/28/2026   4:05 AM        3039544   opera_250_percent.pak
-a---         4/28/2026   4:12 AM       24808081   opera.pak

┏[ ~]
└─> scoop uninstall opera -p
Uninstalling 'opera' (131.0.5877.5).
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Opera.lnk
Unlinking D:\Software\Scoop\Local\apps\opera\current
Removing persisted data.
'opera' was uninstalled

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)