### PR TITLE
ungoogled-chromium: Update to version 148.0.7778.178-1.1, fix checkver, simplify autoupdate

### DIFF
--- a/bucket/ungoogled-chromium.json
+++ b/bucket/ungoogled-chromium.json
@@ -1,23 +1,23 @@
 {
-    "version": "148.0.7778.167-1.1",
+    "version": "148.0.7778.178-1.1",
     "description": "Google Chromium, sans integration with Google.",
     "homepage": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.167-1.1/ungoogled-chromium_148.0.7778.167-1.1_windows_x64.zip",
-            "hash": "f84b1c162b348c57e10b124f3396203a0e69862e7ccb873576d90f8d0b2d0d97",
-            "extract_dir": "ungoogled-chromium_148.0.7778.167-1.1_windows_x64"
+            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.178-1.1/ungoogled-chromium_148.0.7778.178-1.1_windows_x64.zip",
+            "hash": "58a588f75966d1066b0cb98585785370fd6cb56873780428bd18e69b98a20bca",
+            "extract_dir": "ungoogled-chromium_148.0.7778.178-1.1_windows_x64"
         },
         "32bit": {
-            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.167-1.1/ungoogled-chromium_148.0.7778.167-1.1_windows_x86.zip",
-            "hash": "fee42d3e40fd9a05e8733c6045524bff7f7af6eafd86c85942a1c1c8df5a2351",
-            "extract_dir": "ungoogled-chromium_148.0.7778.167-1.1_windows_x86"
+            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.178-1.1/ungoogled-chromium_148.0.7778.178-1.1_windows_x86.zip",
+            "hash": "96f32ebd4a41a3d6de4045f41101f7a3349220c29b9e3d4fbb96dd9226441fa5",
+            "extract_dir": "ungoogled-chromium_148.0.7778.178-1.1_windows_x86"
         },
         "arm64": {
-            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.167-1.1/ungoogled-chromium_148.0.7778.167-1.1_windows_arm64.zip",
-            "hash": "6ad28621257cce1cb101f3dfda9a6d3ee0a5f3c06da9e5a4323eca6449d0e7db",
-            "extract_dir": "ungoogled-chromium_148.0.7778.167-1.1_windows_arm64"
+            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.178-1.1/ungoogled-chromium_148.0.7778.178-1.1_windows_arm64.zip",
+            "hash": "8150bc494b0f763479edc4992eaa66c883fc36eaa8c4013a3de96adf4fadc6c8",
+            "extract_dir": "ungoogled-chromium_148.0.7778.178-1.1_windows_arm64"
         }
     },
     "env_set": {
@@ -39,8 +39,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://api.github.com/repos/ungoogled-software/ungoogled-chromium-windows/releases",
-        "jsonpath": "$[?(@.prerelease == false)].tag_name"
+        "github": "https://github.com/ungoogled-software/ungoogled-chromium-windows"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/ungoogled-chromium.json
+++ b/bucket/ungoogled-chromium.json
@@ -1,24 +1,27 @@
 {
-    "version": "147.0.7727.137-1.1",
+    "version": "148.0.7778.167-1.1",
     "description": "Google Chromium, sans integration with Google.",
     "homepage": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/147.0.7727.137-1.1/ungoogled-chromium_147.0.7727.137-1.1_windows_x64.zip",
-            "hash": "e2684d7a59064c2d104c68c7de3224e11459bf7320a23868db290f2dab1e8a21",
-            "extract_dir": "ungoogled-chromium_147.0.7727.137-1.1_windows_x64"
+            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.167-1.1/ungoogled-chromium_148.0.7778.167-1.1_windows_x64.zip",
+            "hash": "f84b1c162b348c57e10b124f3396203a0e69862e7ccb873576d90f8d0b2d0d97",
+            "extract_dir": "ungoogled-chromium_148.0.7778.167-1.1_windows_x64"
         },
         "32bit": {
-            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/147.0.7727.137-1.1/ungoogled-chromium_147.0.7727.137-1.1_windows_x86.zip",
-            "hash": "15c66f1797a7b9769dbda208ed70077a908f45d6f9cc234e575ca18e98b30c59",
-            "extract_dir": "ungoogled-chromium_147.0.7727.137-1.1_windows_x86"
+            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.167-1.1/ungoogled-chromium_148.0.7778.167-1.1_windows_x86.zip",
+            "hash": "fee42d3e40fd9a05e8733c6045524bff7f7af6eafd86c85942a1c1c8df5a2351",
+            "extract_dir": "ungoogled-chromium_148.0.7778.167-1.1_windows_x86"
         },
         "arm64": {
-            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/147.0.7727.137-1.1/ungoogled-chromium_147.0.7727.137-1.1_windows_arm64.zip",
-            "hash": "0b69145d7abd92205542a3cf001f0a74fe9ebf6a58e1b1f38f548e6a9ae31081",
-            "extract_dir": "ungoogled-chromium_147.0.7727.137-1.1_windows_arm64"
+            "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/148.0.7778.167-1.1/ungoogled-chromium_148.0.7778.167-1.1_windows_arm64.zip",
+            "hash": "6ad28621257cce1cb101f3dfda9a6d3ee0a5f3c06da9e5a4323eca6449d0e7db",
+            "extract_dir": "ungoogled-chromium_148.0.7778.167-1.1_windows_arm64"
         }
+    },
+    "env_set": {
+        "CHROME_EXECUTABLE": "$dir\\chrome.exe"
     },
     "bin": [
         [
@@ -34,38 +37,23 @@
             "--user-data-dir=\"$dir\\User Data\""
         ]
     ],
-    "env_set": {
-        "CHROME_EXECUTABLE": "$dir\\chrome.exe"
-    },
     "persist": "User Data",
     "checkver": {
-        "github": "https://github.com/ungoogled-software/ungoogled-chromium-windows",
-        "regex": "releases/tag/((?<main>[\\d.]+-\\d).(?<release>\\d))"
+        "url": "https://api.github.com/repos/ungoogled-software/ungoogled-chromium-windows/releases",
+        "jsonpath": "$[?(@.prerelease == false)].tag_name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/$version/ungoogled-chromium_$version_windows_x64.zip",
-                "hash": {
-                    "url": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/windows/64bit/$matchMain",
-                    "xpath": "//ul/li/a[contains(text(), \"$basename\")]/../ul/li[contains(text(), \"SHA256:\")]/code"
-                },
                 "extract_dir": "ungoogled-chromium_$version_windows_x64"
             },
             "32bit": {
                 "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/$version/ungoogled-chromium_$version_windows_x86.zip",
-                "hash": {
-                    "url": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/windows/32bit/$matchMain",
-                    "xpath": "//ul/li/a[contains(text(), \"$basename\")]/../ul/li[contains(text(), \"SHA256:\")]/code"
-                },
                 "extract_dir": "ungoogled-chromium_$version_windows_x86"
             },
             "arm64": {
                 "url": "https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/$version/ungoogled-chromium_$version_windows_arm64.zip",
-                "hash": {
-                    "url": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/windows/arm64/$matchMain",
-                    "xpath": "//ul/li/a[contains(text(), \"$basename\")]/../ul/li[contains(text(), \"SHA256:\")]/code"
-                },
                 "extract_dir": "ungoogled-chromium_$version_windows_arm64"
             }
         }


### PR DESCRIPTION
Closes #17874

* Updated to 148.0.7778.167-1.1
* Simplified checkver: Use GitHub API + JSON path to exclude prerelease and only return tag_name
* Simplified autoupdate: Hash is added to GitHub releases artifacts, and Scoop handles that by default
* Reorder some manifest properties to align with authoring guidelines

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
