### PR TITLE
ts-release: Add version 0.0.7

### DIFF
--- a/bucket/ts-release.json
+++ b/bucket/ts-release.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.0.7",
+    "description": "Portable artifact and package-manager distribution planning for TypeScript projects.",
+    "homepage": "https://github.com/mannyc2/ts-release",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mannyc2/ts-release/releases/download/v0.0.7/ts-release-0.0.7-windows-x64.exe#/ts-release.exe",
+            "hash": "f9ae1b944f852312cc5bfca4ed6bac1388045ab13dd9065dbff69864501d51a7"
+        }
+    },
+    "bin": "ts-release.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mannyc2/ts-release/releases/download/v$version/ts-release-$version-windows-x64.exe#/ts-release.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ts-release`, a CLI for portable artifact and package-manager distribution planning for TypeScript projects.

The manifest installs the published Windows x64 binary from the upstream GitHub Release and shims it as `ts-release`.

Closes #18185

## Eligibility note

The package request is intentionally transparent that `ts-release` is newly published and does not currently meet the stated popularity threshold. If the popularity criterion is applied strictly, closing or deferring this PR is understandable.

## Validation

- Parsed `bucket/ts-release.json` with `python3 -m json.tool`
- Confirmed `bucket/ts-release.json` uses CRLF line endings, matching existing bucket manifests
- Downloaded the `v0.0.7` Windows asset and verified the SHA256 hash matches the manifest

I could not run the full Scoop/Pester bucket test locally because this Linux environment does not have PowerShell/Scoop installed, so I expect the upstream Windows CI to provide the full install validation if maintainers decide the package request is eligible.