### PR TITLE
fluxdown: Add version 0.4.7

### DIFF
--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.55",
+    "version": "0.2.1",
     "description": "A Rust-powered download manager with HTTP, FTP, BitTorrent and HLS/DASH streaming support.",
     "homepage": "https://fluxdown.zerx.dev",
     "license": {
@@ -25,12 +25,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.1.55/FluxDown-0.1.55-windows-x64-portable.zip",
-            "hash": "4dfd497a4e9901dda9179a19e1857f5b6c97bcb8651f3b2041c7ec8fd7f17798"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.1/FluxDown-0.2.1-windows-x64-portable.zip",
+            "hash": "4ed7a96a64d84b2dff298a826b4c3754b57680c2309eef616cecd90030ee3508"
         },
         "arm64": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.1.55/FluxDown-0.1.55-windows-arm64-portable.zip",
-            "hash": "3fd9d54ca258df1ccb217d3fa5f14d55e61dd7408a5cb4447af1d342c8b1d047"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.1/FluxDown-0.2.1-windows-arm64-portable.zip",
+            "hash": "f4befd9db25a83d743b717cafd979c64c084b8a8074e26e3aee6cec569ddef75"
         }
     },
     "pre_install": [

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -8,11 +8,11 @@
     },
     "notes": [
         "FluxDown portable data persistence:",
-        "  - Built-in portable mode: runtime data stored in the app directory",
-        "  - Download history and config persisted via flux_down.db (SQLite)",
-        "  - BT session state (fast-resume) persisted via bt_session/",
-        "  - UI settings (window state, theme, locale) persisted via settings.json",
-        "  - Application logs persisted via logs/",
+        "  - Built-in portable mode: runtime data stored in portable_data/ subdirectory",
+        "  - Download history and config persisted via portable_data/flux_down.db (SQLite)",
+        "  - BT session state (fast-resume) persisted via portable_data/bt_session/",
+        "  - UI settings (window state, theme, locale) persisted via portable_data/settings.json",
+        "  - Application logs persisted via portable_data/logs/",
         "  - All data is preserved across updates",
         "",
         "Browser extensions (required for download interception):",
@@ -34,6 +34,7 @@
         }
     },
     "pre_install": [
+        "if (!(Test-Path \"$dir\\portable_data\")) { New-Item -ItemType Directory \"$dir\\portable_data\" -Force | Out-Null }",
         "if (!(Test-Path \"$dir\\flux_down.db\")) { New-Item -ItemType File \"$dir\\flux_down.db\" -Force | Out-Null }",
         "if (!(Test-Path \"$dir\\settings.json\")) { Set-Content \"$dir\\settings.json\" '{}' -Encoding UTF8 }"
     ],
@@ -47,7 +48,8 @@
         "flux_down.db",
         "bt_session",
         "settings.json",
-        "logs"
+        "logs",
+        "portable_data"
     ],
     "checkver": {
         "github": "https://github.com/zerx-lab/FluxDown"

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.1",
+    "version": "0.2.3",
     "description": "A Rust-powered download manager with HTTP, FTP, BitTorrent and HLS/DASH streaming support.",
     "homepage": "https://fluxdown.zerx.dev",
     "license": {
@@ -25,12 +25,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.1/FluxDown-0.2.1-windows-x64-portable.zip",
-            "hash": "4ed7a96a64d84b2dff298a826b4c3754b57680c2309eef616cecd90030ee3508"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.3/FluxDown-0.2.3-windows-x64-portable.zip",
+            "hash": "e85f0eae285e661f69639187c3ceba7799726823b343abd212d2fb5e926a7b3f"
         },
         "arm64": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.1/FluxDown-0.2.1-windows-arm64-portable.zip",
-            "hash": "f4befd9db25a83d743b717cafd979c64c084b8a8074e26e3aee6cec569ddef75"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.3/FluxDown-0.2.3-windows-arm64-portable.zip",
+            "hash": "82a427ff25d4af920612e69fa345c9f7a62e5795b4a971f56c61b8ba934ada58"
         }
     },
     "pre_install": [

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,6 +1,6 @@
 {
     "version": "0.1.55",
-    "description": "Free, blazing-fast multi-protocol download manager (IDM alternative) powered by a Rust engine. Supports HTTP/HTTPS/FTP/BitTorrent/HLS with intelligent segmentation.",
+    "description": "A Rust-powered download manager with HTTP, FTP, BitTorrent and HLS/DASH streaming support.",
     "homepage": "https://fluxdown.zerx.dev",
     "license": {
         "identifier": "AGPL-3.0-only",
@@ -18,7 +18,10 @@
         "Browser extensions (required for download interception):",
         "  Chrome: https://chromewebstore.google.com/detail/fluxdown/meleenglfggcmcajknpeeeiobnpfmahc",
         "  Firefox: https://addons.mozilla.org/firefox/addon/fluxdown",
-        "  Edge: https://microsoftedge.microsoft.com/addons/detail/fluxdown/nglkkjbogjghekbhhcnccnpfedjbdhhd"
+        "  Edge: https://microsoftedge.microsoft.com/addons/detail/fluxdown/nglkkjbogjghekbhhcnccnpfedjbdhhd",
+        "",
+        "Command-line client:",
+        "  https://github.com/zerx-lab/FluxDown/releases/tag/cli-v$version"
     ],
     "architecture": {
         "64bit": {
@@ -30,9 +33,10 @@
             "hash": "3fd9d54ca258df1ccb217d3fa5f14d55e61dd7408a5cb4447af1d342c8b1d047"
         }
     },
-    "pre_install": "if (!(Test-Path \"$dir\\flux_down.db\")) { New-Item -ItemType File \"$dir\\flux_down.db\" -Force | Out-Null }",
-    "post_install": "if (!(Test-Path \"$dir\\settings.json\")) { New-Item -ItemType File \"$dir\\settings.json\" -Force | Out-Null }",
-    "bin": "flux_down.exe",
+    "pre_install": [
+        "if (!(Test-Path \"$dir\\flux_down.db\")) { New-Item -ItemType File \"$dir\\flux_down.db\" -Force | Out-Null }",
+        "if (!(Test-Path \"$dir\\settings.json\")) { Set-Content \"$dir\\settings.json\" '{}' -Encoding UTF8 }"
+    ],
     "shortcuts": [
         [
             "flux_down.exe",
@@ -45,20 +49,6 @@
         "settings.json",
         "logs"
     ],
-    "uninstaller": {
-        "script": [
-            "Stop-Process -Name flux_down -Force -ErrorAction SilentlyContinue",
-            "Start-Sleep -Milliseconds 1500",
-            "$appDir = Split-Path $dir -Parent",
-            "$shell = New-Object -ComObject WScript.Shell",
-            "@(\"$env:APPDATA\", \"$env:ProgramData\") | ForEach-Object {",
-            "    $lnk = \"$_\\Microsoft\\Windows\\Start Menu\\Programs\\FluxDown.lnk\"",
-            "    if ((Test-Path $lnk) -and ($shell.CreateShortcut($lnk).TargetPath -like \"$appDir\\*\")) {",
-            "        Remove-Item $lnk -Force -ErrorAction SilentlyContinue",
-            "    }",
-            "}"
-        ]
-    },
     "checkver": {
         "github": "https://github.com/zerx-lab/FluxDown"
     },
@@ -72,7 +62,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/SHA256SUMS.txt"
+            "url": "$baseurl/SHA256SUMS.txt"
         }
     }
 }

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -33,24 +33,14 @@
             "hash": "82a427ff25d4af920612e69fa345c9f7a62e5795b4a971f56c61b8ba934ada58"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$dir\\portable_data\")) { New-Item -ItemType Directory \"$dir\\portable_data\" -Force | Out-Null }",
-        "if (!(Test-Path \"$dir\\flux_down.db\")) { New-Item -ItemType File \"$dir\\flux_down.db\" -Force | Out-Null }",
-        "if (!(Test-Path \"$dir\\settings.json\")) { Set-Content \"$dir\\settings.json\" '{}' -Encoding UTF8 }"
-    ],
+    "pre_install": "if (!(Test-Path \"$dir\\portable_data\")) { New-Item -ItemType Directory \"$dir\\portable_data\" -Force | Out-Null }",
     "shortcuts": [
         [
             "flux_down.exe",
             "FluxDown"
         ]
     ],
-    "persist": [
-        "flux_down.db",
-        "bt_session",
-        "settings.json",
-        "logs",
-        "portable_data"
-    ],
+    "persist": "portable_data",
     "checkver": {
         "github": "https://github.com/zerx-lab/FluxDown"
     },

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,0 +1,78 @@
+{
+    "version": "0.1.55",
+    "description": "Free, blazing-fast multi-protocol download manager (IDM alternative) powered by a Rust engine. Supports HTTP/HTTPS/FTP/BitTorrent/HLS with intelligent segmentation.",
+    "homepage": "https://fluxdown.zerx.dev",
+    "license": {
+        "identifier": "AGPL-3.0-only",
+        "url": "https://github.com/zerx-lab/FluxDown/blob/main/LICENSE"
+    },
+    "notes": [
+        "FluxDown portable data persistence:",
+        "  - Built-in portable mode: runtime data stored in the app directory",
+        "  - Download history and config persisted via flux_down.db (SQLite)",
+        "  - BT session state (fast-resume) persisted via bt_session/",
+        "  - UI settings (window state, theme, locale) persisted via settings.json",
+        "  - Application logs persisted via logs/",
+        "  - All data is preserved across updates",
+        "",
+        "Browser extensions (required for download interception):",
+        "  Chrome: https://chromewebstore.google.com/detail/fluxdown/meleenglfggcmcajknpeeeiobnpfmahc",
+        "  Firefox: https://addons.mozilla.org/firefox/addon/fluxdown",
+        "  Edge: https://microsoftedge.microsoft.com/addons/detail/fluxdown/nglkkjbogjghekbhhcnccnpfedjbdhhd"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.1.55/FluxDown-0.1.55-windows-x64-portable.zip",
+            "hash": "4dfd497a4e9901dda9179a19e1857f5b6c97bcb8651f3b2041c7ec8fd7f17798"
+        },
+        "arm64": {
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.1.55/FluxDown-0.1.55-windows-arm64-portable.zip",
+            "hash": "3fd9d54ca258df1ccb217d3fa5f14d55e61dd7408a5cb4447af1d342c8b1d047"
+        }
+    },
+    "pre_install": "if (!(Test-Path \"$dir\\flux_down.db\")) { New-Item -ItemType File \"$dir\\flux_down.db\" -Force | Out-Null }",
+    "post_install": "if (!(Test-Path \"$dir\\settings.json\")) { New-Item -ItemType File \"$dir\\settings.json\" -Force | Out-Null }",
+    "bin": "flux_down.exe",
+    "shortcuts": [
+        [
+            "flux_down.exe",
+            "FluxDown"
+        ]
+    ],
+    "persist": [
+        "flux_down.db",
+        "bt_session",
+        "settings.json",
+        "logs"
+    ],
+    "uninstaller": {
+        "script": [
+            "Stop-Process -Name flux_down -Force -ErrorAction SilentlyContinue",
+            "Start-Sleep -Milliseconds 1500",
+            "$appDir = Split-Path $dir -Parent",
+            "$shell = New-Object -ComObject WScript.Shell",
+            "@(\"$env:APPDATA\", \"$env:ProgramData\") | ForEach-Object {",
+            "    $lnk = \"$_\\Microsoft\\Windows\\Start Menu\\Programs\\FluxDown.lnk\"",
+            "    if ((Test-Path $lnk) -and ($shell.CreateShortcut($lnk).TargetPath -like \"$appDir\\*\")) {",
+            "        Remove-Item $lnk -Force -ErrorAction SilentlyContinue",
+            "    }",
+            "}"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/zerx-lab/FluxDown"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/FluxDown-$version-windows-x64-portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/FluxDown-$version-windows-arm64-portable.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v$version/SHA256SUMS.txt"
+        }
+    }
+}

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.3",
+    "version": "0.4.1",
     "description": "A Rust-powered download manager with HTTP, FTP, BitTorrent and HLS/DASH streaming support.",
     "homepage": "https://fluxdown.zerx.dev",
     "license": {
@@ -20,17 +20,17 @@
         "  Firefox: https://addons.mozilla.org/firefox/addon/fluxdown",
         "  Edge: https://microsoftedge.microsoft.com/addons/detail/fluxdown/nglkkjbogjghekbhhcnccnpfedjbdhhd",
         "",
-        "Command-line client:",
-        "  https://github.com/zerx-lab/FluxDown/releases/tag/cli-v$version"
+        "Command-line client (latest stable):",
+        "  https://github.com/zerx-lab/FluxDown/releases/tag/cli-v0.3.2"
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.3/FluxDown-0.2.3-windows-x64-portable.zip",
-            "hash": "e85f0eae285e661f69639187c3ceba7799726823b343abd212d2fb5e926a7b3f"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.4.1/FluxDown-0.4.1-windows-x64-portable.zip",
+            "hash": "f5fefdc194eb621c34c3717dc28aa7dbe0b68f57e74c7ba058a6a0d8c031871e"
         },
         "arm64": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.2.3/FluxDown-0.2.3-windows-arm64-portable.zip",
-            "hash": "82a427ff25d4af920612e69fa345c9f7a62e5795b4a971f56c61b8ba934ada58"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.4.1/FluxDown-0.4.1-windows-arm64-portable.zip",
+            "hash": "f77fefe22e7e26ae588caca9ec9536a894ff2f37b9f60934b0916a2d414188b4"
         }
     },
     "pre_install": "if (!(Test-Path \"$dir\\portable_data\")) { New-Item -ItemType Directory \"$dir\\portable_data\" -Force | Out-Null }",

--- a/bucket/fluxdown.json
+++ b/bucket/fluxdown.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.4.1",
+    "version": "0.4.7",
     "description": "A Rust-powered download manager with HTTP, FTP, BitTorrent and HLS/DASH streaming support.",
     "homepage": "https://fluxdown.zerx.dev",
     "license": {
@@ -18,22 +18,18 @@
         "Browser extensions (required for download interception):",
         "  Chrome: https://chromewebstore.google.com/detail/fluxdown/meleenglfggcmcajknpeeeiobnpfmahc",
         "  Firefox: https://addons.mozilla.org/firefox/addon/fluxdown",
-        "  Edge: https://microsoftedge.microsoft.com/addons/detail/fluxdown/nglkkjbogjghekbhhcnccnpfedjbdhhd",
-        "",
-        "Command-line client (latest stable):",
-        "  https://github.com/zerx-lab/FluxDown/releases/tag/cli-v0.3.2"
+        "  Edge: https://microsoftedge.microsoft.com/addons/detail/fluxdown/nglkkjbogjghekbhhcnccnpfedjbdhhd"
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.4.1/FluxDown-0.4.1-windows-x64-portable.zip",
-            "hash": "f5fefdc194eb621c34c3717dc28aa7dbe0b68f57e74c7ba058a6a0d8c031871e"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.4.7/FluxDown-0.4.7-windows-x64-portable.zip",
+            "hash": "2de8975135e3e7856ddd36787db3625cf88972f24e8404ac313e5162acafed53"
         },
         "arm64": {
-            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.4.1/FluxDown-0.4.1-windows-arm64-portable.zip",
-            "hash": "f77fefe22e7e26ae588caca9ec9536a894ff2f37b9f60934b0916a2d414188b4"
+            "url": "https://github.com/zerx-lab/FluxDown/releases/download/v0.4.7/FluxDown-0.4.7-windows-arm64-portable.zip",
+            "hash": "b6967f757f1bb826de298c3fd193b895f43b55614fadcda818ace5fb0c60e823"
         }
     },
-    "pre_install": "if (!(Test-Path \"$dir\\portable_data\")) { New-Item -ItemType Directory \"$dir\\portable_data\" -Force | Out-Null }",
     "shortcuts": [
         [
             "flux_down.exe",


### PR DESCRIPTION
Add FluxDown - a free, blazing-fast multi-protocol download manager (IDM alternative) powered by a Rust engine.

- Homepage: https://fluxdown.zerx.dev
- Repo: https://github.com/zerx-lab/FluxDown (106 stars, 5 forks)
- License: AGPL-3.0-only
- Portable x64 install with Start Menu shortcut

Closes #17922

- [x] Use conventional PR title
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)