### PR TITLE
dgdemux: Add version 1.0.0.85

### DIFF
--- a/bucket/dgdemux.json
+++ b/bucket/dgdemux.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0.85",
-    "description": "DGDemux is a standalone demuxer for BluRay/UHD disks.",
+    "description": "A standalone demuxer for BluRay/UHD disks.",
     "homepage": "https://www.rationalqm.us/dgdemux/dgdemux.html",
     "license": "Freeware",
     "suggest": {
@@ -31,7 +31,7 @@
     ],
     "checkver": {
         "url": "https://www.videohelp.com/software/DGDemux",
-        "regex": "DGDemux_([\\d.]+).zip"
+        "regex": "DGDemux_([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/dgdemux.json
+++ b/bucket/dgdemux.json
@@ -1,0 +1,43 @@
+{
+    "version": "1.0.0.85",
+    "description": "DGDemux is a standalone demuxer for BluRay/UHD disks.",
+    "homepage": "https://www.rationalqm.us/dgdemux/dgdemux.html",
+    "license": "Freeware",
+    "suggest": {
+        "dovi-tool": "extras/dovi-tool"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://www.videohelp.com/download/DGDemux_1.0.0.85.zip",
+            "hash": "7a61750d8f9a26356e8115fb3ceb843eb8bd9a9715909d4f02cc0c01741ccbc3"
+        }
+    },
+    "pre_install": "'dovi_tool.exe', 'dovi_tool.txt', 'MediaInfoCLI.exe', 'MediaInfoCLI.txt', 'thdmerge_*.zip' | ForEach-Object { Remove-Item \"$dir\\$_\" }",
+    "bin": "DGDemux.exe",
+    "shortcuts": [
+        [
+            "DGDemuxGUI.exe",
+            "DGDemux\\DGDemuxGUI"
+        ],
+        [
+            "DGDemuxGUI_Files.exe",
+            "DGDemux\\DGDemuxGUI Files"
+        ]
+    ],
+    "persist": [
+        "DGDemux.ini",
+        "DGDemux_Files.ini",
+        "finished.wav"
+    ],
+    "checkver": {
+        "url": "https://www.videohelp.com/software/DGDemux",
+        "regex": "DGDemux_([\\d.]+).zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.videohelp.com/download/DGDemux_$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
# Summary
DGDemux is a sort-of sister application to the already packaged [eac3to](https://github.com/ScoopInstaller/Main/blob/master/bucket/eac3to.json), and is maintained by the same author.
This PR follows after eac3to and uses similar logic for the autoupdate/checkver.
This software bundles several independant applications (dovi_tool, mediainfo, etc.) which are already packaged by scoop, so I added a pre_install script to remove them.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #18255
<!--
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
