### PR TITLE
lmstudio: Add version 0.4.13-1

### DIFF
--- a/bucket/lmstudio.json
+++ b/bucket/lmstudio.json
@@ -3,22 +3,25 @@
     "description": "Discover, download, and run local LLMs (llama.cpp, MLX). Chat UI and OpenAI-compatible local API server.",
     "homepage": "https://lmstudio.ai",
     "license": {
-        "identifier": "Freeware",
-        "url": "https://lmstudio.ai/terms"
+        "identifier": "Proprietary",
+        "url": "https://lmstudio.ai/app-terms"
     },
     "architecture": {
         "64bit": {
             "url": "https://installers.lmstudio.ai/win32/x64/0.4.13-1/LM-Studio-0.4.13-1-x64.exe#/dl.7z",
-            "hash": "85e4e85b9a855ae628355619f36e607610047c8376a2c55b9d5ad078467b52f7",
-            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+            "hash": "85e4e85b9a855ae628355619f36e607610047c8376a2c55b9d5ad078467b52f7"
         },
         "arm64": {
             "url": "https://installers.lmstudio.ai/win32/arm64/0.4.13-1/LM-Studio-0.4.13-1-arm64.exe#/dl.7z",
-            "hash": "2d55c91d72aa8cdd5af16447dd7b750d90074306ad22305ee881b750d1d10f56",
-            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\""
+            "hash": "2d55c91d72aa8cdd5af16447dd7b750d90074306ad22305ee881b750d1d10f56"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*.exe\" -Recurse -Force -ErrorAction Ignore",
+    "installer": {
+        "script": [
+            "Get-Item -Path \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item -Path \"$dir\\`$*\", \"$dir\\Uninst*.exe\" -Force -Recurse -ErrorAction Ignore"
+        ]
+    },
     "bin": "resources\\app\\.webpack\\lms.exe",
     "shortcuts": [
         [
@@ -28,8 +31,8 @@
     ],
     "checkver": {
         "url": "https://lmstudio.ai/download",
-        "regex": "\\\\\"version\\\\\":\\\\\"([\\d.]+)\\\\\"[^}]{0,400}?\\\\\"build\\\\\":\\\\\"(\\d+)\\\\\"",
-        "replace": "$1-$2"
+        "regex": "\\\\\"version\\\\\":\\\\\"(?<ver>[\\d.]+)\\\\\",\\\\\"build\\\\\":\\\\\"(?<build>\\d+)\\\\\"",
+        "replace": "${ver}-${build}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/lmstudio.json
+++ b/bucket/lmstudio.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.4.13-1",
+    "description": "Discover, download, and run local LLMs (llama.cpp, MLX). Chat UI and OpenAI-compatible local API server.",
+    "homepage": "https://lmstudio.ai",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://lmstudio.ai/terms"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://installers.lmstudio.ai/win32/x64/0.4.13-1/LM-Studio-0.4.13-1-x64.exe#/dl.7z",
+            "hash": "85e4e85b9a855ae628355619f36e607610047c8376a2c55b9d5ad078467b52f7",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        },
+        "arm64": {
+            "url": "https://installers.lmstudio.ai/win32/arm64/0.4.13-1/LM-Studio-0.4.13-1-arm64.exe#/dl.7z",
+            "hash": "2d55c91d72aa8cdd5af16447dd7b750d90074306ad22305ee881b750d1d10f56",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\""
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*.exe\" -Recurse -Force -ErrorAction Ignore",
+    "bin": "resources\\app\\.webpack\\lms.exe",
+    "shortcuts": [
+        [
+            "LM Studio.exe",
+            "LM Studio"
+        ]
+    ],
+    "checkver": {
+        "url": "https://lmstudio.ai/download",
+        "regex": "\\\\\"version\\\\\":\\\\\"([\\d.]+)\\\\\"[^}]{0,400}?\\\\\"build\\\\\":\\\\\"(\\d+)\\\\\"",
+        "replace": "$1-$2"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://installers.lmstudio.ai/win32/x64/$version/LM-Studio-$version-x64.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://installers.lmstudio.ai/win32/arm64/$version/LM-Studio-$version-arm64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17842

### New manifest: `lmstudio`

Adds a manifest for [LM Studio](https://lmstudio.ai) — a desktop app to discover, download, and run local LLMs (llama.cpp, MLX, etc.) with a chat UI and OpenAI-compatible local API server.

#### Extras acceptance criteria

- [x] **Reasonably well-known / widely used** — flagship org [lmstudio-ai](https://github.com/lmstudio-ai) has ~11.2k followers; companion CLI repo [lms](https://github.com/lmstudio-ai/lms) has ~4.8k stars / 393 forks.
- [x] **English UI and documentation** — interface and [docs](https://lmstudio.ai/docs/app) are in English (localization available but English is primary).
- [x] **Latest stable release** — 0.4.13-1 (stable channel; beta releases live on a separate page).
- [x] **Full version** — free for personal *and* work use under the [terms of use](https://lmstudio.ai/terms); no trial limitations.
- [x] **Standard install / Scoop-compatible extraction** — electron-builder NSIS, handled with the same `#/dl.7z` + `Expand-7zipArchive $PLUGINSDIR\app-*.7z` pattern as `signal`.

#### Manifest details

- **Architectures:** `64bit` and `arm64`
- **Shortcut:** `LM Studio`
- **Bin:** `lms` (LM Studio CLI, shipped at `resources\app\.webpack\lms.exe`)
- **checkver / autoupdate:** scrapes version + build from https://lmstudio.ai/download (Next.js flight data, single regex captures both `version` and `build` and joins them with `replace: ""-""`)

#### Validation

- `bin\formatjson.ps1 -App lmstudio` — OK
- `bin\checkurls.ps1 -App lmstudio` — 2/2 URLs OK
- `bin\checkver.ps1 -App lmstudio -Update -ForceUpdate` — version + both hashes resolved correctly
- `scoop install` and `scoop uninstall` tested locally on Windows 11 x64; `LM Studio.exe` launches, `lms` shim works, start-menu shortcut created and removed cleanly