### PR TITLE
clang-tools-static-binaries: Add version 2026.06.15-a56c0263

### DIFF
--- a/bucket/clang-apply-replacements.json
+++ b/bucket/clang-apply-replacements.json
@@ -1,0 +1,34 @@
+{
+    "version": "2026.06.15-a56c0263",
+    "description": "Tool to apply replacements from clang-tidy or clang-format.",
+    "homepage": "https://clang.llvm.org/extra/clang-apply-replacements/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-apply-replacements-22_windows-amd64.exe#/clang-apply-replacements.exe",
+            "hash": "sha512:3e2fb1450e08b22c27b5b41ba72de5bd6671169e39d81d69b11061be295c94390d33d7bc94121001e3b78a7af4862a032ceafb744de1b45ad62ac428fda77133"
+        },
+        "arm64": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-apply-replacements-22_windows-arm64.exe#/clang-apply-replacements.exe",
+            "hash": "sha512:ecac7f6de2c7dfc71396da4a304140c90b57dfc11a1f37a8ff9ab5f7c9b9710e077448a3203b99de1536660618f33abdb450fb68fd031ec847e100de8a71a51d"
+        }
+    },
+    "bin": "clang-apply-replacements.exe",
+    "checkver": {
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-apply-replacements-22_windows-amd64.exe#/clang-apply-replacements.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-apply-replacements-22_windows-arm64.exe#/clang-apply-replacements.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512sum",
+            "regex": "$sha512\\s+"
+        }
+    }
+}

--- a/bucket/clang-apply-replacements.json
+++ b/bucket/clang-apply-replacements.json
@@ -15,7 +15,8 @@
     },
     "bin": "clang-apply-replacements.exe",
     "checkver": {
-        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clang-format.json
+++ b/bucket/clang-format.json
@@ -1,0 +1,34 @@
+{
+    "version": "2026.06.15-a56c0263",
+    "description": "Tool to format C/C++/Java/JavaScript/Objective-C/Protobuf/TypeScript code.",
+    "homepage": "https://clang.llvm.org/docs/ClangFormat.html",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-format-22_windows-amd64.exe#/clang-format.exe",
+            "hash": "sha512:d3d47b543446e0b698ea0a5ddc7e7e2857d4c7fa6dccbc94e82e07dda0b5be37b51c7b794957b0263ecaa7b9992ed5b5554a62001ea1a9fe829e72e3a7f251df"
+        },
+        "arm64": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-format-22_windows-arm64.exe#/clang-format.exe",
+            "hash": "sha512:40473adaf02241269e372a1a8f9acb33288f55da177a1e53a66d20c3433488f60c253fb84d9e2df4e78e855ac551abde1b8fcb92854ef50f8f7973f186c6dbe2"
+        }
+    },
+    "bin": "clang-format.exe",
+    "checkver": {
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-format-22_windows-amd64.exe#/clang-format.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-format-22_windows-arm64.exe#/clang-format.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512sum",
+            "regex": "$sha512\\s+"
+        }
+    }
+}

--- a/bucket/clang-format.json
+++ b/bucket/clang-format.json
@@ -15,7 +15,8 @@
     },
     "bin": "clang-format.exe",
     "checkver": {
-        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clang-include-cleaner.json
+++ b/bucket/clang-include-cleaner.json
@@ -15,7 +15,8 @@
     },
     "bin": "clang-include-cleaner.exe",
     "checkver": {
-        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clang-include-cleaner.json
+++ b/bucket/clang-include-cleaner.json
@@ -1,0 +1,34 @@
+{
+    "version": "2026.06.15-a56c0263",
+    "description": "Tool to detect unused and missing #include directives in C/C++.",
+    "homepage": "https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-include-cleaner-22_windows-amd64.exe#/clang-include-cleaner.exe",
+            "hash": "sha512:f7cc82f756c36a5e3a2b384790a3b79f885033237e989e6c4ce9746530f1ebdce9ca755fb81e937d1c72c1617cea42636da5176f8b4584db5eea0f4c0ffad82f"
+        },
+        "arm64": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-include-cleaner-22_windows-arm64.exe#/clang-include-cleaner.exe",
+            "hash": "sha512:321394dafdfda14cce64c4c0b917f6ff796586f570a9522e266e3e1255b789e0ec1b44547cfd469bc9202ec1d040afdcd84855aa08cc4bf28feb70da23ea83b6"
+        }
+    },
+    "bin": "clang-include-cleaner.exe",
+    "checkver": {
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-include-cleaner-22_windows-amd64.exe#/clang-include-cleaner.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-include-cleaner-22_windows-arm64.exe#/clang-include-cleaner.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512sum",
+            "regex": "$sha512\\s+"
+        }
+    }
+}

--- a/bucket/clang-query.json
+++ b/bucket/clang-query.json
@@ -15,7 +15,8 @@
     },
     "bin": "clang-query.exe",
     "checkver": {
-        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clang-query.json
+++ b/bucket/clang-query.json
@@ -1,0 +1,34 @@
+{
+    "version": "2026.06.15-a56c0263",
+    "description": "Tool to interactively inspect and traverse Clang ASTs.",
+    "homepage": "https://clang.llvm.org/extra/clang-query/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-query-22_windows-amd64.exe#/clang-query.exe",
+            "hash": "sha512:9aa7bc4b86adb74579419a98588bdae54ce91884eaf7545c9c418f5cd0d8aa79ec36536aae71df7318b0a9fbf5e703c39a96299e5054884551d89c469a0e1fc3"
+        },
+        "arm64": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-query-22_windows-arm64.exe#/clang-query.exe",
+            "hash": "sha512:65d95cd82384ef33efa92450f179aabc237ecf8ac0f9de8beeb5d8bb37ceb37af5abcb8b12e63e976d157f59e11a55d2fec2eec1d362fc0e38aaef9883561df9"
+        }
+    },
+    "bin": "clang-query.exe",
+    "checkver": {
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-query-22_windows-amd64.exe#/clang-query.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-query-22_windows-arm64.exe#/clang-query.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512sum",
+            "regex": "$sha512\\s+"
+        }
+    }
+}

--- a/bucket/clang-tidy.json
+++ b/bucket/clang-tidy.json
@@ -15,7 +15,8 @@
     },
     "bin": "clang-tidy.exe",
     "checkver": {
-        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries",
+        "regex": "([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/clang-tidy.json
+++ b/bucket/clang-tidy.json
@@ -1,0 +1,34 @@
+{
+    "version": "2026.06.15-a56c0263",
+    "description": "Clang-based C/C++ static analysis tool.",
+    "homepage": "https://clang.llvm.org/extra/clang-tidy/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-tidy-22_windows-amd64.exe#/clang-tidy.exe",
+            "hash": "sha512:1200f75df7fe722c33f82bae7b41b690da44d95fec694d6eac132cdec9c87874456ec72b2b754b520dceba14ef73e15d4f34d437563f5a53322ba9ae6bd0a95d"
+        },
+        "arm64": {
+            "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/2026.06.15-a56c0263/clang-tidy-22_windows-arm64.exe#/clang-tidy.exe",
+            "hash": "sha512:5b2d977621b4393319fd7b15b37110626f7176b6871e8dc53a3c98f0567103f757c37119e5667ae2ace06c613f40ed71395f81c2b718393e73cbc9ce5b1c73bc"
+        }
+    },
+    "bin": "clang-tidy.exe",
+    "checkver": {
+        "github": "https://github.com/cpp-linter/clang-tools-static-binaries"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-tidy-22_windows-amd64.exe#/clang-tidy.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/$version/clang-tidy-22_windows-arm64.exe#/clang-tidy.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512sum",
+            "regex": "$sha512\\s+"
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Extras/issues/18063

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->