### PR TITLE
anki: Update to version 26.05, add arm64 support

### DIFF
--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -17,8 +17,7 @@
         "   'set \"ANKI_LAUNCHER=%USB_ROOT%\\anki\"'",
         "   'set \"ANKI_BASE=%USB_ROOT%\\data\"'",
         "   'start /b \"\" \"%ANKI_LAUNCHER%\"'",
-        ") | Set-Content \"$dir\\anki.cmd\" -Encoding ASCII",
-        "Remove-Item \"$dir\\`$*\" -Recurse"
+        ") | Set-Content \"$dir\\anki.cmd\" -Encoding ASCII"
     ],
     "extract_dir": "PFiles64\\Anki",
     "bin": "anki.cmd",

--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -32,7 +32,7 @@
     ],
     "persist": "data",
     "checkver": {
-        "url": "https://api.github.com/repos/ankitects/anki/releases",
+        "github": "https://api.github.com/repos/ankitects/anki/releases",
         "jsonpath": "$[*].assets[*].browser_download_url",
         "regex": "download/(?<version>[\\d.]+)/anki-\\k<version>-win-x64\\.msi"
     },

--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -32,9 +32,7 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://api.github.com/repos/ankitects/anki/releases",
-        "jsonpath": "$[*].assets[*].browser_download_url",
-        "regex": "download/(?<version>[\\d.]+)/anki-\\k<version>-win-x64\\.msi"
+        "github": "https://github.com/ankitects/anki"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -1,12 +1,12 @@
 {
-    "version": "25.09",
+    "version": "26.05",
     "description": "Powerful and intelligent flash cards",
     "homepage": "https://apps.ankiweb.net",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ankitects/anki/releases/download/25.09/anki-launcher-25.09-windows.exe#/dl.7z",
-            "hash": "398f690a8208bd381dc2d4220720a82f6d2249c1fd1b38f46a90db356cb7c69e"
+            "url": "https://github.com/ankitects/anki/releases/download/26.05/anki-26.05-win-x64.msi",
+            "hash": "2047f71d7771add993e15f2f01a56ea41617967ae5b3d6d3f402cbc40716c5e0"
         }
     },
     "pre_install": [
@@ -14,13 +14,13 @@
         "   '@echo off'",
         "   'echo Starting Anki...'",
         "   'set \"USB_ROOT=%~dp0\"'",
-        "   'set \"ANKI_LAUNCHER_VENV_ROOT=%USB_ROOT%\\programfiles\"'",
         "   'set \"ANKI_LAUNCHER=%USB_ROOT%\\anki\"'",
         "   'set \"ANKI_BASE=%USB_ROOT%\\data\"'",
         "   'start /b \"\" \"%ANKI_LAUNCHER%\"'",
         ") | Set-Content \"$dir\\anki.cmd\" -Encoding ASCII",
         "Remove-Item \"$dir\\`$*\" -Recurse"
     ],
+    "extract_dir": "PFiles64\\Anki",
     "bin": "anki.cmd",
     "shortcuts": [
         [
@@ -30,23 +30,17 @@
             "anki.exe"
         ]
     ],
-    "persist": [
-        "data",
-        "programfiles"
-    ],
+    "persist": "data",
     "checkver": {
-        "github": "https://api.github.com/repos/ankitects/anki/releases",
+        "url": "https://api.github.com/repos/ankitects/anki/releases",
         "jsonpath": "$[*].assets[*].browser_download_url",
-        "regex": "download/(?<version>[\\d.]+)/anki-launcher-\\k<version>-windows\\.exe"
+        "regex": "download/(?<version>[\\d.]+)/anki-\\k<version>-win-x64\\.msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-launcher-$version-windows.exe#/dl.7z"
+                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-win-x64.msi"
             }
-        },
-        "hash": {
-            "url": "$baseurl/anki-launcher-$version-checksums.txt"
         }
     }
 }

--- a/bucket/anki.json
+++ b/bucket/anki.json
@@ -6,7 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/ankitects/anki/releases/download/26.05/anki-26.05-win-x64.msi",
-            "hash": "2047f71d7771add993e15f2f01a56ea41617967ae5b3d6d3f402cbc40716c5e0"
+            "hash": "2047f71d7771add993e15f2f01a56ea41617967ae5b3d6d3f402cbc40716c5e0",
+            "extract_dir": "PFiles64\\Anki"
+        },
+        "arm64": {
+            "url": "https://github.com/ankitects/anki/releases/download/26.05/anki-26.05-win-arm64.msi",
+            "hash": "c354b8d2df56232a8a4158b17a155b6e132a1be56bded66e8c0fed0fa4ac8005",
+            "extract_dir": "PFiles64\\Anki"
         }
     },
     "pre_install": [
@@ -19,7 +25,6 @@
         "   'start /b \"\" \"%ANKI_LAUNCHER%\"'",
         ") | Set-Content \"$dir\\anki.cmd\" -Encoding ASCII"
     ],
-    "extract_dir": "PFiles64\\Anki",
     "bin": "anki.cmd",
     "shortcuts": [
         [
@@ -31,12 +36,17 @@
     ],
     "persist": "data",
     "checkver": {
-        "github": "https://github.com/ankitects/anki"
+        "github": "https://api.github.com/repos/ankitects/anki/releases",
+        "jsonpath": "$[*].assets[*].browser_download_url",
+        "regex": "download/(?<version>[\\d.]+)/anki-\\k<version>-win-x64\\.msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-win-x64.msi"
+            },
+            "arm64": {
+                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-win-arm64.msi"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

https://github.com/ankitects/anki/releases/tag/26.05
> A standard MSI installer is provided for Windows.
A Windows ARM64 build is available.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #18148 and fixes the following:
- Anki has switched to an MSI installer and changed its installer's filename
- The program's files now install to the target directory's root path; the programfiles persist is no longer necessary
- ~~Simplified checkver as recommended~~

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
