### PR TITLE
snoretoast: Add version 0.9.0

### DIFF
--- a/bucket/snoretoast.json
+++ b/bucket/snoretoast.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.9.0",
+    "description": "A command line application capable of creating Windows Toast notifications.",
+    "homepage": "https://invent.kde.org/libraries/snoretoast",
+    "license": "LGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.kde.org/Attic/snoretoast/0.9.0/bin/snoretoast-0.9.0-1247-windows-cl-msvc2019-x86_64.7z",
+            "hash": "2e3a050c0c0017b0f325e5d2d1918ec9615391bcd54b11942cd8ddc619616e86"
+        }
+    },
+    "extract_dir": "bin",
+    "bin": "snoretoast.exe"
+}

--- a/bucket/snoretoast.json
+++ b/bucket/snoretoast.json
@@ -2,7 +2,7 @@
     "version": "0.9.0",
     "description": "A command line application capable of creating Windows Toast notifications.",
     "homepage": "https://invent.kde.org/libraries/snoretoast",
-    "license": "LGPL-3.0-only",
+    "license": "LGPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://download.kde.org/Attic/snoretoast/0.9.0/bin/snoretoast-0.9.0-1247-windows-cl-msvc2019-x86_64.7z",


### PR DESCRIPTION
It probably doesn’t support `autoupdate` at the moment. I couldn’t find any information regarding automated builds related to version 0.9.0.

Closes #18045 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
