### PR TITLE
flutter@3.44.4: Add arm64 support

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.44.3",
+    "version": "3.44.4",
     "description": "Google's SDK for crafting beautiful, fast user experiences for mobile, web, and desktop",
     "homepage": "https://flutter.dev",
     "license": "BSD-3-Clause",
@@ -17,8 +17,8 @@
         ],
         "Visual Studio Code with Flutter extension": "extras/vscode"
     },
-    "url": "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_3.44.3-stable.zip",
-    "hash": "8ebf8bc70779e8bd7959175ebd3e77d5b1a6a8d2b1fa690fa9c2d4aa1aaa4154",
+    "url": "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_3.44.4-stable.zip",
+    "hash": "8f2d6224fc6872d2f7f180de86cde989fcea3776efe0edf48a9aac2cd9be2b1b",
     "architecture": {
         "arm64": {
             "post_install": [

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -3,7 +3,11 @@
     "description": "Google's SDK for crafting beautiful, fast user experiences for mobile, web, and desktop",
     "homepage": "https://flutter.dev",
     "license": "BSD-3-Clause",
-    "notes": " - Run 'flutter doctor' to see if there are any platform dependencies you need to complete the setup.",
+    "notes": [
+        " - Run 'flutter doctor' to see if there are any platform dependencies you need to complete the setup.",
+        "Though only x64 sdk are officially distributed, we can repurpose it to get arm64 sdk, see:",
+        "https://github.com/flutter/flutter/issues/186730#issuecomment-4573214964"
+    ],
     "suggest": {
         "Android SDK Tools": "android-clt",
         "Android Studio": "extras/android-studio",
@@ -15,6 +19,15 @@
     },
     "url": "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_3.44.3-stable.zip",
     "hash": "8ebf8bc70779e8bd7959175ebd3e77d5b1a6a8d2b1fa690fa9c2d4aa1aaa4154",
+    "architecture": {
+        "arm64": {
+            "post_install": [
+                "Remove-Item -path \"$dir\\bin\\cache\\engine-dart-sdk.stamp\" -Force -ErrorAction Ignore",
+                "Write-Host \"Repurposing the sdk for arm64, please wait in patience!\" -ForegroundColor Green",
+                "cmd /c \"$dir\\bin\\flutter.bat\" doctor -v"
+            ]
+        }
+    },
     "extract_dir": "flutter",
     "env_add_path": "bin",
     "env_set": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Since 3.44.0, the flutter sdk for windows arm64 can be retrieved in the release channel.
I think it is time to add scoop support for it.
Details can be found here:
https://github.com/flutter/flutter/issues/186730#issuecomment-4573214964
https://github.com/flutter/flutter/issues/62597#issuecomment-4572851264


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
