### PR TITLE
fluxdown: Add version 0.1.42

### DIFF
--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.1.42",
+    "description": "FluxDown - A modern multi-protocol download manager (Portable) built with Rust",
+    "homepage": "https://fluxdown.zerx.dev",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://fluxdown.zerx.dev"
+    },
+    "notes": "FluxDown portable data persistence: runtime data stored in the app directory",
+    "architecture": {
+        "64bit": {
+            "url": "https://fluxdown.zerx.dev/api/download/FluxDown-0.1.42-windows-x64-portable.zip",
+            "hash": "24b8a236b6cf05943558408b9e870a9c491a5449b1a950d1822d20819757cf3b"
+        }
+    },
+    "shortcuts": [
+        ["flux_down.exe", "FluxDown"]
+    ],
+    "persist": "flux_down.db",
+    "checkver": {
+        "url": "https://fluxdown.zerx.dev/api/release",
+        "jp": "version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://fluxdown.zerx.dev/api/download/FluxDown-$version-windows-x64-portable.zip"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
+    }
+}


### PR DESCRIPTION
Add FluxDown, a modern multi-protocol download manager built with Rust (Portable).

Relates to #17922