### PR TITLE
office-tool-plus@11.5.7.0: Switch to framework-dependent version

### DIFF
--- a/bucket/office-tool-plus.json
+++ b/bucket/office-tool-plus.json
@@ -30,10 +30,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_with_runtime_v$version_x64.7z"
+                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_v$version_x64.zip"
             },
             "arm64": {
-                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_with_runtime_v$version_arm64.7z"
+                "url": "https://github.com/YerongAI/Office-Tool/releases/download/v$version/Office_Tool_v$version_arm64.zip"
             }
         }
     }

--- a/bucket/office-tool-plus.json
+++ b/bucket/office-tool-plus.json
@@ -3,13 +3,16 @@
     "description": "A powerful and useful tool for Office deployments",
     "homepage": "https://www.officetool.plus",
     "license": "GPL-3.0-or-later",
+    "suggest": {
+        ".NET Desktop Runtime 10.0": "versions/windowsdesktop-runtime-10.0"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.5.7.0/Office_Tool_with_runtime_v11.5.7.0_x64.7z",
+            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.5.7.0/Office_Tool_v11.5.7.0_x64.zip",
             "hash": "0ea722c9a646006cfe645ae464f3f9a052110d5f444a0e1166996c2fef791a85"
         },
         "arm64": {
-            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.5.7.0/Office_Tool_with_runtime_v11.5.7.0_arm64.7z",
+            "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.5.7.0/Office_Tool_v11.5.7.0_arm64.zip",
             "hash": "457f41128110509c474b81bd464d4db9c6a14d580f84779a0cb2c178a41df969"
         }
     },

--- a/bucket/office-tool-plus.json
+++ b/bucket/office-tool-plus.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.5.7.0/Office_Tool_v11.5.7.0_x64.zip",
-            "hash": "0ea722c9a646006cfe645ae464f3f9a052110d5f444a0e1166996c2fef791a85"
+            "hash": "cb0fd9db95d0ffd73c642eb29ac24964e51dc651ac3762ae56f2521bad8480d8"
         },
         "arm64": {
             "url": "https://github.com/YerongAI/Office-Tool/releases/download/v11.5.7.0/Office_Tool_v11.5.7.0_arm64.zip",
-            "hash": "457f41128110509c474b81bd464d4db9c6a14d580f84779a0cb2c178a41df969"
+            "hash": "65e6184857edb01365cd42b64f134cc71e29195286ccd615d79d45d99cc34a30"
         }
     },
     "extract_dir": "Office Tool",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Switch `office-tool-plus` to the package variant that does not bundle the .NET Windows Desktop Runtime, and add `versions/windowsdesktop-runtime-10.0` as a suggested runtime package, as this reuses runtime and aligns with the philosophy of other manifests in scoop.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #18172

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
