### PR TITLE
filecast: Add version 1.0.0

### DIFF
--- a/bucket/filecast.json
+++ b/bucket/filecast.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.0",
+    "description": "Send a file to every machine on your LAN at once over UDP broadcast/multicast",
+    "homepage": "https://github.com/gistrec/filecast",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gistrec/filecast/releases/download/v1.0.0/filecast-windows-x86_64.exe#/filecast.exe",
+            "hash": "d084600ec4e8410fa99ba5b9a39df837214456b1a62827c8f4135d0eb0114f19"
+        }
+    },
+    "bin": "filecast.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gistrec/filecast/releases/download/v$version/filecast-windows-x86_64.exe#/filecast.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [filecast](https://github.com/gistrec/filecast) — a cross-platform CLI that sends a single file to every host on the same LAN at once over UDP broadcast or IP multicast, with automatic retransmission of dropped packets, end-to-end SHA-256 verification, and resumable receives (MIT). Single portable `.exe`, shimmed as `filecast`; `checkver: github` + `autoupdate`; hash matches the release `checksums.txt`.

I searched Extras' issues and PRs and found no existing filecast package request or manifest.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

**Acceptability disclosure (re: CodeRabbit's `not-meet-criteria` flag):** I did **not** open a Package Request issue, because the request template's first required criterion is "at least 100 stars and/or 50 forks," and filecast is currently at **58 stars / 1 fork** — below that bar. I'm leaving this PR up for maintainer discretion rather than affirming a criterion it doesn't yet meet: hold until it crosses the threshold, or close and I'll resubmit with a proper Package Request issue once it does. The manifest itself is complete and correct if you'd prefer to keep it queued.