### PR TITLE
winuxcmd: Add version 0.12.0

### DIFF
--- a/bucket/winuxcmd.json
+++ b/bucket/winuxcmd.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.12.0",
+    "description": "Linux-style command set for Windows terminals.",
+    "homepage": "https://github.com/caomengxuan666/WinuxCmd",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/caomengxuan666/WinuxCmd/releases/download/v0.12.0/WinuxCmd-0.12.0-win-x64.zip",
+            "hash": "55d00ed7367cc404f39fcf3fb8f35f29a50f0e6373e48b59412a29ec98e50fd5",
+            "extract_dir": "WinuxCmd-0.12.0-win-x64"
+        },
+        "arm64": {
+            "url": "https://github.com/caomengxuan666/WinuxCmd/releases/download/v0.12.0/WinuxCmd-0.12.0-win-arm64.zip",
+            "hash": "f2bd6f4f64048936e2336da2dbdaa8f1b365c57e6fdcf33fe12f808f994639b5",
+            "extract_dir": "WinuxCmd-0.12.0-win-arm64"
+        }
+    },
+    "post_install": [
+        "Push-Location $dir",
+        ".\\create_links.ps1 -Force",
+        "Pop-Location"
+    ],
+    "env_add_path": ".",
+    "bin": "winuxcmd.exe",
+    "checkver": {
+        "github": "https://github.com/caomengxuan666/WinuxCmd"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/caomengxuan666/WinuxCmd/releases/download/v$version/WinuxCmd-$version-win-x64.zip",
+                "extract_dir": "WinuxCmd-$version-win-x64"
+            },
+            "arm64": {
+                "url": "https://github.com/caomengxuan666/WinuxCmd/releases/download/v$version/WinuxCmd-$version-win-arm64.zip",
+                "extract_dir": "WinuxCmd-$version-win-arm64"
+            }
+        }
+    }
+}


### PR DESCRIPTION
winuxcmd: Add version 0.12.0

Adds WinuxCmd, a Linux-style command set for Windows terminals.

Relates to #17969

The previous submission to the Main bucket was closed as not meeting Main criteria, so this PR targets Extras.

Implementation notes:

- Uses architecture-specific x64 and ARM64 release zips.
- Runs `create_links.ps1 -Force` after install so command links such as `ls.exe`, `cat.exe`, and `rm.exe` are generated.
- Adds the install directory to PATH so the generated command links are available.
- Includes `checkver` and `autoupdate` using GitHub releases.

Validation performed locally:

- JSON parsed successfully with `ConvertFrom-Json`.
- x64 and ARM64 SHA256 hashes match the downloaded v0.12.0 release zips.
- Verified archive roots:
  - `WinuxCmd-0.12.0-win-x64`
  - `WinuxCmd-0.12.0-win-arm64`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the Contributing Guide.