### PR TITLE
cinny@4.12.5: Change URL of binary to no updater version

### DIFF
--- a/bucket/cinny.json
+++ b/bucket/cinny.json
@@ -9,8 +9,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cinnyapp/cinny-desktop/releases/download/v4.12.5/Cinny_desktop-x86_64.msi",
-            "hash": "7724311d098eccb09f8a054b0d36ae967ad1be5387ebef53e5e5b94e6d006ea6"
+            "url": "https://github.com/cinnyapp/cinny-desktop/releases/download/v4.12.5/Cinny_desktop-x86_64-no_updater.msi",
+            "hash": "45e9f91bc7027aefbfd915d15bfe2043463230e4821949f6183f31a501ae574f"
         }
     },
     "extract_dir": "PFiles\\Cinny",
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cinnyapp/cinny-desktop/releases/download/v$version/Cinny_desktop-x86_64.msi"
+                "url": "https://github.com/cinnyapp/cinny-desktop/releases/download/v$version/Cinny_desktop-x86_64-no_updater.msi"
             }
         }
     }


### PR DESCRIPTION
Since having built it updater means the updater will install any new release with privilege which defeats the whole purpose of installing app via scoop.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
