### PR TITLE
yaak@2026.4.0: Fix shortcuts

### DIFF
--- a/bucket/yaak.json
+++ b/bucket/yaak.json
@@ -12,7 +12,7 @@
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Force -Recurse -ErrorAction Ignore",
     "shortcuts": [
         [
-            "yaak-app.exe",
+            "yaak-app-client.exe",
             "Yaak"
         ]
     ],


### PR DESCRIPTION
## Description

Fix the `shortcuts` field in `yaak.json` to use the correct executable name.

The upstream project renamed the main executable from `yaak-app.exe` to `yaak-app-client.exe` in recent releases. This caused shortcut creation to fail during `scoop install yaak`:

```
Creating shortcut for Yaak (yaak-app.exe) failed: Couldn't find C:\Users\Fang\scoop\apps\yaak\current\yaak-app.exe
```

## Motivation and Context

Fixes the broken shortcut creation when installing yaak via Scoop. The app installs and runs correctly, but the Start Menu shortcut is not created due to the exe name mismatch.

## How Has This Been Tested?

Verified the actual executable name in the installed yaak directory:

```
C:\Users\Fang\scoop\apps\yaak\current\yaak-app-client.exe
```

The only `.exe` files in the install directory are:
- `yaak-app-client.exe` (main app)
- `vendored/node/yaaknode.exe`
- `vendored/protoc/yaakprotoc.exe`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `master` branch.
- [x] I have verified the manifest works by installing and checking the shortcut is created correctly.