### PR TITLE
powertoys@0.100.0: Fix runtime issues by copying required files in the installer script

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -31,8 +31,8 @@
             "    Expand-MsiArchive \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup.msi\" \"$dir\" -ExtractDir 'PowerToys'",
             "}",
             "Remove-Item \"$dir\\.tmp\", \"$dir\\$fname\" -Force -Recurse",
-            "Get-Content \"$dir\\WinUI3Apps\\hardlinks.txt\" | ForEach-Object {",
-            "    Copy-Item \"$dir\\$_\" \"$dir\\WinUI3Apps\\$_\"",
+            "Get-Content \"$dir\\WinUI3Apps\\hardlinks.txt\" -ErrorAction Ignore | ForEach-Object {",
+            "    Copy-Item \"$dir\\$_\" \"$dir\\WinUI3Apps\\$_\" -Force",
             "}"
         ]
     },

--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -30,7 +30,10 @@
             "} else {",
             "    Expand-MsiArchive \"$dir\\.tmp\\AttachedContainer\\PowerToysSetup.msi\" \"$dir\" -ExtractDir 'PowerToys'",
             "}",
-            "Remove-Item \"$dir\\.tmp\", \"$dir\\$fname\" -Force -Recurse"
+            "Remove-Item \"$dir\\.tmp\", \"$dir\\$fname\" -Force -Recurse",
+            "Get-Content \"$dir\\WinUI3Apps\\hardlinks.txt\" | ForEach-Object {",
+            "    Copy-Item \"$dir\\$_\" \"$dir\\WinUI3Apps\\$_\"",
+            "}"
         ]
     },
     "post_install": [


### PR DESCRIPTION
Now, PowerToys installer has a post-process to copy some files between installed folders, see https://github.com/microsoft/PowerToys/pull/47233

Without this copy process, dialogs to show runtime issues are pop-upped like mentioned as #18010 and https://github.com/microsoft/PowerToys/issues/48432

This PR reflects the copy step to the installer script and will resolve the issues above.

Closes #18010.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
