### PR TITLE
lfk: Add version 0.12.0

### DIFF
--- a/bucket/lfk.json
+++ b/bucket/lfk.json
@@ -13,12 +13,12 @@
             "hash": "1753dd0fe47217cbb295b4117f2f6a0cb4458f5732795eba69b69cb9fddac665"
         }
     },
-    "bin": "lfk.exe",
     "env_set": {
         "LFK_CONFIG_DIR": "$persist_dir/config",
         "LFK_STATE_DIR": "$persist_dir/state",
         "LFK_DATA_DIR": "$persist_dir/data"
     },
+    "bin": "lfk.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/lfk.json
+++ b/bucket/lfk.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.12.0",
+    "description": "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters",
+    "homepage": "https://github.com/janosmiko/lfk",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/janosmiko/lfk/releases/download/v0.12.0/lfk_0.12.0_windows_amd64.zip",
+            "hash": "339a590ef33be2e6bc97614a8755fa14e35b44e2ce2a2b6fa96f6955dc5571e3"
+        },
+        "arm64": {
+            "url": "https://github.com/janosmiko/lfk/releases/download/v0.12.0/lfk_0.12.0_windows_arm64.zip",
+            "hash": "1753dd0fe47217cbb295b4117f2f6a0cb4458f5732795eba69b69cb9fddac665"
+        }
+    },
+    "bin": "lfk.exe",
+    "env_set": {
+        "LFK_CONFIG_DIR": "$persist_dir/config",
+        "LFK_STATE_DIR": "$persist_dir/state",
+        "LFK_DATA_DIR": "$persist_dir/data"
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/janosmiko/lfk/releases/download/v$version/lfk_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/janosmiko/lfk/releases/download/v$version/lfk_$version_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256  $basename\\n"
+        }
+    }
+}


### PR DESCRIPTION
Adds a Scoop manifest for [lfk](https://github.com/janosmiko/lfk) — a keyboard-focused Kubernetes TUI (Apache-2.0, Go). `env_set` points `LFK_CONFIG_DIR` / `LFK_STATE_DIR` / `LFK_DATA_DIR` at `$persist_dir`, so config, state, and logs persist across updates.

Closes #17823

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)