### PR TITLE
speccy: Fix file path error in `pre_install` script

### DIFF
--- a/bucket/speccy.json
+++ b/bucket/speccy.json
@@ -32,6 +32,9 @@
     },
     "pre_install": [
         "Set-Content \"$dir\\portable.dat\" '#PORTABLE#' -Encoding ASCII",
+        "if (-not (Test-Path \"$dir\\Speccy*.exe\")) {",
+        "   Get-ChildItem -Path \"$dir\" -Filter \"Speccy*.exe\" -Recurse | Resolve-Path | ForEach-Object { Move-Item -Path $_ -Destination \"$dir\" }",
+        "}",
         "'$*', 'uninst.exe', \"Speccy$(if ($architecture -eq '32bit') { '64' }).exe\" | ForEach-Object { Remove-Item -Recurse -Force \"$dir\\$_\" }",
         "if(!(Test-Path \"$persist_dir\\Speccy.ini\")) {",
         "   Set-Content \"$dir\\Speccy.ini\" (@('[Software\\Piriform\\Speccy]', 'NeedUpdate=0') -join \"`r`n\") -Encoding ASCII",

--- a/bucket/speccy.json
+++ b/bucket/speccy.json
@@ -33,7 +33,7 @@
     "pre_install": [
         "Set-Content \"$dir\\portable.dat\" '#PORTABLE#' -Encoding ASCII",
         "if (-not (Test-Path \"$dir\\Speccy*.exe\")) {",
-        "    Get-ChildItem -Path \"$dir\" -Filter \"Speccy*.exe\" -Recurse | Resolve-Path | ForEach-Object { Move-Item -Path $_ -Destination \"$dir\" }",
+        "    Get-ChildItem -Path \"$dir\" -Filter \"Speccy*.exe\" -Recurse | ForEach-Object { Move-Item -Path $_.FullName -Destination \"$dir\" -ErrorAction Stop }",
         "}",
         "'$*', 'uninst.exe', \"Speccy$(if ($architecture -eq '32bit') { '64' }).exe\" | ForEach-Object { Remove-Item -Recurse -Force \"$dir\\$_\" }",
         "if(!(Test-Path \"$persist_dir\\Speccy.ini\")) {",

--- a/bucket/speccy.json
+++ b/bucket/speccy.json
@@ -33,11 +33,11 @@
     "pre_install": [
         "Set-Content \"$dir\\portable.dat\" '#PORTABLE#' -Encoding ASCII",
         "if (-not (Test-Path \"$dir\\Speccy*.exe\")) {",
-        "   Get-ChildItem -Path \"$dir\" -Filter \"Speccy*.exe\" -Recurse | Resolve-Path | ForEach-Object { Move-Item -Path $_ -Destination \"$dir\" }",
+        "    Get-ChildItem -Path \"$dir\" -Filter \"Speccy*.exe\" -Recurse | Resolve-Path | ForEach-Object { Move-Item -Path $_ -Destination \"$dir\" }",
         "}",
         "'$*', 'uninst.exe', \"Speccy$(if ($architecture -eq '32bit') { '64' }).exe\" | ForEach-Object { Remove-Item -Recurse -Force \"$dir\\$_\" }",
         "if(!(Test-Path \"$persist_dir\\Speccy.ini\")) {",
-        "   Set-Content \"$dir\\Speccy.ini\" (@('[Software\\Piriform\\Speccy]', 'NeedUpdate=0') -join \"`r`n\") -Encoding ASCII",
+        "    Set-Content \"$dir\\Speccy.ini\" (@('[Software\\Piriform\\Speccy]', 'NeedUpdate=0') -join \"`r`n\") -Encoding ASCII",
         "}"
     ],
     "persist": "Speccy.ini",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Update the `pre_install` to find executable files and move to app root folder

Test running after change shows the bug is solved

```
...
Running pre_install script...done.
Linking ~\scoop\apps\speccy\current => ~\scoop\apps\speccy\1.34.84
Creating shim for 'Speccy'.
Making C:\Users\A1\scoop\shims\speccy.exe a GUI binary.
Creating shortcut for Speccy (Speccy64.exe)
Persisting Speccy.ini
'speccy' (1.34.84) was installed successfully!
```

Closes #18127
Closes #18116

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
