### PR TITLE
picocrypt-ng: Update license identifier

### DIFF
--- a/bucket/picocrypt.json
+++ b/bucket/picocrypt.json
@@ -2,7 +2,7 @@
     "version": "1.49",
     "description": "A small encryption tool with a focus on security, simplicity, and reliability.",
     "homepage": "https://github.com/Picocrypt/Picocrypt",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Picocrypt/Picocrypt/releases/download/1.49/Picocrypt.exe",


### PR DESCRIPTION
I mistakenly thought that as long as “Later” was mentioned in the LICENSE, it meant a “-or-later” agreement.
But it seems that the phrase (at your option) any later version isn’t present anywhere in the entire repository, and the LICENSE file also doesn’t explicitly mention “Later” in its header.

https://github.com/search?q=repo%3APicocrypt-NG%2FPicocrypt-NG%20any%20later%20version&type=code

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
