### PR TITLE
darktable@5.6.0: Fix extraction, add arm64 version

### DIFF
--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-win64.exe",
             "hash": "b42989195dfff44540c0b767b407987329ca99853612304cbbf14c48d1d3f803"
+        },
+        "arm64": {
+            "url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-woa64.exe",
+            "hash": "b7737d54d6ee007816ae0a1fad3ca3677588735e1432887a917bc55f818f5268"
         }
     },
     "innosetup": true,
@@ -25,11 +29,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-win64.exe",
-                "hash": {
-                    "url": "https://github.com/darktable-org/darktable/releases/tag/release-$matchHead"
-                }
+                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-win64.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-woa64.exe"
             }
+        },
+        "hash": {
+            "url": "https://github.com/darktable-org/darktable/releases/tag/release-$matchHead"
         }
     }
 }

--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -5,11 +5,11 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-win64.exe#/dl.7z",
+            "url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-win64.exe",
             "hash": "b42989195dfff44540c0b767b407987329ca99853612304cbbf14c48d1d3f803"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst*\" -Force -Recurse",
+    "innosetup": true,
     "bin": "bin\\darktable.exe",
     "shortcuts": [
         [
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-win64.exe#/dl.7z",
+                "url": "https://github.com/darktable-org/darktable/releases/download/release-$matchHead/darktable-$version-win64.exe",
                 "hash": {
                     "url": "https://github.com/darktable-org/darktable/releases/tag/release-$matchHead"
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
> Between 5.4.1 and 5.6.0, the setup file changed from using NSIS to using InnoSetup. Since InnoSetup setup files cannot be extracted with 7-Zip, the installation fails.

Closes #18103
Closes #18107
Closes #18108
<!--
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
