### PR TITLE
ripsync: Add version 1.2.0

### DIFF
--- a/bucket/ripsync.json
+++ b/bucket/ripsync.json
@@ -5,14 +5,14 @@
     "license": "MIT OR Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/beeboyd/ripsync/releases/download/v1.0.0/ripsync-v1.0.0-x86_64-pc-windows-msvc.zip",
-            "hash": "0000000000000000000000000000000000000000000000000000000000000000",
-            "extract_dir": "ripsync-v1.0.0-x86_64-pc-windows-msvc"
+            "url": "https://github.com/beeboyd/ripsync/releases/download/v1.2.0/ripsync-v1.2.0-x86_64-pc-windows-msvc.zip",
+            "hash": "a59981beb41f118295b16dd795a089e211865ea95ebb26183396c04f5e43689d",
+            "extract_dir": "ripsync-v1.2.0-x86_64-pc-windows-msvc"
         },
         "arm64": {
-            "url": "https://github.com/beeboyd/ripsync/releases/download/v1.0.0/ripsync-v1.0.0-aarch64-pc-windows-msvc.zip",
-            "hash": "0000000000000000000000000000000000000000000000000000000000000000",
-            "extract_dir": "ripsync-v1.0.0-aarch64-pc-windows-msvc"
+            "url": "https://github.com/beeboyd/ripsync/releases/download/v1.2.0/ripsync-v1.2.0-aarch64-pc-windows-msvc.zip",
+            "hash": "04a5c26626a453d5f6560ba567096e6a56130fd29058bc595c74445cc3296a2c",
+            "extract_dir": "ripsync-v1.2.0-aarch64-pc-windows-msvc"
         }
     },
     "bin": "ripsync.exe",

--- a/bucket/ripsync.json
+++ b/bucket/ripsync.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.2.0",
+    "description": "A fast, memory-safe local directory sync tool — rsync's superpower, none of its footguns.",
+    "homepage": "https://github.com/beeboyd/ripsync",
+    "license": "MIT OR Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/beeboyd/ripsync/releases/download/v1.0.0/ripsync-v1.0.0-x86_64-pc-windows-msvc.zip",
+            "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "extract_dir": "ripsync-v1.0.0-x86_64-pc-windows-msvc"
+        },
+        "arm64": {
+            "url": "https://github.com/beeboyd/ripsync/releases/download/v1.0.0/ripsync-v1.0.0-aarch64-pc-windows-msvc.zip",
+            "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "extract_dir": "ripsync-v1.0.0-aarch64-pc-windows-msvc"
+        }
+    },
+    "bin": "ripsync.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/beeboyd/ripsync/releases/download/v$version/ripsync-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "ripsync-v$version-x86_64-pc-windows-msvc"
+            },
+            "arm64": {
+                "url": "https://github.com/beeboyd/ripsync/releases/download/v$version/ripsync-v$version-aarch64-pc-windows-msvc.zip",
+                "extract_dir": "ripsync-v$version-aarch64-pc-windows-msvc"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add ripsync v1.2.0 to Scoop extras bucket

Platform-optimized Rust rsync replacement with:
- 3-8x faster delta hashing (parallel Rayon)
- Page-aligned I/O buffers
- macOS kernel-level acceleration
- Linux io_uring large file splice batching
- Vectorized checksums (~8 GiB/s)

Cross-platform support: Linux (x86_64/aarch64), macOS (x86_64/arm64), Windows (x86_64/arm64)
Released: https://github.com/BeeBoyD/ripsync/releases/tag/v1.2.0