### PR TITLE
kanata: Update to version 1.11.0, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/kanata.json
+++ b/bucket/kanata.json
@@ -1,21 +1,32 @@
 {
-    "version": "1.9.0",
+    "version": "1.11.0",
     "description": "A software keyboard remapper.",
     "homepage": "https://github.com/jtroo/kanata",
     "license": "LGPL-3.0-only",
     "notes": "Configuration Guide: https://github.com/jtroo/kanata/blob/main/docs/config.adoc",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jtroo/kanata/releases/download/v1.9.0/kanata.exe",
-            "hash": "18bdeaa4c51ce404ece4d94b6fa00aa355062dd703236398eeb12e684493ddcb"
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.11.0/windows-binaries-x64.zip",
+            "hash": "db43d06e7f8d0578bc77585bc24bb385cc99862e942e5554dbf3dec02bf081e9",
+            "bin": [
+                [
+                    "kanata_windows_tty_winIOv2_x64.exe",
+                    "Kanata"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "kanata_windows_gui_winIOv2_x64.exe",
+                    "Kanata"
+                ]
+            ]
         }
     },
-    "bin": "kanata.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jtroo/kanata/releases/download/v$version/kanata.exe"
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/windows-binaries-x64.zip"
             }
         }
     }

--- a/bucket/kanata.json
+++ b/bucket/kanata.json
@@ -4,6 +4,9 @@
     "homepage": "https://github.com/jtroo/kanata",
     "license": "LGPL-3.0-only",
     "notes": "Configuration Guide: https://github.com/jtroo/kanata/blob/main/docs/config.adoc",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/jtroo/kanata/releases/download/v1.11.0/windows-binaries-x64.zip",
@@ -63,6 +66,9 @@
             "arm64": {
                 "url": "https://github.com/jtroo/kanata/releases/download/v$version/windows-binaries-arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sums"
         }
     }
 }

--- a/bucket/kanata.json
+++ b/bucket/kanata.json
@@ -28,6 +28,30 @@
                     "Kanata-cmd"
                 ]
             ]
+        },
+        "arm64": {
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.11.0/windows-binaries-arm64.zip",
+            "hash": "cbc52b520f62a68cc032df1cfbb93d5793b02612449b9bab573ecd781b253e1f",
+            "bin": [
+                [
+                    "kanata_windows_tty_winIOv2_arm64.exe",
+                    "Kanata"
+                ],
+                [
+                    "kanata_windows_tty_winIOv2_cmd_allowed_arm64.exe",
+                    "Kanata-cmd"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "kanata_windows_gui_winIOv2_arm64.exe",
+                    "Kanata"
+                ],
+                [
+                    "kanata_windows_gui_winIOv2_cmd_allowed_arm64.exe",
+                    "Kanata-cmd"
+                ]
+            ]
         }
     },
     "checkver": "github",
@@ -35,6 +59,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/jtroo/kanata/releases/download/v$version/windows-binaries-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/windows-binaries-arm64.zip"
             }
         }
     }

--- a/bucket/kanata.json
+++ b/bucket/kanata.json
@@ -12,12 +12,20 @@
                 [
                     "kanata_windows_tty_winIOv2_x64.exe",
                     "Kanata"
+                ],
+                [
+                    "kanata_windows_tty_winIOv2_cmd_allowed_x64.exe",
+                    "Kanata-cmd"
                 ]
             ],
             "shortcuts": [
                 [
                     "kanata_windows_gui_winIOv2_x64.exe",
                     "Kanata"
+                ],
+                [
+                    "kanata_windows_gui_winIOv2_cmd_allowed_x64.exe",
+                    "Kanata-cmd"
                 ]
             ]
         }


### PR DESCRIPTION
- Fix autoupdate.
- Add shortcuts for the GUI executable files.
- Merge kanata-cmd.
- Add ARM64 architecture.

Close #15529

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
