### PR TITLE
igv: Add version 2.19.8

### DIFF
--- a/bucket/igv.json
+++ b/bucket/igv.json
@@ -9,7 +9,6 @@
             "hash": "6152f8a3ee1ed6b35532fb6fa18155f858c559504287c1beab1b68946c265892"
         }
     },
-    "bin": "igv.bat",
     "shortcuts": [
         [
             "igv-launcher.bat",

--- a/bucket/igv.json
+++ b/bucket/igv.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.19.8",
+    "description": "Easy visualization of various genomics/bioinformatics file formats, including but not limited to BAM, VCF, and GFF3.",
+    "homepage": "https://igv.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://data.broadinstitute.org/igv/projects/downloads/2.19/IGV_Win_2.19.8-WithJava-installer.exe",
+            "hash": "6152f8a3ee1ed6b35532fb6fa18155f858c559504287c1beab1b68946c265892"
+        }
+    },
+    "bin": "igv.bat",
+    "shortcuts": [
+        [
+            "igv-launcher.bat",
+            "IGV",
+            "",
+            "IGV_64.ico"
+        ]
+    ],
+    "pre_install": [
+        "Get-ChildItem \"$dir\\IGV_Win_*installer.exe\" | Expand-7zipArchive -DestinationPath $dir -Removal",
+        "Remove-Item \"$dir\\uninstaller.exe\" -Force"
+    ],
+    "checkver": {
+        "url": "https://igv.org/doc/desktop/DownloadPage/",
+        "regex": "version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://data.broadinstitute.org/igv/projects/downloads/$majorVersion.$minorVersion/IGV_Win_$version-WithJava-installer.exe"
+            }
+        }
+    }
+}

--- a/bucket/igv.json
+++ b/bucket/igv.json
@@ -1,14 +1,16 @@
 {
     "version": "2.19.8",
     "description": "Easy visualization of various genomics/bioinformatics file formats, including but not limited to BAM, VCF, and GFF3.",
-    "homepage": "https://igv.org/",
+    "homepage": "https://igv.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://data.broadinstitute.org/igv/projects/downloads/2.19/IGV_Win_2.19.8-WithJava-installer.exe",
+            "url": "https://data.broadinstitute.org/igv/projects/downloads/2.19/IGV_Win_2.19.8-WithJava-installer.exe#/dl.7z",
             "hash": "6152f8a3ee1ed6b35532fb6fa18155f858c559504287c1beab1b68946c265892"
         }
     },
+    "pre_install": "Remove-Item \"$dir\\uninstall*\" -Recurse -Force",
+    "bin": "igv.bat",
     "shortcuts": [
         [
             "igv-launcher.bat",
@@ -17,10 +19,6 @@
             "IGV_64.ico"
         ]
     ],
-    "pre_install": [
-        "Get-ChildItem \"$dir\\IGV_Win_*installer.exe\" | Expand-7zipArchive -DestinationPath $dir -Removal",
-        "Remove-Item \"$dir\\uninstaller.exe\" -Force"
-    ],
     "checkver": {
         "url": "https://igv.org/doc/desktop/DownloadPage/",
         "regex": "version ([\\d.]+)"
@@ -28,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://data.broadinstitute.org/igv/projects/downloads/$majorVersion.$minorVersion/IGV_Win_$version-WithJava-installer.exe"
+                "url": "https://data.broadinstitute.org/igv/projects/downloads/$majorVersion.$minorVersion/IGV_Win_$version-WithJava-installer.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Closes #17503

This manifest installs IGV **including java**. Previous PR (#18135) manifest installs IGV without java, and the user is required to install java21+ separately to make IGV work. 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
