### PR TITLE
polyml: Add version 5.9.1

### DIFF
--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -16,5 +16,17 @@
             "PolyML.exe",
             "PolyML"
         ]
-    ]
+    ],
+    "checkver": {
+        "github": "https://api.github.com/repos/polyml/polyml/releases",
+        "jsonpath": "$....name",
+        "regex": "PolyML(?<version>[\\d.]*)-64bit.msi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/polyml/polyml/releases/download/v$version/PolyML$version-64bit.msi"
+            }
+        }
+    }
 }

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -16,5 +16,16 @@
             "PolyML.exe",
             "PolyML"
         ]
-    ]
+    ],
+   "checkver": {
+     "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
+     "jsonpath": "$..browser_download_url",
+     "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
+   },
+   "autoupdate": {
+     "url": "https://github.com/polyml/polyml/releases/download/v$matchTag/PolyML$version-64bit.msi",
+     "hash": {
+       "url": "$baseurl/SHA256sums.txt"
+     }
+   }
 }

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -16,13 +16,5 @@
             "PolyML.exe",
             "PolyML"
         ]
-    ],
-    "checkver": {
-        "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
-        "jsonpath": "$..browser_download_url",
-        "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
-    },
-    "autoupdate": {
-        "url": "https://github.com/polyml/polyml/releases/download/v$version/PolyML$version-64bit.msi"
-    }
+    ]
 }

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -1,31 +1,20 @@
 {
-  "version": "5.9.1",
-  "description": "An implementation of Standard ML",
-  "homepage": "https://github.com/polyml/polyml/",
-  "license": "LGPL-2.1-only",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/polyml/polyml/releases/download/v5.9.1/PolyML5.9.1-64bit.msi",
-      "hash": "06C7C11A9BE151D3F3C9016F9CDD66186031FC9620AC26013D258E9781AE41EB"
-    }
-  },
-  "extract_dir": "PFiles/Poly ML",
-  "bin": "PolyML.exe",
-  "shortcuts": [
-    [
-      "PolyML.exe",
-      "PolyML"
+    "version": "5.9.1",
+    "description": "An implementation of Standard ML",
+    "homepage": "https://github.com/polyml/polyml/",
+    "license": "LGPL-2.1-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/polyml/polyml/releases/download/v5.9.1/PolyML5.9.1-64bit.msi",
+            "hash": "06C7C11A9BE151D3F3C9016F9CDD66186031FC9620AC26013D258E9781AE41EB"
+        }
+    },
+    "extract_dir": "PFiles/Poly ML",
+    "bin": "PolyML.exe",
+    "shortcuts": [
+        [
+            "PolyML.exe",
+            "PolyML"
+        ]
     ]
-  ],
-  "checkver": {
-    "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
-    "jsonpath": "$..browser_download_url",
-    "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
-  },
-  "autoupdate": {
-    "url": "https://github.com/polyml/polyml/releases/download/v$matchTag/PolyML$version-64bit.msi",
-    "hash": {
-      "url": "$baseurl/SHA256sums.txt"
-    }
-  }
 }

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -23,7 +23,7 @@
      "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
    },
    "autoupdate": {
-     "url": "https://github.com/polyml/polyml/releases/download/v$matchTag/PolyML$version-64bit.msi",
+     "url": "https://github.com/polyml/polyml/releases/download/v$version/PolyML$version-64bit.msi",
      "hash": {
        "url": "$baseurl/SHA256sums.txt"
      }

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -2,7 +2,7 @@
   "version": "5.9.1",
   "description": "An implementation of Standard ML",
   "homepage": "https://github.com/polyml/polyml/",
-  "license": "LGPL-2.1",
+  "license": "LGPL-2.1-only",
   "architecture": {
     "64bit": {
       "url": "https://github.com/polyml/polyml/releases/download/v5.9.1/PolyML5.9.1-64bit.msi",
@@ -20,10 +20,10 @@
   "checkver": {
     "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
     "jsonpath": "$..browser_download_url",
-    "regex": "download/v(?<tag>[\\d.]+)/PolyML.([\\d.]+)-64bit\\.msi"
+    "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
   },
   "autoupdate": {
-    "url": "https://github.com/polyml/polyml/releases/download/v$matchTag/PolyML.$version-64bit.msi",
+    "url": "https://github.com/polyml/polyml/releases/download/v$matchTag/PolyML$version-64bit.msi",
     "hash": {
       "url": "$baseurl/SHA256sums.txt"
     }

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -1,0 +1,31 @@
+{
+  "version": "5.9.1",
+  "description": "An implementation of Standard ML",
+  "homepage": "https://github.com/polyml/polyml/",
+  "license": "LGPL-2.1",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/polyml/polyml/releases/download/v5.9.1/PolyML5.9.1-64bit.msi",
+      "hash": "06C7C11A9BE151D3F3C9016F9CDD66186031FC9620AC26013D258E9781AE41EB"
+    }
+  },
+  "extract_dir": "PFiles/Poly ML",
+  "bin": "PolyML.exe",
+  "shortcuts": [
+    [
+      "PolyML.exe",
+      "PolyML"
+    ]
+  ],
+  "checkver": {
+    "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
+    "jsonpath": "$..browser_download_url",
+    "regex": "download/v(?<tag>[\\d.]+)/PolyML.([\\d.]+)-64bit\\.msi"
+  },
+  "autoupdate": {
+    "url": "https://github.com/polyml/polyml/releases/download/v$matchTag/PolyML.$version-64bit.msi",
+    "hash": {
+      "url": "$baseurl/SHA256sums.txt"
+    }
+  }
+}

--- a/bucket/polyml.json
+++ b/bucket/polyml.json
@@ -17,15 +17,12 @@
             "PolyML"
         ]
     ],
-   "checkver": {
-     "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
-     "jsonpath": "$..browser_download_url",
-     "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
-   },
-   "autoupdate": {
-     "url": "https://github.com/polyml/polyml/releases/download/v$version/PolyML$version-64bit.msi",
-     "hash": {
-       "url": "$baseurl/SHA256sums.txt"
-     }
-   }
+    "checkver": {
+        "github": "https://api.github.com/repos/polyml/polyml/releases/latest",
+        "jsonpath": "$..browser_download_url",
+        "regex": "download/v(?<tag>[\\d.]+)/PolyML([\\d.]+)-64bit\\.msi"
+    },
+    "autoupdate": {
+        "url": "https://github.com/polyml/polyml/releases/download/v$version/PolyML$version-64bit.msi"
+    }
 }


### PR DESCRIPTION
Closes #17766

The program has a GUI interface for the intepreter.

Auto update is missing, because in the latest release, the binary for windows is still not published.

Autoupdate has been added back.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
