### PR TITLE
installerclean: Add version 1.9.2

### DIFF
--- a/bucket/installerclean.json
+++ b/bucket/installerclean.json
@@ -10,7 +10,6 @@
             "hash": "c844ee11b274fb85e03a0ae0d41c6aee22c5aec94c6732e37ca905197eececa5"
         }
     },
-    "bin": "InstallerClean-portable.exe",
     "shortcuts": [
         [
             "InstallerClean-portable.exe",
@@ -21,11 +20,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/no-faff/InstallerClean/releases/download/v$version/InstallerClean-portable.exe",
-                "hash": {
-                    "url": "$url.sha256"
-                }
+                "url": "https://github.com/no-faff/InstallerClean/releases/download/v$version/InstallerClean-portable.exe"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/installerclean.json
+++ b/bucket/installerclean.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.9.2",
+    "description": "Open source tool to safely clean orphaned Windows Installer files and reclaim disk space.",
+    "homepage": "https://github.com/no-faff/InstallerClean",
+    "license": "MIT",
+    "notes": "Requires administrator privileges to access C:\\Windows\\Installer.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/no-faff/InstallerClean/releases/download/v1.9.2/InstallerClean-portable.exe",
+            "hash": "c844ee11b274fb85e03a0ae0d41c6aee22c5aec94c6732e37ca905197eececa5"
+        }
+    },
+    "bin": "InstallerClean-portable.exe",
+    "shortcuts": [
+        [
+            "InstallerClean-portable.exe",
+            "InstallerClean"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/no-faff/InstallerClean/releases/download/v$version/InstallerClean-portable.exe",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
InstallerClean is an open source (MIT) tool that safely cleans orphaned files from `C:\Windows\Installer` to reclaim disk space. GUI app, 64-bit only, so Extras rather than Main.

This supersedes #17617, which was closed at v1.5.0 as too new, with an invitation to resubmit once the criteria were met. They now are:

- Reasonably well-known: 105 stars (the guideline is 100+).
- 25,000 downloads across GitHub, MajorGeeks and Softpedia
- Latest stable version: v1.9.2.
- Full version, not a trial: free and MIT.
- English interface and documentation.
- Standard install: a single portable exe from a version-specific GitHub release URL, no pre or post-install scripts. `checkver` and `autoupdate` are wired to the release `.sha256`.

Actively maintained, 11 releases on from that PR, and already distributed via winget, Chocolatey, Softpedia and a self-hosted Scoop bucket.

Package-request issue: #18139
