### PR TITLE
rescuetime: Update to version 3.2.12.3, enable checkver

### DIFF
--- a/bucket/rescuetime.json
+++ b/bucket/rescuetime.json
@@ -3,7 +3,7 @@
     "description": "Automatic application time-tracking and productive advisor",
     "homepage": "https://www.rescuetime.com",
     "license": {
-        "identifier": "Freeware",
+        "identifier": "Proprietary",
         "url": "https://www.rescuetime.com/tos"
     },
     "notes": "Consider installing the RescueTime extension for your browser.",

--- a/bucket/rescuetime.json
+++ b/bucket/rescuetime.json
@@ -7,8 +7,12 @@
         "url": "https://www.rescuetime.com/tos"
     },
     "notes": "Consider installing the RescueTime extension for your browser.",
-    "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_3.2.12.3.exe",
-    "hash": "ac2c55a8944b530a8b9de8e534a77e39a20733375e23cf96e0348e943fd1dba2",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_3.2.12.3.exe",
+            "hash": "ac2c55a8944b530a8b9de8e534a77e39a20733375e23cf96e0348e943fd1dba2"
+        }
+    },
     "innosetup": true,
     "bin": "RescueTime.exe",
     "shortcuts": [
@@ -22,6 +26,10 @@
         "regex": "<strong>([\\d.]+)</strong> - <span>[^<]*\\(Release\\)"
     },
     "autoupdate": {
-        "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_$version.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_$version.exe"
+            }
+        }
     }
 }

--- a/bucket/rescuetime.json
+++ b/bucket/rescuetime.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.0.10",
+    "version": "3.2.12.3",
     "description": "Automatic application time-tracking and productive advisor",
     "homepage": "https://www.rescuetime.com",
     "license": {
@@ -7,8 +7,8 @@
         "url": "https://www.rescuetime.com/tos"
     },
     "notes": "Consider installing the RescueTime extension for your browser.",
-    "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_3.0.0.10.exe",
-    "hash": "a571fa1efbfd23b4a6c690eafd985e16f7fa43e5813d950350a108ea89b5c2e9",
+    "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_3.2.12.3.exe",
+    "hash": "ac2c55a8944b530a8b9de8e534a77e39a20733375e23cf96e0348e943fd1dba2",
     "innosetup": true,
     "bin": "RescueTime.exe",
     "shortcuts": [
@@ -17,6 +17,10 @@
             "RescueTime"
         ]
     ],
+    "checkver": {
+        "url": "https://www.rescuetime.com/release-notes/windows/rtx",
+        "regex": "<strong>([\\d.]+)</strong> - <span>[^<]*\\(Release\\)"
+    },
     "autoupdate": {
         "url": "https://www.rescuetime.com/installers/RescueTimeInstaller_$version.exe"
     }


### PR DESCRIPTION
The manifest was stuck on 3.0.0.10 because there is no `checkver`, so excavator never picked up new releases. This bumps it to the current 3.2.12.3 (hash computed from the official installer) and adds a `checkver` against the official release notes page so it stays up to date going forward.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)