### PR TITLE
exosnap: Add version 0.1.0

### DIFF
--- a/bucket/exosnap.json
+++ b/bucket/exosnap.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.1.0",
+    "description": "Windows-native screen / application / region recorder with an NVIDIA NVENC pipeline, multi-track audio, webcam overlay, and diagnostics.",
+    "homepage": "https://github.com/Exoridus/exosnap",
+    "license": "GPL-3.0-or-later",
+    "notes": [
+        "ExoSnap 0.1.0 is a pre-v1 preview. Settings/preset/history formats may change before 1.0.0.",
+        "Requires an NVIDIA GPU with supported NVENC and the Microsoft Visual C++ 2022 x64 runtime.",
+        "Settings are stored under %LOCALAPPDATA%\\ExoSnap and are preserved across updates and uninstall."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Exoridus/exosnap/releases/download/v0.1.0/ExoSnap-0.1.0-windows-x64-portable.zip",
+            "hash": "f046cfd7d50db1ed1d07394e5da79a9d0a34a7968ffdeb6878db75486ba31ef0",
+            "extract_dir": "ExoSnap-0.1.0-windows-x64-portable"
+        }
+    },
+    "shortcuts": [
+        ["exosnap.exe", "ExoSnap"]
+    ],
+    "checkver": {
+        "github": "https://github.com/Exoridus/exosnap"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Exoridus/exosnap/releases/download/v$version/ExoSnap-$version-windows-x64-portable.zip",
+                "hash": {
+                    "url": "https://github.com/Exoridus/exosnap/releases/download/v$version/ExoSnap-$version-windows-x64-portable.sha256"
+                },
+                "extract_dir": "ExoSnap-$version-windows-x64-portable"
+            }
+        }
+    }
+}

--- a/bucket/exosnap.json
+++ b/bucket/exosnap.json
@@ -3,6 +3,7 @@
     "description": "Windows-native screen / application / region recorder with an NVIDIA NVENC pipeline, multi-track audio, webcam overlay, and diagnostics.",
     "homepage": "https://github.com/Exoridus/exosnap",
     "license": "GPL-3.0-or-later",
+    "depends": "extras/vcredist2022",
     "notes": [
         "ExoSnap 0.1.0 is a pre-v1 preview. Settings/preset/history formats may change before 1.0.0.",
         "Requires an NVIDIA GPU with supported NVENC and the Microsoft Visual C++ 2022 x64 runtime.",


### PR DESCRIPTION
Adds a manifest for **ExoSnap** 0.1.0 — a Windows-native screen / application / region recorder (NVIDIA NVENC pipeline, multi-track audio, webcam overlay, diagnostics). GUI app, so it belongs in Extras.

- Portable ZIP from the official GitHub Release (`Exoridus/exosnap`), GPL-3.0-or-later.
- `extract_dir` matches the single top-level folder in the archive.
- `checkver` (github) + `autoupdate` wired to the versioned asset and its `.sha256` sidecar.
- Hash verified against the published release asset; manifest validates against the Scoop schema.
- Shortcut to `exosnap.exe`.

Release: https://github.com/Exoridus/exosnap/releases/tag/v0.1.0