### PR TITLE
dbxignore: Add version 1.0.5

### DIFF
--- a/bucket/dbxignore.json
+++ b/bucket/dbxignore.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.5",
+  "description": "Sync Dropbox ignore markers with hierarchical .dropboxignore files.",
+  "homepage": "https://github.com/kiloscheffer/dbxignore",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/kiloscheffer/dbxignore/releases/download/v1.0.5/dbxignore-windows-x86_64.zip",
+      "hash": "f904e7a8aa520a9db770409b6a551cbb76a9634c46aae9a63ad92654f6c02b28"
+    }
+  },
+  "bin": [
+    "dbxignore.exe",
+    "dbxignorew.exe"
+  ],
+  "uninstaller": {
+    "script": [
+      "if (schtasks /Query /TN dbxignore 2>$null) {",
+      "    & \"$dir\\dbxignore.exe\" uninstall --yes",
+      "}"
+    ]
+  },
+  "notes": [
+    "Run 'dbxignore install' once to register the daemon with Task Scheduler.",
+    "'scoop uninstall dbxignore' will automatically deregister the daemon."
+  ],
+  "checkver": {
+    "github": "https://github.com/kiloscheffer/dbxignore"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/kiloscheffer/dbxignore/releases/download/v$version/dbxignore-windows-x86_64.zip"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

[dbxignore](https://github.com/kiloscheffer/dbxignore) is a CLI utility that syncs Dropbox ignore markers with hierarchical `.dropboxignore` files (`.gitignore`-style), so directories like `node_modules/` can be marked unsynced from a tracked rules file rather than via Dropbox's right-click UI.

- **License**: MIT
- **Version**: 1.0.5
- **Type**: CLI (non-GUI) — fits Extras
- **Distribution**: PyInstaller onedir bundle, shipped as `dbxignore-windows-x86_64.zip` on each GitHub Release

## Manifest highlights

- `bin:` exposes both `dbxignore.exe` (console) and `dbxignorew.exe` (GUI-subsystem variant used by daemon registrations to avoid stealing focus)
- `uninstaller:` script auto-deregisters the Task Scheduler daemon entry on `scoop uninstall`, guarded by `schtasks /Query` so it's a no-op when the user never ran `dbxignore install`
- `checkver` + `autoupdate` use the GitHub release tag pattern; the dbxignore release workflow bumps the third-party `kiloscheffer/scoop-dbxignore` bucket on each release via `jq`, so the same autoupdate URL pattern is already validated against actual releases

## Validation

Installed and uninstalled locally from the manifest in this PR on Windows 11:

```powershell
scoop install .\bucket\dbxignore.json
# Extracted cleanly to ~/scoop/apps/dbxignore/1.0.5/, both shims created.

dbxignore --version
# dbxignore.exe, version 1.0.5  (via Scoop shim)

scoop uninstall dbxignore
# Uninstaller hook ran cleanly.

schtasks /Query /TN dbxignore
# ERROR: The system cannot find the file specified.  (task removed by hook)
```

Cosmetic note: install emits four `download.ps1:690` "Invalid URI" warnings on the cache-hit extraction path — originates in Scoop's own `url_remote_filename` (see Scoop issues #3664 / #2722 / #4050), not this manifest. Extraction completes successfully despite the warnings.

## Contributing guideline confirmation

- [x] Read [the Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Manifest tested locally (install + uninstall)
- [x] Field order follows the JSON layout in CONTRIBUTING.md
- [x] License is a valid SPDX identifier (MIT)
- [x] Single-item array conventions followed where applicable (URL/hash are single strings under `architecture.64bit`)
