### PR TITLE
gitwink: Add version 0.2.1

### DIFF
--- a/bucket/gitwink.json
+++ b/bucket/gitwink.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.1",
+    "description": "Tray-resident, read-only git glance for the AI-agent era.",
+    "homepage": "https://github.com/var-gg/gitwink",
+    "license": "MIT",
+    "notes": [
+        "gitwink is a tray-resident app. Launch it from the Start Menu shortcut; it then lives in the system tray.",
+        "Requires the Microsoft Edge WebView2 runtime - preinstalled on Windows 11. On older Windows 10 builds, install it from https://developer.microsoft.com/microsoft-edge/webview2/ if gitwink fails to start.",
+        "User data (cache.db, settings.json) lives in %APPDATA%\\gg.var.gitwink and is preserved across updates and uninstalls."
+    ],
+    "extract_dir": "PFiles\\gitwink",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/var-gg/gitwink/releases/download/v0.2.1/gitwink_0.2.1_x64_en-US.msi",
+            "hash": "5a8bc24163cea5106febb7aa5dd05d4e3eb251ec2678d148e340d5179b7d7854"
+        }
+    },
+    "pre_uninstall": "Get-Process -Name gitwink -ErrorAction SilentlyContinue | Stop-Process -Force",
+    "shortcuts": [
+        [
+            "gitwink.exe",
+            "gitwink"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/var-gg/gitwink/releases/download/v$version/gitwink_$version_x64_en-US.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[gitwink](https://github.com/var-gg/gitwink) is a tray-resident, read-only git glance tool — it surfaces recent commit activity across your local git repositories without opening a heavyweight editor.

- **License:** MIT
- **Homepage:** https://github.com/var-gg/gitwink

### Notes

- Built with Tauri; ships as a WiX MSI. The manifest uses `extract_dir` because the bundle nests the binary under `PFiles\gitwink\`.
- `checkver` / `autoupdate` verified against GitHub releases; `checkurls` and `checkhashes` pass.
- Installed, updated, and uninstalled locally — the tray app launches correctly from the extracted layout.
- The MSI is currently **unsigned**; Scoop verifies each download against the pinned SHA256. Authenticode signing via SignPath Foundation is in progress and will be picked up automatically by autoupdate once live — no manifest change required.