### PR TITLE
wsl-ui: Add version 0.19.0

### DIFF
--- a/bucket/wsl-ui.json
+++ b/bucket/wsl-ui.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.19.0",
+    "description": "A WSL2 Manager desktop application providing a GUI for managing WSL2 distros, settings, networking, and services. Built with Tauri, Vite, React, and TypeScript.",
+    "homepage": "https://github.com/octasoft-ltd/wsl-ui",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/octasoft-ltd/wsl-ui/releases/download/v0.19.0/WSL.UI_0.19.0_x64_portable.exe#/wsl-ui.exe",
+            "hash": "394d5f1b5cf9ee8415df871166645a974810f9ec499318b062138879aaa11407"
+        },
+        "arm64": {
+            "url": "https://github.com/octasoft-ltd/wsl-ui/releases/download/v0.19.0/WSL.UI_0.19.0_arm64_portable.exe#/wsl-ui.exe",
+            "hash": "f2ae5fce94f51a7b0eee8db69aab89242707c6381f544613b4ffbb6604b65654"
+        }
+    },
+    "bin": "wsl-ui.exe",
+    "shortcuts": [
+        [
+            "wsl-ui.exe",
+            "WSL UI"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/octasoft-ltd/wsl-ui/releases/download/v$version/WSL.UI_$version_x64_portable.exe#/wsl-ui.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/octasoft-ltd/wsl-ui/releases/download/v$version/WSL.UI_$version_arm64_portable.exe#/wsl-ui.exe"
+            }
+        }
+    }
+}

--- a/bucket/wsl-ui.json
+++ b/bucket/wsl-ui.json
@@ -1,7 +1,7 @@
 {
     "version": "0.19.0",
     "description": "A WSL2 Manager desktop application providing a GUI for managing WSL2 distros, settings, networking, and services. Built with Tauri, Vite, React, and TypeScript.",
-    "homepage": "https://github.com/octasoft-ltd/wsl-ui",
+    "homepage": "https://wsl-ui.octasoft.co.uk",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
@@ -13,14 +13,15 @@
             "hash": "f2ae5fce94f51a7b0eee8db69aab89242707c6381f544613b4ffbb6604b65654"
         }
     },
-    "bin": "wsl-ui.exe",
     "shortcuts": [
         [
             "wsl-ui.exe",
             "WSL UI"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/octasoft-ltd/wsl-ui"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
## Summary

Adds `bucket/wsl-ui.json` at v0.19.0 so users can `scoop install wsl-ui`. Manifest covers x64 and arm64 with `_portable.exe` assets renamed to `wsl-ui.exe` via URL fragment, includes `bin`, `shortcuts` ("WSL UI"), `checkver: "github"`, and per-arch `autoupdate` URLs matching the project's `releases/download/v$version/WSL.UI_$version_<arch>_portable.exe` pattern.

Closes #17807