### PR TITLE
picocrypt-ng: Update license identifier

### DIFF
--- a/bucket/picocrypt-ng.json
+++ b/bucket/picocrypt-ng.json
@@ -2,7 +2,7 @@
     "version": "2.14",
     "description": "A very small, very simple, yet very secure encryption tool.",
     "homepage": "https://github.com/Picocrypt-NG/Picocrypt-NG",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": [

--- a/bucket/picocrypt-ng.json
+++ b/bucket/picocrypt-ng.json
@@ -1,17 +1,17 @@
 {
-    "version": "2.14",
+    "version": "2.15",
     "description": "A very small, very simple, yet very secure encryption tool.",
     "homepage": "https://github.com/Picocrypt-NG/Picocrypt-NG",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/Picocrypt-NG/Picocrypt-NG/releases/download/2.14/Picocrypt-NG-portable.exe#/Picocrypt-NG.exe",
-                "https://github.com/Picocrypt-NG/Picocrypt-NG/releases/download/2.14/Picocrypt-NG-cli.exe#/picocrypt.exe"
+                "https://github.com/Picocrypt-NG/Picocrypt-NG/releases/download/2.15/Picocrypt-NG-portable.exe#/Picocrypt-NG.exe",
+                "https://github.com/Picocrypt-NG/Picocrypt-NG/releases/download/2.15/Picocrypt-NG-cli.exe#/picocrypt.exe"
             ],
             "hash": [
-                "a9029ff7aac60b2e0b218888e6db17df0f631f98aed72be18b98ca76952e1960",
-                "9c5a9acbbc6cb1d8057516c6fb3eea034f10a1463f5087ae729b1df690332124"
+                "8ed67a25e1384692f27bec371d4157200e993b1b48a233b7c74f0fbb5dfbacfd",
+                "c6ecab138091c81c2e4c927ed1f6d3ba51789dae460de47f650ac30b05a39fae"
             ]
         }
     },


### PR DESCRIPTION
I mistakenly thought that as long as “Later” was mentioned in the LICENSE, it meant a “-or-later” agreement.
But it seems that the phrase (at your option) any later version isn’t present anywhere in the entire repository, and the LICENSE file also doesn’t explicitly mention “Later” in its header.

https://github.com/search?q=repo%3APicocrypt-NG%2FPicocrypt-NG%20any%20later%20version&type=code

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
