### PR TITLE
lfk: Add version 0.14.18

### DIFF
--- a/bucket/lfk.json
+++ b/bucket/lfk.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.14.18",
+    "description": "Lightning Fast Kubernetes navigator - keyboard-focused TUI for managing K8s clusters",
+    "homepage": "https://github.com/janosmiko/lfk",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/janosmiko/lfk/releases/download/v0.14.18/lfk_0.14.18_windows_amd64.zip",
+            "hash": "575f4d325816723f585b0ee26399c1a4093376aaf0c69f71c374bec141c8dab1"
+        },
+        "arm64": {
+            "url": "https://github.com/janosmiko/lfk/releases/download/v0.14.18/lfk_0.14.18_windows_arm64.zip",
+            "hash": "db93d4bc099f1e633f3cd86fa455f4cd3b010d959f2841aa01c4f15b29190753"
+        }
+    },
+    "env_set": {
+        "LFK_CONFIG_DIR": "$persist_dir/config",
+        "LFK_STATE_DIR": "$persist_dir/state",
+        "LFK_DATA_DIR": "$persist_dir/data"
+    },
+    "bin": "lfk.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/janosmiko/lfk/releases/download/v$version/lfk_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/janosmiko/lfk/releases/download/v$version/lfk_$version_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256  $basename\\n"
+        }
+    }
+}


### PR DESCRIPTION
Closes #17823

Adds a Scoop manifest for [lfk](https://github.com/janosmiko/lfk) v0.14.18 - a lightning-fast, keyboard-focused, yazi-inspired terminal UI for navigating and managing Kubernetes clusters (543 stars).

Manifest details:
- Windows AMD64 and ARM64 downloads with verified SHA-256 hashes from the release `checksums.txt`.
- `bin: lfk.exe` (the binary is at the zip root, no rename needed).
- `env_set` maps config/state/data dirs under `$persist_dir`.
- `checkver` + `autoupdate` configured for future releases.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)