### PR TITLE
con-terminal: Add version 0.1.0-beta.58

### DIFF
--- a/bucket/con-terminal.json
+++ b/bucket/con-terminal.json
@@ -1,0 +1,53 @@
+{
+    "version": "0.1.0-beta.58",
+    "description": "The Native Terminal Emulator with a builtin AI Harness",
+    "homepage": "https://con.nowledge.co/",
+    "license": "MIT",
+    "notes": "We recommend turning off automatic updates within the app.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/nowledge-co/con-terminal/releases/download/v0.1.0-beta.58/con-0.1.0-beta.58-windows-x86_64.zip",
+            "hash": "3d19770d74efda35e3e04de33be6075e661a7ae934566c317a65ff394f63a00f"
+        }
+    },
+    "post_install": [
+        "$appDataPath = \"$env:APPDATA\\con-terminal\"",
+        "$persistPath = \"$persist_dir\\Roaming\"",
+        "if (Test-Path $appDataPath) {",
+        "    Remove-Item $appDataPath -Recurse -Force",
+        "}",
+        "if (-Not (Test-Path $persistPath)) {",
+        "    New-Item -Path \"$persistPath\" -ItemType Directory | Out-Null",
+        "}",
+        "New-Item -ItemType Junction -Path \"$appDataPath\" -Target \"$persistPath\" | Out-Null"
+    ],
+    "bin": [
+        [
+            "con-app.exe",
+            "con-app"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "con-app.exe",
+            "Con"
+        ]
+    ],
+    "post_uninstall": [
+        "$appDataPath = \"$env:APPDATA\\con-terminal\"",
+        "if (Test-Path $appDataPath) {",
+        "    Remove-Item $appDataPath -Recurse -Force",
+        "}"
+    ],
+    "checkver": {
+        "url": "https://github.com/nowledge-co/con-terminal/releases/latest",
+        "re": "/tag/v?([\\d\\w.-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/nowledge-co/con-terminal/releases/download/v$version/con-$version-windows-x86_64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[con-terminal](https://github.com/nowledge-co/con-terminal) is a native terminal emulator with a builtin AI harness.

Closes ScoopInstaller/Versions#2839 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
