### PR TITLE
portable-virtualbox@6.4.10.5.1.22: fixed download link, checkver and autoupdate

### DIFF
--- a/bucket/portable-virtualbox.json
+++ b/bucket/portable-virtualbox.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.vbox.me/",
     "license": "GPL-2.0-only,CC-BY-NC-SA-3.0",
     "url": [
-        "http://files.vbox.me/files/Portable-VirtualBox_v5.1.22-Starter_v6.4.10-Win_all.exe#/dl.7z",
+        "https://vbox.me/files/Portable-VirtualBox_v5.1.22-Starter_v6.4.10-Win_all.exe#/dl.7z",
         "https://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1.22-115126-Win.exe#/VirtualBox.exe",
         "https://download.virtualbox.org/virtualbox/5.1.22/Oracle_VM_VirtualBox_Extension_Pack-5.1.22-115126.vbox-extpack#/Extension"
     ],
@@ -21,8 +21,28 @@
             "Portable VirtualBox"
         ]
     ],
-    "checkver": "VirtualBox_v(?<vbox>[\\d.]+)-Starter_v(?<version>[\\d.]+)-Win_all.exe</a>",
+    "checkver": {
+        "script": [
+            "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content",
+            "$regex = 'VirtualBox_v(?<vbox>[\\d.]+)-Starter_v(?<version>[\\d.]+)-Win_all.exe'",
+            "if (!($cont -match $regex)) { error \"Could not match $regex in $url\"; continue }",
+            "$vboxVersion = $($matches.vbox)",
+            "$fullversion = \"$($matches.version).$($matches.vbox)\"",
+            "",
+            "$nextUrl = \"https://download.virtualbox.org/virtualbox/$vboxVersion/\"",
+            "$nextCont = (Invoke-WebRequest $nextUrl -UseBasicParsing).Content",
+            "$nextRegex = \"VirtualBox-$vboxVersion-(?<vboxbuild>\\d+)-Win.exe\"",
+            "if (!($nextCont -match $nextRegex)) { error \"Could not match $nextRegex in $nextUrl\"; continue }",
+            "$vboxbuild = $($matches.vboxbuild)",
+            "\"$fullversion $vboxVersion $vboxbuild\""
+        ],
+        "regex": "([\\d.]+) (?<vboxversion>[\\d.]+) (?<vboxbuild>[\\d]+)"
+    },
     "autoupdate": {
-        "url": "http://files.vbox.me/files/Portable-VirtualBox_v$matchVbox-Starter_v$matchVersion-Win_all.exe#/dl.7z"
+        "url": [
+            "https://vbox.me/files/Portable-VirtualBox_v$matchVboxversion-Starter_v$matchHead-Win_all.exe#/dl.7z",
+            "https://download.virtualbox.org/virtualbox/$matchVboxversion/VirtualBox-$matchVboxversion-$matchVboxbuild-Win.exe#/VirtualBox.exe",
+            "https://download.virtualbox.org/virtualbox/$matchVboxversion/Oracle_VM_VirtualBox_Extension_Pack-$matchVboxversion-$matchVboxbuild.vbox-extpack#/Extension"
+        ]
     }
 }

--- a/bucket/portable-virtualbox.json
+++ b/bucket/portable-virtualbox.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.4.10",
+    "version": "6.4.10.5.1.22",
     "description": "A portable VirtualBox downloader and launcher written by Runar Buvik",
     "homepage": "https://www.vbox.me/",
     "license": "GPL-2.0-only,CC-BY-NC-SA-3.0",
@@ -23,16 +23,12 @@
     ],
     "checkver": {
         "script": [
-            "$cont = (Invoke-WebRequest $url -UseBasicParsing).Content",
-            "$regex = 'VirtualBox_v(?<vbox>[\\d.]+)-Starter_v(?<version>[\\d.]+)-Win_all.exe'",
-            "if (!($cont -match $regex)) { error \"Could not match $regex in $url\"; continue }",
+            "$page -match 'VirtualBox_v(?<vbox>[\\d.]+)-Starter_v(?<version>[\\d.]+)-Win_all.exe'",
             "$vboxVersion = $($matches.vbox)",
             "$fullversion = \"$($matches.version).$($matches.vbox)\"",
-            "",
-            "$nextUrl = \"https://download.virtualbox.org/virtualbox/$vboxVersion/\"",
-            "$nextCont = (Invoke-WebRequest $nextUrl -UseBasicParsing).Content",
-            "$nextRegex = \"VirtualBox-$vboxVersion-(?<vboxbuild>\\d+)-Win.exe\"",
-            "if (!($nextCont -match $nextRegex)) { error \"Could not match $nextRegex in $nextUrl\"; continue }",
+            "$url = \"https://download.virtualbox.org/virtualbox/$vboxVersion/\"",
+            "$page = (Invoke-WebRequest $url -UseBasicParsing).Content",
+            "$page -match \"VirtualBox-$vboxVersion-(?<vboxbuild>\\d+)-Win.exe\"",
             "$vboxbuild = $($matches.vboxbuild)",
             "\"$fullversion $vboxVersion $vboxbuild\""
         ],


### PR DESCRIPTION
Closes #1677

Fixed the first of 3 download links. The auto update was not implemented for the latter two, so added those. Since not all information was found on one webpage, I converted it to a script. Looks Ok now, although the 6 numbers do make a long version now.

- [x ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 