### PR TITLE
antigravity-ide: Add version 2.0.1

### DIFF
--- a/bucket/antigravity-ide.json
+++ b/bucket/antigravity-ide.json
@@ -1,0 +1,73 @@
+{
+    "version": "2.0.1",
+    "description": "AI-powered IDE developed by Google, designed for prioritizing AI agents platform for software development.",
+    "homepage": "https://antigravity.google/product/antigravity-ide",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://antigravity.google/terms"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.1-4861014005645312/windows-x64/Antigravity%20IDE.exe",
+            "hash": "3204782745d819cb1cc96c03c841951ffe7c9936e6d9640018382daf1ecab3e0"
+        },
+        "arm64": {
+            "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.1-4861014005645312/windows-arm64/Antigravity%20IDE.exe",
+            "hash": "dd79f3fae109d88aceb8a28716d09aa1994e58e0f3b13ffd6b3574ac44117105"
+        }
+    },
+    "innosetup": true,
+    "extract_dir": "{code_GetDestDir}",
+    "post_install": [
+        "if (!(Test-Path \"$dir\\data\\extensions\") -and (Test-Path \"$env:USERPROFILE\\.antigravity\\extensions\")) {",
+        "    info '[Portable Mode] Copying extensions...'",
+        "    Copy-Item \"$env:USERPROFILE\\.antigravity\\extensions\" \"$dir\\data\" -Recurse",
+        "}",
+        "if (!(Test-Path \"$dir\\data\\user-data\") -and (Test-Path \"$env:AppData\\Antigravity\")) {",
+        "    info '[Portable Mode] Copying user data...'",
+        "    Copy-Item \"$env:AppData\\Antigravity\" \"$dir\\data\\user-data\" -Recurse",
+        "}",
+        "$extensions_file = \"$dir\\data\\extensions\\extensions.json\"",
+        "if ((Test-Path \"$extensions_file\")) {",
+        "    info 'Adjusting path in extensions file...'",
+        "    (Get-Content \"$extensions_file\") -replace '(?<=antigravity(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "Antigravity IDE.exe",
+            "Antigravity IDE",
+            "--user-data-dir $dir\\data\\user-data --extensions-dir $dir\\data\\extensions"
+        ]
+    ],
+    "bin": [
+        [
+            "bin\\antigravity-ide.cmd",
+            "antigravity-ide",
+            "--user-data-dir $dir\\data\\user-data --extensions-dir $dir\\data\\extensions"
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "url": "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/win32-x64-user/stable/latest",
+        "regex": "antigravity/stable/(?<version>[\\d.]+)-(?<build>\\d+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/$version-$matchBuild/windows-x64/Antigravity%20IDE.exe",
+                "hash": {
+                    "url": "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/win32-x64-user/stable/$version",
+                    "jsonpath": "$.sha256hash"
+                }
+            },
+            "arm64": {
+                "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/$version-$matchBuild/windows-arm64/Antigravity%20IDE.exe",
+                "hash": {
+                    "url": "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/win32-arm64-user/stable/$version",
+                    "jsonpath": "$.sha256hash"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
> Antigravity has transitioned into a modular multi-agent Hub architecture (v2.0). To support this shift, the original editor component has been decoupled and is now maintained as a standalone package named Antigravity IDE.

Copied from antigravity@1.23.2. Closes #17837.
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
