### PR TITLE
parabolic: Update version to 2026.5.0 

### DIFF
--- a/bucket/parabolic.json
+++ b/bucket/parabolic.json
@@ -11,7 +11,7 @@
     },
     "shortcuts": [
         [
-            "org.nickvision.tubeconverter.qt.exe",
+            "org.nickvision.tubeconverter.winui.exe",
             "Parabolic"
         ]
     ],

--- a/bucket/parabolic.json
+++ b/bucket/parabolic.json
@@ -4,10 +4,6 @@
     "homepage": "https://github.com/NickvisionApps/Parabolic",
     "license": "GPL-3.0",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/NickvisionApps/Parabolic/releases/download/2025.1.4/NickvisionParabolic_V2025.1.4_Windows.zip",
-            "hash": "94c644159d23c222a9b2ca9eb11f95f0655fd6b3a026129a3df8d9286a8733c0"
-        },
         "64bit": {
             "url": "https://github.com/NickvisionApps/Parabolic/releases/download/2025.1.4/NickvisionParabolic_V2025.1.4_Windows.zip",
             "hash": "94c644159d23c222a9b2ca9eb11f95f0655fd6b3a026129a3df8d9286a8733c0"
@@ -22,9 +18,6 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/NickvisionApps/Parabolic/releases/download/$version/NickvisionParabolic_V$version_Windows.zip"
-            },
             "64bit": {
                 "url": "https://github.com/NickvisionApps/Parabolic/releases/download/$version/NickvisionParabolic_V$version_Windows.zip"
             }

--- a/bucket/parabolic.json
+++ b/bucket/parabolic.json
@@ -1,0 +1,33 @@
+{
+    "version": "2025.1.4",
+    "description": "A basic yt-dlp frontend. Supports downloading videos in multiple formats (mp4, webm, mp3, opus, flac, and wav)",
+    "homepage": "https://github.com/NickvisionApps/Parabolic",
+    "license": "GPL-3.0",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/NickvisionApps/Parabolic/releases/download/2025.1.4/NickvisionParabolic_V2025.1.4_Windows.zip",
+            "hash": "94c644159d23c222a9b2ca9eb11f95f0655fd6b3a026129a3df8d9286a8733c0"
+        },
+        "64bit": {
+            "url": "https://github.com/NickvisionApps/Parabolic/releases/download/2025.1.4/NickvisionParabolic_V2025.1.4_Windows.zip",
+            "hash": "94c644159d23c222a9b2ca9eb11f95f0655fd6b3a026129a3df8d9286a8733c0"
+        }
+    },
+    "shortcuts": [
+        [
+            "org.nickvision.tubeconverter.qt.exe",
+            "Parabolic"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/NickvisionApps/Parabolic/releases/download/$version/NickvisionParabolic_V$version_Windows.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/NickvisionApps/Parabolic/releases/download/$version/NickvisionParabolic_V$version_Windows.zip"
+            }
+        }
+    }
+}

--- a/bucket/parabolic.json
+++ b/bucket/parabolic.json
@@ -1,25 +1,29 @@
 {
-    "version": "2025.1.4",
-    "description": "A basic yt-dlp frontend. Supports downloading videos in multiple formats (mp4, webm, mp3, opus, flac, and wav)",
-    "homepage": "https://github.com/NickvisionApps/Parabolic",
-    "license": "GPL-3.0",
+    "version": "2026.5.0",
+    "description": "A powerful yt-dlp frontend.",
+    "homepage": "https://flathub.org/en/apps/org.nickvision.tubeconverter",
+    "license": "MIT|Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/NickvisionApps/Parabolic/releases/download/2025.1.4/NickvisionParabolic_V2025.1.4_Windows.zip",
-            "hash": "94c644159d23c222a9b2ca9eb11f95f0655fd6b3a026129a3df8d9286a8733c0"
+            "url": "https://github.com/NickvisionApps/Parabolic/releases/download/2026.5.0/NickvisionParabolicPortable.zip",
+            "hash": "d6c25b4968a35209b225e5342ea147eeca8091247a99bbb6d6011c64839ecf97"
         }
     },
+    "extract_dir": "Release",
     "shortcuts": [
         [
-            "org.nickvision.tubeconverter.winui.exe",
-            "Parabolic"
+            "Nickvision.Parabolic.WinUI.exe",
+            "Parabolic",
+            "--portable"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/NickvisionApps/Parabolic"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/NickvisionApps/Parabolic/releases/download/$version/NickvisionParabolic_V$version_Windows.zip"
+                "url": "https://github.com/NickvisionApps/Parabolic/releases/download/$version/NickvisionParabolicPortable.zip"
             }
         }
     }


### PR DESCRIPTION
I wanted to try to fix the [parabolic: Add version 2025.1.4](https://github.com/ScoopInstaller/Extras/pull/15267) manifest on Github Web, but instead I created a new PR🤔.

Closes #15242 
Release to https://github.com/ScoopInstaller/Extras/pull/15267

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->