### PR TITLE
yuri: Add version 1.7

### DIFF
--- a/bucket/yuri.json
+++ b/bucket/yuri.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.7",
+    "description": "Yuri Esoteric Programming Language",
+    "homepage": "https://kazooki123.github.io/yurilang-docs",
+    "license": "GPL-3.0-or-later",
+    "url": "https://codeberg.org/Kazooki123/yurilang/archive/v1.7.zip",
+    "hash": "8009BE7C48C9E3F505476904B8575067942E10ABDBA52753C58BD95663FC3134",
+    "extract_dir": "yurilang",
+    "bin": "yuri.ps1",
+    "suggest": {
+        "python": "python"
+    },
+    "pre_install": [
+        "./install.bat"
+    ],
+    "checkver": {
+        "url": "https://codeberg.org/api/v1/repos/Kazooki123/yurilang/releases/latest",
+        "regex": "tag/v?([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://codeberg.org/Kazooki123/yurilang/archive/v$version.zip",
+        "extract_dir": "yurilang"
+    }
+}

--- a/bucket/yuri.json
+++ b/bucket/yuri.json
@@ -1,17 +1,17 @@
 {
     "version": "1.7",
     "description": "Yuri Esoteric Programming Language",
-    "homepage": "https://kazooki123.github.io/yurilang-docs",
+    "homepage": "https://codeberg.org/Kazooki123/yurilang",
     "license": "GPL-3.0-or-later",
     "url": "https://codeberg.org/Kazooki123/yurilang/archive/v1.7.zip",
     "hash": "8009BE7C48C9E3F505476904B8575067942E10ABDBA52753C58BD95663FC3134",
     "extract_dir": "yurilang",
-    "bin": "yuri.ps1",
+    "bin": "yuri.cmd",
     "suggest": {
         "python": "python"
     },
     "pre_install": [
-        "./install.bat"
+        "python \"$dir\\install.py\""
     ],
     "checkver": {
         "url": "https://codeberg.org/api/v1/repos/Kazooki123/yurilang/releases/latest",


### PR DESCRIPTION
Add YuriLang v1.7

Yurilang is a python written esoteric programming language that uses Yuri media as keywords, functions (built ins as well), and more. It has vendors to support built in libraries.

- Package request: https://github.com/ScoopInstaller/Extras/issues/18077
- Homepage: https://codeberg.org/Kazooki123/yurilang
- License: GPL-3.0-or-later

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)