### PR TITLE
fluxdown: Add version 0.1.54

### DIFF
--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,0 +1,45 @@
+{
+    "version": "0.1.54",
+    "description": "Free, blazing-fast multi-protocol download manager (IDM alternative) powered by a Rust engine. Supports HTTP/HTTPS/FTP/BitTorrent/HLS with intelligent segmentation.",
+    "homepage": "https://fluxdown.zerx.dev",
+    "license": "AGPL-3.0-only",
+    "notes": [
+        "FluxDown is a portable install. Settings and data are written next to flux_down.exe under the Scoop apps directory.",
+        "The browser extension talks to the app via a Native Messaging Host; run FluxDown once so it can register the NMH manifest.",
+        "The build is not code-signed, so Windows SmartScreen may warn on first launch."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.1.54/FluxDown-0.1.54-windows-x64-portable.zip",
+            "hash": "466fc333aba6cc22d743856d7b53148aa7adfd11492d0d41864f6010a5134ada"
+        },
+        "arm64": {
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.1.54/FluxDown-0.1.54-windows-arm64-portable.zip",
+            "hash": "7ca89ea4ffd819d26ab336b0c20d6aaaab6afe5dbcbafba951a48ed2d2633555"
+        }
+    },
+    "bin": "flux_down.exe",
+    "shortcuts": [
+        [
+            "flux_down.exe",
+            "FluxDown"
+        ]
+    ],
+    "persist": [
+        "settings.json"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/FluxDown-$version-windows-x64-portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/FluxDown-$version-windows-arm64-portable.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/SHA256SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for **FluxDown**, a free, open-source (AGPL-3.0), Rust-powered multi-protocol download manager (IDM alternative). Supports HTTP/HTTPS/FTP/BitTorrent/HLS with intelligent segmentation and a browser extension.

- Homepage / repo: https://github.com/zerx-lab/FluxDown
- Portable install (x64 + arm64), installs `flux_down.exe` with a Start Menu shortcut
- `checkver`: "github"; `autoupdate` pulls hashes from the release `SHA256SUMS.txt`
- `persist`: `settings.json` (portable build stores settings next to the exe)

The pinned `hash` values were computed with SHA-256 directly from the published v0.1.54 portable zips.

Note: starting with the next release the upstream CI attaches `SHA256SUMS.txt` to each desktop release so the `autoupdate.hash.url` resolves; the v0.1.54 hashes above are pinned explicitly.