### PR TITLE
snipe: Add version 140.0.7339.127

### DIFF
--- a/bucket/snipe.json
+++ b/bucket/snipe.json
@@ -1,0 +1,35 @@
+{
+    "version": "140.0.7339.127",
+    "description": "A private, de-Googled web browser built on Ungoogled Chromium with zero telemetry, uBlock Origin and Ruffle/Flash built in. Runs on Windows XP through 11.",
+    "homepage": "https://browser.snipeoffice.org/",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/steve12345585/snipe-x64-base/releases/download/v140.0.7339.127/SnipeBrowser-140.0.7339.127-win-x64-portable.zip",
+            "hash": "e8bb81b37f202488f9d382a7217c774ea1664177e4cab0b8afc114b932ec4c2d",
+            "extract_dir": "Snipe"
+        },
+        "32bit": {
+            "url": "https://github.com/steve12345585/snipe-x64-base/releases/download/v140-32bit/SnipeBrowser-140.0.7339.127-win-x86-portable.zip",
+            "hash": "fb0cc30199f9049be47e428de9c0977a3631b04937397d6c0c1af688d2853876",
+            "extract_dir": "Snipe"
+        }
+    },
+    "bin": "Snipe.exe",
+    "shortcuts": [
+        [
+            "Snipe.exe",
+            "Snipe"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/steve12345585/snipe-x64-base"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/steve12345585/snipe-x64-base/releases/download/v$version/SnipeBrowser-$version-win-x64-portable.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Snipe (de-Googled Chromium 140 browser). Portable-zip manifest, 64+32-bit, verified hashes, extract_dir Snipe, bin Snipe.exe.