### PR TITLE
oryxis: Add version 0.8.1

### DIFF
--- a/bucket/oryxis.json
+++ b/bucket/oryxis.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Modern SSH client built in Rust (encrypted vault, P2P sync, AI, Kubernetes)",
     "homepage": "https://github.com/wilsonglasser/oryxis",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wilsonglasser/oryxis/releases/download/v0.8.0/oryxis-windows-x86_64.zip",
-            "hash": "f768cc4a3fe41e76ffbb0e3a96cc0bfb7c23f5490bb541be397fc76c6b0cb753"
+            "url": "https://github.com/wilsonglasser/oryxis/releases/download/v0.8.1/oryxis-windows-x86_64.zip",
+            "hash": "38b4e20fbf8e4f762109454ef0f5282c62e245eb4f99b3689340a42a60167a2e"
         },
         "arm64": {
-            "url": "https://github.com/wilsonglasser/oryxis/releases/download/v0.8.0/oryxis-windows-aarch64.zip",
-            "hash": "0ab2045b00648e82645246aba1300fdc11a1a6263330f1b153d7d5c5acdf739a"
+            "url": "https://github.com/wilsonglasser/oryxis/releases/download/v0.8.1/oryxis-windows-aarch64.zip",
+            "hash": "3f408ee5dc23b4d50f9924e9094c47437791467d75b8ce8e766530eb55b8fe7d"
         }
     },
     "bin": "oryxis.exe",

--- a/bucket/oryxis.json
+++ b/bucket/oryxis.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.8.0",
+    "description": "Modern SSH client built in Rust (encrypted vault, P2P sync, AI, Kubernetes)",
+    "homepage": "https://github.com/wilsonglasser/oryxis",
+    "license": "AGPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wilsonglasser/oryxis/releases/download/v0.8.0/oryxis-windows-x86_64.zip",
+            "hash": "f768cc4a3fe41e76ffbb0e3a96cc0bfb7c23f5490bb541be397fc76c6b0cb753"
+        },
+        "arm64": {
+            "url": "https://github.com/wilsonglasser/oryxis/releases/download/v0.8.0/oryxis-windows-aarch64.zip",
+            "hash": "0ab2045b00648e82645246aba1300fdc11a1a6263330f1b153d7d5c5acdf739a"
+        }
+    },
+    "bin": "oryxis.exe",
+    "shortcuts": [
+        [
+            "oryxis.exe",
+            "Oryxis"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wilsonglasser/oryxis/releases/download/v$version/oryxis-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/wilsonglasser/oryxis/releases/download/v$version/oryxis-windows-aarch64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #17991

Adds [Oryxis](https://github.com/wilsonglasser/oryxis), a Rust-native SSH client (encrypted vault, P2P sync, embedded terminal, AGPL-3.0).

- x64 + arm64 from the official GitHub release zips
- `checkver`/`autoupdate` wired to the GitHub releases
- Manifest validates as JSON

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)