### PR TITLE
bulk-crap-uninstaller: Update GitHub repo URLs

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -44,10 +44,6 @@
             "64bit": {
                 "url": "https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/releases/download/v$matchTag/BCUninstaller_$version_portable.zip"
             }
-        },
-        "hash": {
-            "url": "https://sourceforge.net/projects/bulk-crap-uninstaller/files/v$matchTag/",
-            "regex": "$basename.*?\"sha1\":\"$sha1"
         }
     }
 }

--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -2,11 +2,14 @@
     "version": "6.2.0",
     "description": "Bulk program uninstaller with advanced automation",
     "homepage": "https://www.bcuninstaller.com/",
-    "license": "Apache-2.0",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/blob/master/Licence.txt"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v6.2/BCUninstaller_6.2.0_portable.zip",
-            "hash": "sha1:5bb928e9222bffa897fa5fe424e6a1f119365d57",
+            "url": "https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/releases/download/v6.2/BCUninstaller_6.2.0_portable.zip",
+            "hash": "93f6c3543fdffa02159967decfb887e035b3904a7d9087f3e5d806bbf06c7b78",
             "extract_dir": "win-x64"
         }
     },
@@ -14,9 +17,6 @@
         "ensure \"$persist_dir\" | Out-Null",
         "Copy-Item \"$persist_dir\\BCUninstaller.settings\" \"$dir\" -ErrorAction 'SilentlyContinue'"
     ],
-    "uninstaller": {
-        "script": "Copy-Item \"$dir\\BCUninstaller.settings\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force"
-    },
     "bin": [
         "BCU-console.exe",
         "BCUninstaller.exe",
@@ -31,15 +31,18 @@
             "Bulk Crap Uninstaller"
         ]
     ],
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\BCUninstaller.settings\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force"
+    },
     "checkver": {
-        "github": "https://api.github.com/repos/Klocman/Bulk-Crap-Uninstaller/releases/latest",
+        "github": "https://api.github.com/repos/BCUninstaller/Bulk-Crap-Uninstaller/releases/latest",
         "jsonpath": "$.assets[*].browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+)/BCUninstaller_([\\d.]+)_portable(?:-[\\w]+)?\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$matchTag/BCUninstaller_$version_portable.zip"
+                "url": "https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/releases/download/v$matchTag/BCUninstaller_$version_portable.zip"
             }
         },
         "hash": {

--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -13,10 +13,7 @@
             "extract_dir": "win-x64"
         }
     },
-    "pre_install": [
-        "ensure \"$persist_dir\" | Out-Null",
-        "Copy-Item \"$persist_dir\\BCUninstaller.settings\" \"$dir\" -ErrorAction 'SilentlyContinue'"
-    ],
+    "pre_install": "Copy-Item \"$persist_dir\\BCUninstaller.settings\" \"$dir\" -ErrorAction Ignore",
     "bin": [
         "BCU-console.exe",
         "BCUninstaller.exe",
@@ -32,7 +29,10 @@
         ]
     ],
     "uninstaller": {
-        "script": "Copy-Item \"$dir\\BCUninstaller.settings\" \"$persist_dir\" -ErrorAction 'SilentlyContinue' -Force"
+        "script": [
+            "ensure \"$persist_dir\" | Out-Null",
+            "Copy-Item \"$dir\\BCUninstaller.settings\" \"$persist_dir\" -ErrorAction Ignore -Force"
+        ]
     },
     "checkver": {
         "github": "https://api.github.com/repos/BCUninstaller/Bulk-Crap-Uninstaller/releases/latest",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Change exists since v6.2.0 (per [changelog](https://github.com/BCUninstaller/Bulk-Crap-Uninstaller/releases/tag/v6.2))

> Moved the repository under a new BCUninstaller organization (old links still work)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
