### PR TITLE
foobar2000(-encoders): Fix capitalization and casing

### DIFF
--- a/bucket/foobar2000-encoders.json
+++ b/bucket/foobar2000-encoders.json
@@ -15,18 +15,18 @@
     "installer": {
         "script": [
             "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
-            "$FoobarDir = $(appdir foobar2000 $global)",
-            "if (Test-Path \"$FoobarDir\") {",
-            "    Get-ChildItem -Path \"$FoobarDir\\current\" -Filter \"encoders\" | Remove-Item -Force -Recurse",
-            "    New-Item \"$FoobarDir\\current\\encoders\" -ItemType Junction -Target \"$dir\" | Out-Null",
+            "$foobarDir = $(appdir foobar2000 $global)",
+            "if (Test-Path \"$foobarDir\") {",
+            "    Get-ChildItem -Path \"$foobarDir\\current\" -Filter \"encoders\" | Remove-Item -Force -Recurse",
+            "    New-Item \"$foobarDir\\current\\encoders\" -ItemType Junction -Target \"$dir\" | Out-Null",
             "}"
         ]
     },
     "uninstaller": {
         "script": [
-            "$FoobarDir = $(appdir foobar2000 $global)",
-            "if (Test-Path \"$FoobarDir\") {",
-            "    Get-ChildItem -Path \"$FoobarDir\\current\" -Filter \"encoders\" | Remove-Item -Force -Recurse",
+            "$foobarDir = $(appdir foobar2000 $global)",
+            "if (Test-Path \"$foobarDir\") {",
+            "    Get-ChildItem -Path \"$foobarDir\\current\" -Filter \"encoders\" | Remove-Item -Force -Recurse",
             "}"
         ]
     },

--- a/bucket/foobar2000-encoders.json
+++ b/bucket/foobar2000-encoders.json
@@ -7,7 +7,7 @@
         "url": "https://www.foobar2000.org/license"
     },
     "suggest": {
-        "Foobar2000": "extras/foobar2000"
+        "foobar2000": "extras/foobar2000"
     },
     "notes": "The binaries are conveniently installed into a subfolder of the foobar2000 installation folder. Current versions of foobar2000 will automatically recognize these encoders and no longer ask you for encoder binary location.",
     "url": "https://www.foobar2000.org/files/Free_Encoder_Pack-2026-03-13.exe#/dl.7z",

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -46,7 +46,7 @@
     "shortcuts": [
         [
             "foobar2000.exe",
-            "Foobar2000"
+            "foobar2000"
         ]
     ],
     "persist": "profile",


### PR DESCRIPTION
`foobar2000`:
- Changed the shortcut capitalization from `Foobar2000` to `foobar2000` to match the official stylization (https://www.foobar2000.org/).

`foobar2000-encoders`:
- Changed capitalization of the suggested `foobar2000` app from `Foobar2000` to `foobar2000` to match the actual capitalization of the manifest.
- Changed the casing on local variables from PascalCase to camelCase to conform to both Scoop and PowerShell standards.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
