### PR TITLE
tinta: Add version 2.0.0

### DIFF
--- a/bucket/tinta.json
+++ b/bucket/tinta.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "description": "Fast, lightweight markdown viewer for Windows (native Direct2D, <1 MB, no Electron)",
+    "homepage": "https://tinta.cc",
+    "license": "MIT",
+    "url": "https://github.com/oipoistar/tinta/releases/download/v2.0.0/tinta.exe",
+    "hash": "53f9ca3fbee3284487fa43c6b3eb05710ec639abf16be5ebba48af07a3f3822f",
+    "bin": "tinta.exe",
+    "checkver": {
+        "github": "https://github.com/oipoistar/tinta"
+    },
+    "autoupdate": {
+        "url": "https://github.com/oipoistar/tinta/releases/download/v$version/tinta.exe"
+    }
+}


### PR DESCRIPTION
Adds **Tinta** — a fast, lightweight markdown viewer for Windows. Native C++/Direct2D, single portable exe under 1 MB, MIT licensed.

- Homepage: https://tinta.cc
- Repo: https://github.com/oipoistar/tinta (author submitting own app)
- `hash` computed directly from the v2.0.0 release asset (SHA256)
- `checkver` uses the standard GitHub template; `autoupdate` URL follows the `v$version` tag pattern used by all releases
- Portable exe, `bin` shim gives users a `tinta` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)