### PR TITLE
uniclipboard: Add version 0.19.1

### DIFF
--- a/bucket/uniclipboard.json
+++ b/bucket/uniclipboard.json
@@ -1,0 +1,41 @@
+{
+    "version": "0.16.0",
+    "description": "Encrypted peer-to-peer clipboard sync between your devices",
+    "homepage": "https://uniclipboard.app",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.16.0/UniClipboard_0.16.0_x64-portable.zip",
+            "hash": "5a87576265caa1b7541344e76253b889ee166a09326bd154711c5af8716e954c"
+        },
+        "arm64": {
+            "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.16.0/UniClipboard_0.16.0_arm64-portable.zip",
+            "hash": "7715861bff5ab8f63dc0759f481748d46f8898f2c576c2684d87c2200390d359"
+        }
+    },
+    "bin": "UniClipboard.exe",
+    "shortcuts": [
+        [
+            "UniClipboard.exe",
+            "UniClipboard"
+        ]
+    ],
+    "persist": "data",
+    "notes": [
+        "UniClipboard runs in portable mode here: your encrypted data lives in the persisted 'data' folder next to the executable and is kept across updates.",
+        "Requires the Microsoft Edge WebView2 Runtime (preinstalled on current Windows 10/11)."
+    ],
+    "checkver": {
+        "github": "https://github.com/UniClipboard/UniClipboard"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v$version/UniClipboard_$version_x64-portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v$version/UniClipboard_$version_arm64-portable.zip"
+            }
+        }
+    }
+}

--- a/bucket/uniclipboard.json
+++ b/bucket/uniclipboard.json
@@ -3,10 +3,7 @@
     "description": "Encrypted peer-to-peer clipboard sync between your devices",
     "homepage": "https://uniclipboard.app",
     "license": "AGPL-3.0-only",
-    "notes": [
-        "UniClipboard runs in portable mode here: your encrypted data lives in the persisted `data` folder next to the executable and is kept across updates.",
-        "Requires the Microsoft Edge WebView2 Runtime (pre-installed on current Windows 10/11)."
-    ],
+    "notes": "UniClipboard runs in portable mode here: your encrypted data lives in the persisted `data` folder next to the executable and is kept across updates.",
     "suggest": {
         "Microsoft Edge WebView2": "extras/webview2"
     },

--- a/bucket/uniclipboard.json
+++ b/bucket/uniclipboard.json
@@ -1,16 +1,23 @@
 {
-    "version": "0.16.0",
+    "version": "0.19.1",
     "description": "Encrypted peer-to-peer clipboard sync between your devices",
     "homepage": "https://uniclipboard.app",
     "license": "AGPL-3.0-only",
+    "notes": [
+        "UniClipboard runs in portable mode here: your encrypted data lives in the persisted `data` folder next to the executable and is kept across updates.",
+        "Requires the Microsoft Edge WebView2 Runtime (pre-installed on current Windows 10/11)."
+    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.16.0/UniClipboard_0.16.0_x64-portable.zip",
-            "hash": "5a87576265caa1b7541344e76253b889ee166a09326bd154711c5af8716e954c"
+            "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.19.1/UniClipboard_0.19.1_x64-portable.zip",
+            "hash": "283108b517f3dcfe96d0e6f97fc0ec0bcd36214cf2d3a92e010afc958e4dd107"
         },
         "arm64": {
-            "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.16.0/UniClipboard_0.16.0_arm64-portable.zip",
-            "hash": "7715861bff5ab8f63dc0759f481748d46f8898f2c576c2684d87c2200390d359"
+            "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.19.1/UniClipboard_0.19.1_arm64-portable.zip",
+            "hash": "195326304afc30f6f4a0b9b8dd6b0489c95f40d1772a5b10c5032e38e9b3e5f7"
         }
     },
     "bin": "UniClipboard.exe",
@@ -21,10 +28,6 @@
         ]
     ],
     "persist": "data",
-    "notes": [
-        "UniClipboard runs in portable mode here: your encrypted data lives in the persisted 'data' folder next to the executable and is kept across updates.",
-        "Requires the Microsoft Edge WebView2 Runtime (preinstalled on current Windows 10/11)."
-    ],
     "checkver": {
         "github": "https://github.com/UniClipboard/UniClipboard"
     },
@@ -36,6 +39,9 @@
             "arm64": {
                 "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v$version/UniClipboard_$version_arm64-portable.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS.txt"
         }
     }
 }


### PR DESCRIPTION
Closes #18182

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Adds UniClipboard to the Extras bucket.

Validation completed so far:
- Confirmed no existing `bucket/uniclipboard.json` in ScoopInstaller/Extras.
- Confirmed v0.16.0 is the latest stable UniClipboard release.
- Confirmed both portable ZIP URLs are reachable.
- Downloaded both portable ZIPs and verified their SHA256 hashes.
- Confirmed `bucket/uniclipboard.json` is valid JSON.

Still to complete before marking ready for review:
- Windows local Scoop install/uninstall verification.