### PR TITLE
nitrax-mathematical-keyboard: Add version 1.1.2

### DIFF
--- a/bucket/nitrax-mathematical-keyboard.json
+++ b/bucket/nitrax-mathematical-keyboard.json
@@ -2,7 +2,7 @@
     "version": "1.1.2",
     "description": "Windows companion app for typing mathematical, Greek and scientific symbols with the Nitrax Mathematical Keyboard.",
     "homepage": "https://mathematicalkeyboard.com/",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-only",
     "url": "https://github.com/NitraxMathematicalKeyboard/download-keyboard-layout/releases/download/v1.1.2/NitraxMathKeyboard.exe",
     "hash": "45b44cc733cda3b3a5b170ace89d8aab2a02f3feeaf568b5c72c1c77ecc616b6",
     "shortcuts": [

--- a/bucket/nitrax-mathematical-keyboard.json
+++ b/bucket/nitrax-mathematical-keyboard.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.1.2",
+    "description": "Windows companion app for typing mathematical, Greek and scientific symbols with the Nitrax Mathematical Keyboard.",
+    "homepage": "https://mathematicalkeyboard.com/",
+    "license": "GPL-2.0",
+    "url": "https://github.com/NitraxMathematicalKeyboard/download-keyboard-layout/releases/download/v1.1.2/NitraxMathKeyboard.exe",
+    "hash": "45b44cc733cda3b3a5b170ace89d8aab2a02f3feeaf568b5c72c1c77ecc616b6",
+    "shortcuts": [
+        [
+            "NitraxMathKeyboard.exe",
+            "Nitrax Mathematical Keyboard"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/NitraxMathematicalKeyboard/download-keyboard-layout"
+    },
+    "autoupdate": {
+        "url": "https://github.com/NitraxMathematicalKeyboard/download-keyboard-layout/releases/download/v$version/NitraxMathKeyboard.exe"
+    }
+}


### PR DESCRIPTION
Adds Nitrax Mathematical Keyboard 1.1.2 to Scoop Extras.

Package request: https://github.com/ScoopInstaller/Extras/issues/18065

Validation performed locally:
- JSON validation passed
- formatjson.ps1 passed
- checkver.ps1 detected 1.1.2
- Clean install passed
- Launch passed
- Uninstall passed
- Second clean install passed

This PR modifies only bucket/nitrax-mathematical-keyboard.json.