### PR TITLE
shutter-encoder@20.2: Fix `extract_dir`, fix persistence

### DIFF
--- a/bucket/shutter-encoder.json
+++ b/bucket/shutter-encoder.json
@@ -1,19 +1,26 @@
 {
     "version": "20.2",
-    "description": "Multimedia file converter",
+    "description": "A professional video compression tool accessible to all, mostly based on FFmpeg.",
     "homepage": "https://www.shutterencoder.com/",
-    "license": "GPL-3.0-or-later",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/paulpacifico/shutter-encoder/blob/master/LICENSE.txt"
+    },
     "architecture": {
         "64bit": {
             "url": "https://www.shutterencoder.com/Shutter%20Encoder%2020.2%20Windows%2064bits.zip",
-            "hash": "8a2e2d53e6ae461f116cbe85236487534c1b9e6bd9aeb784d4672aa4c30a08b8",
-            "extract_dir": "Shutter Encoder 20.2 Windows 64bits"
+            "hash": "8a2e2d53e6ae461f116cbe85236487534c1b9e6bd9aeb784d4672aa4c30a08b8"
         }
     },
+    "extract_dir": "Shutter Encoder",
     "shortcuts": [
         [
             "Shutter Encoder.exe",
             "Shutter Encoder"
+        ],
+        [
+            "Shutter Encoder (OpenGL).exe",
+            "Shutter Encoder (OpenGL)"
         ]
     ],
     "persist": "settings.xml",
@@ -24,8 +31,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.shutterencoder.com/Shutter%20Encoder%20$version%20Windows%2064bits.zip",
-                "extract_dir": "Shutter Encoder $version Windows 64bits"
+                "url": "https://www.shutterencoder.com/Shutter%20Encoder%20$version%20Windows%2064bits.zip"
             }
         }
     }

--- a/bucket/shutter-encoder.json
+++ b/bucket/shutter-encoder.json
@@ -13,6 +13,11 @@
         }
     },
     "extract_dir": "Shutter Encoder",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\settings.xml\")) {",
+        "   New-Item -Path \"$dir\\settings.xml\" -ItemType File | Out-Null",
+        "}"
+    ],
     "shortcuts": [
         [
             "Shutter Encoder.exe",
@@ -22,11 +27,6 @@
             "Shutter Encoder (OpenGL).exe",
             "Shutter Encoder (OpenGL)"
         ]
-    ],
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\settings.xml\")) {",
-        "   New-Item -Path \"$dir\\settings.xml\" -ItemType File | Out-Null",
-        "}"
     ],
     "persist": "settings.xml",
     "checkver": {

--- a/bucket/shutter-encoder.json
+++ b/bucket/shutter-encoder.json
@@ -23,6 +23,11 @@
             "Shutter Encoder (OpenGL)"
         ]
     ],
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\settings.xml\")) {",
+        "   New-Item -Path \"$dir\\settings.xml\" -ItemType File | Out-Null",
+        "}"
+    ],
     "persist": "settings.xml",
     "checkver": {
         "url": "https://www.shutterencoder.com/en/",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

For clarification: OpenGL was an option in previous versions as well, but it used a VBScript and not a PE, which wasn't optimal [for obvious reasons](<https://techcommunity.microsoft.com/blog/windows-itpro-blog/vbscript-deprecation-timelines-and-next-steps/4148301>).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #18178
<!--or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
