### PR TITLE
selectandtranslate: Add version 1.0.0

### DIFF
--- a/bucket/selectandtranslate.json
+++ b/bucket/selectandtranslate.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.0",
+    "description": "Free Windows tool for system-wide text translation, screenshot OCR translation, and AI vocabulary building (GPT-4o). No account required, data stored locally.",
+    "homepage": "https://selectandtranslate.z7.web.core.windows.net/",
+    "license": "Freeware",
+    "url": "https://selectandtranslate.blob.core.windows.net/downloads/SelectAndTranslate_Setup_v1.0.0.exe#/dl.exe",
+    "hash": "534c4593ff791a9194e0f759064b57591f5641d2d9577889fc7acec6b4436c85",
+    "innosetup": true,
+    "bin": "SelectAndTranslate.exe",
+    "shortcuts": [
+        [
+            "SelectAndTranslate.exe",
+            "SelectAndTranslate"
+        ]
+    ],
+    "checkver": {
+        "url": "https://selectandtranslate.z7.web.core.windows.net/",
+        "regex": "SelectAndTranslate_Setup_v([\\d.]+)\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://selectandtranslate.blob.core.windows.net/downloads/SelectAndTranslate_Setup_v$version.exe#/dl.exe"
+    }
+}


### PR DESCRIPTION
SelectAndTranslate: Add version 1.0.0

Adds a manifest for **SelectAndTranslate**, a free (Freeware) Windows 10+ desktop translation tool: system-wide select-to-translate (GPT-4o), screenshot OCR translation, and AI vocabulary building. No account required; data stored locally.

- Homepage: https://selectandtranslate.z7.web.core.windows.net/
- Installer: Inno Setup (`innosetup: true`), x64, hosted on Azure Blob
- SHA256 verified against the live download (51.7 MB).
- Already published on winget as `YanaYuan.SelectAndTranslate`.

### I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

- [x] I have read the wiki and understand how to contribute a manifest.
- [x] The manifest installs and the hash matches the download.

> Note: `bin`/`shortcuts` reference `SelectAndTranslate.exe` (standard Inno Setup convention for this app). Happy to adjust the executable name if a reviewer finds it differs.