### PR TITLE
tora: Add version 0.1.0

### DIFF
--- a/bucket/tora.json
+++ b/bucket/tora.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "0.1.0",
+    "description": "Lightweight tiling window manager for Windows, driven by CLI + IPC.",
+    "homepage": "https://github.com/TooruTora/tora-wm",
+    "license": "MIT OR Apache-2.0",
+    "url": "https://github.com/TooruTora/tora-wm/releases/download/v0.1.0/tora-v0.1.0-x86_64-pc-windows-msvc.zip",
+    "hash": "sha256:c85cab3ad47eaee07e2ec28b00c67ed3f49f7659b72a898a6e06766de7fe844b",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TooruTora/tora-wm/releases/download/v0.1.0/tora-v0.1.0-x86_64-pc-windows-msvc.zip",
+            "hash": "sha256:c85cab3ad47eaee07e2ec28b00c67ed3f49f7659b72a898a6e06766de7fe844b"
+        }
+    },
+    "bin": "tora.exe",
+    "notes": [
+        "tora ships with four bundled addons under .\\addons\\.",
+        "Disable any of them via [addons] disabled = [...] in your tora.toml.",
+        "Bring your own hotkey daemon (AutoHotkey / whkd / PowerToys);",
+        "see docs\\examples\\example.ahk in this install for a sample layout."
+    ],
+    "checkver": {
+        "github": "https://github.com/TooruTora/tora-wm"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TooruTora/tora-wm/releases/download/v$version/tora-v$version-x86_64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds [tora](https://github.com/TooruTora/tora-wm) v0.1.0 — a lightweight tiling window manager for Windows, written in Rust.

A single `tora.exe` binary owns layout and per-monitor workspaces; every feature that can live outside the core (borders, transparency, sloppy focus, per-app rules) ships as a separate addon process that opts in via the daemon's named-pipe IPC. Users bring their own hotkey daemon (AutoHotkey, whkd, PowerToys) and bind keys to `tora <subcommand>`.

## Manifest details

- Source: `https://github.com/TooruTora/tora-wm/releases/download/v0.1.0/tora-v0.1.0-x86_64-pc-windows-msvc.zip`
- SHA256: `c85cab3ad47eaee07e2ec28b00c67ed3f49f7659b72a898a6e06766de7fe844b`
- License: MIT OR Apache-2.0
- 64-bit only; ships `tora.exe` plus four bundled addon binaries

## Checklist

- [x] Manifest validates against the Scoop schema
- [x] `autoupdate` block points at the GitHub releases URL pattern and `.sha256` sidecar
- [x] `checkver` configured for GitHub releases
- [x] Tested locally with `scoop install` from the bucket