### PR TITLE
rssguard: Update to version 5.2.1, switch to webviewer variant

### DIFF
--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -1,8 +1,15 @@
 {
     "version": "5.2.1",
-    "description": "A simple, light and easy-to-use RSS/ATOM feed aggregator",
+    "description": "A simple, light and easy-to-use RSS/ATOM feed aggregator (WebEngine-based viewer variant).",
     "homepage": "https://github.com/martinrotter/rssguard",
     "license": "GPL-3.0-only",
+    "notes": [
+        "As of version 5.1.0, RSSGuard offers a text-based viewer variant and a WebEngine-based variant.",
+        "This package provides the WebEngine-based viewer variant.",
+        "For more information, please refer to:",
+        "- https://github.com/martinrotter/rssguard/releases/tag/5.1.0",
+        "- https://rssguard.readthedocs.io/en/latest/features/article-display.html"
+    ],
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },

--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0.4",
+    "version": "5.2.1",
     "description": "A simple, light and easy-to-use RSS/ATOM feed aggregator",
     "homepage": "https://github.com/martinrotter/rssguard",
     "license": "GPL-3.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/martinrotter/rssguard/releases/download/5.0.4/rssguard-5.0.4-qt6-win10.7z",
-            "hash": "a8ebba9a72587392057c62195e523e7c165e7d84f379136d170223855f67c4b7"
+            "url": "https://github.com/martinrotter/rssguard/releases/download/5.2.1/rssguard-5.2.1-web-qt6-win10.7z",
+            "hash": "1e549474e0c486ca646b65cf7b55ad422354ce9ca84595752d2b0fcf89bae662"
         }
     },
     "pre_install": "Remove-Item \"$dir\\vc_redis*\"",
@@ -20,15 +20,11 @@
         ]
     ],
     "persist": "data5",
-    "checkver": {
-        "github": "https://api.github.com/repos/martinrotter/rssguard/releases/latest",
-        "jsonpath": "$.assets[?(@.name =~ /^rssguard-([\\d.]+)-([\\w]+)-win10.7z$/)].name",
-        "regex": "rssguard-(?<version>([\\d.]+))-(?<commit>[\\w]+)-win10.7z"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/martinrotter/rssguard/releases/download/$version/rssguard-$version-$matchCommit-win10.7z"
+                "url": "https://github.com/martinrotter/rssguard/releases/download/$version/rssguard-$version-web-qt6-win10.7z"
             }
         }
     }

--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -20,11 +20,15 @@
         ]
     ],
     "persist": "data5",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://api.github.com/repos/martinrotter/rssguard/releases",
+        "jsonpath": "$[*].assets[?(@.name =~ /^rssguard-([\\d.]+)-web-(qt\\d+)-win10\\.7z$/)].name",
+        "regex": "rssguard-(?<version>([\\d.]+))-web-(?<qt>qt\\d+)-win10\\.7z"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/martinrotter/rssguard/releases/download/$version/rssguard-$version-web-qt6-win10.7z"
+                "url": "https://github.com/martinrotter/rssguard/releases/download/$version/rssguard-$version-web-$matchQt-win10.7z"
             }
         }
     }

--- a/bucket/rssguard.json
+++ b/bucket/rssguard.json
@@ -22,7 +22,7 @@
     "persist": "data5",
     "checkver": {
         "github": "https://api.github.com/repos/martinrotter/rssguard/releases",
-        "jsonpath": "$[*].assets[?(@.name =~ /^rssguard-([\\d.]+)-web-(qt\\d+)-win10\\.7z$/)].name",
+        "jsonpath": "$[*].assets[*].name",
         "regex": "rssguard-(?<version>([\\d.]+))-web-(?<qt>qt\\d+)-win10\\.7z"
     },
     "autoupdate": {


### PR DESCRIPTION
Closes #18210 

https://rssguard.readthedocs.io/en/latest/features/article-display.html

Note that rssguard has been updated from 5.0.4 -> 5.2.1. Since version [5.1.0](https://github.com/martinrotter/rssguard/releases/tag/5.1.0), functionality has been split in two:
> Downloads are now split into `TextBrowserViewer` and `WebEngineViewer` variants

I only fixed the manifest, and don't know which of those should be in this manifest. I went with `web` for now, but asking the issuer if my guess is right. The alternative has an url ending with `rssguard-$version-text-qt6-win10.7z`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
