### PR TITLE
batch-print-kit: Add version 0.2.0

### DIFF
--- a/bucket/batch-print-kit.json
+++ b/bucket/batch-print-kit.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "description": "Open-source Windows batch printing tool with queue review, Explorer integration, printer-driver settings, and PDF printing via SumatraPDF.",
+  "homepage": "https://lihongyu5432-ux.github.io/BatchPrintKit/",
+  "license": "MIT",
+  "url": "https://github.com/lihongyu5432-ux/BatchPrintKit/releases/download/v0.2.0/BatchPrintKit-v0.2.0-win64.zip",
+  "hash": "782b959419054433b2b8252c9b7d8bcd0eb29d9492a8b075bbd6e45b0fcc10df",
+  "bin": [
+    [
+      "BatchPrintKit.exe",
+      "batch-print-kit"
+    ]
+  ],
+  "shortcuts": [
+    [
+      "BatchPrintKit.exe",
+      "Batch Print Kit"
+    ]
+  ],
+  "checkver": {
+    "github": "https://github.com/lihongyu5432-ux/BatchPrintKit"
+  },
+  "autoupdate": {
+    "url": "https://github.com/lihongyu5432-ux/BatchPrintKit/releases/download/v$version/BatchPrintKit-v$version-win64.zip"
+  }
+}


### PR DESCRIPTION
Adds Batch Print Kit, an open-source Windows batch printing tool with queue review, Explorer integration, printer-driver settings, and PDF printing via SumatraPDF.

Homepage: https://lihongyu5432-ux.github.io/BatchPrintKit/
Release: https://github.com/lihongyu5432-ux/BatchPrintKit/releases/tag/v0.2.0