### PR TITLE
vroid-studio: Update to version 2.13.0

### DIFF
--- a/bucket/vroid-studio.json
+++ b/bucket/vroid-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.11.0",
+    "version": "2.13.0",
     "description": "3D character maker",
     "homepage": "https://vroid.com/en/studio",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.vroid.com/dist/tEuggsKrtY/VRoidStudio-v2.11.0-win.exe",
-            "hash": "6d5887a8682ff6012a8e9ba9de11b20c42922e8d6a83a5388dcd80dfb5667280"
+            "url": "https://download.vroid.com/dist/dxy77TdlP1/VRoidStudio-v2.13.0-win.exe",
+            "hash": "77e7f23b4349997df1043eaaf5e3871d54044e3a320d2112409caa6979db72c7"
         }
     },
     "innosetup": true,
@@ -21,7 +21,10 @@
         ]
     ],
     "persist": "uWintab.log",
-    "checkver": "https://download.vroid.com/dist/(?<distId>[\\w]+)/VRoidStudio-v(?<version>[\\d.]+)-win\\.exe",
+    "checkver": {
+        "url": "https://web.archive.org/web/2/https://vroid.com/en/studio",
+        "regex": "download\\.vroid\\.com/dist/(?<distId>[\\w]+)/VRoidStudio-v(?<version>[\\d.]+)-win\\.exe"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/vroid-studio.json
+++ b/bucket/vroid-studio.json
@@ -21,10 +21,7 @@
         ]
     ],
     "persist": "uWintab.log",
-    "checkver": {
-        "url": "https://web.archive.org/web/2/https://vroid.com/en/studio",
-        "regex": "download\\.vroid\\.com/dist/(?<distId>[\\w]+)/VRoidStudio-v(?<version>[\\d.]+)-win\\.exe"
-    },
+    "checkver": "https://download.vroid.com/dist/(?<distId>[\\w]+)/VRoidStudio-v(?<version>[\\d.]+)-win\\.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
- Update to version 2.13.0
- ~~Fix checkver by using Wayback Machine to bypass Cloudflare 403 errors~~
- ~~Update checkver regex to handle Wayback Machine URL rewrites~~

Relates to #17933

/verify