### PR TITLE
halloy: Update to version 2026.7.2, switch to innosetup

### DIFF
--- a/bucket/halloy.json
+++ b/bucket/halloy.json
@@ -1,15 +1,15 @@
 {
-    "version": "2026.7.1",
+    "version": "2026.7.2",
     "description": "Halloy is an open-source IRC client written in Rust, with the iced GUI library.",
     "homepage": "https://halloy.squidowl.org/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/squidowl/halloy/releases/download/2026.7.1/halloy-installer.msi",
-            "hash": "dcc3d18abf39d26ee6c97a661e4103c65c401a2f5e162aa4fd8028c4a5f0ad34"
+            "url": "https://github.com/squidowl/halloy/releases/download/2026.7.2/halloy-installer.exe",
+            "hash": "f74342417154ff21df3e40168cc548374a9c38a5cf558637991f52154c21fb25"
         }
     },
-    "extract_dir": "PFiles64/Halloy",
+    "innosetup": true,
     "installer": {
         "script": [
             "if (!(Test-Path \"$persist_dir\\config.toml\")) {",
@@ -24,11 +24,11 @@
             "    if (Test-Path \"$env:AppData\\halloy\") {",
             "        Copy-Item \"$env:AppData\\halloy\\*\" \"$dir\" -Recurse -Exclude '*config.toml' -ErrorAction SilentlyContinue",
             "    }",
-            "} else { Move-Item \"$persist_dir\\*\" \"$dir\" -Include '*.log', '*.gz', '*.toml' }"
+            "} else { Move-Item \"$persist_dir\\*\" \"$dir\" -Include '*.log', '*.gz', '*.toml' -ErrorAction SilentlyContinue}"
         ]
     },
     "uninstaller": {
-        "script": "Move-Item \"$dir\\*\" \"$persist_dir\" -Include '*.log', '*.gz', '*.toml'"
+        "script": "Move-Item \"$dir\\*\" \"$persist_dir\" -Include '*.log', '*.gz', '*.toml' -ErrorAction SilentlyContinue"
     },
     "persist": [
         "themes",
@@ -46,11 +46,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/squidowl/halloy/releases/download/$version/halloy-installer.msi"
+                "url": "https://github.com/squidowl/halloy/releases/download/$version/halloy-installer.exe"
             }
-        },
-        "hash": {
-            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/halloy.json
+++ b/bucket/halloy.json
@@ -1,7 +1,7 @@
 {
     "version": "2026.7.2",
     "description": "Halloy is an open-source IRC client written in Rust, with the iced GUI library.",
-    "homepage": "https://halloy.squidowl.org/",
+    "homepage": "https://halloy.chat/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
@@ -15,7 +15,7 @@
             "if (!(Test-Path \"$persist_dir\\config.toml\")) {",
             "    $configContent = '# Halloy config.",
             "# For a complete list of available options,",
-            "# please visit https://halloy.squidowl.org/configuration/index.html",
+            "# please visit https://halloy.chat/configuration",
             "[servers.liberachat]",
             "    nickname = \"halloy8765\"",
             "    server = \"irc.libera.chat\"",


### PR DESCRIPTION
Closes #18117 

Changed url to extension `.exe`, removed `autoupdate.hash` (so it uses github mode), added `innosetup` and removed `extract_dir`. Also suppressed errors from Move-Item.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->