### PR TITLE
hotkey-detective: Update license identifier

### DIFF
--- a/bucket/hotkey-detective.json
+++ b/bucket/hotkey-detective.json
@@ -2,7 +2,7 @@
     "version": "1.1.0",
     "description": "A small program for investigating stolen key combinations under Windows 7 and later.",
     "homepage": "https://github.com/ITachiLab/hotkey-detective",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0",
     "url": "https://github.com/ITachiLab/hotkey-detective/releases/download/1.1.0/hotkey-detective-1.1.0.zip",
     "hash": "a1c0027d32c2346fd4cb98d63dc9f2b5e861f75653809983fea8afbd16d7aa35",
     "architecture": {

--- a/bucket/hotkey-detective.json
+++ b/bucket/hotkey-detective.json
@@ -2,7 +2,7 @@
     "version": "1.1.0",
     "description": "A small program for investigating stolen key combinations under Windows 7 and later.",
     "homepage": "https://github.com/ITachiLab/hotkey-detective",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "url": "https://github.com/ITachiLab/hotkey-detective/releases/download/1.1.0/hotkey-detective-1.1.0.zip",
     "hash": "a1c0027d32c2346fd4cb98d63dc9f2b5e861f75653809983fea8afbd16d7aa35",
     "architecture": {


### PR DESCRIPTION
I mistakenly thought that as long as “Later” was mentioned in the LICENSE, it meant a “-or-later” agreement.
But it seems that the phrase (at your option) any later version isn’t present anywhere in the entire repository, and the LICENSE file also doesn’t explicitly mention “Later” in its header.

https://github.com/search?q=repo%3AITachiLab%2Fhotkey-detective%20any%20later%20version&type=code

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
