### PR TITLE
osmonitor: Add version 10.6.23

### DIFF
--- a/bucket/osmonitor.json
+++ b/bucket/osmonitor.json
@@ -1,0 +1,32 @@
+﻿{
+    "version": "10.6.23",
+    "description": "Centralized IT administration and network management console for enterprise LANs (10-Day Trial Version).",
+    "homepage": "https://www.os-monitor.com",
+    "license": "Shareware",
+    "url": "https://www.os-monitor.com/OsMonitorServerSetup10.6.23.exe",
+    "hash": "51f1371c90667ac4f80a7597e777260dd83e4893a70c2c7276fbc7ac8c2999fc",
+    "installer": {
+        "args": [
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART",
+            "/SP-",
+            "/DIR="$dir""
+        ]
+    },
+    "uninstaller": {
+        "file": "unins000.exe",
+        "args": [
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART"
+        ]
+    },
+    "bin": "OsMonitorServer.exe",
+    "shortcuts": [
+        [
+            "OsMonitorServer.exe",
+            "OsMonitor Management Console"
+        ]
+    ]
+}


### PR DESCRIPTION
Add new manifest for OsMonitor Management Console (10-Day Trial Version).

**Note for Reviewers:**
This package uses the `installer` directive rather than `innosetup: true` because it requires administrative privileges to silently register two required MS OCX components during the installation process.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)