### PR TITLE
qbittorrent: Refactor pre_install script, persist `qt.conf`

### DIFF
--- a/bucket/qbittorrent.json
+++ b/bucket/qbittorrent.json
@@ -1,10 +1,10 @@
 {
     "version": "5.2.0",
     "description": "Free and reliable P2P Bittorent client.",
-    "homepage": "https://www.qbittorrent.org/",
+    "homepage": "https://www.qbittorrent.org",
     "license": {
-        "identifier": "GPL-2.0-only",
-        "url": "https://github.com/qbittorrent/qBittorrent/blob/master/COPYING"
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/qbittorrent/qBittorrent/blob/HEAD/COPYING"
     },
     "notes": [
         "For file associations, run:",
@@ -17,26 +17,17 @@
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse -ErrorAction SilentlyContinue",
-        "if ((!(Test-Path \"$persist_dir\\profile\")) -and ((Test-Path \"$persist_dir\\..\\qbittorrent-portable\\profile\") -or (Test-Path \"$env:APPDATA\\qBittorrent\"))) {",
-        "    Write-Host \"Scoop is migrating qbittorrent to use portable mode by default.\" -ForegroundColor Yellow",
-        "    Write-Host \"For details, see: https://github.com/ScoopInstaller/Extras/issues/5845\" -ForegroundColor Yellow",
-        "    if ((Test-Path \"$persist_dir\\..\\qbittorrent-portable\\profile\") -and (Test-Path \"$env:APPDATA\\qBittorrent\")) {",
-        "        Write-Host \"Both portable and non-portable qBittorrent profile exist.\" -ForegroundColor Yellow",
-        "        Write-Host \"Scoop will prioritize and import the non-portable one.\" -ForegroundColor Yellow",
-        "    }",
-        "    New-Item \"$persist_dir\\profile\" -ItemType Directory | Out-Null",
-        "    if (Test-Path \"$env:APPDATA\\qBittorrent\") {",
-        "        Write-Host \"Copying non-portable profile's config and data to Scoop persist directory...\" -ForegroundColor Yellow",
-        "        Copy-Item \"$env:APPDATA\\qBittorrent\" \"$persist_dir\\profile\\qBittorrent\\config\" -Recurse | Out-Null",
-        "        Copy-Item \"$env:LOCALAPPDATA\\qBittorrent\" \"$persist_dir\\profile\\qBittorrent\\data\" -Recurse | Out-Null",
-        "    } else {",
-        "        Write-Host \"Copying portable profile's config and data to Scoop persist directory...\" -ForegroundColor Yellow",
-        "        Write-Host \"If you haven't setup an absolute download path before torrenting, please manually migrate affected torrents, as they use relative path by default for storaging.\" -ForegroundColor Yellow",
-        "        Write-Host \"Or you can move them to an absolute download path in qbittorrent-portable and cleanly (re)install qbittorrent to let migration script to take care of them.\" -ForegroundColor Yellow",
-        "        Copy-Item \"$persist_dir\\..\\qbittorrent-portable\\profile\\qBittorrent\\config\" \"$persist_dir\\profile\\qBittorrent\\config\" -Recurse | Out-Null",
-        "        Copy-Item \"$persist_dir\\..\\qbittorrent-portable\\profile\\qBittorrent\\data\" \"$persist_dir\\profile\\qBittorrent\\data\" -Recurse | Out-Null",
-        "    }",
+        "$data_dir = \"$persist_dir\\profile\\qBittorrent\\data\"",
+        "$configuration_dir = \"$persist_dir\\profile\\qBittorrent\\config\"",
+        "$data_dir, $configuration_dir | ForEach-Object { ensure $_ | Out-Null }",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst*\" -Force -Recurse -ErrorAction SilentlyContinue",
+        "if (-not (Test-Path -Path \"$data_dir\\*\") -and (Test-Path -Path \"$env:LOCALAPPDATA\\qBittorrent\\*\")) {",
+        "    Write-Host \"`nINFO  Migrating qBittorrent data to '$data_dir'...\" -ForegroundColor DarkGray",
+        "    Copy-Item -Path \"$env:LOCALAPPDATA\\qBittorrent\\*\" -Destination $data_dir -Force -Exclude 'cache' -Recurse",
+        "}",
+        "if (-not (Test-Path -Path \"$configuration_dir\\*\") -and (Test-Path -Path \"$env:APPDATA\\qBittorrent\\*\")) {",
+        "    Write-Host \"INFO  Migrating qBittorrent configurations to '$configuration_dir'...\" -ForegroundColor DarkGray",
+        "    Copy-Item -Path \"$env:APPDATA\\qBittorrent\\*\" -Destination $configuration_dir -Force -Recurse",
         "}"
     ],
     "post_install": [
@@ -56,7 +47,10 @@
             "qBittorrent"
         ]
     ],
-    "persist": "profile",
+    "persist": [
+        "profile",
+        "qt.conf"
+    ],
     "uninstaller": {
         "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }"
     },


### PR DESCRIPTION
### Summary

Updates `qbittorrent` license information and restructures the `pre_install` script for improved maintainability and a cleaner installation experience.

### Related issues or pull requests

- Relates to #12170 
- Relates to https://github.com/ScoopInstaller/Versions/pull/2855

### Changes

- Update `license` to **GPL-3.0-or-later** and update the reference URL to use `HEAD`.
- Refactor `pre_install` script:
  - Replace complex nested migration logic with streamlined checks for configuration and data paths.
  - Integrate the `ensure` helper function for robust directory initialization.
  - Implement a `cache` exclusion during data migration to avoid unnecessary persistence.
- Expand `persist` to include `qt.conf` alongside the `profile` directory.

### Notes

- This refactor removes the legacy check for `qbittorrent-portable` paths in favor of a direct migration from standard system locations to the Scoop persist directory, aligning with the current repository standards.
- Adding `qt.conf` to the persist list ensures that user-defined Qt framework settings (like DPI scaling or plugin paths) are preserved across updates.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras][ qbittorrent ≡]
└─> scoop install .\bucket\qbittorrent.json
Installing 'qbittorrent' (5.2.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket\qbittorrent.json'
Loading qbittorrent_5.2.0_x64_setup.exe from cache.
Checking hash of qbittorrent_5.2.0_x64_setup.exe... OK.
Extracting qbittorrent_5.2.0_x64_setup.exe... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\qbittorrent\current => D:\Software\Scoop\Local\apps\qbittorrent\5.2.0
Creating shim for 'qbittorrent'.
Making D:\Software\Scoop\Local\shims\qbittorrent.exe a GUI binary.
Creating shortcut for qBittorrent (qbittorrent.exe)
Persisting profile
Persisting qt.conf
Running post_install script... Done.
'qbittorrent' (5.2.0) was installed successfully!
Notes
-----
For file associations, run:
reg import "D:\Software\Scoop\Local\apps\qbittorrent\current\install-associations.reg"
-----

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)