### PR TITLE
boinc@8.2.11: Fix decompress error

### DIFF
--- a/bucket/boinc.json
+++ b/bucket/boinc.json
@@ -16,12 +16,13 @@
     },
     "installer": {
         "script": [
-            "Start-Process \"$dir\\$fname\" -ArgumentList '/extract'",
             "$msiDir = \"$env:windir\\Downloaded Installations\\BOINC\"",
+            "$since = Get-Date",
+            "Start-Process \"$dir\\$fname\" -ArgumentList '/extract'",
             "$msi = $null; $deadline = (Get-Date).AddSeconds(60)",
             "while (-not $msi -and (Get-Date) -lt $deadline) {",
             "    Start-Sleep -Seconds 2",
-            "    $msi = Get-ChildItem $msiDir -Recurse -Filter 'BOINC.msi' -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1",
+            "    $msi = Get-ChildItem $msiDir -Recurse -Filter 'BOINC.msi' -ErrorAction SilentlyContinue | Where-Object LastWriteTime -ge $since | Sort-Object LastWriteTime -Descending | Select-Object -First 1",
             "}",
             "$extract = if ($architecture -eq '64bit') { 'Program Files 64' } else { 'program files' }",
             "if ($msi)",

--- a/bucket/boinc.json
+++ b/bucket/boinc.json
@@ -3,7 +3,6 @@
     "description": "Volunteer scientific or grid computing client",
     "homepage": "https://boinc.berkeley.edu/",
     "license": "LGPL-3.0-or-later",
-    "depends": "isx",
     "notes": [
         "Set DATADIR and INSTALLDIR in:",
         "Computer\\HKEY_LOCAL_MACHINE\\SOFTWARE\\Space Sciences Laboratory, U.C. Berkeley\\BOINC Setup"
@@ -17,11 +16,20 @@
     },
     "installer": {
         "script": [
-            "Invoke-ExternalCommand ((Get-Command 'isx' -CommandType Application).Source) -ArgumentList \"$dir\\$fname\" -LogPath \"$dir\\isx.log\" | Out-Null",
-            "$folder = Get-ChildItem \"$dir\" -Directory | Select-Object -First 1 -ExpandProperty FullName",
+            "Start-Process \"$dir\\$fname\" -ArgumentList '/a'",
+            "Start-Sleep -Seconds 5",
+            "$msi = Get-ChildItem 'C:\\Windows\\Downloaded Installations\\BOINC' -Recurse -Filter 'BOINC.msi' | Sort-Object LastWriteTime -Descending | Select-Object -First 1",
             "$extract = if ($architecture -eq '64bit') { 'Program Files 64' } else { 'program files' }",
-            "Expand-MsiArchive \"$folder\\BOINC.msi\" \"$dir\" -ExtractDir \"$extract\\BOINC\" -Removal",
-            "Remove-Item $folder -Force -Recurse"
+            "if ($msi)",
+            "{",
+            "   Write-Host \"MSI located, unpacking... This may take a moment.\"",
+            "   Expand-MsiArchive $msi.FullName \"$dir\" -ExtractDir \"$extract\\BOINC\" -Removal",
+            "}",
+            "else",
+            "{",
+            "   Write-Host \"MSI not found, installation may have failed.\" -ForegroundColor Red",
+            "   exit 1", 
+            "}"
         ]
     },
     "post_install": [

--- a/bucket/boinc.json
+++ b/bucket/boinc.json
@@ -16,9 +16,13 @@
     },
     "installer": {
         "script": [
-            "Start-Process \"$dir\\$fname\" -ArgumentList '/a'",
-            "Start-Sleep -Seconds 5",
-            "$msi = Get-ChildItem 'C:\\Windows\\Downloaded Installations\\BOINC' -Recurse -Filter 'BOINC.msi' | Sort-Object LastWriteTime -Descending | Select-Object -First 1",
+            "Start-Process \"$dir\\$fname\" -ArgumentList '/extract'",
+            "$msiDir = \"$env:windir\\Downloaded Installations\\BOINC\"",
+            "$msi = $null; $deadline = (Get-Date).AddSeconds(60)",
+            "while (-not $msi -and (Get-Date) -lt $deadline) {",
+            "    Start-Sleep -Seconds 2",
+            "    $msi = Get-ChildItem $msiDir -Recurse -Filter 'BOINC.msi' -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1",
+            "}",
             "$extract = if ($architecture -eq '64bit') { 'Program Files 64' } else { 'program files' }",
             "if ($msi)",
             "{",

--- a/bucket/boinc.json
+++ b/bucket/boinc.json
@@ -32,7 +32,7 @@
             "else",
             "{",
             "   Write-Host \"MSI not found, installation may have failed.\" -ForegroundColor Red",
-            "   exit 1", 
+            "   exit 1",
             "}"
         ]
     },


### PR DESCRIPTION
Closes #16602 

The extraction method needed to be changed a bit. I couldn't figure out how to set a destination, the .msi always ends up on the same spot (C:\Windows\Downloaded Installations\BOINC). Since isx is no longer used, I also removed the depends.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)