### PR TITLE
github-copilot: Add version 1.0.11

### DIFF
--- a/bucket/github-copilot.json
+++ b/bucket/github-copilot.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/github/app",
     "license": {
         "identifier": "Proprietary",
-        "url": "https://github.com/github/app"
+        "url": "https://github.com/github/app/blob/main/License.md"
     },
     "notes": "Requires an active GitHub Copilot subscription (Pro, Pro+, Business, or Enterprise) and Git installed.",
     "architecture": {
@@ -17,9 +17,10 @@
             "hash": "fbba1e7d8e3120da752d568af0d7d0d1a0615b67ad948373751d44ee6ff09abb"
         }
     },
+    "extract_dir": "PFiles\\GitHub Copilot",
     "shortcuts": [
         [
-            "PFiles\\GitHub Copilot\\github.exe",
+            "github.exe",
             "GitHub Copilot"
         ]
     ],

--- a/bucket/github-copilot.json
+++ b/bucket/github-copilot.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "GitHub Copilot, an agent-native desktop development environment.",
     "homepage": "https://github.com/github/app",
     "license": {
@@ -9,12 +9,12 @@
     "notes": "Requires an active GitHub Copilot subscription (Pro, Pro+, Business, or Enterprise) and Git installed.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/github/app/releases/download/v1.0.10/GitHub-Copilot-windows-x64.msi",
-            "hash": "8c12433987eea3868cf976aeb38ce5cc4953940ee9854730fb27b3617918b4c5"
+            "url": "https://github.com/github/app/releases/download/v1.0.11/GitHub-Copilot-windows-x64.msi",
+            "hash": "3effbe3c36f265c0244aba8bc7d4bfd68150ca16cfd2bd8692c5afe4480c31cc"
         },
         "arm64": {
-            "url": "https://github.com/github/app/releases/download/v1.0.10/GitHub-Copilot-windows-arm64.msi",
-            "hash": "fbba1e7d8e3120da752d568af0d7d0d1a0615b67ad948373751d44ee6ff09abb"
+            "url": "https://github.com/github/app/releases/download/v1.0.11/GitHub-Copilot-windows-arm64.msi",
+            "hash": "e280e18e98b98f6aa43a77244f8c7c9feb89bdaf09c79c1700a507bd4d44215c"
         }
     },
     "extract_dir": "PFiles\\GitHub Copilot",

--- a/bucket/github-copilot.json
+++ b/bucket/github-copilot.json
@@ -1,12 +1,20 @@
 {
     "version": "1.0.10",
-    "description": "GitHub Copilot desktop app - agent-native development environment",
+    "description": "GitHub Copilot, an agent-native desktop development environment.",
     "homepage": "https://github.com/github/app",
-    "license": "Proprietary",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://github.com/github/app"
+    },
+    "notes": "Requires an active GitHub Copilot subscription (Pro, Pro+, Business, or Enterprise) and Git installed.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/github/app/releases/download/v1.0.10/GitHub-Copilot-windows-x64.msi",
             "hash": "8c12433987eea3868cf976aeb38ce5cc4953940ee9854730fb27b3617918b4c5"
+        },
+        "arm64": {
+            "url": "https://github.com/github/app/releases/download/v1.0.10/GitHub-Copilot-windows-arm64.msi",
+            "hash": "fbba1e7d8e3120da752d568af0d7d0d1a0615b67ad948373751d44ee6ff09abb"
         }
     },
     "shortcuts": [
@@ -15,13 +23,14 @@
             "GitHub Copilot"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/github/app"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/github/app/releases/download/v$version/GitHub-Copilot-windows-x64.msi"
+            },
+            "arm64": {
+                "url": "https://github.com/github/app/releases/download/v$version/GitHub-Copilot-windows-arm64.msi"
             }
         }
     }

--- a/bucket/github-copilot.json
+++ b/bucket/github-copilot.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.0.10",
+    "description": "GitHub Copilot desktop app - agent-native development environment",
+    "homepage": "https://github.com/github/app",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/github/app/releases/download/v1.0.10/GitHub-Copilot-windows-x64.msi",
+            "hash": "8c12433987eea3868cf976aeb38ce5cc4953940ee9854730fb27b3617918b4c5"
+        }
+    },
+    "shortcuts": [
+        [
+            "PFiles\\GitHub Copilot\\github.exe",
+            "GitHub Copilot"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/github/app"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/github/app/releases/download/v$version/GitHub-Copilot-windows-x64.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for the GitHub Copilot desktop app (https://github.com/github/app), the agent-native development environment, now GA for Windows.

- 64-bit MSI installer from official github/app releases
- checkver + autoupdate configured against GitHub releases
- shortcut for the GitHub Copilot app

Relates to GUI app -> Extras bucket

- [x] Use conventional PR title
- [x] I have read the Contributing Guide



Closes #18181
