### PR TITLE
soundswitch@7.1.0: Fix file naming issue, add arm64 support

### DIFF
--- a/bucket/soundswitch.json
+++ b/bucket/soundswitch.json
@@ -3,10 +3,20 @@
     "description": "Switch your default playback devices and/or recording devices using simple hotkeys",
     "homepage": "https://soundswitch.aaflalo.me/",
     "license": "GPL-2.0-or-later",
+    "url": "https://github.com/Belphemur/SoundSwitch/releases/download/v7.1.0/SoundSwitch_v7.1.0.0_Release_Installer.exe",
+    "hash": "49967673307e44e2152347a28d410d47bafdd99e009155924bf1c9a2521615bd",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Belphemur/SoundSwitch/releases/download/v7.1.0/SoundSwitch_v7.1.0.0_Release_Installer.exe",
-            "hash": "49967673307e44e2152347a28d410d47bafdd99e009155924bf1c9a2521615bd"
+            "pre_install": [
+                "Get-ChildItem $dir -Filter '*,2*' -Recurse | Remove-Item -Force",
+                "Get-ChildItem $dir -Filter '*,1*' -Recurse | Rename-Item -NewName { $_.Name -replace ',1', '' } -Force"
+            ]
+        },
+        "arm64": {
+            "pre_install": [
+                "Get-ChildItem $dir -Filter '*,1*' -Recurse | Remove-Item -Force",
+                "Get-ChildItem $dir -Filter '*,2*' -Recurse | Rename-Item -NewName { $_.Name -replace ',2', '' } -Force"
+            ]
         }
     },
     "innosetup": true,
@@ -22,10 +32,6 @@
         "regex": "v([\\d.]+)/SoundSwitch_v([\\d.]+)_Release_Installer\\.exe"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/Belphemur/SoundSwitch/releases/download/v$version/SoundSwitch_v$match2_Release_Installer.exe"
-            }
-        }
+        "url": "https://github.com/Belphemur/SoundSwitch/releases/download/v$version/SoundSwitch_v$match2_Release_Installer.exe"
     }
 }


### PR DESCRIPTION
The SoundSwitch v7.1.0 installer uses suffixes for filenames (`,1` for x64 and `,2` for ARM64).

This PR optimizes the manifest by:
1. Moving common `url` and `hash` to the root (as both architectures use the same installer).
2. Adding explicit `64bit` and `arm64` architecture support.
3. Implementing `pre_install` scripts to clean up incompatible binaries and rename the correct ones by removing architecture suffixes.

This ensures proper installation and shortcut creation on both x64 and ARM64 Windows systems.

- [x] Use conventional PR title: `soundswitch: fix file naming issue and add arm64 support in v7.1.0`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)