### PR TITLE
mpv(-git): Switch to using more reliable build sources

### DIFF
--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.41.0-dev-g62f149466-28302012960",
+    "version": "0.41.0-17156-62f149466",
     "description": "A free, open source, and cross-platform media player",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
@@ -33,18 +33,24 @@
         "script": [
             "$run = ($page | ConvertFrom-Json).workflow_runs[0]",
             "$req = Invoke-WebRequest \"https://raw.githubusercontent.com/mpv-player/mpv/$($run.head_sha)/MPV_VERSION\" -UseBasicParsing",
-            "@{'ver' = $req.Content.Trim() -replace 'UNKNOWN', \"dev-g$($run.head_sha.Substring(0, 9))-$($run.id)\"} | ConvertTo-Json"
+            "$ver = \"$($req.Content.Trim().Split('-')[0])-$($run.run_number)-$($run.head_sha)\"",
+            "@{'result' = \"$ver $($run.id)\"} | ConvertTo-Json"
         ],
-        "jsonpath": "$.ver"
+        "jsonpath": "$.result",
+        "regex": "(?<version>(?<base>[\\d.]+)-\\d+-(?<sha>[a-f0-9]{9}))[a-f0-9]* (?<id>\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$matchBase-dev-g$matchSha-$matchId-x86_64-pc-windows-msvc.zip"
             },
             "arm64": {
-                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$version-aarch64-pc-windows-msvc.zip"
+                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$matchBase-dev-g$matchSha-$matchId-aarch64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.github.com/repos/mpv-player/mpv/actions/runs/$matchId/artifacts",
+            "jsonpath": "$.artifacts[?(@.name== '$basenameNoExt')].digest"
         }
     }
 }

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -12,8 +12,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-06-28-5abce15f1c/mpv-x86_64-v3-20260628-git-5abce15f1c.7z",
-            "hash": "d84b0971373f5747e69efde6650c742a477a1a70c38911884a243e5f4b145aac"
+            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-06-28-5abce15f1c/mpv-x86_64-20260628-git-5abce15f1c.7z",
+            "hash": "568cbc5e28f44fbe95f5f4f290bb3e53062a74b4e5ad116c1a3f155f20022a8f"
         },
         "arm64": {
             "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-06-28-5abce15f1c/mpv-aarch64-20260628-git-5abce15f1c.7z",
@@ -37,7 +37,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-x86_64-v3-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
+                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-x86_64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
             },
             "arm64": {
                 "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-aarch64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.41.0-17156-62f149466",
+    "version": "2026-06-28-5abce15f1c",
     "description": "A free, open source, and cross-platform media player",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
@@ -12,14 +12,15 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v0.41.0-dev-g62f149466-28302012960-x86_64-pc-windows-msvc.zip",
-            "hash": "55930fbd3694126dd4779fe235b33ea6dd05ff5035e872bd06060c11886ca64f"
+            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-06-28-5abce15f1c/mpv-x86_64-v3-20260628-git-5abce15f1c.7z",
+            "hash": "d84b0971373f5747e69efde6650c742a477a1a70c38911884a243e5f4b145aac"
         },
         "arm64": {
-            "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v0.41.0-dev-g62f149466-28302012960-aarch64-pc-windows-msvc.zip",
-            "hash": "daa7042a7a16aed96b30170facc5e9fba71378840da981bbc2f952b2e596666d"
+            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-06-28-5abce15f1c/mpv-aarch64-20260628-git-5abce15f1c.7z",
+            "hash": "df70833a1b82ee0899b757d0620d797ed78acc09c4406af8370bc617bf6ce263"
         }
     },
+    "pre_install": "'updater.bat', 'installer' | ForEach-Object { Remove-Item \"$dir\\$_\" }",
     "env_add_path": ".",
     "shortcuts": [
         [
@@ -29,28 +30,18 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://api.github.com/repos/mpv-player/mpv/actions/workflows/build.yml/runs?branch=master&status=success",
-        "script": [
-            "$run = ($page | ConvertFrom-Json).workflow_runs[0]",
-            "$req = Invoke-WebRequest \"https://raw.githubusercontent.com/mpv-player/mpv/$($run.head_sha)/MPV_VERSION\" -UseBasicParsing",
-            "$ver = \"$($req.Content.Trim().Split('-')[0])-$($run.run_number)-$($run.head_sha)\"",
-            "@{'result' = \"$ver $($run.id)\"} | ConvertTo-Json"
-        ],
-        "jsonpath": "$.result",
-        "regex": "(?<version>(?<base>[\\d.]+)-\\d+-(?<sha>[a-f0-9]{9}))[a-f0-9]* (?<id>\\d+)"
+        "github": "https://github.com/zhongfly/mpv-winbuild",
+        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})-(?<commit>[a-f0-9]+)",
+        "replace": "${year}-${month}-${day}-${commit}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$matchBase-dev-g$matchSha-$matchId-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-x86_64-v3-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
             },
             "arm64": {
-                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$matchBase-dev-g$matchSha-$matchId-aarch64-pc-windows-msvc.zip"
+                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-aarch64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
             }
-        },
-        "hash": {
-            "url": "https://api.github.com/repos/mpv-player/mpv/actions/runs/$matchId/artifacts",
-            "jsonpath": "$.artifacts[?(@.name== '$basenameNoExt')].digest"
         }
     }
 }

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -1,10 +1,10 @@
 {
-    "version": "20260610",
-    "description": "Video player based on MPlayer/mplayer2 (builds by shinchiro)",
+    "version": "0.41.0-dev-g62f149466-28302012960",
+    "description": "A free, open source, and cross-platform media player",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
     "notes": [
-        "To set and unset file type associations and AutoPlay handlers, run '$dir\\installer\\mpv-install.bat' and '$dir\\installer\\mpv-uninstall.bat' as administrator, respectively.",
+        "To set and unset file type associations and AutoPlay handlers, run '$dir\\mpv-register.bat' and '$dir\\mpv-unregister.bat', respectively.",
         "You can use Icaros ('nonportable/icaros-np') to enable thumbnails for all media types."
     ],
     "suggest": {
@@ -12,19 +12,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260610/mpv-x86_64-20260610-git-304426c.7z",
-            "hash": "facac536baa73c7b925771af5e39a3c9cb16b8d75b59a6e9800de89799dffca7"
-        },
-        "32bit": {
-            "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260610/mpv-i686-20260610-git-304426c.7z",
-            "hash": "ce5ffa43c7cb599e0fff619f199452d17c22ed8f3b2f5bbf8f914d5da34db941"
+            "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v0.41.0-dev-g62f149466-28302012960-x86_64-pc-windows-msvc.zip",
+            "hash": "55930fbd3694126dd4779fe235b33ea6dd05ff5035e872bd06060c11886ca64f"
         },
         "arm64": {
-            "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260610/mpv-aarch64-20260610-git-304426c.7z",
-            "hash": "0781fdffeef27a40a7f266631d1ca9e5c1d0f82868a1678c58d23e0b1bd1eb98"
+            "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v0.41.0-dev-g62f149466-28302012960-aarch64-pc-windows-msvc.zip",
+            "hash": "daa7042a7a16aed96b30170facc5e9fba71378840da981bbc2f952b2e596666d"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\updater.bat\"",
     "env_add_path": ".",
     "shortcuts": [
         [
@@ -34,20 +29,21 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "github": "https://api.github.com/repos/shinchiro/mpv-winbuild-cmake/releases/latest",
-        "jsonpath": "$.assets[*].browser_download_url",
-        "regex": "mpv-x86_64-(\\d+)-git-(?<commit>[\\da-f]+)\\.7z"
+        "url": "https://api.github.com/repos/mpv-player/mpv/actions/workflows/build.yml/runs?branch=master&status=success",
+        "script": [
+            "$run = ($page | ConvertFrom-Json).workflow_runs[0]",
+            "$req = Invoke-WebRequest \"https://raw.githubusercontent.com/mpv-player/mpv/$($run.head_sha)/MPV_VERSION\" -UseBasicParsing",
+            "@{'ver' = $req.Content.Trim() -replace 'UNKNOWN', \"dev-g$($run.head_sha.Substring(0, 9))-$($run.id)\"} | ConvertTo-Json"
+        ],
+        "jsonpath": "$.ver"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-x86_64-$version-git-$matchCommit.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-i686-$version-git-$matchCommit.7z"
+                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$version-x86_64-pc-windows-msvc.zip"
             },
             "arm64": {
-                "url": "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$version/mpv-aarch64-$version-git-$matchCommit.7z"
+                "url": "https://nightly.link/mpv-player/mpv/workflows/build/master/mpv-v$version-aarch64-pc-windows-msvc.zip"
             }
         }
     }

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -20,7 +20,7 @@
             "hash": "df70833a1b82ee0899b757d0620d797ed78acc09c4406af8370bc617bf6ce263"
         }
     },
-    "pre_install": "'updater.bat', 'installer' | ForEach-Object { Remove-Item \"$dir\\$_\" }",
+    "pre_install": "'updater.bat', 'installer' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
     "env_add_path": ".",
     "shortcuts": [
         [

--- a/bucket/mpv.json
+++ b/bucket/mpv.json
@@ -1,24 +1,23 @@
 {
     "version": "0.41.0",
-    "description": "Video player based on MPlayer/mplayer2 (builds by shinchiro)",
+    "description": "A free, open source, and cross-platform media player",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
-    "notes": "You can use Icaros ('nonportable/icaros-np') to enable thumbnails for all media types.",
+    "notes": [
+        "To set and unset file type associations and AutoPlay handlers, run '$dir\\mpv-register.bat' and '$dir\\mpv-unregister.bat', respectively.",
+        "You can use Icaros ('nonportable/icaros-np') to enable thumbnails for all media types."
+    ],
     "suggest": {
         "yt-dlp": "yt-dlp"
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-0.41.0-x86_64.7z",
-            "hash": "sha1:094cb7b3c7550b7e5d5205a34e68e57733a69caf"
-        },
-        "32bit": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-0.41.0-i686.7z",
-            "hash": "sha1:0fd3d3ef4cb7213faf3be7ba02a3985ecfe838b6"
+            "url": "https://github.com/mpv-player/mpv/releases/download/v0.41.0/mpv-v0.41.0-x86_64-pc-windows-msvc.zip",
+            "hash": "4e197f729f5071c6772f35fffd96e0f36e3e8a044bd9479b136bb09b7c6a80ff"
         },
         "arm64": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-0.41.0-aarch64.7z",
-            "hash": "sha1:00b0596ae929669abbedc64004d2a19ccf530b68"
+            "url": "https://github.com/mpv-player/mpv/releases/download/v0.41.0/mpv-v0.41.0-aarch64-pc-windows-msvc.zip",
+            "hash": "a822abeffd0ac88951f4084f3425f949842aa17d616f880637ebe9041e482e97"
         }
     },
     "env_add_path": ".",
@@ -30,19 +29,15 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "sourceforge": "mpv-player-windows/release",
-        "regex": "mpv-([\\d.]+)-"
+        "github": "https://github.com/mpv-player/mpv"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-$version-x86_64.7z"
-            },
-            "32bit": {
-                "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-$version-i686.7z"
+                "url": "https://github.com/mpv-player/mpv/releases/download/v$version/mpv-v$version-x86_64-pc-windows-msvc.zip"
             },
             "arm64": {
-                "url": "https://downloads.sourceforge.net/project/mpv-player-windows/release/mpv-$version-aarch64.7z"
+                "url": "https://github.com/mpv-player/mpv/releases/download/v$version/mpv-v$version-aarch64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
# Summary
Replaces the third-party shinchiro builds (which have been having reliability issues recently) with first-party binaries for stable releases and zhongfly for git latest binaries.
Note that, since upstream does not provide 32bit builds, support has been effectively dropped.
Description has also been updated to match the current iteration of the mpv homepage.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
