### PR TITLE
ratty: Add version 0.4.1

### DIFF
--- a/bucket/ratty.json
+++ b/bucket/ratty.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.4.1",
+    "description": "GPU-rendered terminal emulator with inline 3D graphics",
+    "homepage": "https://ratty-term.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/orhun/ratty/releases/download/v0.4.1/ratty-x86_64-pc-windows-msvc.zip",
+            "hash": "7f9b5f70263b5271adbd7b33771956fdf7a321049fcc40588fd117d68fbeb0f6"
+        }
+    },
+    "bin": "ratty.exe",
+    "shortcuts": [
+        [
+            "ratty.exe",
+            "Ratty"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/orhun/ratty"
+    },
+    "autoupdate": {
+        "url": "https://github.com/orhun/ratty/releases/download/v$version/ratty-x86_64-pc-windows-msvc.zip",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://ratty-term.org/

Notes:
- Application icon is currently not set for the executable.
- A console window pops up when launched directly from the Start menu.
- I have created an upstream PR to address both of these issues: https://github.com/orhun/ratty/pull/87

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
