### PR TITLE
rightwheel: Add version 2.10.3

### DIFF
--- a/bucket/RightWheel.json
+++ b/bucket/RightWheel.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.10.3",
+    "description": "Mouse shortcut panel for Windows — hold right-click and scroll to instantly launch apps, trigger shortcuts, run commands and open URLs.",
+    "homepage": "https://chautnus.github.io/RightWheel/",
+    "license": "Freeware",
+    "url": "https://github.com/chautnus/RightWheel/releases/download/v2.10.3/RightWheel.exe",
+    "hash": "sha256:1d4cc62c03a17429825a9ecdb871418489e42ff7ceb55cbbf38bc623867f9449",
+    "bin": "RightWheel.exe",
+    "shortcuts": [["RightWheel.exe", "RightWheel"]],
+    "checkver": {
+        "github": "https://github.com/chautnus/RightWheel"
+    },
+    "autoupdate": {
+        "url": "https://github.com/chautnus/RightWheel/releases/download/v$version/RightWheel.exe"
+    }
+}


### PR DESCRIPTION
### Description

Adds a Scoop manifest for **RightWheel** v2.10.3.

**RightWheel** is a mouse shortcut panel for Windows - hold right-click and scroll to instantly launch apps, trigger shortcuts, run commands, and open URLs. It is a portable single-executable application with no installer required.

- Homepage: https://chautnus.github.io/RightWheel/
- GitHub: https://github.com/chautnus/RightWheel
- License: Freeware (free trial available, \.99 for full license)
- Portable: single .exe, no installation needed

### Manifest details

- Version: 2.10.3
- SHA256 hash verified
- checkver and utoupdate configured to track GitHub releases