### PR TITLE
goshs: Update GitHub repo URLs

### DIFF
--- a/bucket/goshs.json
+++ b/bucket/goshs.json
@@ -4,19 +4,19 @@
     "homepage": "https://goshs.de",
     "license": {
         "identifier": "MIT",
-        "url": "https://github.com/patrickhener/goshs/blob/HEAD/LICENSE"
+        "url": "https://github.com/goshs-labs/goshs/blob/HEAD/LICENSE"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/patrickhener/goshs/releases/download/v2.1.0/goshs_v2.1.0_windows_x86_64.zip",
+            "url": "https://github.com/goshs-labs/goshs/releases/download/v2.1.0/goshs_v2.1.0_windows_x86_64.zip",
             "hash": "2506aa18be3c6088acd8e3451c240e45775af7d9f66a6423e47488c21126b162"
         },
         "32bit": {
-            "url": "https://github.com/patrickhener/goshs/releases/download/v2.1.0/goshs_v2.1.0_windows_386.zip",
+            "url": "https://github.com/goshs-labs/goshs/releases/download/v2.1.0/goshs_v2.1.0_windows_386.zip",
             "hash": "c083923e1afcd0d20331b2590168f1fbbba5ca40c7b6d7379e74c0374ec224d5"
         },
         "arm64": {
-            "url": "https://github.com/patrickhener/goshs/releases/download/v2.1.0/goshs_v2.1.0_windows_arm64.zip",
+            "url": "https://github.com/goshs-labs/goshs/releases/download/v2.1.0/goshs_v2.1.0_windows_arm64.zip",
             "hash": "0d635f66e8e1d346f68e271881f6977dd4c9a4029903e003575741cb32be55c7"
         }
     },
@@ -27,18 +27,18 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/patrickhener/goshs"
+        "github": "https://github.com/goshs-labs/goshs"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/patrickhener/goshs/releases/download/v$version/goshs_v$version_windows_x86_64.zip"
+                "url": "https://github.com/goshs-labs/goshs/releases/download/v$version/goshs_v$version_windows_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/patrickhener/goshs/releases/download/v$version/goshs_v$version_windows_386.zip"
+                "url": "https://github.com/goshs-labs/goshs/releases/download/v$version/goshs_v$version_windows_386.zip"
             },
             "arm64": {
-                "url": "https://github.com/patrickhener/goshs/releases/download/v$version/goshs_v$version_windows_arm64.zip"
+                "url": "https://github.com/goshs-labs/goshs/releases/download/v$version/goshs_v$version_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
The [goshs](https://github.com/goshs-labs/gosh) project has recently migrated to a github organisation, github does currently redirect to the new repo, but the url has been updated as the redirect is a tempoary measure

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
