### PR TITLE
fluxdown: Add version 0.1.42

### DIFF
--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.1.42",
+    "description": "FluxDown - A modern multi-protocol download manager (Portable) built with Rust",
+    "homepage": "https://fluxdown.zerx.dev",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "hash": "24b8a236b6cf05943558408b9e870a9c491a5449b1a950d1822d20819757cf3b",
+            "url": "https://fluxdown.zerx.dev/api/download/FluxDown-0.1.42-windows-x64-portable.zip"
+        }
+    },
+    "shortcuts": [
+        [
+            "flux_down.exe",
+            "FluxDown"
+        ]
+    ],
+    "checkver": {
+        "jp": "version",
+        "url": "https://fluxdown.zerx.dev/api/release"
+    },
+    "autoupdate": {
+        "hash": {
+            "mode": "download"
+        },
+        "architecture": {
+            "64bit": {
+                "url": "https://fluxdown.zerx.dev/api/download/FluxDown-$version-windows-x64-portable.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add FluxDown, a modern multi-protocol download manager built with Rust (Portable).

Relates to #17922