### PR TITLE
leopardwm: Add version 0.1.10

### DIFF
--- a/bucket/leopardwm.json
+++ b/bucket/leopardwm.json
@@ -1,18 +1,19 @@
 {
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "Scroll-first tiling window manager for Windows, inspired by niri.",
     "homepage": "https://github.com/jcardama/LeopardWM",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jcardama/LeopardWM/releases/download/v0.1.10/LeopardWM-0.1.10-x86_64-windows.zip",
-            "hash": "24805c7261f6caf61a8e1fa5ecd7dd70dba3203da4033c9ab008cb1fc210da6e",
-            "extract_dir": "LeopardWM-0.1.10-x86_64-windows"
+            "url": "https://github.com/jcardama/LeopardWM/releases/download/v0.1.11/LeopardWM-0.1.11-x86_64-windows.zip",
+            "hash": "c114c0bd423391d9a57ff45aea869f71deded38bccd50d2cdcf7caad17141f84",
+            "extract_dir": "LeopardWM-0.1.11-x86_64-windows"
         }
     },
     "bin": [
         "leopardwm.exe",
-        "leopardwm-cli.exe"
+        "leopardwm-cli.exe",
+        "lwm.exe"
     ],
     "notes": [
         "Run 'leopardwm-cli run' to start the daemon, or 'leopardwm-cli help' for the full command list.",

--- a/bucket/leopardwm.json
+++ b/bucket/leopardwm.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.1.10",
+    "description": "Scroll-first tiling window manager for Windows, inspired by niri.",
+    "homepage": "https://github.com/jcardama/LeopardWM",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jcardama/LeopardWM/releases/download/v0.1.10/LeopardWM-0.1.10-x86_64-windows.zip",
+            "hash": "24805c7261f6caf61a8e1fa5ecd7dd70dba3203da4033c9ab008cb1fc210da6e",
+            "extract_dir": "LeopardWM-0.1.10-x86_64-windows"
+        }
+    },
+    "bin": [
+        "leopardwm.exe",
+        "leopardwm-cli.exe"
+    ],
+    "notes": [
+        "Run 'leopardwm-cli run' to start the daemon, or 'leopardwm-cli help' for the full command list.",
+        "Configuration lives at %APPDATA%\\leopardwm\\config\\config.toml (created on first run)."
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jcardama/LeopardWM/releases/download/v$version/LeopardWM-$version-x86_64-windows.zip",
+                "extract_dir": "LeopardWM-$version-x86_64-windows"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [LeopardWM](https://github.com/jcardama/LeopardWM) — a scroll-first tiling window manager for Windows 10/11, inspired by niri/PaperWM. Written in Rust, GPL-3.0.

The manifest installs both binaries (`leopardwm.exe`, `leopardwm-cli.exe`) and points at the project's GitHub Releases. `checkver: github` + `autoupdate` use the standard release URL pattern so future versions auto-bump.

Tested locally:

- `scoop install <path-to-manifest>` — downloads, hash check passes, shims created
- `leopardwm-cli --version` reports 0.1.10
- `leopardwm-cli status` connects to a running daemon
- `scoop uninstall leopardwm` cleans up correctly