### PR TITLE
ternix: Add version 1.0.0

### DIFF
--- a/bucket/ternix.json
+++ b/bucket/ternix.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.0.0",
+    "description": "Ternix is a modern, feature-rich SSH and remote session manager built with Electron.",
+    "homepage": "https://github.com/PraneethReddy-github/ternix",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PraneethReddy-github/ternix/releases/download/v1.0.0/Ternix.1.0.0.exe#/ternix.exe",
+            "hash": "1b010de33e11003d88ab40a98269f35f6fde4e32cd2ccda3a3ed07f8ef792d6f"
+        }
+    },
+    "bin": "ternix.exe",
+    "shortcuts": [
+        [
+            "ternix.exe",
+            "Ternix"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PraneethReddy-github/ternix/releases/download/v$version/Ternix.$version.exe#/ternix.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds the Ternix terminal app.

- Homepage: https://github.com/PraneethReddy-github/ternix
- Version: 1.0.0
- Description: Ternix is a modern, feature-rich SSH and remote session manager built with Electron.

Checks:
- [x] Tested locally with `scoop install bucket/ternix.json`
- [x] Hash matches release asset
- [x] Auto-update configuration is provided
