### PR TITLE
aws-nosql-workbench: Update to version 3.20.0, fix autoupdate

### DIFF
--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -24,21 +24,12 @@
     ],
     "checkver": {
         "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkbenchDocumentHistory.html",
-        "script": [
-            "if (-not ($page -match '>(?<version>[\\d.]+)<')) { throw 'Version not found in documentation' }",
-            "$version = $matches.version",
-            "$url = \"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.settingup.html\"",
-            "$page = Invoke-WebRequest -Uri $url -UseBasicParsing | Select-Object -ExpandProperty Content",
-            "if (-not ($page -match \"href=`\"https://(?<url>\\w+).cloudfront.net/NoSQL_Workbench.exe`\"\")) { throw 'CloudFront URL not found in setup page' }",
-            "$url = $matches.url",
-            "Write-Output \"$version $url\""
-        ],
-        "regex": "(?<version>[\\d.]+) (?<url>\\w+)"
+        "regex": ">([\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://$matchUrl.cloudfront.net/NoSQL_Workbench.exe#/dl.7z"
+                "url": "https://dy9cqqaswpltd.cloudfront.net/NoSQL_Workbench.exe#/dl.7z"
             }
         },
         "hash": {

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -25,20 +25,20 @@
     "checkver": {
         "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkbenchDocumentHistory.html",
         "script": [
-            "$page -match '>(?<version>[\\d.]+)<'",
+            "if (-not ($page -match '>(?<version>[\\d.]+)<')) { throw 'Version not found in documentation' }",
             "$version = $matches.version",
             "$url = \"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.settingup.html\"",
             "$page = Invoke-WebRequest -Uri $url -UseBasicParsing | Select-Object -ExpandProperty Content",
-            "$page -match \"href=`\"(?<url>https://\\w+.cloudfront.net/NoSQL_Workbench.exe)`\"\"",
+            "if (-not ($page -match \"href=`\"https://(?<url>\\w+).cloudfront.net/NoSQL_Workbench.exe`\"\")) { throw 'CloudFront URL not found in setup page' }",
             "$url = $matches.url",
             "Write-Output \"$version $url\""
         ],
-        "regex": "(?<version>[\\d.]+) (?<url>https://\\w+.cloudfront.net/NoSQL_Workbench.exe)"
+        "regex": "(?<version>[\\d.]+) (?<url>\\w+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "$matchUrl#/dl.7z"
+                "url": "https://$matchUrl.cloudfront.net/NoSQL_Workbench.exe#/dl.7z"
             }
         },
         "hash": {

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.13.5",
+    "version": "3.20.0",
     "description": "NoSQL database designer for Amazon DynamoDB and Amazon Keyspaces",
     "homepage": "https://aws.amazon.com/dynamodb/nosql-workbench/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-3.13.5.exe#/dl.7z",
-            "hash": "sha512:b0366dc4f85b5acc66a4af6c643d3f4d32ea2e8ed2ece820e1250c22f7aaa8a1d1a483ea36f660ab604bd668e5959d0b9ac9edf0cb30d42f3f6072d76d44c84e",
+            "url": "https://dy9cqqaswpltd.cloudfront.net/NoSQL_Workbench.exe#/dl.7z",
+            "hash": "sha512:ad678fdfb06f7555f608aa82b9b25aba31b334dc24790aa96091b40728c0458536aec0f9aec669f902d503d34176d4d142a1cdf58a6f58d514518fdd2901f95e",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
@@ -24,12 +24,21 @@
     ],
     "checkver": {
         "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkbenchDocumentHistory.html",
-        "regex": ">([\\d.]+)<"
+        "script": [
+            "$page -match '>(?<version>[\\d.]+)<'",
+            "$version = $matches.version",
+            "$url = \"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.settingup.html\"",
+            "$page = Invoke-WebRequest -Uri $url -UseBasicParsing | Select-Object -ExpandProperty Content",
+            "$page -match \"href=`\"(?<url>https://\\w+.cloudfront.net/NoSQL_Workbench.exe)`\"\"",
+            "$url = $matches.url",
+            "Write-Output \"$version $url\""
+        ],
+        "regex": "(?<version>[\\d.]+) (?<url>https://\\w+.cloudfront.net/NoSQL_Workbench.exe)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe#/dl.7z"
+                "url": "$matchUrl#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
Closes #18097

Update to 3.20.0, update checkver and autoupdate.url.
Feel free to modify the script part, I was not sure in what extend we should match the download link, or maybe not at all.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
