### PR TITLE
dbx: Add version 0.5.24

### DIFF
--- a/bucket/dbx.json
+++ b/bucket/dbx.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.5.24",
+    "description": "Lightweight, cross-platform database management tool",
+    "homepage": "https://dbxio.com",
+    "license": "AGPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/t8y2/dbx/releases/download/v0.5.24/DBX_0.5.24_x64-setup.exe",
+            "hash": "176ed3678ea2c0bda8e2658b17cf422891e4747c4ce02fb9f7f993ba1b8a3606"
+        }
+    },
+    "installer": {
+        "args": ["/S", "/D=$dir"]
+    },
+    "uninstaller": {
+        "file": "uninstall.exe",
+        "args": ["/S"]
+    },
+    "checkver": {
+        "github": "https://github.com/t8y2/dbx"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/t8y2/dbx/releases/download/v$version/DBX_$version_x64-setup.exe"
+            }
+        }
+    }
+}

--- a/bucket/dbx.json
+++ b/bucket/dbx.json
@@ -2,7 +2,7 @@
     "version": "0.5.24",
     "description": "Lightweight, cross-platform database management tool",
     "homepage": "https://dbxio.com",
-    "license": "AGPL-3.0",
+    "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/t8y2/dbx/releases/download/v0.5.24/DBX_0.5.24_x64-setup.exe",

--- a/bucket/dbx.json
+++ b/bucket/dbx.json
@@ -1,28 +1,31 @@
 {
-    "version": "0.5.24",
-    "description": "Lightweight, cross-platform database management tool",
+    "version": "0.5.45",
+    "description": "Lightweight, cross-platform database client",
     "homepage": "https://dbxio.com",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/t8y2/dbx/releases/download/v0.5.24/DBX_0.5.24_x64-setup.exe",
-            "hash": "176ed3678ea2c0bda8e2658b17cf422891e4747c4ce02fb9f7f993ba1b8a3606"
+            "url": "https://github.com/t8y2/dbx/releases/download/v0.5.45/DBX_0.5.45_x64-portable.zip",
+            "hash": "622260f04dbb62960976af26f0119552d4a68d962ac426f51d84c0315350cf46"
         }
     },
-    "installer": {
-        "args": ["/S", "/D=$dir"]
+    "shortcuts": [
+        [
+            "DBX.exe",
+            "DBX"
+        ]
+    ],
+    "env_set": {
+        "DBX_DATA_DIR": "$dir\\data"
     },
-    "uninstaller": {
-        "file": "uninstall.exe",
-        "args": ["/S"]
-    },
+    "persist": "data",
     "checkver": {
         "github": "https://github.com/t8y2/dbx"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/t8y2/dbx/releases/download/v$version/DBX_$version_x64-setup.exe"
+                "url": "https://github.com/t8y2/dbx/releases/download/v$version/DBX_$version_x64-portable.zip"
             }
         }
     }


### PR DESCRIPTION
**DBX** is a lightweight, cross-platform database management tool.

- **Homepage:** https://dbxio.com
- **GitHub:** https://github.com/t8y2/dbx
- **Stars:** 2,435 ⭐
- **License:** AGPL-3.0-only

**Description:** 15MB, lightweight, cross-platform database client. Supports MySQL, PostgreSQL, SQLite, Redis, MongoDB, DuckDB, ClickHouse, SQL Server and more.

Closes https://github.com/ScoopInstaller/Extras/issues/17915

> [!NOTE]
> This manifest was previously distributed via `t8y2/scoop-bucket` — this PR migrates it to the official Scoop Extras bucket.
