### PR TITLE
quickclipboard: Add version 0.4.0

### DIFF
--- a/bucket/quickclipboard.json
+++ b/bucket/quickclipboard.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.3.2",
+    "description": "QuickClipboard - A powerful clipboard management tool (Portable)",
+    "homepage": "https://quickclipboard.cn/",
+    "license": {
+        "identifier": "Apache-2.0"
+    },
+    "notes": "Portable version: data is saved to the 'data' subdirectory under the app folder and persisted.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mosheng1/QuickClipboard/releases/download/v0.3.2/QuickClipboard_0.3.2_portable.exe#/QuickClipboard_portable.exe",
+            "hash": "1d7135681fb63f3b313015df623bae7ba7dd7174ec9833fca7cf9f09101a4419"
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\data\")) { New-Item -ItemType Directory -Force -Path \"$persist_dir\\data\" | Out-Null }"
+    ],
+    "shortcuts": [
+        [
+            "QuickClipboard_portable.exe",
+            "QuickClipboard"
+        ]
+    ],
+    "persist": "data",
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name QuickClipboard_portable -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/mosheng1/QuickClipboard"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mosheng1/QuickClipboard/releases/download/v$version/QuickClipboard_$version_portable.exe#/QuickClipboard_portable.exe"
+            }
+        },
+        "hash": {
+            "mode": "github"
+        }
+    }
+}

--- a/bucket/quickclipboard.json
+++ b/bucket/quickclipboard.json
@@ -1,20 +1,16 @@
 {
-    "version": "0.3.2",
-    "description": "QuickClipboard - A powerful clipboard management tool (Portable)",
-    "homepage": "https://quickclipboard.cn/",
-    "license": {
-        "identifier": "Apache-2.0"
-    },
+    "##": "Keep the '_portable.exe' suffix when renaming the binary to make it run in portable mode.",
+    "version": "0.4.0",
+    "description": "Efficient clipboard management tool with support for text, images, and file history.",
+    "homepage": "https://quickclipboard.cn/en",
+    "license": "Apache-2.0",
     "notes": "Portable version: data is saved to the 'data' subdirectory under the app folder and persisted.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mosheng1/QuickClipboard/releases/download/v0.3.2/QuickClipboard_0.3.2_portable.exe#/QuickClipboard_portable.exe",
-            "hash": "1d7135681fb63f3b313015df623bae7ba7dd7174ec9833fca7cf9f09101a4419"
+            "url": "https://github.com/mosheng1/QuickClipboard/releases/download/v0.4.0/QuickClipboard_0.4.0_portable.exe#/QuickClipboard_portable.exe",
+            "hash": "664c259b14b338b56256f6f5372120f8a583f381bc9483d130fc214109efab84"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\data\")) { New-Item -ItemType Directory -Force -Path \"$persist_dir\\data\" | Out-Null }"
-    ],
     "shortcuts": [
         [
             "QuickClipboard_portable.exe",
@@ -22,12 +18,6 @@
         ]
     ],
     "persist": "data",
-    "uninstaller": {
-        "script": [
-            "Stop-Process -Name QuickClipboard_portable -Force -ErrorAction SilentlyContinue",
-            "Start-Sleep -Milliseconds 1500"
-        ]
-    },
     "checkver": {
         "github": "https://github.com/mosheng1/QuickClipboard"
     },
@@ -36,9 +26,6 @@
             "64bit": {
                 "url": "https://github.com/mosheng1/QuickClipboard/releases/download/v$version/QuickClipboard_$version_portable.exe#/QuickClipboard_portable.exe"
             }
-        },
-        "hash": {
-            "mode": "github"
         }
     }
 }


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Add QuickClipboard — a lightweight, portable clipboard manager with history, screenshot, OCR, and smart grouping.

**Features:**
- Clipboard history tracking (text, images, files)
- Built-in screenshot tool
- OCR (Optical Character Recognition)
- Smart clipboard grouping and search
- Portable edition — all data saved to `data/` subdirectory and persisted via `persist`
- Auto-update via GitHub Releases API + GitHub hash extraction

**Technical notes:**
- Portable executable, no installation needed — runs directly after download
- Data saved to app-local `data/` directory, persisted by Scoop
- Uninstaller terminates the process before removal and cleans up Start Menu shortcuts with target path verification (avoids removing non-Scoop shortcuts with the same name)

添加 QuickClipboard —— 轻量级便携式剪贴板管理工具，支持历史记录、截图、OCR 和智能分组。

**功能特性：**
- 剪贴板历史记录（文本、图片、文件）
- 内置截图工具
- OCR（光学字符识别）
- 智能剪贴板分组与搜索
- 便携版 —— 所有数据保存在 `data/` 子目录，通过 `persist` 持久化
- 通过 GitHub Releases API 自动更新 + GitHub hash 提取

**技术说明：**
- 便携式可执行文件，无需安装，下载即用
- 数据保存在应用目录下的 `data/` 文件夹，由 Scoop persist 管理
- 卸载器在移除前终止进程，并清理开始菜单快捷方式（通过目标路径校验避免误删同名非 Scoop 快捷方式）
