### PR TITLE
leopardwm: Add version 0.2.2

### DIFF
--- a/bucket/leopardwm.json
+++ b/bucket/leopardwm.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.2",
+    "description": "A scroll-first tiling window manager for Windows 10/11.",
+    "homepage": "https://github.com/jcardama/LeopardWM",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jcardama/LeopardWM/releases/download/v0.2.2/LeopardWM-0.2.2-x86_64-windows.zip",
+            "hash": "09d7ff38becb33f12584c5fcc0a843d34cfd28b688744e62d6973b30d408d91c",
+            "extract_dir": "LeopardWM-0.2.2-x86_64-windows"
+        }
+    },
+    "bin": [
+        "lwm.exe",
+        "leopardwm-cli.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jcardama/LeopardWM/releases/download/v$version/LeopardWM-$version-x86_64-windows.zip",
+                "extract_dir": "LeopardWM-$version-x86_64-windows"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256\\s+\\*?$basename"
+        }
+    }
+}


### PR DESCRIPTION
Adds [LeopardWM](https://github.com/jcardama/LeopardWM) — a scroll-first tiling window manager for Windows 10/11, written in Rust (GPL-3.0).

Re-submission of #17777, updated to the current release (0.2.2). A user has since requested Scoop availability (jcardama/LeopardWM#42).

- Shims the CLI binaries (`lwm`, `leopardwm-cli`); the daemon (`leopardwm.exe`) and watchdog ship in the same directory and are launched by the CLI.
- `checkver: github` + `autoupdate` pull the hash from each release's `checksums.txt`, so future versions bump automatically.
- The manifest hash matches the published `checksums.txt` for v0.2.2 and the release zip URL resolves.

Happy to adjust per review.
