### PR TITLE
(chore): Explicitly specify GitHub mode when using GitHub API

### DIFF
--- a/bucket/86box.json
+++ b/bucket/86box.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/86Box/86Box/releases/latest",
+        "github": "https://api.github.com/repos/86Box/86Box/releases/latest",
         "jsonpath": "$.assets[*].browser_download_url",
         "regex": "v(?<version>[\\d.]+)/86Box-Windows-64-b(?<build>\\d+)\\.zip"
     },

--- a/bucket/adventuregamestudio.json
+++ b/bucket/adventuregamestudio.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/adventuregamestudio/ags/releases/latest",
+        "github": "https://api.github.com/repos/adventuregamestudio/ags/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /AGS.+exe/i)].browser_download_url",
         "regex": "download/v([\\d.]+)/(?<name>.+)"
     },

--- a/bucket/aegisub-arch1t3cht.json
+++ b/bucket/aegisub-arch1t3cht.json
@@ -47,7 +47,7 @@
         "config"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/arch1t3cht/Aegisub/releases/latest",
+        "github": "https://api.github.com/repos/arch1t3cht/Aegisub/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "^migration([0-9]+-[0-9]+)$"
     },

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -17,7 +17,7 @@
         "age-plugin-batchpass.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FiloSottile/age/releases",
+        "github": "https://api.github.com/repos/FiloSottile/age/releases",
         "regex": "/age-v([\\w.-]+)-windows"
     },
     "autoupdate": {

--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -35,7 +35,7 @@
         "programfiles"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ankitects/anki/releases",
+        "github": "https://api.github.com/repos/ankitects/anki/releases",
         "regex": "download/(?<version>[\\d.]+)/anki-launcher-\\k<version>-windows\\.exe"
     },
     "autoupdate": {

--- a/bucket/anytype.json
+++ b/bucket/anytype.json
@@ -24,7 +24,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/anyproto/anytype-ts/releases",
+        "github": "https://api.github.com/repos/anyproto/anytype-ts/releases",
         "regex": "Anytype\\.Setup\\.([\\d.]+)\\.exe\""
     },
     "autoupdate": {

--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/archimatetool/archi.io/releases",
+        "github": "https://api.github.com/repos/archimatetool/archi.io/releases",
         "regex": "download/(?<tag>[^/]+)/Archi-Win64-(?<version>[\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/bambu-studio.json
+++ b/bucket/bambu-studio.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/bambulab/BambuStudio/releases/latest",
+        "github": "https://api.github.com/repos/bambulab/BambuStudio/releases/latest",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /Bambu_Studio_win-.*\\.zip/i)].browser_download_url",
         "regex": "download/(?<tag>(?:v|V)?(?<version>[\\d.]+))/(?<filename>Bambu_Studio_win-.*\\.zip)"
     },

--- a/bucket/biblioteq.json
+++ b/bucket/biblioteq.json
@@ -23,7 +23,7 @@
     ],
     "persist": ".biblioteq",
     "checkver": {
-        "url": "https://api.github.com/repos/textbrowser/biblioteq/releases",
+        "github": "https://api.github.com/repos/textbrowser/biblioteq/releases",
         "jsonpath": "$[?(@.assets[0].url)].tag_name"
     },
     "autoupdate": {

--- a/bucket/bitwarden.json
+++ b/bucket/bitwarden.json
@@ -22,7 +22,7 @@
     ],
     "persist": "bitwarden-appdata",
     "checkver": {
-        "url": "https://api.github.com/repos/bitwarden/clients/releases",
+        "github": "https://api.github.com/repos/bitwarden/clients/releases",
         "regex": "tag/desktop-v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/bloop.json
+++ b/bucket/bloop.json
@@ -14,7 +14,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/BloopAI/bloop/releases",
+        "github": "https://api.github.com/repos/BloopAI/bloop/releases",
         "regex": "bloop_([\\d.]+)_x64-setup.exe"
     },
     "autoupdate": {

--- a/bucket/boilr.json
+++ b/bucket/boilr.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/PhilipK/BoilR/releases/latest",
+        "github": "https://api.github.com/repos/PhilipK/BoilR/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "/v\\.([\\d.]+)/windows_BoilR\\.exe"
     },

--- a/bucket/browseros.json
+++ b/bucket/browseros.json
@@ -30,7 +30,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://api.github.com/repos/browseros-ai/BrowserOS/releases/latest",
+        "github": "https://api.github.com/repos/browseros-ai/BrowserOS/releases/latest",
         "regex": "download/(?<tag>[^/]+)/BrowserOS_v(?<version>[\\d.]+)_x64_installer\\.exe"
     },
     "autoupdate": {

--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -32,7 +32,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Klocman/Bulk-Crap-Uninstaller/releases/latest",
+        "github": "https://api.github.com/repos/Klocman/Bulk-Crap-Uninstaller/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+)/BCUninstaller_([\\d.]+)_portable(?:-[\\w]+)?\\.zip"
     },

--- a/bucket/cake-wallet.json
+++ b/bucket/cake-wallet.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/cake-tech/cake_wallet/releases",
+        "github": "https://api.github.com/repos/cake-tech/cake_wallet/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "Cake_Wallet_v([\\d.]+)_Windows\\.exe"
     },

--- a/bucket/capframex.json
+++ b/bucket/capframex.json
@@ -29,7 +29,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/CXWorld/CapFrameX/releases",
+        "github": "https://api.github.com/repos/CXWorld/CapFrameX/releases",
         "jsonpath": "$[?(@.tag_name =~ /^(?!.*beta).+$/)].tag_name",
         "regex": "(?<tag>v(?<version>[\\d.]+)[^\"]*)"
     },

--- a/bucket/cefflashbrowser.json
+++ b/bucket/cefflashbrowser.json
@@ -25,7 +25,7 @@
     ],
     "persist": "Caches",
     "checkver": {
-        "url": "https://api.github.com/repos/Mzying2001/CefFlashBrowser/releases/latest",
+        "github": "https://api.github.com/repos/Mzying2001/CefFlashBrowser/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/(?<tag>[\\d.]+)/FlashBrowser_x64_v([\\d.]+)\\.zip"
     },

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -36,7 +36,7 @@
     },
     "persist": "User Data",
     "checkver": {
-        "url": "https://api.github.com/repos/Hibbiki/chromium-win64/tags",
+        "github": "https://api.github.com/repos/Hibbiki/chromium-win64/tags",
         "jsonpath": "$..name",
         "regex": "v([\\d.\\-r]+)"
     },

--- a/bucket/clementine.json
+++ b/bucket/clementine.json
@@ -13,7 +13,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/clementine-player/Clementine/releases/latest",
+        "github": "https://api.github.com/repos/clementine-player/Clementine/releases/latest",
         "jsonpath": "$.tag_name"
     },
     "autoupdate": {

--- a/bucket/clingo.json
+++ b/bucket/clingo.json
@@ -18,7 +18,7 @@
         "lpconvert.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/potassco/clingo/releases",
+        "github": "https://api.github.com/repos/potassco/clingo/releases",
         "regex": "clingo-([\\d.]+)-win64\\.zip"
     },
     "autoupdate": {

--- a/bucket/compactgui.json
+++ b/bucket/compactgui.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ImminentFate/CompactGUI/releases",
+        "github": "https://api.github.com/repos/ImminentFate/CompactGUI/releases",
         "jsonpath": "$..tag_name",
         "regex": "v([\\d.]+)\""
     },

--- a/bucket/converseen.json
+++ b/bucket/converseen.json
@@ -14,7 +14,7 @@
     ],
     "persist": "settings",
     "checkver": {
-        "url": "https://api.github.com/repos/Faster3ck/Converseen/releases/latest",
+        "github": "https://api.github.com/repos/Faster3ck/Converseen/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "converseen-(?<version>[\\d\\.+]+)-(?<build>\\d+)-win32-portable.zip"
     },

--- a/bucket/debugtron.json
+++ b/bucket/debugtron.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/pd4d10/debugtron/releases",
+        "github": "https://api.github.com/repos/pd4d10/debugtron/releases",
         "jsonpath": "$..tag_name",
         "regex": "v([\\d.]+)\""
     },

--- a/bucket/deeplx.json
+++ b/bucket/deeplx.json
@@ -15,7 +15,7 @@
     },
     "bin": "deeplx.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/OwO-Network/DeepLX/releases",
+        "github": "https://api.github.com/repos/OwO-Network/DeepLX/releases",
         "regex": "tag/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/dismplusplus.json
+++ b/bucket/dismplusplus.json
@@ -62,7 +62,7 @@
         "Config\\Config.ini"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Chuyu-Team/Dism-Multi-language/releases/latest",
+        "github": "https://api.github.com/repos/Chuyu-Team/Dism-Multi-language/releases/latest",
         "jsonpath": "$.assets[0].browser_download_url",
         "regex": "v(?<tag>[\\d.]+)/Dism%2B%2B(?<version>[\\d.]+[\\w]?)\\.zip"
     },

--- a/bucket/dn-famitracker.json
+++ b/bucket/dn-famitracker.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Dn-Programming-Core-Management/Dn-FamiTracker/releases/latest",
+        "github": "https://api.github.com/repos/Dn-Programming-Core-Management/Dn-FamiTracker/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/Dn([\\d.]+)/Dn-FamiTracker_v(?<short>[\\d]+)_(x64|Win32)_Release\\.7z"
     },

--- a/bucket/dosbox-x.json
+++ b/bucket/dosbox-x.json
@@ -30,7 +30,7 @@
     ],
     "persist": "dosbox.conf",
     "checkver": {
-        "url": "https://api.github.com/repos/joncampbell123/dosbox-x/releases/latest",
+        "github": "https://api.github.com/repos/joncampbell123/dosbox-x/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "dosbox-x-v([\\d.]+).*vsbuild-arm64-(?<releasearm64>\\d+).*vsbuild-win32-(?<releasewin32>\\d+).*vsbuild-win64-(?<releasewin64>\\d+)"
     },

--- a/bucket/duckdns.json
+++ b/bucket/duckdns.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/XWolfOverride/DuckDNS/releases/latest",
+        "github": "https://api.github.com/repos/XWolfOverride/DuckDNS/releases/latest",
         "regex": "/releases/tag/([\\w.]+)"
     },
     "autoupdate": {

--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -62,7 +62,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/duplicati/duplicati/releases/latest",
+        "github": "https://api.github.com/repos/duplicati/duplicati/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "v(.*)"
     },

--- a/bucket/effekseer.json
+++ b/bucket/effekseer.json
@@ -35,7 +35,7 @@
         "Tool\\config.network.xml"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/effekseer/Effekseer/releases",
+        "github": "https://api.github.com/repos/effekseer/Effekseer/releases",
         "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /Win\\.zip/i)].browser_download_url",
         "regex": "(?i)download/([\\w.]+)/Effekseer"
     },

--- a/bucket/exhyperv.json
+++ b/bucket/exhyperv.json
@@ -29,7 +29,7 @@
     ],
     "persist": "Config.xml",
     "checkver": {
-        "url": "https://api.github.com/repos/Justsenger/ExHyperV/releases",
+        "github": "https://api.github.com/repos/Justsenger/ExHyperV/releases",
         "jsonpath": "$[?(@.tag_name =~ /^v?[\\d.]+$/i)].tag_name",
         "regex": "(?i)(?<tag>v?(?<version>[\\d.]+))"
     },

--- a/bucket/fancontrol.json
+++ b/bucket/fancontrol.json
@@ -23,7 +23,7 @@
         "Plugins"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Rem0o/FanControl.Releases/releases/latest",
+        "github": "https://api.github.com/repos/Rem0o/FanControl.Releases/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "/V([\\d.]+)/FanControl_([\\d.]+)_net_(?<netver>(?!4_8)(?!7_0)[\\d_]+).zip"
     },

--- a/bucket/ffstudio.json
+++ b/bucket/ffstudio.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Draver93/ff-studio/releases/latest",
+        "github": "https://api.github.com/repos/Draver93/ff-studio/releases/latest",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /FFStudio_.*\\.msi/i)].browser_download_url",
         "regex": "download/v(?<version>[\\d.]+)/FFStudio_0.2.7_x64_en-US-(?<commit>[a-f0-9]+)\\.msi"
     },

--- a/bucket/fluidsynth.json
+++ b/bucket/fluidsynth.json
@@ -20,7 +20,7 @@
     },
     "env_add_path": "bin",
     "checkver": {
-        "url": "https://api.github.com/repos/FluidSynth/fluidsynth/releases",
+        "github": "https://api.github.com/repos/FluidSynth/fluidsynth/releases",
         "jsonpath": "$..assets[?(@.name =~ /win(?!.+glib).+\\.zip$/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?([\\d.]+))/(?<prefix>[^\"]+)-x(?:64|86)(?<suffix>-[^\"]+)?\\.zip"
     },

--- a/bucket/folo.json
+++ b/bucket/folo.json
@@ -32,7 +32,7 @@
     ],
     "persist": "UserData",
     "checkver": {
-        "url": "https://api.github.com/repos/RSSNext/Folo/releases",
+        "github": "https://api.github.com/repos/RSSNext/Folo/releases",
         "regex": "desktop/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/fontforge.json
+++ b/bucket/fontforge.json
@@ -25,7 +25,7 @@
         "bin/ffpython.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/fontforge/fontforge/releases/latest",
+        "github": "https://api.github.com/repos/fontforge/fontforge/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "(\\d{8})/(?<fname>FontForge-\\d{4}-\\d{2}-\\d{2}-Windows(?<arch>-x64)?(?<release>[-r\\d]*?)?.exe)"
     },

--- a/bucket/free-shooter.json
+++ b/bucket/free-shooter.json
@@ -26,7 +26,7 @@
     ],
     "persist": "freeshooter.ini",
     "checkver": {
-        "url": "https://api.github.com/repos/henrypp/freeshooter/releases/latest",
+        "github": "https://api.github.com/repos/henrypp/freeshooter/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v.([\\d.]+)\\/freeshooter-(?<short>[\\d.]+)-bin\\.7z"
     },

--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest",
+        "github": "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Win.+\\.7z$/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>[^/]+)/(?<name>FreeCAD[^\\d]([0-9a-f.-]+)(?:-conda)?-Win.+)"
     },

--- a/bucket/freetube.json
+++ b/bucket/freetube.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FreeTubeApp/FreeTube/tags",
+        "github": "https://api.github.com/repos/FreeTubeApp/FreeTube/tags",
         "jsonpath": "$[0].name",
         "regex": "v([\\w.-]+)"
     },

--- a/bucket/fvim.json
+++ b/bucket/fvim.json
@@ -24,7 +24,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/yatli/fvim/releases/latest",
+        "github": "https://api.github.com/repos/yatli/fvim/releases/latest",
         "script": [
             "$LatestRelease = $page | ConvertFrom-Json",
             "[string]::Format(",

--- a/bucket/garbro.json
+++ b/bucket/garbro.json
@@ -12,7 +12,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/morkt/GARbro/releases/latest",
+        "github": "https://api.github.com/repos/morkt/GARbro/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "GARbro-v([\\d.]+).rar"
     },

--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -33,7 +33,7 @@
     },
     "persist": "Ghidra/Configurations",
     "checkver": {
-        "url": "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest",
+        "github": "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "ghidra_([\\d.]+)_PUBLIC_(?<releasedate>\\d+)\\.zip",
         "replace": "${1}-${2}"

--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -25,7 +25,7 @@
     ],
     "persist": "GitExtensions.settings",
     "checkver": {
-        "url": "https://api.github.com/repos/gitextensions/gitextensions/releases/latest",
+        "github": "https://api.github.com/repos/gitextensions/gitextensions/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "/v(?<tag>[\\d.]+)/GitExtensions-Portable-(?:x[\\d.]+)-(?<version>[\\d.]+)-(?<commit>[\\w]+).zip"
     },

--- a/bucket/github.json
+++ b/bucket/github.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/desktop/desktop/tags",
+        "github": "https://api.github.com/repos/desktop/desktop/tags",
         "regex": "tags/release-([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -31,7 +31,7 @@
     ],
     "persist": "etc\\gnucash\\environment.local",
     "checkver": {
-        "url": "https://api.github.com/repos/Gnucash/gnucash/releases/latest",
+        "github": "https://api.github.com/repos/Gnucash/gnucash/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "/download/([\\d.]+)/gnucash-([\\w.-]+)\\.setup\\.exe"
     },

--- a/bucket/goldendict.json
+++ b/bucket/goldendict.json
@@ -26,7 +26,7 @@
         "content"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/goldendict/goldendict/releases",
+        "github": "https://api.github.com/repos/goldendict/goldendict/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "GoldenDict-([\\d.]+)_\\.QT_(?<build>[\\d]+)\\.64bit\\.7z"
     },

--- a/bucket/gossip.json
+++ b/bucket/gossip.json
@@ -22,7 +22,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/mikedilger/gossip/releases/latest",
+        "github": "https://api.github.com/repos/mikedilger/gossip/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+)/gossip.([\\d.]+)\\.msi"
     },

--- a/bucket/hemmelig.json
+++ b/bucket/hemmelig.json
@@ -14,7 +14,7 @@
     },
     "bin": "hemmelig.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/HemmeligOrg/Hemmelig.app/releases",
+        "github": "https://api.github.com/repos/HemmeligOrg/Hemmelig.app/releases",
         "regex": "/tag/(?<tag>cli-[Vv]?(?<version>[\\d.]+))"
     },
     "autoupdate": {

--- a/bucket/hoppscotch.json
+++ b/bucket/hoppscotch.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/hoppscotch/releases/releases/latest",
+        "github": "https://api.github.com/repos/hoppscotch/releases/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "v(?<version>[\\d.]+-\\d+)"
     },

--- a/bucket/hydrus-network.json
+++ b/bucket/hydrus-network.json
@@ -33,7 +33,7 @@
     ],
     "persist": "db",
     "checkver": {
-        "url": "https://api.github.com/repos/hydrusnetwork/hydrus/releases",
+        "github": "https://api.github.com/repos/hydrusnetwork/hydrus/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<version>[\\d.]+[a-z]{0,1})/Hydrus\\.Network\\.\\k<version>\\.-\\.Windows\\.-\\.Extract\\.only\\.zip"
     },

--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -24,7 +24,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/icsharpcode/ILSpy/releases",
+        "github": "https://api.github.com/repos/icsharpcode/ILSpy/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /ILSpy_binaries_(?:[\\d.]+)-x64\\.zip$/i)].browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+)/ILSpy_binaries_([\\d.]+)-x64\\.zip"
     },

--- a/bucket/inkscape-extension-sozi.json
+++ b/bucket/inkscape-extension-sozi.json
@@ -24,7 +24,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/sozi-projects/Sozi/releases/latest",
+        "github": "https://api.github.com/repos/sozi-projects/Sozi/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "/v(?<tag>[\\d.]+)/sozi-extras-media-([\\d.]+)-(?<build>[\\d]+)-inkscape-1.0.zip"
     },

--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Kong/insomnia/releases",
+        "github": "https://api.github.com/repos/Kong/insomnia/releases",
         "regex": "\"core@([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/insomnium.json
+++ b/bucket/insomnium.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ArchGPT/insomnium/releases",
+        "github": "https://api.github.com/repos/ArchGPT/insomnium/releases",
         "regex": "\"core@([^\"]+)\""
     },
     "autoupdate": {

--- a/bucket/ios-webkit-debug-proxy.json
+++ b/bucket/ios-webkit-debug-proxy.json
@@ -11,7 +11,7 @@
     },
     "bin": "ios_webkit_debug_proxy.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/google/ios-webkit-debug-proxy/releases",
+        "github": "https://api.github.com/repos/google/ios-webkit-debug-proxy/releases",
         "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.browser_download_url =~ /win64/i)])].tag_name",
         "regex": "(?<=\")(?<tag>v?([\\d.]+))(?=\")"
     },

--- a/bucket/ipfilter-updater.json
+++ b/bucket/ipfilter-updater.json
@@ -14,7 +14,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/DavidMoore/ipfilter/releases",
+        "github": "https://api.github.com/repos/DavidMoore/ipfilter/releases",
         "jsonpath": "$.[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/jasper.json
+++ b/bucket/jasper.json
@@ -29,7 +29,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/jasperapp/jasper/releases",
+        "github": "https://api.github.com/repos/jasperapp/jasper/releases",
         "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.browser_download_url =~ /windows/i)])].tag_name",
         "regex": "(?<=\")(?<tag>v?([\\d.]+))(?=\")"
     },

--- a/bucket/jexiftoolgui.json
+++ b/bucket/jexiftoolgui.json
@@ -15,7 +15,7 @@
     ],
     "persist": "logs",
     "checkver": {
-        "url": "https://api.github.com/repos/hvdwolf/jExifToolGUI/releases/latest",
+        "github": "https://api.github.com/repos/hvdwolf/jExifToolGUI/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "jExifToolGUI-([\\d.]+)-win-x86_64_with-jre\\.zip"
     },

--- a/bucket/kdoc-formatter.json
+++ b/bucket/kdoc-formatter.json
@@ -15,7 +15,7 @@
     "extract_dir": "kdoc-formatter-1.6.9",
     "bin": "bin\\kdoc-formatter.bat",
     "checkver": {
-        "url": "https://api.github.com/repos/tnorbye/kdoc-formatter/releases/latest",
+        "github": "https://api.github.com/repos/tnorbye/kdoc-formatter/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+)/kdoc-formatter-([\\d.]+)\\.zip"
     },

--- a/bucket/librecad.json
+++ b/bucket/librecad.json
@@ -54,7 +54,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/LibreCAD/LibreCAD/releases/latest",
+        "github": "https://api.github.com/repos/LibreCAD/LibreCAD/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /win/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?([\\d.]+))/LibreCAD-(?<string>v?[\\d.-]+[+-]g\\w+)?-win"
     },

--- a/bucket/lightbulb.json
+++ b/bucket/lightbulb.json
@@ -32,7 +32,7 @@
     ],
     "persist": "Settings.json",
     "checkver": {
-        "url": "https://api.github.com/repos/Tyrrrz/LightBulb/tags",
+        "github": "https://api.github.com/repos/Tyrrrz/LightBulb/tags",
         "regex": "tags/([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/linkerd.json
+++ b/bucket/linkerd.json
@@ -11,7 +11,7 @@
     },
     "bin": "linkerd.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/linkerd/linkerd2/releases?per_page=100",
+        "github": "https://api.github.com/repos/linkerd/linkerd2/releases?per_page=100",
         "regex": "download/stable-([\\d.]+)/link"
     },
     "autoupdate": {

--- a/bucket/liteide.json
+++ b/bucket/liteide.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/visualfc/liteide/releases",
+        "github": "https://api.github.com/repos/visualfc/liteide/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /liteidex[\\d.-]+-win64-qt[\\d.]+\\.zip/)].browser_download_url",
         "regex": "liteidex([\\d.-]+)-win64-qt(?<qt>[\\d.]+)\\.zip"
     },

--- a/bucket/magicavoxel.json
+++ b/bucket/magicavoxel.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ephtracy/ephtracy.github.io/releases",
+        "github": "https://api.github.com/repos/ephtracy/ephtracy.github.io/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "MagicaVoxel-([\\d.]+)-win64\\.zip"
     },

--- a/bucket/mediaelch.json
+++ b/bucket/mediaelch.json
@@ -47,7 +47,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Komet/MediaElch/releases/latest",
+        "github": "https://api.github.com/repos/Komet/MediaElch/releases/latest",
         "regex": "MediaElch_win_10_or_later_Qt6_(?<version>[\\d\\.]+)(?<detail>[\\w\\d-_]+).zip"
     },
     "autoupdate": {

--- a/bucket/meshroom.json
+++ b/bucket/meshroom.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/alicevision/Meshroom/releases/latest",
+        "github": "https://api.github.com/repos/alicevision/Meshroom/releases/latest",
         "jsonpath": "$.body",
         "regex": "(?i)\\[[^[]+-([\\d.]+)[^[]+Windows\\]\\(.+records/(?<doi>[\\d]+)/files/(?<name>[^]]+)\\)"
     },

--- a/bucket/moosync.json
+++ b/bucket/moosync.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Moosync/Moosync/releases/latest",
+        "github": "https://api.github.com/repos/Moosync/Moosync/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /x64.+\\.exe$/i)].browser_download_url",
         "regex": "(?i)download/Moosync-v([\\d.]+)/(?<name>[^\"]+)"
     },

--- a/bucket/mpc-hc-fork.json
+++ b/bucket/mpc-hc-fork.json
@@ -44,7 +44,7 @@
         "default.mpcpl"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/clsid2/mpc-hc/releases/latest",
+        "github": "https://api.github.com/repos/clsid2/mpc-hc/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/(?<tag>[\\d.]+)\\/MPC-HC.([\\d.]+).x64.exe"
     },

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -34,7 +34,7 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://api.github.com/repos/shinchiro/mpv-winbuild-cmake/releases/latest",
+        "github": "https://api.github.com/repos/shinchiro/mpv-winbuild-cmake/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "mpv-x86_64-(\\d+)-git-(?<commit>[\\da-f]+)\\.7z"
     },

--- a/bucket/neovim-qt.json
+++ b/bucket/neovim-qt.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/equalsraf/neovim-qt/releases",
+        "github": "https://api.github.com/repos/equalsraf/neovim-qt/releases",
         "regex": "tag/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/notesnook.json
+++ b/bucket/notesnook.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/streetwriters/notesnook/releases",
+        "github": "https://api.github.com/repos/streetwriters/notesnook/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/v([\\d.]+)/notesnook_win_x64_portable.exe"
     },

--- a/bucket/odict.json
+++ b/bucket/odict.json
@@ -11,7 +11,7 @@
     },
     "bin": "odict.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/TheOpenDictionary/odict/releases",
+        "github": "https://api.github.com/repos/TheOpenDictionary/odict/releases",
         "regex": "download/cli/v([\\d.]+)/odict"
     },
     "autoupdate": {

--- a/bucket/onlyoffice-desktopeditors.json
+++ b/bucket/onlyoffice-desktopeditors.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ONLYOFFICE/DesktopEditors/releases",
+        "github": "https://api.github.com/repos/ONLYOFFICE/DesktopEditors/releases",
         "regex": "v([\\d.]+)/DesktopEditors_x64\\.exe"
     },
     "autoupdate": {

--- a/bucket/persepolis.json
+++ b/bucket/persepolis.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/persepolisdm/persepolis/releases/latest",
+        "github": "https://api.github.com/repos/persepolisdm/persepolis/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "persepolis_([\\d.]+)_windows"
     },

--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -45,7 +45,7 @@
         "Themes"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/JosefNemec/Playnite/releases/latest",
+        "github": "https://api.github.com/repos/JosefNemec/Playnite/releases/latest",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /download\\/[\\d.]+\\/.*?\\.(?:7z|zip)/)].browser_download_url",
         "regex": "download/(?<version>[\\d.]+)/(?<file>.*?\\.(?:7z|zip))"
     },

--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -77,7 +77,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/microsoft/PowerToys/releases",
+        "github": "https://api.github.com/repos/microsoft/PowerToys/releases",
         "jsonpath": "$[0].assets[*].browser_download_url",
         "regex": "/releases/download/(?<tag>[\\w.]+)/PowerToysUserSetup-([\\d.]+)-x64\\.exe"
     },

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/prusa3d/PrusaSlicer/releases/latest",
+        "github": "https://api.github.com/repos/prusa3d/PrusaSlicer/releases/latest",
         "regex": "PrusaSlicer-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/puttie.json
+++ b/bucket/puttie.json
@@ -40,7 +40,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/lalbornoz/PuTTie/releases/latest",
+        "github": "https://api.github.com/repos/lalbornoz/PuTTie/releases/latest",
         "regex": "(?s)Release-(?<sha>[0-9a-f]{8}).*?updated_at.*?(\\d{4})-(\\d{2})-(\\d{2})",
         "replace": "${1}${2}${3}-${sha}"
     },

--- a/bucket/qefi-entry-manager.json
+++ b/bucket/qefi-entry-manager.json
@@ -12,7 +12,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Inokinoki/QEFIEntryManager/releases/latest",
+        "github": "https://api.github.com/repos/Inokinoki/QEFIEntryManager/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/(?<prefix>[v|V][\\.]?)?([\\d.]+)/QEFI.Entry.Manager.for.Windows.Qt(?<qt>[\\d.]+)\\.zip"
     },

--- a/bucket/redasm.json
+++ b/bucket/redasm.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/REDasmOrg/REDasm/releases",
+        "github": "https://api.github.com/repos/REDasmOrg/REDasm/releases",
         "regex": "/REDasm_([\\d.]+)_Windows_x86_64\\.zip"
     },
     "autoupdate": {

--- a/bucket/regiontoshare.json
+++ b/bucket/regiontoshare.json
@@ -14,7 +14,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/tom-englert/RegionToShare/releases/latest",
+        "github": "https://api.github.com/repos/tom-englert/RegionToShare/releases/latest",
         "script": [
             "$Release = $page | ConvertFrom-Json",
             "$Release.tag_name, $Release.name -join ' '"

--- a/bucket/retroshare.json
+++ b/bucket/retroshare.json
@@ -29,7 +29,7 @@
     ],
     "persist": "Data",
     "checkver": {
-        "url": "https://api.github.com/repos/RetroShare/RetroShare/releases/latest",
+        "github": "https://api.github.com/repos/RetroShare/RetroShare/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Windows-Portable/i)].browser_download_url",
         "regex": "download/v([\\d.]+)/RetroShare-(?<commit>[^\"]+)-Windows-Portable-(?<build>[\\w.-]+?)(?<!-tor)(?=(?:-x64|-x86)?\\.7z)"
     },

--- a/bucket/ripme.json
+++ b/bucket/ripme.json
@@ -18,7 +18,7 @@
     ],
     "persist": "rips",
     "checkver": {
-        "url": "https://api.github.com/repos/ripmeapp2/ripme/releases/latest",
+        "github": "https://api.github.com/repos/ripmeapp2/ripme/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/(?<tag>[\\d.]+)/ripme-([\\d.]+)-(?<num>[\\d.]+)-(?<commit>[a-fA-F0-9]+)\\.jar"
     },

--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -21,7 +21,7 @@
     ],
     "persist": "data5",
     "checkver": {
-        "url": "https://api.github.com/repos/martinrotter/rssguard/releases/latest",
+        "github": "https://api.github.com/repos/martinrotter/rssguard/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /^rssguard-([\\d.]+)-([\\w]+)-win10.7z$/)].name",
         "regex": "rssguard-(?<version>([\\d.]+))-(?<commit>[\\w]+)-win10.7z"
     },

--- a/bucket/saber.json
+++ b/bucket/saber.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/saber-notes/saber/releases/latest",
+        "github": "https://api.github.com/repos/saber-notes/saber/releases/latest",
         "regex": "(?sm)browser_download_url.*?releases/download/v([\\d.]+)/SaberInstaller_v([\\d.]+)(?<extra>_([\\d]+))?\\.exe"
     },
     "autoupdate": {

--- a/bucket/scoop-completion.json
+++ b/bucket/scoop-completion.json
@@ -37,7 +37,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Moeologist/scoop-completion/tags",
+        "github": "https://api.github.com/repos/Moeologist/scoop-completion/tags",
         "regex": "tags/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/scoop-sd.json
+++ b/bucket/scoop-sd.json
@@ -7,7 +7,7 @@
     "hash": "50b58db02522383cb3a149716036738bc0cb626846a0c328f3009a544bd5c5ee",
     "bin": "scoop-sd.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/ergolyam/scoop-search-directory/releases/latest",
+        "github": "https://api.github.com/repos/ergolyam/scoop-search-directory/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "(?<prefix>[\\w-]+)v(?<version>[\\d.]+)"
     },

--- a/bucket/sdl2-image.json
+++ b/bucket/sdl2-image.json
@@ -115,7 +115,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/libsdl-org/SDL_image/releases",
+        "github": "https://api.github.com/repos/libsdl-org/SDL_image/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/sdl2-mixer.json
+++ b/bucket/sdl2-mixer.json
@@ -115,7 +115,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/libsdl-org/SDL_mixer/releases",
+        "github": "https://api.github.com/repos/libsdl-org/SDL_mixer/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/sdl2-ttf.json
+++ b/bucket/sdl2-ttf.json
@@ -116,7 +116,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/libsdl-org/SDL_ttf/releases",
+        "github": "https://api.github.com/repos/libsdl-org/SDL_ttf/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/sdl2.json
+++ b/bucket/sdl2.json
@@ -79,7 +79,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/libsdl-org/SDL/releases",
+        "github": "https://api.github.com/repos/libsdl-org/SDL/releases",
         "regex": "release-(2.[\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/shaderglass.json
+++ b/bucket/shaderglass.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/mausimus/ShaderGlass/releases/latest",
+        "github": "https://api.github.com/repos/mausimus/ShaderGlass/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "/download/(?<tag>v?[\\d.]+)/ShaderGlass-(?<version>[\\d.]+)-win-x64\\.zip"
     },

--- a/bucket/simplewall.json
+++ b/bucket/simplewall.json
@@ -33,7 +33,7 @@
         "profile.xml"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/henrypp/simplewall/releases/latest",
+        "github": "https://api.github.com/repos/henrypp/simplewall/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "simplewall-([\\d.]+)-bin\\.(7z|zip)"
     },

--- a/bucket/skylark.json
+++ b/bucket/skylark.json
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/adonais/skylark/releases/latest",
+        "github": "https://api.github.com/repos/adonais/skylark/releases/latest",
         "regex": "/download/(?<tag>\\d+)/skylark_x64-v([\\d.]+)\\.7z"
     },
     "autoupdate": {

--- a/bucket/so.json
+++ b/bucket/so.json
@@ -15,7 +15,7 @@
     },
     "bin": "so.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/samtay/so/releases",
+        "github": "https://api.github.com/repos/samtay/so/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "v([\\d.]+)/so-x86_64-pc-windows-msvc\\.zip"
     },

--- a/bucket/soundswitch.json
+++ b/bucket/soundswitch.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Belphemur/SoundSwitch/releases/latest",
+        "github": "https://api.github.com/repos/Belphemur/SoundSwitch/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "v([\\d.]+)/SoundSwitch_v([\\d.]+)_Release_Installer\\.exe"
     },

--- a/bucket/sozi.json
+++ b/bucket/sozi.json
@@ -35,7 +35,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/sozi-projects/Sozi/releases",
+        "github": "https://api.github.com/repos/sozi-projects/Sozi/releases",
         "jsonpath": "$[?(@.prerelease == false)]",
         "regex": "/v(?<tag>[\\d.]+)/Sozi.Setup.([\\d.]+)-(?<build>[\\d]+).exe"
     },

--- a/bucket/spicetify-themes.json
+++ b/bucket/spicetify-themes.json
@@ -25,7 +25,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/spicetify/spicetify-themes/commits",
+        "github": "https://api.github.com/repos/spicetify/spicetify-themes/commits",
         "regex": "([\\d-]+T)(\\d+):(\\d+):(\\d+)",
         "replace": "$1$2.$3.$4"
     },

--- a/bucket/spotify-qt.json
+++ b/bucket/spotify-qt.json
@@ -17,7 +17,7 @@
     ],
     "bin": "spotify-qt.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/kraxarn/spotify-qt/releases/latest",
+        "github": "https://api.github.com/repos/kraxarn/spotify-qt/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "\\Av([\\d.-]+)\\Z"
     },

--- a/bucket/stack-wallet.json
+++ b/bucket/stack-wallet.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/cypherstack/stack_wallet/releases/latest",
+        "github": "https://api.github.com/repos/cypherstack/stack_wallet/releases/latest",
         "regex": "/download/(?<tag>[^/]+)/stack_wallet-v(?<version>[\\d.]+)-windows\\.zip"
     },
     "autoupdate": {

--- a/bucket/standardnotes.json
+++ b/bucket/standardnotes.json
@@ -22,7 +22,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/standardnotes/app/releases/latest",
+        "github": "https://api.github.com/repos/standardnotes/app/releases/latest",
         "regex": "@standardnotes/desktop@([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/status.json
+++ b/bucket/status.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/status-im/status-app/releases/latest",
+        "github": "https://api.github.com/repos/status-im/status-app/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "StatusIm-Desktop-(?<Ver>[\\d.]+)-(?<Build>[\\w]+)-x86_64\\.",
         "replace": "${Ver}-${Build}"

--- a/bucket/streamlabs-obs.json
+++ b/bucket/streamlabs-obs.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/streamlabs/desktop/tags?per_page=100",
+        "github": "https://api.github.com/repos/streamlabs/desktop/tags?per_page=100",
         "regex": "\"v([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -36,7 +36,7 @@
     ],
     "persist": "config",
     "checkver": {
-        "url": "https://api.github.com/repos/streamlink/windows-builds/releases/latest",
+        "github": "https://api.github.com/repos/streamlink/windows-builds/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "streamlink-([\\d.\\-]+)-py(?<py>\\d+)-x86_64\\.zip"
     },

--- a/bucket/subsync.json
+++ b/bucket/subsync.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/sc0ty/subsync/releases/latest",
+        "github": "https://api.github.com/repos/sc0ty/subsync/releases/latest",
         "jsonpath": "$.name",
         "regex": "subsync\\sv([\\d.]+)"
     },

--- a/bucket/supermium.json
+++ b/bucket/supermium.json
@@ -43,7 +43,7 @@
     },
     "persist": "User Data",
     "checkver": {
-        "url": "https://api.github.com/repos/win32ss/supermium/releases/latest",
+        "github": "https://api.github.com/repos/win32ss/supermium/releases/latest",
         "jsonpath": "$..['tag_name', 'name']",
         "regex": "(?i)\"(?<tag>v?[\\d]+(?<suffix>-[^\"]+)?)\",\"[^\"]+?(?<prefix>[\\d.]+)",
         "replace": "${prefix}${suffix}"

--- a/bucket/suwayomi-server.json
+++ b/bucket/suwayomi-server.json
@@ -21,7 +21,7 @@
     },
     "bin": "suwayomi.ps1",
     "checkver": {
-        "url": "https://api.github.com/repos/Suwayomi/Suwayomi-Server/releases/latest",
+        "github": "https://api.github.com/repos/Suwayomi/Suwayomi-Server/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "Suwayomi-Server-v([\\d.]+)-windows-x64\\.zip"
     },

--- a/bucket/switchhosts.json
+++ b/bucket/switchhosts.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/oldj/SwitchHosts/releases/latest",
+        "github": "https://api.github.com/repos/oldj/SwitchHosts/releases/latest",
         "regex": "SwitchHosts_windows_installer_x64_([\\d.]+)\\.exe"
     },
     "autoupdate": {

--- a/bucket/tcno-acc-switcher.json
+++ b/bucket/tcno-acc-switcher.json
@@ -24,7 +24,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/TCNOco/TcNo-Acc-Switcher/releases/latest",
+        "github": "https://api.github.com/repos/TCNOco/TcNo-Acc-Switcher/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /.+\\.7z/i)].browser_download_url",
         "regex": "(?i)download/([\\d._-]+)/(?<name>(?![^\"]+CEF)[^\"]+\\.7z)"
     },

--- a/bucket/tern-subtitle-file-translator.json
+++ b/bucket/tern-subtitle-file-translator.json
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/1c7/Translate-Subtitle-File/releases/latest",
+        "github": "https://api.github.com/repos/1c7/Translate-Subtitle-File/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Windows.+/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?([\\d.-]+))/(?<name>[^\"]+)"
     },

--- a/bucket/thonny.json
+++ b/bucket/thonny.json
@@ -16,7 +16,7 @@
     },
     "persist": "user_data",
     "checkver": {
-        "url": "https://api.github.com/repos/thonny/thonny/releases",
+        "github": "https://api.github.com/repos/thonny/thonny/releases",
         "regex": "thonny-([\\d.]+)-windows-portable\\.zip"
     },
     "autoupdate": {

--- a/bucket/thorium.json
+++ b/bucket/thorium.json
@@ -37,7 +37,7 @@
     },
     "persist": "USER_DATA",
     "checkver": {
-        "url": "https://api.github.com/repos/Alex313031/Thorium-Win/releases",
+        "github": "https://api.github.com/repos/Alex313031/Thorium-Win/releases",
         "regex": "/releases/tag/M(?<version>(?:\\d+\\.){3}\\d+)"
     },
     "autoupdate": {

--- a/bucket/tlaplus-toolbox.json
+++ b/bucket/tlaplus-toolbox.json
@@ -26,7 +26,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/tlaplus/tlaplus/releases",
+        "github": "https://api.github.com/repos/tlaplus/tlaplus/releases",
         "jsonpath": "$[0].tag_name",
         "regex": "v([\\d.]+)"
     },

--- a/bucket/todolist.json
+++ b/bucket/todolist.json
@@ -41,7 +41,7 @@
         "Resources\\TaskLists"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/abstractspoon/ToDoList_Downloads/commits",
+        "github": "https://api.github.com/repos/abstractspoon/ToDoList_Downloads/commits",
         "jsonpath": "$..message",
         "regex": "Update todolist_exe.zip to (\\d+[\\d.]+\\.\\d+)"
     },

--- a/bucket/total-registry.json
+++ b/bucket/total-registry.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/zodiacon/TotalRegistry/releases",
+        "github": "https://api.github.com/repos/zodiacon/TotalRegistry/releases",
         "regex": "download/v([\\d.]+)/"
     },
     "autoupdate": {

--- a/bucket/ubports-installer.json
+++ b/bucket/ubports-installer.json
@@ -32,7 +32,7 @@
     ],
     "persist": "APPDATA",
     "checkver": {
-        "url": "https://api.github.com/repos/ubports/ubports-installer/releases",
+        "github": "https://api.github.com/repos/ubports/ubports-installer/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/download/(?<tag>[\\w.-]+)/ubports-installer_([\\w.-]+)_win_x64\\.exe"
     },

--- a/bucket/uefitool.json
+++ b/bucket/uefitool.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/LongSoft/UEFITool/releases/latest",
+        "github": "https://api.github.com/repos/LongSoft/UEFITool/releases/latest",
         "jsonpath": "$.tag_name"
     },
     "autoupdate": {

--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -29,7 +29,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Bioruebe/UniExtract2/releases",
+        "github": "https://api.github.com/repos/Bioruebe/UniExtract2/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v([\\w.-]+)/(?<filename>\\w+\\.zip)"
     },

--- a/bucket/universal-android-debloater.json
+++ b/bucket/universal-android-debloater.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/0x192/universal-android-debloater/releases",
+        "github": "https://api.github.com/repos/0x192/universal-android-debloater/releases",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/vcxsrv.json
+++ b/bucket/vcxsrv.json
@@ -31,7 +31,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/marchaesen/vcxsrv/releases/latest",
+        "github": "https://api.github.com/repos/marchaesen/vcxsrv/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/(?<tag>[\\d.]+)/vcxsrv-64.([\\d.]+).installer.exe"
     },

--- a/bucket/virgo.json
+++ b/bucket/virgo.json
@@ -13,7 +13,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/henkman/virgo/releases/latest",
+        "github": "https://api.github.com/repos/henkman/virgo/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "v\\.([\\d.]+)"
     },

--- a/bucket/wasabi-wallet.json
+++ b/bucket/wasabi-wallet.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/WalletWasabi/WalletWasabi/releases/latest",
+        "github": "https://api.github.com/repos/WalletWasabi/WalletWasabi/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "/download/v(?<tag>[\\d.]+)/Wasabi-(?<version>[\\d.]+)-win-x64.zip"
     },

--- a/bucket/windterm.json
+++ b/bucket/windterm.json
@@ -33,7 +33,7 @@
     ],
     "persist": ".wind",
     "checkver": {
-        "url": "https://api.github.com/repos/kingToolbox/WindTerm/releases/latest",
+        "github": "https://api.github.com/repos/kingToolbox/WindTerm/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "WindTerm_([\\d.]+)_Windows_Portable"
     },

--- a/bucket/wox.json
+++ b/bucket/wox.json
@@ -24,7 +24,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/Wox-launcher/Wox/releases",
+        "github": "https://api.github.com/repos/Wox-launcher/Wox/releases",
         "jsonpath": "$[?(@.prerelease == false)].html_url",
         "regex": "(?i)tag/v([\\d.]+)(?=\")"
     },

--- a/bucket/yacreader.json
+++ b/bucket/yacreader.json
@@ -30,7 +30,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/YACReader/yacreader/releases/latest",
+        "github": "https://api.github.com/repos/YACReader/yacreader/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "YACReader-v([\\d.]+)-winx64-7z"
     },

--- a/bucket/yesplaymusic.json
+++ b/bucket/yesplaymusic.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/qier222/YesPlayMusic/releases/latest",
+        "github": "https://api.github.com/repos/qier222/YesPlayMusic/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Setup.+exe/i)].browser_download_url",
         "regex": "download/v([\\d.-]+)/(?<name>[^\"]+)(?=\")"
     },

--- a/bucket/yoke.json
+++ b/bucket/yoke.json
@@ -11,7 +11,7 @@
     },
     "bin": "yoke.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/yokecd/yoke/releases",
+        "github": "https://api.github.com/repos/yokecd/yoke/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "yoke_v([\\d.]+)_windows_amd64\\.exe\\.gz"
     },

--- a/bucket/youtube-dl-gui.json
+++ b/bucket/youtube-dl-gui.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/oleksis/youtube-dl-gui/releases/latest",
+        "github": "https://api.github.com/repos/oleksis/youtube-dl-gui/releases/latest",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "v([\\d.]+)/yt-dlg-(?<Release>[\\d.]+).msi"
     },

--- a/bucket/zeronet.json
+++ b/bucket/zeronet.json
@@ -22,7 +22,7 @@
         "log"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/HelloZeroNet/ZeroNet-win/branches",
+        "github": "https://api.github.com/repos/HelloZeroNet/ZeroNet-win/branches",
         "jsonpath": "$[?(@.name == 'dist-win64')].commit.sha"
     },
     "autoupdate": {

--- a/deprecated/fmedia.json
+++ b/deprecated/fmedia.json
@@ -20,7 +20,7 @@
     ],
     "persist": "fmedia.conf",
     "checkver": {
-        "url": "https://api.github.com/repos/stsaz/fmedia/releases",
+        "github": "https://api.github.com/repos/stsaz/fmedia/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "fmedia-([\\d.]+)-windows-x64.zip"
     },

--- a/deprecated/nekoray.json
+++ b/deprecated/nekoray.json
@@ -23,7 +23,7 @@
     ],
     "persist": "config",
     "checkver": {
-        "url": "https://api.github.com/repos/MatsuriDayo/nekoray/releases/latest",
+        "github": "https://api.github.com/repos/MatsuriDayo/nekoray/releases/latest",
         "regex": "nekoray-([\\d.]+)-(?<extra>[\\d-]+)-windows64"
     },
     "autoupdate": {


### PR DESCRIPTION
Per ScoopInstaller/Scoop#6641, to make authenticated GitHub API requests with a token in checkver, GitHub mode must be explicitly specified. Additionally, `checkver.github` now allows configuring either a GitHub repo URL or a GitHub API URL.

Some `checkver` may still not work. However, since there is still another breaking change (ScoopInstaller/Scoop#6653) that hasn't been merged yet, we may wait until it is merged before fixing this issue to avoid duplicating work.

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
