### PR TITLE
losslesscut: Improve notes, fix post_install script

### DIFF
--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "notes": [
         "For .mp4 and .mkv file associations, run:",
-        "\"$dir\\install-associations.reg\""
+        "reg import \"$dir\\install-associations.reg\""
     ],
     "architecture": {
         "64bit": {

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -13,13 +13,6 @@
             "hash": "baf7106576999e1460f918054e3ad4ae38a95469892cc6a1a97b4131f02818e4"
         }
     },
-    "bin": "LosslessCut.exe",
-    "shortcuts": [
-        [
-            "LosslessCut.exe",
-            "LosslessCut"
-        ]
-    ],
     "post_install": [
         "$dirpath = \"$dir\".Replace('\\', '\\\\')",
         "'install-associations', 'uninstall-associations' | ForEach-Object {",
@@ -29,6 +22,13 @@
         "        $content | Set-Content -Path \"$dir\\$_.reg\"",
         "    }",
         "}"
+    ],
+    "bin": "LosslessCut.exe",
+    "shortcuts": [
+        [
+            "LosslessCut.exe",
+            "LosslessCut"
+        ]
     ],
     "uninstaller": {
         "script": [

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -19,6 +19,7 @@
         "    if (Test-Path \"$bucketsdir\\extras\\scripts\\losslesscut\\$_.reg\") {",
         "        $content = Get-Content \"$bucketsdir\\extras\\scripts\\losslesscut\\$_.reg\"",
         "        $content = $content.Replace('$dirpath', $dirpath)",
+        "        if ($global) { $content = $content -replace 'HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE' }",
         "        $content | Set-Content -Path \"$dir\\$_.reg\"",
         "    }",
         "}"
@@ -32,12 +33,7 @@
     ],
     "uninstaller": {
         "script": [
-            "if ($cmd -eq 'uninstall') {",
-            "    $regkey = Get-ItemProperty -Path 'HKCU:\\SOFTWARE\\Classes\\Applications\\LosslessCut.exe' -ErrorAction SilentlyContinue",
-            "    if ($regkey) {",
-            "        reg import \"$dir\\uninstall-associations.reg\"",
-            "    }",
-            "}"
+            "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" *> $null }"
         ]
     },
     "checkver": "github",

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -32,9 +32,7 @@
         ]
     ],
     "uninstaller": {
-        "script": [
-            "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" *> $null }"
-        ]
+        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" *> $null }"
     },
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
this PR is related to
- #17889 
- #16723 

and simply:
a) improves the post-install notes and makes it clearer
b) puts `bin` and `shortcuts` fields after `post_install` and before `uninstaller` ([CONTRIBUTING](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md#for-scoop-buckets))

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
