### PR TITLE
ferrite: Add version 0.3.0

### DIFF
--- a/bucket/ferrite.json
+++ b/bucket/ferrite.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.3.0",
+    "description": "Fast, native Markdown editor built with Rust",
+    "homepage": "https://getferrite.dev/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/OlaProeis/Ferrite/releases/download/v0.3.0/ferrite-portable-windows-x64.zip",
+            "hash": "703421fb9c560a1f85a9bedcc0d2debec0223554bee0bab4e1a79c83d961474a"
+        }
+    },
+    "bin": "ferrite.exe",
+    "persist": "portable",
+    "shortcuts": [
+        [
+            "ferrite.exe",
+            "Ferrite"
+        ]
+    ],
+    "notes": [
+        "Ferrite portable stores settings, sessions, and user data in the persisted 'portable' directory next to ferrite.exe.",
+        "If you want a traditional machine-wide Windows install instead, use the upstream ferrite-windows-x64.msi asset."
+    ],
+    "checkver": {
+        "github": "https://github.com/OlaProeis/Ferrite"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/OlaProeis/Ferrite/releases/download/v$version/ferrite-portable-windows-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds Ferrite to the Extras bucket.

App details:
- Homepage: https://getferrite.dev/
- Repository: https://github.com/OlaProeis/Ferrite
- License: MIT

Package details:
- Uses the official portable Windows x64 ZIP asset from GitHub Releases
- Persists the upstream `portable` directory, which stores settings, sessions, and user data
- Includes `checkver` and `autoupdate`

Verification:
- Official release asset digest matched local SHA256
- Passed local Scoop bucket tests via `Import-Bucket-Tests.ps1`
