### PR TITLE
mpv-git: Adopt timestamp-based versioning for intra-day builds

### DIFF
--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -1,5 +1,5 @@
 {
-    "version": "2026-07-04-33111f3212",
+    "version": "202607041246",
     "description": "A free, open source, and cross-platform media player",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
@@ -30,17 +30,18 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "github": "https://github.com/zhongfly/mpv-winbuild",
-        "regex": "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})-(?<commit>[a-f0-9]+)",
-        "replace": "${year}-${month}-${day}-${commit}"
+        "github": "https://api.github.com/repos/zhongfly/mpv-winbuild",
+        "jsonpath": "$..['tag_name', 'name']",
+        "regex": "(?<tag>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})-(?<commit>[a-f0-9]{10})).*?(?<hour>\\d{2}):(?<minute>\\d{2})",
+        "replace": "${year}${month}${day}${hour}${minute}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-x86_64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
+                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$matchTag/mpv-x86_64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
             },
             "arm64": {
-                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$version/mpv-aarch64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
+                "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/$matchTag/mpv-aarch64-$matchYear$matchMonth$matchDay-git-$matchCommit.7z"
             }
         }
     }

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -30,7 +30,7 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "github": "https://api.github.com/repos/zhongfly/mpv-winbuild",
+        "url": "https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest",
         "jsonpath": "$..['tag_name', 'name']",
         "regex": "(?<tag>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})-(?<commit>[a-f0-9]{10})).*?(?<hour>\\d{2}):(?<minute>\\d{2})",
         "replace": "${year}${month}${day}${hour}${minute}"

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -30,7 +30,7 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest",
+        "github": "https://api.github.com/repos/zhongfly/mpv-winbuild/releases/latest",
         "jsonpath": "$..['tag_name', 'name']",
         "regex": "(?<tag>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})-(?<commit>[a-f0-9]{10})).*?(?<hour>\\d{2}):(?<minute>\\d{2})",
         "replace": "${year}${month}${day}${hour}${minute}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
# Summary
zhongfly releases new mpv-git builds twice per day. Because they are tagged as YYYY-MM-DD-SHA, versions produced within the same day are not monotonically increasing, causing Scoop's updater to sometimes ignore the second daily build.
This PR ensures a monotonically increasing version string to eliminate this edge case. Additionally, it should enable users on older shinchiro builds to auto-update to the new zhongfly builds without using `--force`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
