### PR TITLE
flclash@0.8.93: Add notes, add arm64 support

### DIFF
--- a/bucket/flclash.json
+++ b/bucket/flclash.json
@@ -3,10 +3,21 @@
     "description": "A multi-platform proxy client based on ClashMeta, simple and easy to use, open-source and ad-free.",
     "homepage": "https://github.com/chen08209/FlClash",
     "license": "GPL-3.0",
+    "notes": [
+        "Once you set up TUN mode successfully, the older versions of FlClash may be hard to remove by running 'scoop cleanup flclash'.",
+        "In that case, try running the following command with priviledge.",
+        "sc.exe config FlClashHelperService binPath=\"$dir\\FlClashHelperService.exe\"",
+        "This command will modify the FlClashHelperService with a flexible path to the executable.",
+        "Also, FlClash may be hard to uninstall due the running FlClashHelperService, just kill it with Task Manager or run 'sc.exe stop FlClashHelperService' with priviledge."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/chen08209/FlClash/releases/download/v0.8.93/FlClash-0.8.93-windows-amd64.zip",
             "hash": "8381c9db07c568519e7554bb224afebd98766c5ffeb13dd1f1b9e6eca72f100a"
+        },
+        "arm64": {
+            "url": "https://github.com/chen08209/FlClash/releases/download/v0.8.93/FlClash-0.8.93-windows-arm64.zip",
+            "hash": "4e0d193af6dd22f866558793d17ffe8a48e7b4ce156016eef2194dfdaee9f2a2"
         }
     },
     "shortcuts": [
@@ -20,10 +31,10 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/chen08209/FlClash/releases/download/v$version/FlClash-$version-windows-amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/chen08209/FlClash/releases/download/v$version/FlClash-$version-windows-arm64.zip"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/flclash.json
+++ b/bucket/flclash.json
@@ -2,7 +2,7 @@
     "version": "0.8.93",
     "description": "A multi-platform proxy client based on ClashMeta, simple and easy to use, open-source and ad-free.",
     "homepage": "https://github.com/chen08209/FlClash",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "notes": [
         "Once you set up TUN mode successfully, the older versions of FlClash may be hard to remove by running 'scoop cleanup flclash'.",
         "In that case, try running the following command with privilege.",
@@ -35,6 +35,9 @@
             "arm64": {
                 "url": "https://github.com/chen08209/FlClash/releases/download/v$version/FlClash-$version-windows-arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }

--- a/bucket/flclash.json
+++ b/bucket/flclash.json
@@ -5,10 +5,10 @@
     "license": "GPL-3.0",
     "notes": [
         "Once you set up TUN mode successfully, the older versions of FlClash may be hard to remove by running 'scoop cleanup flclash'.",
-        "In that case, try running the following command with priviledge.",
+        "In that case, try running the following command with privilege.",
         "sc.exe config FlClashHelperService binPath=\"$dir\\FlClashHelperService.exe\"",
         "This command will modify the FlClashHelperService with a flexible path to the executable.",
-        "Also, FlClash may be hard to uninstall due the running FlClashHelperService, just kill it with Task Manager or run 'sc.exe stop FlClashHelperService' with priviledge."
+        "Also, FlClash may be hard to uninstall due the running FlClashHelperService, just kill it with Task Manager or run 'sc.exe stop FlClashHelperService' with privilege."
     ],
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Yes, the newest release of FlClash don't have dedicated hash files anymore, and Arm64 support is back.
And I add some notes for those who are interested in TUN mode.



- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
