### PR TITLE
pong-ball: Add version 1.0.0

### DIFF
--- a/bucket/pong-ball.json
+++ b/bucket/pong-ball.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0",
+    "description": "A minimalist physics-based terminal Pong game with score history",
+    "homepage": "https://pongball.mvp-subha.me",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/subhadeeproy3902/pong-ball/releases/download/v1.0.0/pong-ball_windows_amd64.zip",
+            "hash": "9bed2c657c8d67f745fbc5e8cf478b15b52bf6ce63ec8f2c180a6ce6ac8446f3"
+        }
+    },
+    "bin": "pong-ball.exe",
+    "checkver": {
+        "github": "https://github.com/subhadeeproy3902/pong-ball"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/subhadeeproy3902/pong-ball/releases/download/v$version/pong-ball_windows_amd64.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/subhadeeproy3902/pong-ball/releases/download/v$version/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
### Add `pong-ball` version 1.0.0

**pong-ball** — a minimalist, physics-based Pong game for the terminal. Single static Go binary, no runtime dependencies.

- Homepage: https://pongball.mvp-subha.me
- Source: https://github.com/subhadeeproy3902/pong-ball
- Release: https://github.com/subhadeeproy3902/pong-ball/releases/tag/v1.0.0

### Manifest notes
- New manifest, first version `1.0.0`.
- Installs `pong-ball.exe` (64-bit) from the official GitHub release.
- `hash` matches the release `checksums.txt`.
- `checkver` uses the GitHub strategy and `autoupdate` derives the hash from the release `checksums.txt`, so future versions auto-bump cleanly.

### Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] Manifest is valid JSON with `checkver` + `autoupdate`.
- [x] The app is not already present in the main bucket or Extras.
- [x] The download URL points to the official upstream release.
