### PR TITLE
wmux: Add version 0.8.2

### DIFF
--- a/bucket/wmux
+++ b/bucket/wmux
@@ -1,0 +1,16 @@
+{
+    "version": "0.8.2",
+    "description": "Windows cmux terminal fork with vertical tabs and notifications for AI coding agents",
+    "homepage": "https://github.com/amirlehmam/wmux",
+    "license": "MIT",
+    "url": "https://github.com/amirlehmam/wmux/releases/download/v0.8.2/wmux-0.8.2-win-x64.zip",
+    "hash": "sha256:09F1038D81C1E58026D3F5EB8B11D590A1B77F186A8B295094E80A2718C6DDD6",
+    "bin": "wmux.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/amirlehmam/wmux/releases/download/v$version/wmux-$version-win-x64.zip",
+        "hash": {
+            "mode": "download"
+        }
+    }
+}


### PR DESCRIPTION
Closes #17996

Adds [wmux](https://github.com/amirlehmam/wmux), a Windows [cmux](https://github.com/manaflow-ai/cmux) fork.

- x64 from the official GitHub release zips
- `checkver`/`autoupdate` wired to the GitHub releases
- Manifest validates as JSON

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
