### PR TITLE
forgum: Add version 1.0.3

### DIFF
--- a/bucket/forgum.json
+++ b/bucket/forgum.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0.3",
+    "description": "Cowsay + Fortune + Lolcat PowerShell module with 107 animal cows",
+    "homepage": "https://github.com/harish2222/Forgum",
+    "license": "MIT",
+    "url": "https://github.com/harish2222/Forgum/releases/download/v1.0.3/Forgum-v1.0.3.zip",
+    "hash": "d9f6623d7dbe1581cbbb1fd58fd748fc0eac5ced576c9fdb0daf31f5f857d262",
+    "depends": "pwsh",
+    "powershell": {
+        "ver": "5.1"
+    },
+    "installer": {
+        "script": [
+            "Copy-Item -Path \"$dir\\Forgum\\*\" -Destination \"$env:USERPROFILE\\Documents\\PowerShell\\Modules\\Forgum\" -Recurse -Force",
+            "Copy-Item -Path \"$dir\\setup.ps1\" -Destination \"$env:USERPROFILE\\Documents\\PowerShell\\Modules\\Forgum\\setup.ps1\" -Force",
+            "& \"$env:USERPROFILE\\Documents\\PowerShell\\Modules\\Forgum\\setup.ps1\" -NonInteractive -Force"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item -Path \"$env:USERPROFILE\\Documents\\PowerShell\\Modules\\Forgum\" -Recurse -Force -ErrorAction SilentlyContinue"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/harish2222/Forgum"
+    },
+    "autoupdate": {
+        "url": "https://github.com/harish2222/Forgum/releases/download/v$version/Forgum-v$version.zip"
+    }
+}


### PR DESCRIPTION
### Add forgum v1.0.3

**Package**: Forgum — Cowsay + Fortune + Lolcat PowerShell module
**Version**: 1.0.3
**License**: MIT
**Homepage**: https://github.com/harish2222/Forgum

#### Package Request
Closes https://github.com/harish2222/Forgum/issues/1

#### Acceptance Criteria Confirmation
- [x] **Well-known usage**: Cowsay + Fortune + Lolcat is a widely-used terminal tool combination
- [x] **Stable release**: v1.0.3 with CI passing on Ubuntu, Windows, macOS
- [x] **English docs/interface**: Full English README, wiki with 11 guides
- [x] **MIT License**: OSI-approved permissive license
- [x] **No bundled binaries**: Pure PowerShell module, no native code

#### Checklist
- [x] Manifest is valid JSON
- [x] URL points to GitHub Release
- [x] SHA256 hash matches release asset
- [x] \checkver\ configured for autoupdate
- [x] License is MIT
- [x] No bundled executables

#### Links
- Repository: https://github.com/harish2222/Forgum
- Release: https://github.com/harish2222/Forgum/releases/tag/v1.0.3
- CI: https://github.com/harish2222/Forgum/actions/workflows/ci.yml
- Test results: 150 tests passing on Ubuntu, Windows, macOS
- Proof of legitimacy: https://github.com/harish2222/Forgum/tree/main/package-managers/proof
