### PR TITLE
openwhispr: Add version 1.7.4

### DIFF
--- a/bucket/openwhispr.json
+++ b/bucket/openwhispr.json
@@ -3,10 +3,10 @@
     "description": "Voice-to-text dictation app with local and cloud models",
     "homepage": "https://openwhispr.com",
     "license": "MIT",
-    "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe#/dl.7z",
-    "hash": "256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55",
     "architecture": {
         "64bit": {
+            "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe#/dl.7z",
+            "hash": "256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55",
             "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
         }
     },
@@ -21,6 +21,10 @@
         "github": "https://github.com/OpenWhispr/openwhispr"
     },
     "autoupdate": {
-        "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v$version/OpenWhispr-Setup-$version.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v$version/OpenWhispr-Setup-$version.exe#/dl.7z"
+            }
+        }
     }
 }

--- a/bucket/openwhispr.json
+++ b/bucket/openwhispr.json
@@ -10,7 +10,7 @@
             "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse -Force",
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse -Force",
     "shortcuts": [
         [
             "OpenWhispr.exe",

--- a/bucket/openwhispr.json
+++ b/bucket/openwhispr.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.7.3",
+    "version": "1.7.4",
     "description": "Voice-to-text dictation app with local and cloud models",
     "homepage": "https://openwhispr.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe#/dl.7z",
-            "hash": "256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55",
+            "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.4/OpenWhispr-Setup-1.7.4.exe#/dl.7z",
+            "hash": "sha512:15e070fb6044792ef38ada64ec03bab74507f3a4385ba4d69cca4819999e7d09fb47ce1a2c68ba1c2fb5d198a2e6cb4c4dcd778ef5f90c56afb997398ed1b2eb",
             "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
         }
     },
@@ -25,6 +25,10 @@
             "64bit": {
                 "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v$version/OpenWhispr-Setup-$version.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "regex": "(?sm)$basename.*?sha512:\\s+$base64"
         }
     }
 }

--- a/bucket/openwhispr.json
+++ b/bucket/openwhispr.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.7.3",
+    "description": "Voice-to-text dictation app with local and cloud models",
+    "homepage": "https://openwhispr.com",
+    "license": "MIT",
+    "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v1.7.3/OpenWhispr-Setup-1.7.3.exe#/dl.7z",
+    "hash": "256a49099fc6f8ed2b81c7898f8dac704ee7190ccca76cc351508cafcd0a3f55",
+    "architecture": {
+        "64bit": {
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse -Force",
+    "shortcuts": [
+        [
+            "OpenWhispr.exe",
+            "OpenWhispr"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/OpenWhispr/openwhispr"
+    },
+    "autoupdate": {
+        "url": "https://github.com/OpenWhispr/openwhispr/releases/download/v$version/OpenWhispr-Setup-$version.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
Add [OpenWhispr](https://openwhispr.com) v1.7.3 — voice-to-text dictation app with local/cloud models, privacy-first, MIT license.

Closes #18189

- **Homepage:** https://openwhispr.com
- **License:** MIT
- **64-bit only:** NSIS installer via electron-builder