### PR TITLE
brows3: Add version 0.2.43

### DIFF
--- a/bucket/brows3.json
+++ b/bucket/brows3.json
@@ -3,16 +3,24 @@
     "description": "A high-performance, open-source Amazon S3 browser and desktop client built with Rust and Tauri",
     "homepage": "https://brows3.app",
     "license": "MIT",
-    "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v0.2.43/Brows3_0.2.43_x64-portable.zip",
-    "hash": "4348fefda06117490ed6795e34cc2bdc9512329a35b82e10ff5cffb336834d2c",
-    "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_0.2.43_x64-portable",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v0.2.43/Brows3_0.2.43_x64-portable.zip",
+            "hash": "4348fefda06117490ed6795e34cc2bdc9512329a35b82e10ff5cffb336834d2c",
+            "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_0.2.43_x64-portable"
+        }
+    },
     "bin": "Brows3.exe",
     "checkver": {
         "github": "https://github.com/rgcsekaraa/brows3",
         "regex": "app-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v$version/Brows3_$version_x64-portable.zip",
-        "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_$version_x64-portable"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v$version/Brows3_$version_x64-portable.zip",
+                "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_$version_x64-portable"
+            }
+        }
     }
 }

--- a/bucket/brows3.json
+++ b/bucket/brows3.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.43",
+    "description": "A high-performance, open-source Amazon S3 browser and desktop client built with Rust and Tauri",
+    "homepage": "https://brows3.app",
+    "license": "MIT",
+    "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v0.2.43/Brows3_0.2.43_x64-portable.zip",
+    "hash": "4348fefda06117490ed6795e34cc2bdc9512329a35b82e10ff5cffb336834d2c",
+    "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_0.2.43_x64-portable",
+    "bin": "Brows3.exe",
+    "checkver": {
+        "github": "https://github.com/rgcsekaraa/brows3",
+        "regex": "app-v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v$version/Brows3_$version_x64-portable.zip",
+        "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_$version_x64-portable"
+    }
+}

--- a/bucket/brows3.json
+++ b/bucket/brows3.json
@@ -7,10 +7,16 @@
         "64bit": {
             "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v0.2.43/Brows3_0.2.43_x64-portable.zip",
             "hash": "4348fefda06117490ed6795e34cc2bdc9512329a35b82e10ff5cffb336834d2c",
-            "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_0.2.43_x64-portable"
+            "extract_dir": "src-tauri\\target\\release\\bundle\\portable\\Brows3_0.2.43_x64-portable"
         }
     },
-    "bin": "Brows3.exe",
+    "post_install": "Remove-Item \"$dir\\src-tauri\" -Recurse -ErrorAction SilentlyContinue",
+    "shortcuts": [
+        [
+            "Brows3.exe",
+            "Brows3"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/rgcsekaraa/brows3",
         "regex": "app-v([\\d.]+)"
@@ -19,7 +25,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/rgcsekaraa/brows3/releases/download/app-v$version/Brows3_$version_x64-portable.zip",
-                "extract_dir": "src-tauri/target/release/bundle/portable/Brows3_$version_x64-portable"
+                "extract_dir": "src-tauri\\target\\release\\bundle\\portable\\Brows3_$version_x64-portable"
             }
         }
     }


### PR DESCRIPTION
Add [brows3](https://github.com/rgcsekaraa/brows3/releases/latest), a super fast open-source S3 browser, S3 explorer, and desktop client for Amazon S3, MinIO, Cloudflare R2, Wasabi, and other S3-compatible storage.

---

Closes https://github.com/ScoopInstaller/Extras/issues/18252