### PR TITLE
ffmetrics: Add version 1.7.0

### DIFF
--- a/bucket/ffmetrics.json
+++ b/bucket/ffmetrics.json
@@ -4,12 +4,8 @@
     "homepage": "https://github.com/fifonik/FFMetrics",
     "license": "Unknown",
     "depends": "main/FFMpeg",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/fifonik/FFMetrics/releases/download/v1.7.0/FFMetrics.1.7.0.zip",
-            "hash": "455b6be162d318111ac2993dc7da785633d402f862979abe76ab9f968ddd0c20"
-        }
-    },
+    "url": "https://github.com/fifonik/FFMetrics/releases/download/v1.7.0/FFMetrics.1.7.0.zip",
+    "hash": "455b6be162d318111ac2993dc7da785633d402f862979abe76ab9f968ddd0c20",
     "extract_dir": "FFMetrics",
     "bin": "FFMetrics.exe",
     "shortcuts": [
@@ -20,10 +16,6 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/fifonik/FFMetrics/releases/download/v$version/FFMetrics.$version.zip"
-            }
-        }
+        "url": "https://github.com/fifonik/FFMetrics/releases/download/v$version/FFMetrics.$version.zip"
     }
 }

--- a/bucket/ffmetrics.json
+++ b/bucket/ffmetrics.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.7.0",
+    "description": "An FFMpeg GUI, to visualize quality metrics calculated by FFMpeg.",
+    "homepage": "https://github.com/fifonik/FFMetrics",
+    "license": "Unknown",
+    "depends": "main/FFMpeg",
+    "url": "https://github.com/fifonik/FFMetrics/releases/download/v1.7.0/FFMetrics.1.7.0.zip",
+    "hash": "455b6be162d318111ac2993dc7da785633d402f862979abe76ab9f968ddd0c20",
+    "extract_dir": "FFMetrics",
+    "bin": "FFMetrics.exe",
+    "shortcuts": [
+        [
+            "FFMetrics.exe",
+            "FFMetrics"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/fifonik/FFMetrics/releases/download/v$version/FFMetrics.$version.zip"
+    }
+}

--- a/bucket/ffmetrics.json
+++ b/bucket/ffmetrics.json
@@ -4,8 +4,12 @@
     "homepage": "https://github.com/fifonik/FFMetrics",
     "license": "Unknown",
     "depends": "main/FFMpeg",
-    "url": "https://github.com/fifonik/FFMetrics/releases/download/v1.7.0/FFMetrics.1.7.0.zip",
-    "hash": "455b6be162d318111ac2993dc7da785633d402f862979abe76ab9f968ddd0c20",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fifonik/FFMetrics/releases/download/v1.7.0/FFMetrics.1.7.0.zip",
+            "hash": "455b6be162d318111ac2993dc7da785633d402f862979abe76ab9f968ddd0c20"
+        }
+    },
     "extract_dir": "FFMetrics",
     "bin": "FFMetrics.exe",
     "shortcuts": [
@@ -16,6 +20,10 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/fifonik/FFMetrics/releases/download/v$version/FFMetrics.$version.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fifonik/FFMetrics/releases/download/v$version/FFMetrics.$version.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #17450 

Tested on 64bit but it looks like it works for 32bit too. 
`FILEOS         VOS_UNKNOWN | VOS__WINDOWS32`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
