### PR TITLE
notepadplusplus: Fix persistence

### DIFF
--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -20,8 +20,8 @@
     },
     "pre_install": [
         "# If present from previous installs, removing incorrectly created folders from the persist dir",
-        "if ((Test-Path -Path \"$persist_dir\\config.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\config.xml\" }",
-        "if ((Test-Path -Path \"$persist_dir\\shortcuts.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\shortcuts.xml\" }",
+        "if ((Test-Path -Path \"$persist_dir\\config.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\config.xml\" -Recurse -Force }",
+        "if ((Test-Path -Path \"$persist_dir\\shortcuts.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\shortcuts.xml\" -Recurse -Force }",
         "'config.xml', 'nativeLang.xml', 'session.xml', 'shortcuts.xml', 'userDefineLang.xml' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
         "}",

--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -19,10 +19,9 @@
         }
     },
     "pre_install": [
-        "# If present from previous installs, removing incorrectly created folders from the persist dir",
-        "if ((Test-Path -Path \"$persist_dir\\config.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\config.xml\" -Recurse -Force }",
-        "if ((Test-Path -Path \"$persist_dir\\shortcuts.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\shortcuts.xml\" -Recurse -Force }",
         "'config.xml', 'nativeLang.xml', 'session.xml', 'shortcuts.xml', 'userDefineLang.xml' | ForEach-Object {",
+        "    # If present from previous installs, removing incorrectly created folders from the persist dir",
+        "    if ((Test-Path -Path \"$persist_dir\\$_\" -PathType Container)) { Remove-Item \"$persist_dir\\$_\" -Recurse -Force }",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
         "}",
         "if (!(Test-Path \"$persist_dir\\stylers.xml\")) { Copy-Item \"$dir\\stylers.model.xml\" \"$dir\\stylers.xml\" }"

--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -19,7 +19,10 @@
         }
     },
     "pre_install": [
-        "'session.xml', 'userDefineLang.xml', 'nativeLang.xml' | ForEach-Object {",
+        "# If present from previous installs, removing incorrectly created folders from the persist dir",
+        "if ((Test-Path -Path \"$persist_dir\\config.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\config.xml\" }",
+        "if ((Test-Path -Path \"$persist_dir\\shortcuts.xml\" -PathType Container)) { Remove-Item \"$persist_dir\\shortcuts.xml\" }",
+        "'config.xml', 'nativeLang.xml', 'session.xml', 'shortcuts.xml', 'userDefineLang.xml' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType File | Out-Null }",
         "}",
         "if (!(Test-Path \"$persist_dir\\stylers.xml\")) { Copy-Item \"$dir\\stylers.model.xml\" \"$dir\\stylers.xml\" }"


### PR DESCRIPTION
Add two missing files to the pre_install - if not created then the persist function will create and link to folders instead of files like we need.

config.xml
shortcuts.xml

Also cleans up the folders from previous installs.

Closes #17836

- [x ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 
