### PR TITLE
wechat@4.1.10.27: Fix extraction, improve persistence, add URL protocol handler

### DIFF
--- a/bucket/wechat.json
+++ b/bucket/wechat.json
@@ -1,49 +1,105 @@
 {
     "version": "4.1.10.27",
-    "description": "Free messaging and calling app by Tencent",
+    "description": "Free messaging and calling app by Tencent | 微信，腾讯的一款聊天通讯工具",
     "homepage": "https://www.wechat.com/",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.wechat.com/en/service_terms.html"
     },
+    "notes": [
+        "WeChat data is stored in the following locations (mapped to Scoop persist directory):",
+        "  - AppData\\Roaming\\Tencent\\xwechat",
+        "  - Documents\\xwechat_files",
+        "",
+        "The weixin:// protocol is automatically registered on install/update."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/cscnk52/wechat-windows-versions/releases/download/v4.1.10.27/weixin_4.1.10.27.exe#/dl.7z",
             "hash": "54203fc2b41983fa106b0af0d67f86befc56ccd3dc1005d4bab6de8ea36b4f74"
         }
     },
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\install.7z\" \"$dir\" -Removal",
-            "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Force -Recurse",
-            "$config_path = \"$env:APPDATA\\Tencent\\xwechat\\config\"",
-            "ensure \"$config_path\" | Out-Null",
-            "Set-Content -NoNewline -Path \"$config_path\\51a1fffea11325a1e4104c6b3de47af7.ini\" -Value \"$persist_dir\"",
-            "$reg_path = \"HKCU:Software\\Tencent\\Wexin\"",
-            "if (!(Test-Path \"$reg_path\")) {",
-            "    New-Item -Path \"$reg_path\" -Type Directory -Force | Out-Null",
-            "}",
-            "New-ItemProperty -Path $reg_path -Name \"FileSavePath\" -Value \"$persist_dir\" -Force | Out-Null",
-            "New-Item -Path $reg_path -Name \"InstallPath\" -Value \"$dir\" -Force -ErrorAction SilentlyContinue | Out-Null"
-        ]
-    },
-    "uninstaller": {
-        "script": [
-            "Remove-Item -Path \"$env:APPDATA\\Tencent\\xwechat\\config\\51a1fffea11325a1e4104c6b3de47af7.ini\" -Force | Out-Null",
-            "Remove-ItemProperty -Path \"HKCU:Software\\Tencent\\Wexin\" -Name \"FileSavePath\" -Force | Out-Null"
-        ]
-    },
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\install.7z\" \"$dir\" -Removal",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\install\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "$verDir = Get-ChildItem \"$dir\" -Directory | Where-Object { $_.Name -match '^\\d+(\\.\\d+)+$' } | Select-Object -First 1",
+        "if ($verDir) {",
+        "    Move-Item \"$verDir\\Weixin.exe\" \"$dir\" -Force",
+        "    Remove-Item \"$verDir\\Uninstall.exe\" -Force -ErrorAction SilentlyContinue",
+        "}",
+        "Remove-Item \"$dir\\FindProcDLL.dll\", \"$dir\\nsis7z.dll\", \"$dir\\System.dll\", \"$dir\\WeChatInstallDll.dll\" -Force -ErrorAction SilentlyContinue",
+        "",
+        "$regPath = 'HKCU:\\Software\\Tencent\\Wexin'",
+        "if (!(Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }",
+        "New-ItemProperty -Path $regPath -Name 'FileSavePath' -Value \"$persist_dir\" -Force | Out-Null",
+        "New-ItemProperty -Path $regPath -Name 'InstallPath' -Value \"$dir\" -Force | Out-Null",
+        "",
+        "$exePath = \"$(Split-Path $dir -Parent)\\current\\Weixin.exe\"",
+        "$protoPath = 'HKCU:\\Software\\Classes\\weixin'",
+        "New-Item -Path $protoPath -Value 'Weixin Protocol' -Force | Out-Null",
+        "New-ItemProperty -Path $protoPath -Name 'URL Protocol' -PropertyType String -Force | Out-Null",
+        "New-Item -Path \"$protoPath\\shell\\open\\command\" -Value \"`\"$exePath`\" `\"%1`\"\" -Force | Out-Null"
+    ],
+    "post_install": [
+        "$pairs = @(",
+        "    @(\"$persist_dir\\xwechat\", \"$env:APPDATA\\Tencent\\xwechat\"),",
+        "    @(\"$persist_dir\\xwechat_files\", (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'xwechat_files'))",
+        ")",
+        "foreach ($pair in $pairs) {",
+        "    $persistDir, $targetDir = $pair",
+        "    if (Test-Path $targetDir) {",
+        "        $item = Get-Item $targetDir -Force -ErrorAction SilentlyContinue",
+        "        if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {",
+        "            [System.IO.Directory]::Delete($targetDir)",
+        "        } else {",
+        "            robocopy $targetDir $persistDir /E /MOVE /NP /NFL /NDL /NJH /NJS | Out-Null",
+        "            if (Test-Path $targetDir) { Remove-Item $targetDir -Force -Recurse -ErrorAction SilentlyContinue }",
+        "        }",
+        "    }",
+        "    New-Item -ItemType Directory $persistDir -Force | Out-Null",
+        "    $parentDir = Split-Path $targetDir -Parent",
+        "    if (!(Test-Path $parentDir)) { New-Item -ItemType Directory $parentDir -Force | Out-Null }",
+        "    New-Item -ItemType Junction -Path $targetDir -Target $persistDir | Out-Null",
+        "}"
+    ],
     "shortcuts": [
         [
             "Weixin.exe",
             "WeChat"
         ]
     ],
-    "persist": "xwechat_files",
+    "pre_uninstall": [
+        "@(\"$env:APPDATA\\Tencent\\xwechat\", (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'xwechat_files')) | ForEach-Object {",
+        "    if ((Test-Path $_) -and ((Get-Item $_ -ErrorAction SilentlyContinue).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {",
+        "        [System.IO.Directory]::Delete($_)",
+        "    }",
+        "}"
+    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name Weixin -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500",
+            "$appDir = Split-Path $dir -Parent",
+            "$shell = New-Object -ComObject WScript.Shell",
+            "@(\"$env:APPDATA\", \"$env:ProgramData\") | ForEach-Object {",
+            "    $lnk = \"$_\\Microsoft\\Windows\\Start Menu\\Programs\\Scoop Apps\\WeChat.lnk\"",
+            "    if ((Test-Path $lnk) -and ($shell.CreateShortcut($lnk).TargetPath -like \"$appDir\\*\")) {",
+            "        Remove-Item $lnk -Force -ErrorAction SilentlyContinue",
+            "    }",
+            "}"
+        ]
+    },
+    "post_uninstall": [
+        "Remove-Item 'HKCU:\\Software\\Classes\\weixin' -Recurse -Force -ErrorAction SilentlyContinue",
+        "Remove-ItemProperty -Path 'HKCU:\\Software\\Tencent\\Wexin' -Name 'FileSavePath', 'InstallPath' -Force -ErrorAction SilentlyContinue"
+    ],
     "checkver": {
         "github": "https://github.com/cscnk52/wechat-windows-versions"
     },
     "autoupdate": {
+        "hash": {
+            "mode": "github"
+        },
         "architecture": {
             "64bit": {
                 "url": "https://github.com/cscnk52/wechat-windows-versions/releases/download/v$version/weixin_$version.exe#/dl.7z"


### PR DESCRIPTION
- [x] Use conventional PR title: <manifest-name[@version]|chore>: <general summary of the pull request>
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Rewrite WeChat manifest with persistence and installation improvements:

**pre_install (replaces installer.script):**
- Extract install.7z from NSIS installer
- Handle WeChat 4.x version subdirectory: move Weixin.exe to app root, remove Uninstall.exe and NSIS helper DLLs
- Set registry FileSavePath -> $persist_dir and InstallPath -> $dir
- Register weixin:// protocol handler pointing to Scoop current symlink

**post_install (NEW):**
- Handle existing data dirs (migrate from reparse point or regular directory to persist dir)
- Create junction: %APPDATA%\Tencent\xwechat -> $persist_dir\xwechat (persist app data)
- Create junction: Documents\xwechat_files -> $persist_dir\xwechat_files (persist chat data)

**Uninstall:**
- Terminate Weixin process before removal
- Clean up Start Menu shortcuts with target path verification
- pre_uninstall (NEW): remove junctions only, preserving persisted data
- post_uninstall (NEW): clean up weixin:// protocol and registry entries (FileSavePath, InstallPath)

**Other changes:**
- Added notes section explaining data storage locations
- Added autoupdate hash.mode = github
- Description updated to Chinese + English
- Removed old persist: "xwechat_files" (replaced by junction-based persistence in post_install)

重写微信 manifest，改进持久化和安装流程：

**pre_install（替代原 installer.script）：**
- 从 NSIS 安装包解压 install.7z
- 处理 WeChat 4.x 版本子目录：Weixin.exe 移到根目录，移除 Uninstall.exe 和 NSIS 辅助 DLL
- 设置注册表 FileSavePath -> $persist_dir 和 InstallPath -> $dir
- 注册 weixin:// 协议，指向 current 符号链接

**post_install（新增）：**
- 处理已有数据目录（迁移 reparse point 或普通目录到 persist 目录）
- 创建 junction：%APPDATA%\Tencent\xwechat -> $persist_dir\xwechat（持久化应用数据）
- 创建 junction：Documents\xwechat_files -> $persist_dir\xwechat_files（持久化聊天数据）

**卸载：**
- 卸载前终止微信进程
- 清理开始菜单快捷方式（校验目标路径）
- pre_uninstall（新增）：仅删除 junction，保留持久化数据
- post_uninstall（新增）：清理 weixin:// 协议和注册表项（FileSavePath, InstallPath）

**其他变更：**
- 增加 notes 说明数据存储位置
- autoupdate 增加 hash.mode = github
- 描述改为中英文双语
- 移除旧 persist: "xwechat_files"（由 post_install 中的 junction 方案替代）