### PR TITLE
netcatty: Add version 1.1.1

### DIFF
--- a/bucket/netcatty.json
+++ b/bucket/netcatty.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.1.1",
+    "description": "AI-Powered SSH Client, SFTP Browser & Terminal Manager",
+    "homepage": "https://netcatty.app",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.1/Netcatty-1.1.1-portable-win-x64.exe#/dl.7z",
+            "hash": "sha256:5e112a23c6d48893ea0181c12b0be0c16188193958771a5e78fd4bed010901ea"
+        }
+    },
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Unins*\" -Force -Recurse"
+    ],
+    "bin": "Netcatty.exe",
+    "shortcuts": [
+        [
+            "Netcatty.exe",
+            "Netcatty"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/binaricat/Netcatty"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/binaricat/Netcatty/releases/download/v$version/Netcatty-$version-portable-win-x64.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha256: $base64"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add Netcatty 1.1.1 - AI-Powered SSH Client, SFTP Browser & Terminal Manager

## Testing

- [x] Installed successfully via scoop
- [x] Application launches and runs without errors
- [x] Uninstall works correctly

## Checklist

- [x] Manifest follows Scoop bucket conventions
- [x] Hash verified
- [x] Tested on Windows

/verify