### PR TITLE
opencode-desktop: Update to version 1.14.48, fix autoupdate

### DIFF
--- a/bucket/opencode-desktop.json
+++ b/bucket/opencode-desktop.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.14.41",
+    "version": "1.14.48",
     "description": "The open source AI coding agent.",
     "homepage": "https://opencode.ai/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-desktop-win-x64.exe#/dl.7z",
-            "hash": "c5e650f41b2924f51f58e64be14b446d89a7ca7881f9552577d0c65e72b1d6d9"
+            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-desktop-win-x64.exe#/dl.7z",
+            "hash": "ed844022293ded0d07b94ca2f097434f5432bb1384d871d6fe85b3448b6f0486"
         },
         "arm64": {
-            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-desktop-win-arm64.exe#/dl.7z",
-            "hash": "b243ab11fced7713197c0c4ae2382867c14cdad7ff803b1f1297f7bd68525d68"
+            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-desktop-win-arm64.exe#/dl.7z",
+            "hash": "e6eab56e4bc2e8f18da68f30ecce1f6d80cb2467691d1fa3a37b7c8a41e6ea08"
         }
     },
     "pre_install": [
@@ -29,11 +29,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                    "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-win-x64.exe#/dl.7z"
-                },
-                "arm64": {
-                    "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-win-arm64.exe#/dl.7z"
-                }
+                "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-win-x64.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-win-arm64.exe#/dl.7z"
             }
         }
+    }
 }

--- a/bucket/opencode-desktop.json
+++ b/bucket/opencode-desktop.json
@@ -1,24 +1,21 @@
 {
-    "version": "1.14.33",
+    "version": "1.14.41",
     "description": "The open source AI coding agent.",
     "homepage": "https://opencode.ai/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.33/opencode-desktop-windows-x64.exe#/dl.7z",
-            "hash": "a451d43e32100161e438666684e014080b9f17da17b0e78e86924c9319acd888"
+            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-desktop-win-x64.exe#/dl.7z",
+            "hash": "c5e650f41b2924f51f58e64be14b446d89a7ca7881f9552577d0c65e72b1d6d9"
         },
         "arm64": {
-            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.33/opencode-desktop-windows-arm64.exe#/dl.7z",
-            "hash": "3ec5c0394fb01af970ee220db63c5c99cbd0fa9272a72b6742c645d5b0f0de21"
+            "url": "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-desktop-win-arm64.exe#/dl.7z",
+            "hash": "b243ab11fced7713197c0c4ae2382867c14cdad7ff803b1f1297f7bd68525d68"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse -ErrorAction Ignore",
-    "bin": [
-        [
-            "opencode-cli.exe",
-            "opencode"
-        ]
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-*.7z\" \"$dir\"",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse -ErrorAction Ignore"
     ],
     "shortcuts": [
         [
@@ -32,11 +29,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-windows-x64.exe#/dl.7z"
-            },
-            "arm64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-windows-arm64.exe#/dl.7z"
+                    "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-win-x64.exe#/dl.7z"
+                },
+                "arm64": {
+                    "url": "https://github.com/anomalyco/opencode/releases/download/v$version/opencode-desktop-win-arm64.exe#/dl.7z"
+                }
             }
         }
-    }
 }


### PR DESCRIPTION
### Summary

Migrates `opencode-desktop` manifest handling from the old Tauri-style layout to the current Electron NSIS layout.

### Related issues or pull requests

- Closes N/A

### Changes

- Update download assets to new names:
  - `opencode-desktop-win-x64.exe`
  - `opencode-desktop-win-arm64.exe`
- Update SHA256 hashes for both architectures.
- Add `pre_install` extraction for Electron payload from `\$PLUGINSDIR\app-*.7z`.
- Remove obsolete `bin` entry for `opencode-cli.exe` (not present in Electron package).
- Keep shortcut target as `OpenCode.exe`.
- Update `autoupdate` URLs to match new asset naming.