### PR TITLE
lenovolegiontoolkit: Switch upstream to `SSC-STUDIO/LenovoLegionToolkit`

### DIFF
--- a/bucket/lenovolegiontoolkit.json
+++ b/bucket/lenovolegiontoolkit.json
@@ -1,13 +1,13 @@
-{
-    "version": "2.26.1",
-    "description": "A lightweight alternative to the Lenovo Vantage Software created for Lenovo Legion laptops",
-    "homepage": "https://github.com/BartoszCichecki/LenovoLegionToolkit",
-    "license": "MIT",
+﻿{
+    "version": "3.6.16",
+    "description": "A lightweight Lenovo Vantage and Hotkeys replacement for Lenovo Legion laptops",
+    "homepage": "https://github.com/SSC-STUDIO/LenovoLegionToolkit",
+    "license": "GPL-3.0",
     "suggest": {
-        ".NET Desktop Runtime 8.0": "versions/windowsdesktop-runtime-8.0"
+        ".NET Desktop Runtime 10.0": "versions/windowsdesktop-runtime-lts"
     },
-    "url": "https://github.com/BartoszCichecki/LenovoLegionToolkit/releases/download/2.26.1/LenovoLegionToolkitSetup.exe",
-    "hash": "e7aa9309d4da33ced84e990afbdce08b67966663c2a87909361d451d62d10ec2",
+    "url": "https://github.com/SSC-STUDIO/LenovoLegionToolkit/releases/download/v3.6.16/LenovoLegionToolkit_v3.6.16_Setup.exe",
+    "hash": "07407704427bb5b9b9e87c5a256c41fe60a423537d3b16c0bcb2ae0fe27c7acf",
     "innosetup": true,
     "shortcuts": [
         [
@@ -15,8 +15,10 @@
             "Lenovo Legion Toolkit"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "SSC-STUDIO/LenovoLegionToolkit"
+    },
     "autoupdate": {
-        "url": "https://github.com/BartoszCichecki/LenovoLegionToolkit/releases/download/$version/LenovoLegionToolkitSetup.exe"
+        "url": "https://github.com/SSC-STUDIO/LenovoLegionToolkit/releases/download/v$version/LenovoLegionToolkit_v$version_Setup.exe"
     }
 }


### PR DESCRIPTION
## Summary
- update lenovolegiontoolkit to 3.6.16
- switch homepage and download source to SSC-STUDIO/LenovoLegionToolkit
- update package hash to the 3.6.16 release asset
- align suggested runtime to .NET Desktop Runtime 10.0