### PR TITLE
virtualhere-server@4.8.7: Fix download URL, add arm64 support

### DIFF
--- a/bucket/virtualhere-server.json
+++ b/bucket/virtualhere-server.json
@@ -8,14 +8,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwin64.exe",
-            "hash": "c37c7b30a334ba83c67072381b31661a9bae0baa33ba1f4aa3fa6de06cf04756"
+            "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinw64.exe",
+            "hash": "d8b6b034d5ebb37de5f7401ea319db9ec9d011ec9ebea79bcdf8c804ee8c27d3"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item \"$dir\\config.ini\" | Out-Null }",
     "shortcuts": [
         [
-            "vhusbdwin64.exe",
+            "vhusbdwinw64.exe",
             "VirtualHere USB Server"
         ]
     ],
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwin64.exe"
+                "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinw64.exe"
             }
         }
     }

--- a/bucket/virtualhere-server.json
+++ b/bucket/virtualhere-server.json
@@ -4,18 +4,22 @@
     "homepage": "https://www.virtualhere.com/windows_server_software",
     "license": {
         "identifier": "Proprietary",
-        "url": "https://www.virtualhere.com/client_license"
+        "url": "https://www.virtualhere.com/windows_server_license"
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinw64.exe",
-            "hash": "d8b6b034d5ebb37de5f7401ea319db9ec9d011ec9ebea79bcdf8c804ee8c27d3"
+            "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinw64.exe#/vhusbdwin.exe",
+            "hash": "sha1:ec251c4ac296441e6b56d994b75b91aa8aa2c143"
+        },
+        "arm64": {
+            "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinarmw64.exe#/vhusbdwin.exe",
+            "hash": "sha1:5e45c125ff5d73415eb26441b318b3daf1e57651"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\config.ini\")) { New-Item \"$dir\\config.ini\" | Out-Null }",
     "shortcuts": [
         [
-            "vhusbdwinw64.exe",
+            "vhusbdwin.exe",
             "VirtualHere USB Server"
         ]
     ],
@@ -24,8 +28,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinw64.exe"
+                "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinw64.exe#/vhusbdwin.exe"
+            },
+            "arm64": {
+                "url": "https://www.virtualhere.com/sites/default/files/usbserver/vhusbdwinarmw64.exe#/vhusbdwin.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA1SUM",
+            "regex": "$sha1\\s+$basename"
         }
     }
 }


### PR DESCRIPTION
The upstream file at the URL specified in this manifest was renamed from `vhusbdwin64.exe` to `vhusbdwinw64.exe` (an extra 'w' before 64). The current URL returns HTTP 404, breaking `scoop install virtualhere-server`.

Closes #18204

## Verification

- Old URL (`vhusbdwin64.exe`): HTTP 404
- New URL (`vhusbdwinw64.exe`): HTTP 200, file is a valid PE32+ Windows executable (3,378,096 bytes)
- New SHA256: `d8b6b034d5ebb37de5f7401ea319db9ec9d011ec9ebea79bcdf8c804ee8c27d3`

## Changes

- Update `url` in `architecture.64bit` and `autoupdate.architecture.64bit` (extra 'w' before 64)
- Update `shortcuts[0][0]` to match the new filename
- Refresh `hash` with SHA256 of the new file