### PR TITLE
(chore): Fix checkver & autoupdate

### DIFF
--- a/bucket/audiobookconverter.json
+++ b/bucket/audiobookconverter.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "github": "https://github.com/yermak/AudioBookConverter",
-        "regex": "tag/version_([\\d.]+)(?=\")"
+        "regex": "^version_([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/authpass.json
+++ b/bucket/authpass.json
@@ -18,6 +18,7 @@
     ],
     "checkver": {
         "github": "https://github.com/authpass/authpass",
+        "jsonpath": "$.assets[?(@.name =~ /setup.+exe/i)].browser_download_url",
         "regex": "AuthPass-setup-([\\d._]+).exe"
     },
     "autoupdate": {

--- a/bucket/better-joy.json
+++ b/bucket/better-joy.json
@@ -30,12 +30,13 @@
     ],
     "checkver": {
         "github": "https://github.com/Davidobot/BetterJoy",
-        "regex": "download/v([\\w.]+)/"
+        "jsonpath": "$.assets[?(@.name =~ /BetterJoy.+zip/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/BetterJoy_v([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Davidobot/BetterJoy/releases/download/v$version/BetterJoy_v$version.zip"
+                "url": "https://github.com/Davidobot/BetterJoy/releases/download/$matchTag/BetterJoy_v$version.zip"
             }
         }
     }

--- a/bucket/chrlauncher.json
+++ b/bucket/chrlauncher.json
@@ -34,7 +34,7 @@
     ],
     "checkver": {
         "github": "https://github.com/henrypp/chrlauncher",
-        "regex": "chrlauncher-([\\d.]+)-bin"
+        "regex": "^v\\.([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clamav.json
+++ b/bucket/clamav.json
@@ -38,7 +38,7 @@
     ],
     "checkver": {
         "github": "https://github.com/Cisco-Talos/clamav",
-        "regex": "/releases/tag/clamav-(?:v|V)?([\\d\\.]+)"
+        "regex": "^clamav-([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clavier-plus.json
+++ b/bucket/clavier-plus.json
@@ -19,7 +19,7 @@
     "persist": "Clavier.ini",
     "checkver": {
         "github": "https://github.com/guilryder/clavier-plus",
-        "regex": "download/release([\\d.]+)"
+        "regex": "^release([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/consolez.json
+++ b/bucket/consolez.json
@@ -22,7 +22,8 @@
     ],
     "checkver": {
         "github": "https://github.com/cbucher/console",
-        "regex": "ConsoleZ\\.x64\\.([\\d.]+)\\.zip"
+        "jsonpath": "$.assets[?(@.name =~ /ConsoleZ.+zip/i)].browser_download_url",
+        "regex": "ConsoleZ\\.x64\\.([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/consolez.json
+++ b/bucket/consolez.json
@@ -23,7 +23,7 @@
     "checkver": {
         "github": "https://github.com/cbucher/console",
         "jsonpath": "$.assets[?(@.name =~ /ConsoleZ.+zip/i)].browser_download_url",
-        "regex": "ConsoleZ\\.x64\\.([\\d.]+)"
+        "regex": "x64\\.([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -19,7 +19,8 @@
     ],
     "checkver": {
         "github": "https://github.com/darktable-org/darktable",
-        "regex": "/darktable-([\\d.]+)-win64"
+        "jsonpath": "$.assets[?(@.name =~ /win64/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/darktable-([\\d.]+)-win64"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -23,7 +23,7 @@
     ],
     "checkver": {
         "github": "https://github.com/irwir/eMule",
-        "regex": "eMule v(([\\d\\.]+)[a-z])"
+        "regex": "eMule_v([\\w.]+)-community"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/fluent-reader.json
+++ b/bucket/fluent-reader.json
@@ -21,7 +21,7 @@
     ],
     "checkver": {
         "github": "https://github.com/yang991178/fluent-reader",
-        "regex": "tag/v([\\w.-]+)"
+        "regex": "^v([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/hadoop-winutils.json
+++ b/bucket/hadoop-winutils.json
@@ -14,10 +14,11 @@
     "env_add_path": "bin",
     "checkver": {
         "github": "https://github.com/steveloughran/winutils",
-        "regex": "/releases/download/(?<tag>tag_.*?-)?hadoop-(?<version>[\\d.]+)(?<qualifier>.*?)/"
+        "jsonpath": "$.assets[?(@.name =~ /hadoop/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/hadoop-([\\d.]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/steveloughran/winutils/releases/download/$matchTaghadoop-$version$matchQualifier/hadoop-$version.zip",
+        "url": "https://github.com/steveloughran/winutils/releases/download/$matchTag/hadoop-$version.zip",
         "extract_dir": "hadoop-$version"
     }
 }

--- a/bucket/http-downloader.json
+++ b/bucket/http-downloader.json
@@ -34,8 +34,9 @@
         "http_downloader_settings"
     ],
     "checkver": {
-        "github": "https://github.com/erickutcher/httpdownloader",
-        "regex": "(?i)tag/v([\\d.]+)(?=\")"
+        "github": "https://api.github.com/repos/erickutcher/httpdownloader/releases",
+        "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.browser_download_url =~ /HTTP_Downloader/i)])].tag_name",
+        "regex": "v([\\d.]+)(?=\")"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/icechat.json
+++ b/bucket/icechat.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "github": "https://github.com/icechat/IceChat",
-        "regex": "tag/([\\d.]+)(?=F)"
+        "regex": "([\\d.]+)(?=F)"
     },
     "autoupdate": {
         "url": "https://github.com/icechat/IceChat/releases/download/$versionF/icechat-setup.exe"

--- a/bucket/jqp.json
+++ b/bucket/jqp.json
@@ -18,10 +18,7 @@
         }
     },
     "bin": "jqp.exe",
-    "checkver": {
-        "github": "https://github.com/noahgorstein/jqp",
-        "regex": "tag/v([\\d.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/keepass-plugin-readable-passphrase.json
+++ b/bucket/keepass-plugin-readable-passphrase.json
@@ -14,7 +14,7 @@
     },
     "checkver": {
         "github": "https://github.com/ligos/readablepassphrasegenerator",
-        "regex": "tag/release-([\\d.]+)"
+        "regex": "^release-([\\d.]+)$"
     },
     "autoupdate": {
         "url": "https://github.com/ligos/readablepassphrasegenerator/releases/download/release-$version/ReadablePassphrase.$version.plgx#/ReadablePassphrase.plgx"


### PR DESCRIPTION
### Summary

Fixes and modernizes the `checkver` and `autoupdate` Blocks across multiple manifests to ensure compatibility with GitHub API fallback and robust asset detection.

### Related issues or pull requests

- Relates to #17746
- Relates to #17844

### Changes

- **audiobookconverter**: Refactor `regex` to strictly bind to the exact version string pattern (`^version_([\d.]+)$`).
- **authpass**: Inject a modern `jsonpath` asset locator to safely extract the setup file context.
- **better-joy**: Transition to GitHub API via `jsonpath` distribution filtering and capture the release identifier with `matchTag`.
- **chrlauncher**: Update `regex` to match clean tag boundaries (`^v\.([\d.]+)$`).
- **clamav**: Refactor legacy tag tracking regex to a direct tag match (`^clamav-([\d.]+)$`).
- **clavier-plus**: Optimize pattern to look for targeted release tag strings (`^release([\d.]+)$`).
- **consolez**: Add `jsonpath` verification for the distribution archive before running the version parser.
- **darktable**: Upgrade to `jsonpath` asset query matching `win64`, storing the version tag in `matchTag` to prevent downstream URL breaks.
- **emule-community**: Simplify regex token to gracefully catch the modern `eMule_v([\w.]+)-community` format.
- **fluent-reader**: Align `regex` boundaries with clean semantic versioning tags (`^v([\d.]+)$`).
- **hadoop-winutils**: Total overhaul of the dynamic build variable stack. Replace old `matchQualifier` blocks with a structured `jsonpath` query and dynamic `matchTag` interpolation.
- **http-downloader**: Migrate to the official GitHub Releases API endpoint, explicitly filtering out pre-releases via JSONPath logic.
- **icechat**: Stripped obsolete HTML tag prefixes from the matching pattern.
- **jqp**: Streamline the entire custom block down to standard, native `"checkver": "github"` detection.
- **keepass-plugin-readable-passphrase**: Tighten regex limits to safely parse the clean `^release-([\d.]+)$` schema.

### Notes

* This is a follow-up to https://github.com/ScoopInstaller/Extras/pull/17746, aiming to fix manifests broken by the Scoop-Core checkver breaking changes.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
