### PR TITLE
antigravity: Update to version 2.0.1, fix checkver & autoupdate

### DIFF
--- a/bucket/antigravity.json
+++ b/bucket/antigravity.json
@@ -1,70 +1,72 @@
 {
-    "version": "1.23.2",
-    "description": "AI-powered IDE developed by Google, designed for prioritizing AI agents platform for software development.",
-    "homepage": "https://antigravity.google/",
+    "version": "2.0.1",
+    "description": "Agent orchestration platform developed by Google.",
+    "homepage": "https://antigravity.google/product/antigravity-2",
     "license": {
         "identifier": "Proprietary",
         "url": "https://antigravity.google/terms"
     },
+    "notes": [
+        "Antigravity 2.0 has fully transitioned into an agent orchestration platform.",
+        "The editor component has been decoupled and is now maintained separately as Antigravity IDE.",
+        "For more details, see: https://antigravity.google/blog/introducing-google-antigravity-2-0",
+        "",
+        "Antigravity IDE is available as a separate package: 'extras/antigravity-ide'.",
+        "If you have previously installed Antigravity IDE (v1.x), your data (v1.x) is located in:",
+        "\"$persist_dir\"",
+        "You may need to move the persisted data manually after installing Antigravity IDE v2.x."
+    ],
+    "suggest": {
+        "Antigravity IDE": "extras/antigravity-ide"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.23.2-4781536860569600/windows-x64/Antigravity.exe#/dl.exe",
-            "hash": "3874fc761e5c90b3edf8e0365f506ce22241a88f6881cea09713b3f472c4f6ed"
+            "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.1-6566078776737792/windows-x64/Antigravity-x64.exe#/dl.7z",
+            "hash": "e5689f91e90b31d3affd7b2ae74cfe36abb626f923e4f38f816e0ab6bb85ad6a"
         },
         "arm64": {
-            "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.23.2-4781536860569600/windows-arm64/Antigravity.exe#/dl.exe",
-            "hash": "a14aa1971ad801131adcb12afe216522aadea176c141c4b5d793d216bfe02101"
+            "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.1-6566078776737792/windows-arm/Antigravity-arm64.exe#/dl.7z",
+            "hash": "26c9665cff5f4c5fbc49a81e8e6145ea91510f4a8fa4961e371ea5fb7d00a7a2"
         }
     },
-    "innosetup": true,
-    "extract_dir": "{code_GetDestDir}",
+    "installer": {
+        "script": [
+            "Get-Item \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item \"$dir\\`$*\" -Force -Recurse"
+        ]
+    },
     "post_install": [
-        "if (!(Test-Path \"$dir\\data\\extensions\") -and (Test-Path \"$env:USERPROFILE\\.antigravity\\extensions\")) {",
-        "    info '[Portable Mode] Copying extensions...'",
-        "    Copy-Item \"$env:USERPROFILE\\.antigravity\\extensions\" \"$dir\\data\" -Recurse",
+        "# Disable built-in update mechanism to prevent conflicts with Scoop's update management",
+        "$yaml = \"$dir\\resources\\app-update.yml\"",
+        "$content = Get-Content -Path $yaml | Foreach-Object {",
+        "    if ($_.StartsWith('url')) { \"$($_.Replace('url', '# url')) # Disabled by Scoop\" } else { $_ }",
         "}",
-        "if (!(Test-Path \"$dir\\data\\user-data\") -and (Test-Path \"$env:AppData\\Antigravity\")) {",
-        "    info '[Portable Mode] Copying user data...'",
-        "    Copy-Item \"$env:AppData\\Antigravity\" \"$dir\\data\\user-data\" -Recurse",
-        "}",
-        "$extensions_file = \"$dir\\data\\extensions\\extensions.json\"",
-        "if ((Test-Path \"$extensions_file\")) {",
-        "    info 'Adjusting path in extensions file...'",
-        "    (Get-Content \"$extensions_file\") -replace '(?<=antigravity(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
-        "}"
+        "Set-Content $yaml -Value $content -Encoding ascii"
     ],
     "shortcuts": [
         [
-            "antigravity.exe",
-            "Antigravity",
-            "--user-data-dir $dir\\data\\user-data --extensions-dir $dir\\data\\extensions"
+            "Antigravity.exe",
+            "Antigravity"
         ]
     ],
-    "bin": [
-        [
-            "bin\\antigravity.cmd",
-            "antigravity",
-            "--user-data-dir $dir\\data\\user-data --extensions-dir $dir\\data\\extensions"
-        ]
-    ],
-    "persist": "data",
     "checkver": {
         "url": "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/win32-x64-user/stable/latest",
-        "regex": ".+/antigravity/stable/([.\\d]+)-(?<build>\\d+)/"
+        "jsonpath": "$.url",
+        "regex": "antigravity-hub/(?<version>[\\d.]+)-(?<build>\\d+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/$version-$matchBuild/windows-x64/Antigravity.exe#/dl.exe",
+                "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/$version-$matchBuild/windows-x64/Antigravity-x64.exe#/dl.7z",
                 "hash": {
-                    "url": "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/win32-x64-user/stable/latest",
+                    "url": "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/win32-x64-user/stable/$version",
                     "jsonpath": "$.sha256hash"
                 }
             },
             "arm64": {
-                "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/$version-$matchBuild/windows-arm64/Antigravity.exe#/dl.exe",
+                "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/$version-$matchBuild/windows-arm/Antigravity-arm64.exe#/dl.7z",
                 "hash": {
-                    "url": "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/win32-arm64-user/stable/latest",
+                    "url": "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/win32-arm64-user/stable/$version",
                     "jsonpath": "$.sha256hash"
                 }
             }


### PR DESCRIPTION
### Breaking Change
> https://antigravity.google/blog/introducing-google-antigravity-2-0

> If you already have installed the Antigravity IDE, when that application next updates, it will automatically update to Antigravity 2.0.

This PR allows users who previously installed Antigravity IDE v1.x to upgrade to Antigravity 2.0, an agent orchestration platform.

I find this behavior a bit counterintuitive, though.

Closes #17833
Relates to #17834
Relates to #17840
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
