### PR TITLE
inkwell: Update to version 1.5.2, fix autoupdate

### DIFF
--- a/bucket/inkwell.json
+++ b/bucket/inkwell.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Lightweight Markdown editor with split view, live preview, themes, focus mode, and diff viewer.",
     "homepage": "https://4worlds.gumroad.com/l/inkwell",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/4worlds4w-svg/inkwell/releases/download/v1.5.1/inkwell-windows-x64.zip",
-            "hash": "6e8fd7a26ddd0deeada43936fc2bab4a29e4caf46df9bc4a4c64721e96da0a3a"
+            "url": "https://github.com/4worlds4w-svg/inkwell/releases/download/v1.5.2/inkwell-windows-x64-v1.5.2.zip",
+            "hash": "6aa670696ec22da09e67d262c61a85e439a2ca470bfa182ac6469c04cfd0d797"
         }
     },
     "shortcuts": [
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/4worlds4w-svg/inkwell/releases/download/v$version/inkwell-windows-x64.zip"
+                "url": "https://github.com/4worlds4w-svg/inkwell/releases/download/v$version/inkwell-windows-x64-v$version.zip"
             }
         }
     }


### PR DESCRIPTION
## Summary

Updating Inkwell from 1.5.1 to 1.5.2 (released 2026-06-12).

## Changes

- Version: 1.5.1 → 1.5.2
- 64bit URL and hash refreshed for the v1.5.2 Windows zip
- **autoupdate URL pattern fixed**: the v1.5.2 release asset is named
  `inkwell-windows-x64-v1.5.2.zip` (versioned), not the previous
  `inkwell-windows-x64.zip` (unversioned). The previous pattern can't
  match the new asset — this is why autoupdate didn't pick up 1.5.2.
  The new pattern `inkwell-windows-x64-v$version.zip` matches v1.5.2
  and will match future versions, so autoupdate should run cleanly from
  here.

## What's in 1.5.2

Patch release driven by customer bug reports:

- PDF ordered lists render correctly (multi-paragraph items, embedded code blocks)
- `:::mermaid` fence syntax support (Azure DevOps, VitePress, Docusaurus exports)
- Mermaid diagram colors preserved in PDF export
- New "Render math" toggle for $-heavy documents (shell scripts, code-as-prose)
- PowerShell syntax highlighting (powershell, pwsh, ps, ps1 fences)
- Inline math no longer pairs across line breaks
- Readable export error messages with actionable suggestions

Full release notes: https://github.com/4worlds4w-svg/inkwell/releases/tag/v1.5.2

## Verification

- [x] Manifest validates against the bucket's schema
- [x] URL is accessible (HTTP 200 from GitHub releases)
- [x] SHA256 computed from downloaded artifact