### PR TITLE
pressey-ai-test-generator: Add version 0.3.0

### DIFF
--- a/bucket/pressey-ai-test-generator.json
+++ b/bucket/pressey-ai-test-generator.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.3.0",
+    "description": "AI test generator — create editable practice tests from any topic",
+    "homepage": "https://github.com/Eld3rForce/Pressey-AI-Test-Generator",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Eld3rForce/Pressey-AI-Test-Generator/releases/download/v0.3.0/Pressey.AI.Test.Generator_0.3.0_x64-setup.exe#/dl.7z",
+            "hash": "0d4e8fd06f5065bea497228f35f51df4f51b64451cd8a650bf501891cbb622c8",
+            "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force 2>$null"
+        }
+    },
+    "bin": "pressey-ai-test-generator.exe",
+    "shortcuts": [
+        [
+            "pressey-ai-test-generator.exe",
+            "Pressey AI Test Generator"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Eld3rForce/Pressey-AI-Test-Generator/releases/download/v$version/Pressey.AI.Test.Generator_$version_x64-setup.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add manifest for Pressey AI Test Generator v0.3.0, an open-source desktop app that turns a topic, a document, or a webpage into an editable practice test.

**Upstream:** https://github.com/Eld3rForce/Pressey-AI-Test-Generator
**Release:** https://github.com/Eld3rForce/Pressey-AI-Test-Generator/releases/tag/v0.3.0
**SHA256:** \