### PR TITLE
nilesoft-shell: Persist `imports` directory

### DIFF
--- a/bucket/nilesoft-shell.json
+++ b/bucket/nilesoft-shell.json
@@ -43,7 +43,8 @@
     ],
     "persist": [
         "shell.log",
-        "shell.nss"
+        "shell.nss",
+        "imports"
     ],
     "checkver": {
         "url": "https://nilesoft.org/download/changes",

--- a/bucket/nilesoft-shell.json
+++ b/bucket/nilesoft-shell.json
@@ -24,6 +24,14 @@
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\shell.log\")) { New-Item -ItemType File -Path \"$dir\\shell.log\" | Out-Null }",
+    "post_install": [
+        "'imports' | ForEach-Object {",
+        "    if (Test-Path -Path \"$dir\\$_.original\" -PathType Container) {",
+        "        Copy-Item -Path \"$dir\\$_.original\\*\" -Destination \"$dir\\$_\" -Force -Recurse",
+        "        Remove-Item -Path \"$dir\\$_.original\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "    }",
+        "}"
+    ],
     "pre_uninstall": [
         "if ($cmd -eq 'uninstall') {",
         "    $regkey = Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Classes\\Directory\\background\\shellex\\ContextMenuHandlers\\ @nilesoft.shell' -ErrorAction SilentlyContinue",


### PR DESCRIPTION
Persist the `imports` directory because it can contain user-editable `.nss` files referenced by `shell.nss`.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #18142

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
