### PR TITLE
(chore): Update to latest version, fix checkver/autoupdate logic

### DIFF
--- a/bucket/ani-cli.json
+++ b/bucket/ani-cli.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.13",
+    "version": "4.14",
     "description": "A cli to browse and watch anime (alone AND with friends). This tool scrapes the site allanime.",
     "homepage": "https://github.com/pystardust/ani-cli",
     "license": "GPL-3.0-or-later",
@@ -14,11 +14,11 @@
         ],
         "alternate player": "extras/vlc"
     },
-    "url": "https://github.com/pystardust/ani-cli/releases/download/v4.13/ani-cli",
-    "hash": "17c8a97b034d3e48ba4663d538a5705adfbbffb951fa67650a57f7e4414959e2",
+    "url": "https://raw.githubusercontent.com/pystardust/ani-cli/refs/tags/v4.14/ani-cli",
+    "hash": "bf710f72fd4ecb328f8f2253c913813d8f3ae4a063dcd54aed2e4b117b1b2c37",
     "bin": "ani-cli",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/pystardust/ani-cli/releases/download/v$version/ani-cli"
+        "url": "https://raw.githubusercontent.com/pystardust/ani-cli/refs/tags/v$version/ani-cli"
     }
 }

--- a/bucket/clementine.json
+++ b/bucket/clementine.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.4.1-76-gfd1617827",
+    "version": "1.4.1-78",
     "description": "A modern music player and library organizer.",
     "homepage": "https://www.clementine-player.org/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/clementine-player/Clementine/releases/download/1.4.1-76-gfd1617827/ClementineSetup-1.4.1-76-gfd1617827.exe#/dl.7z",
-    "hash": "b4aa95aa37b96a601ea153c89f1a6d6e07d06fe0b99a54f9b02253b96e150545",
+    "url": "https://github.com/clementine-player/Clementine/releases/download/1.4.1-78-gb55eca391/ClementineSetup-1.4.1-78-gb55eca391.exe#/dl.7z",
+    "hash": "c56bab1e4704c9cc0cb87088f6a16321777f53f461e85857d38b8b4e71332edd",
     "bin": "clementine.exe",
     "shortcuts": [
         [
@@ -13,10 +13,10 @@
         ]
     ],
     "checkver": {
-        "github": "https://api.github.com/repos/clementine-player/Clementine/releases/latest",
-        "jsonpath": "$.tag_name"
+        "github": "https://github.com/clementine-player/Clementine",
+        "regex": "^(?i)(?<tag>v?([\\d.-]+)[-+]g(?<commit>[\\w]+))$"
     },
     "autoupdate": {
-        "url": "https://github.com/clementine-player/Clementine/releases/download/$version/ClementineSetup-$version.exe#/dl.7z"
+        "url": "https://github.com/clementine-player/Clementine/releases/download/$matchTag/ClementineSetup-$matchTag.exe#/dl.7z"
     }
 }

--- a/bucket/cupscale.json
+++ b/bucket/cupscale.json
@@ -18,13 +18,14 @@
     ],
     "persist": "CupscaleData\\models",
     "checkver": {
-        "github": "https://github.com/n00mkrad/cupscale",
-        "regex": "/Cupscale\\.([\\w.]+)\\.zip"
+        "github": "https://api.github.com/repos/n00mkrad/cupscale/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /Cupscale/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/(?<name>Cupscale\\.?([\\w.]+)\\.zip)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/n00mkrad/cupscale/releases/download/$majorVersion.$minorVersion/Cupscale.$version.zip"
+                "url": "https://github.com/n00mkrad/cupscale/releases/download/$matchTag/$matchName"
             }
         },
         "extract_dir": "Cupscale $version"

--- a/bucket/cyberchef.json
+++ b/bucket/cyberchef.json
@@ -1,10 +1,10 @@
 {
-    "version": "11.0.0",
+    "version": "11.2.0",
     "description": "A web app for encryption, encoding, compression and data analysis",
     "homepage": "https://gchq.github.io/CyberChef/",
     "license": "Apache-2.0",
-    "url": "https://github.com/gchq/CyberChef/releases/download/v11.0.0/CyberChef_v11.0.0.zip",
-    "hash": "ccd2d999e30a876437f6115a695ac8701b0d3386c12b65a6dff6761237dfea20",
+    "url": "https://github.com/gchq/CyberChef/releases/download/v11.2.0/CyberChef_d358d82cbcb269d764a2deb598a37043bd054f45.zip#/CyberChef_v11.2.0.7z",
+    "hash": "9abbe74b94af3423b4e0e6d064cf5142df01c5e89d6b222e412fd6f4daf906ac",
     "pre_install": "Rename-Item \"$dir\\CyberChef_v$version.html\" \"CyberChef.html\"",
     "shortcuts": [
         [
@@ -13,9 +13,11 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/gchq/CyberChef"
+        "github": "https://github.com/gchq/CyberChef",
+        "jsonpath": "$.assets[?(@.name =~ /CyberChef/i)].browser_download_url",
+        "regex": "(?i)download/v([\\d.]+)/(?<name>[^\"]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/gchq/CyberChef/releases/download/v$version/CyberChef_v$version.zip"
+        "url": "https://github.com/gchq/CyberChef/releases/download/v$version/$matchName#/CyberChef_v$version.7z"
     }
 }

--- a/bucket/debugviewpp.json
+++ b/bucket/debugviewpp.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.9.0.28",
+    "version": "1.2.0.0",
     "description": "Collect, view and filter application logs.",
     "homepage": "https://github.com/CobaltFusion/DebugViewPP",
     "license": "BSL-1.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.9.0.28/debugviewpp-1.9.0.28-win64.zip",
-            "hash": "9581b77db285bfaaa2516e1d5fc2fb865ffb880e1d35dd07204dde88d0ccb8f8",
-            "extract_dir": "debugviewpp-1.9.0.28-win64/bin"
+            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v.1.20.0.0/Debugview-1.2.0.0-x64.zip",
+            "hash": "eb4e94faf5027ade8d7503309d6dc3127c45955f685b724308124473759cef90",
+            "extract_dir": "Debugview-1.2.0.0-x64"
         }
     },
     "bin": [
@@ -20,12 +20,16 @@
             "Debugview++"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://api.github.com/repos/CobaltFusion/DebugViewPP/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /Debugview.+64.+zip$/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/(?<name>Debugview[^\\d\"]*([\\d.]+)(?![^\"]*upx).*\\.zip)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$version/debugviewpp-$version-win64.zip",
-                "extract_dir": "debugviewpp-$version-win64/bin"
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/$matchTag/$matchName",
+                "extract_dir": "Debugview-$version-x64"
             }
         }
     }

--- a/bucket/effekseer.json
+++ b/bucket/effekseer.json
@@ -1,12 +1,13 @@
 {
-    "version": "1.7.3.0",
+    "version": "1.80.5",
     "homepage": "https://effekseer.github.io/en/index.html",
     "description": "An open source tool that allows easy creation of beautiful particle effects for games and movies. ",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/effekseer/Effekseer/releases/download/1.7.3.0/Effekseer1.7.3.0Win.zip",
-            "hash": "155212c5ec4d365eb1a4a5cbe25a03cfc59893723ec6680e462de4f49e605b69"
+            "url": "https://github.com/effekseer/Effekseer/releases/download/1805/Effekseer1.80.5Win.zip",
+            "hash": "301204073b4982c278b0160d04abd7168b13aeff83e2a9e770858ed5e7dfd0e7",
+            "extract_dir": "Effekseer1.80.5Win"
         }
     },
     "installer": {
@@ -36,13 +37,14 @@
     ],
     "checkver": {
         "github": "https://api.github.com/repos/effekseer/Effekseer/releases",
-        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /Win\\.zip/i)].browser_download_url",
-        "regex": "(?i)download/([\\w.]+)/Effekseer"
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /Win\\.zip$/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/Effekseer([\\w.]+)Win"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/effekseer/Effekseer/releases/download/$version/Effekseer$versionWin.zip"
+                "url": "https://github.com/effekseer/Effekseer/releases/download/$cleanVersion/Effekseer$versionWin.zip",
+                "extract_dir": "Effekseer$versionWin"
             }
         }
     }

--- a/bucket/electron-cash.json
+++ b/bucket/electron-cash.json
@@ -1,10 +1,14 @@
 {
-    "version": "4.4.3",
+    "version": "4.4.5",
     "description": "A Bitcoin Cash SPV Wallet",
     "homepage": "https://electroncash.org",
     "license": "MIT",
-    "url": "https://github.com/Electron-Cash/Electron-Cash/releases/download/4.4.3/Electron-Cash-4.4.3-portable.exe#/Electron-Cash.exe",
-    "hash": "f5ea39933da189d9f94e85a3aaae89d74e42238b5574bc0a19046ac20d8af417",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Electron-Cash/Electron-Cash/releases/download/4.4.5/Electron-Cash-4.4.5-x86_64-portable.exe#/Electron-Cash.exe",
+            "hash": "aafe07ef4fd0417cfbd5308c990fa8b5c085b1e26f38eb03a8aa2e2450c75e3b"
+        }
+    },
     "shortcuts": [
         [
             "Electron-Cash.exe",
@@ -16,7 +20,11 @@
         "github": "https://github.com/Electron-Cash/Electron-Cash"
     },
     "autoupdate": {
-        "url": "https://github.com/Electron-Cash/Electron-Cash/releases/download/$version/Electron-Cash-$version-portable.exe#/Electron-Cash.exe",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Electron-Cash/Electron-Cash/releases/download/$version/Electron-Cash-4.4.5-x86_64-portable.exe#/Electron-Cash.exe"
+            }
+        },
         "hash": {
             "url": "https://raw.githubusercontent.com/Electron-Cash/keys-n-hashes/master/sigs-and-sums/$version/win-linux/SHA256.$basename.txt"
         }

--- a/bucket/electron-cash.json
+++ b/bucket/electron-cash.json
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Electron-Cash/Electron-Cash/releases/download/$version/Electron-Cash-4.4.5-x86_64-portable.exe#/Electron-Cash.exe"
+                "url": "https://github.com/Electron-Cash/Electron-Cash/releases/download/$version/Electron-Cash-$version-x86_64-portable.exe#/Electron-Cash.exe"
             }
         },
         "hash": {

--- a/bucket/heidisql.json
+++ b/bucket/heidisql.json
@@ -1,12 +1,12 @@
 {
-    "version": "12.17",
+    "version": "12.18",
     "description": "See and edit data and structures from computers running one of the database systems MariaDB, MySQL, Microsoft SQL or PostgreSQL.",
     "homepage": "https://www.heidisql.com/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/HeidiSQL/HeidiSQL/releases/download/12.17/HeidiSQL_12.17_64_Portable.zip",
-            "hash": "d40f8c32cbbd43c17e76d95443ef275cd8571652150083b66f382ff1acf141c5"
+            "url": "https://github.com/HeidiSQL/HeidiSQL/releases/download/v12.18/HeidiSQL_12.18_64_Portable.zip",
+            "hash": "ddf61f039b2ab962de672444610277b93deaed1f0c97f5acc3fc511151960b9e"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\portable_settings.txt\")) { New-Item \"$dir\\portable_settings.txt\" | Out-Null }",
@@ -20,12 +20,12 @@
     "persist": "portable_settings.txt",
     "checkver": {
         "github": "https://github.com/HeidiSQL/HeidiSQL",
-        "regex": "tag/([\\d.]+)"
+        "regex": "^(?i)(?<tag>v?([\\d.]+))$"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/HeidiSQL/HeidiSQL/releases/download/$version/HeidiSQL_$version_64_Portable.zip"
+                "url": "https://github.com/HeidiSQL/HeidiSQL/releases/download/v$version/HeidiSQL_$version_64_Portable.zip"
             }
         }
     }

--- a/bucket/iographica.json
+++ b/bucket/iographica.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.0.3",
+    "version": "2.0.2",
     "description": "An application that turns mouse movements into modern art.",
     "homepage": "https://www.iographica.com",
     "license": "Unknown",
-    "url": "https://github.com/anatolyzenkov/IOGraph/releases/download/v1.0.3/IOGraph_v1_0_3.zip",
-    "hash": "66defe2c80c3cf61c56fb6362ef429b6985e1526af78d75ab3bb9cb04edb556a",
+    "url": "https://github.com/anatolyzenkov/IOGraph/releases/download/v2.0.2/IOGraph-windows-v2.0.2.zip",
+    "hash": "01e96c39bdf7ac53b72db8f1e25b7a567e99ad8d60d2f32d2a44df206b73bc5b",
     "shortcuts": [
         [
             "IOGraph.exe",
@@ -12,10 +12,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://iographica.com/update",
-        "regex": "([\\d.]+)"
+        "github": "https://github.com/anatolyzenkov/IOGraph"
     },
     "autoupdate": {
-        "url": "https://github.com/anatolyzenkov/IOGraph/releases/download/v$version/IOGraph_v$underscoreVersion.zip"
+        "url": "https://github.com/anatolyzenkov/IOGraph/releases/download/v$version/IOGraph-windows-v$version.zip"
     }
 }

--- a/bucket/keyguard.json
+++ b/bucket/keyguard.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.9.0-20260428",
+    "version": "2.14.2-20260616",
     "description": "Keyguard is an alternative client for the Bitwarden® platform, created to provide the best user experience possible",
-    "homepage": "https://github.com/AChep/keyguard-app",
+    "homepage": "https://keyguard.dev",
     "license": {
         "identifier": "Proprietary",
         "url": "https://github.com/AChep/keyguard-app/blob/master/LICENSE"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/AChep/keyguard-app/releases/download/r20260428/Keyguard-2.9.0.msi",
-            "hash": "744c4d07df6c154a93da7a2dc7c923b7fc47b364b4509dba4abd08a26bdc3541"
+            "url": "https://github.com/AChep/keyguard-app/releases/download/r20260616/Keyguard-2.14.2.msi",
+            "hash": "45fe35c841945f841a495f565b6a8c540c4b17273a743e9755f867664c1f1384"
         }
     },
     "bin": "Keyguard\\Keyguard.exe",
@@ -20,9 +20,10 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/AChep/keyguard-app/",
-        "regex": "Release v([\\d\\.]+)-([\\d\\.]+)",
-        "replace": "${1}-${2}"
+        "github": "https://github.com/AChep/keyguard-app",
+        "jsonpath": "$.assets[?(@.name =~ /msi$/i)].browser_download_url",
+        "regex": "(?i)download/r(?<suffix>[\\d.]+)/Keyguard-(?<prefix>[\\d.]+)\\.msi",
+        "replace": "${prefix}-${suffix}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/klogg.json
+++ b/bucket/klogg.json
@@ -22,15 +22,16 @@
     ],
     "checkver": {
         "github": "https://github.com/variar/klogg",
-        "regex": "/klogg-([\\d.]+)-Win-x64"
+        "jsonpath": "$.assets[?(@.name =~ /portable\\.zip$/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/klogg-([\\d.]+)(?:-Win)?-x"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/variar/klogg/releases/download/v$majorVersion.$minorVersion/klogg-$version-Win-x64-Qt6-portable.zip"
+                "url": "https://github.com/variar/klogg/releases/download/$matchTag/klogg-$version-Win-x64-Qt6-portable.zip"
             },
             "32bit": {
-                "url": "https://github.com/variar/klogg/releases/download/v$majorVersion.$minorVersion/klogg-$version-Win-x86-Qt5-portable.zip"
+                "url": "https://github.com/variar/klogg/releases/download/$matchTag/klogg-$version-Win-x86-Qt5-portable.zip"
             }
         },
         "hash": {

--- a/bucket/kotatogram.json
+++ b/bucket/kotatogram.json
@@ -27,7 +27,7 @@
     "persist": "tdata",
     "checkver": {
         "github": "https://github.com/kotatogram/kotatogram-desktop",
-        "regex": "Version ([\\d.]+)"
+        "regex": "^k([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/launchy.json
+++ b/bucket/launchy.json
@@ -33,7 +33,7 @@
     ],
     "checkver": {
         "github": "https://github.com/OpenNingia/Launchy",
-        "regex": "tag/launchy-v([\\d.]+)"
+        "regex": "^(?i)launchy-v?([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/maple.json
+++ b/bucket/maple.json
@@ -43,6 +43,7 @@
     ],
     "checkver": {
         "github": "https://github.com/YtFlow/Maple",
+        "jsonpath": "$.assets[?(@.name =~ /Maple.+zip$/i)].browser_download_url",
         "regex": "Maple.App_([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/memreduct.json
+++ b/bucket/memreduct.json
@@ -27,7 +27,7 @@
     "persist": "memreduct.ini",
     "checkver": {
         "github": "https://github.com/henrypp/memreduct",
-        "regex": "tag/v\\.([\\d.]+)"
+        "regex": "^v\\.([\\d.]+)$"
     },
     "autoupdate": {
         "url": "https://github.com/henrypp/memreduct/releases/download/v.$version/memreduct-$version-bin.7z",


### PR DESCRIPTION
### Summary

Updates multiple manifests to their latest versions and refactors their `checkver` and `autoupdate` blocks to use modern JSONPath, robust regex matching, and `$matchTag`/`$matchName` variables to ensure reliable automated updates.

### Changes

- **Version Updates:**
  - Update `ani-cli` to **4.14** (switch source URL to raw github tags)
  - Update `clementine` to **1.4.1-78**
  - Update `cyberchef` to **11.2.0** (with custom asset 7z hash matching)
  - Update `debugviewpp` to **1.2.0.0**
  - Update `effekseer` to **1.80.5**
  - Update `electron-cash` to **4.4.5** (and restructure to `64bit` architecture)
  - Update `heidisql` to **12.18**
  - Update `iographica` to **2.0.2** (and switch `checkver` to GitHub)
  - Update `keyguard` to **2.14.2-20260616**
- **Checkver & Autoupdate Optimizations:**
  - Modernize `checkver` with GitHub API (`jsonpath` and specific asset filtering) for `cupscale`, `cyberchef`, `debugviewpp`, `effekseer`, `keyguard`, `klogg`, and `maple`.
  - Fix case-insensitive anchors (`^(?i)`) and replace patterns in `clementine`, `heidisql`, `kotatogram`, `launchy`, and `memreduct`.

### Notes

* For `electron-cash`, the portable executable has been properly nested inside the `architecture.64bit` block to align with modern upstream releases.
* Modified regex patterns utilize explicit named captures (`<tag>`, `<name>`) where applicable to ensure Scoop's `autoupdate` mechanism evaluates properly without losing fallback variables.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)