### PR TITLE
knitcalc: Add version 1.8.30+53

### DIFF
--- a/bucket/knitcalc.json
+++ b/bucket/knitcalc.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.8.30+53",
+    "description": "Knitting calculator: gauge conversion, increases/decreases distribution, yarn estimation, project notes with photos",
+    "homepage": "https://github.com/dmezhnov/knitcalc",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dmezhnov/knitcalc/releases/download/v1.8.30+53/knitcalc-windows-x64-1.8.30+53.zip",
+            "hash": "21c67d29c9ff73b0bbb58ff1547592f0ad2e9baa9a129349cf0339c53dd5c35a"
+        }
+    },
+    "shortcuts": [
+        [
+            "knitcalc.exe",
+            "KnitCalc"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/dmezhnov/knitcalc/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\d.]+\\+\\d+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dmezhnov/knitcalc/releases/download/v$version/knitcalc-windows-x64-$version.zip",
+                "hash": {
+                    "url": "https://raw.githubusercontent.com/dmezhnov/knitcalc/main/bucket/knitcalc.json",
+                    "jsonpath": "$.hash"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [KnitCalc](https://github.com/dmezhnov/knitcalc) — a knitting calculator (gauge conversion, increases/decreases distribution, yarn estimation, project notes with photos). Open source (MIT), Flutter desktop app.

- Portable zip from GitHub releases, 64bit only.
- `checkver` reads the latest release tag via the GitHub API (versions carry `+build` metadata, e.g. `1.8.30+53`, hence the custom regex).
- `autoupdate` takes the hash from the manifest the app's own CI renders at `bucket/knitcalc.json` on every release, so excavator always finds a matching sha256.

I'm the app's developer.