### PR TITLE
7ztm@2.1.1: Fix download URLs

### DIFF
--- a/bucket/7ztm.json
+++ b/bucket/7ztm.json
@@ -7,8 +7,8 @@
         "url": "http://www.7ztm.de/index.php?cat=01_English&page=01_FAQ"
     },
     "url": [
-        "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.7z#/main.7z",
-        "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.1_hotfix.7z#/hotfix.7z"
+        "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.7z",
+        "http://www.7ztm.de/download.php?cat=00_German&file=7zTM_2.1.1_hotfix.7z"
     ],
     "hash": [
         "d1bb8aa1b5f49c39c606604964fe616009b4598c4f3c02e6fff808fa9d4da15e",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The URLs for this package were not working and were pointing nowhere, so I updated them to the newer ones.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
