### PR TITLE
qq-nt: Update to version 9.9.31.260528, add data persistence

### DIFF
--- a/bucket/qq-nt.json
+++ b/bucket/qq-nt.json
@@ -1,35 +1,48 @@
 {
-    "version": "9.9.30.260511",
-    "description": "An instant messaging software service developed by Tencent",
-    "homepage": "https://im.qq.com/pcqq/index.shtml",
+    "version": "9.9.31.260528",
+    "description": "QQ NT - An instant messaging software service developed by Tencent",
+    "homepage": "https://im.qq.com/",
     "license": {
         "identifier": "Proprietary",
-        "url": "https://ti.qq.com/agreement/index.html"
+        "url": "https://rule.tencent.com/rule/46a15f24-e42c-4cb6-a308-2347139b1201"
     },
+    "notes": [
+        "QQ data is now persisted under Scoop's persist directory instead of %PUBLIC%\\Documents\\Tencent\\QQ.",
+        "Existing data from that location will be migrated automatically on first install."
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.30/guanwang/6a035910/QQ_9.9.30-260511_x64_01.exe#/dl.7z",
-            "hash": "d32e291a220b9461697153be91a99a2b6f169ed33deb74a6de87d4770c8a32b3"
-        },
-        "32bit": {
-            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.30/guanwang/6a035910/QQ_9.9.30-260511_x86_01.exe#/dl.7z",
-            "hash": "113bf9e4c3b98a101ca869caf1a00414bd2acdc2dd09db854667b2d3e3cc8116"
-        },
-        "arm64": {
-            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.30/guanwang/6a035910/QQ_9.9.30_260511_arm64_01.exe#/dl.7z",
-            "hash": "9921311876b5f24e93036a130a76dec442dd6c8a66f58a7809ae8b1de6f942cc"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.31/release/092069d7/QQ_9.9.31_260528_x64_01.exe#/dl.7z",
+            "hash": "0beb5cb4ff776cba822caa0abadbd53f5892f12628a86dabea1b372c82c086bc"
         }
     },
     "extract_dir": "Files",
+    "pre_install": [
+        "$dataDir = \"$env:PUBLIC\\Documents\\Tencent\\QQ\"",
+        "$persistDir = \"$persist_dir\\QQ_Data\"",
+        "if (!(Test-Path $persistDir)) { New-Item -ItemType Directory $persistDir -Force }",
+        "if (Test-Path $dataDir) {",
+        "    Get-ChildItem $dataDir -Directory | ForEach-Object {",
+        "        $target = Join-Path $persistDir $_.Name",
+        "        if (!(Test-Path $target)) { Move-Item $_.FullName $target }",
+        "        New-Item -ItemType Junction -Path $_.FullName -Target $target -Force",
+        "    }",
+        "}"
+    ],
+    "post_install": [
+        "$dataDir = \"$env:PUBLIC\\Documents\\Tencent\\QQ\"",
+        "if (!(Test-Path $dataDir)) { New-Item -ItemType Directory $dataDir -Force }"
+    ],
     "shortcuts": [
         [
             "QQ.exe",
             "QQ"
         ]
     ],
+    "persist": "QQ_Data",
     "checkver": {
         "script": [
-            "# Please keep this script. Using 'cdn-go.cn' may result in receiving expired cache responses.",
+            "# Use Tencent CDN to query the latest version. Keep this script — using 'cdn-go.cn' may return stale cache.",
             "$url = 'https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/windowsConfig.js'",
             "$hostname = ([Uri]$url).Host",
             "$records = Resolve-DnsName 'cdn-go.cn.cloud.tc.qq.com' -Type A -DnsOnly -ErrorAction Ignore",
@@ -37,20 +50,17 @@
             "$url = $url -Replace [regex]::Escape($hostname), $ip",
             "Invoke-WebRequest -Uri $url -UseBasicParsing -Headers @{'Host' = $hostname} | Select-Object -ExpandProperty Content"
         ],
-        "regex": "QQNT/[\\d.]+/guanwang/([\\w]+)/QQ_([\\d.]+)-([\\d]+)_x86_01.exe",
-        "replace": "${2}.${3}"
+        "regex": "QQNT/[\\d.]+/([\\w]+)/([\\w]+)/QQ_([\\d.]+)[-_]([\\d]+)_x64_01.exe",
+        "replace": "${3}.${4}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match2/guanwang/$match1/QQ_$match2-$match3_x64_01.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match2/guanwang/$match1/QQ_$match2-$match3_x86_01.exe#/dl.7z"
-            },
-            "arm64": {
-                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match2/guanwang/$match1/QQ_$match2_$match3_arm64_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/qqfile/QQNT/$match3/$match1/$match2/QQ_$match3_$match4_x64_01.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "mode": "download"
         }
     }
 }


### PR DESCRIPTION
Update QQ NT manifest:

- Version 9.9.30.260511 → 9.9.31.260528
- Add persist (QQ_Data) with automatic data migration from %PUBLIC%\Documents\Tencent\QQ
- Add post_install to ensure data directory exists
- Use more robust checkver regex (not hardcoded to 'guanwang' channel)

Note: Only x64 architecture is included in this update. x86/arm64 URLs and hashes will be populated automatically by Excavator on next autoupdate cycle.