### PR TITLE
foreground: Add version 1.1.0

### DIFF
--- a/bucket/foreground.json
+++ b/bucket/foreground.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.1.0",
+    "description": "Automatic time and activity tracker that records time spent in apps and websites, storing all data locally",
+    "homepage": "https://foreground.computer",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://foreground.computer/buy.html"
+    },
+    "notes": [
+        "Tracking data is stored in '%LOCALAPPDATA%\\HelloCode\\Foreground', and is not persisted by Scoop.",
+        "Consider installing the Foreground extension for your browser."
+    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://foreground.computer/static/builds/1/Foreground_1.1.0_x64_en-US.msi.zip",
+            "hash": "82b28fb6265344316ee654db609608ff7e9c3d0cba7d05eb9dfb2d0a333064ef"
+        }
+    },
+    "pre_install": "Expand-MsiArchive \"$dir\\Foreground_$($version)_x64_en-US.msi\" \"$dir\" -ExtractDir 'PFiles\\Foreground' -Removal | Out-Null",
+    "shortcuts": [
+        [
+            "Foreground.exe",
+            "Foreground"
+        ]
+    ],
+    "pre_uninstall": "Stop-Process -Name 'Foreground' -ErrorAction SilentlyContinue",
+    "checkver": "static/builds/(?<Build>\\d+)/Foreground_(?<version>[\\d.]+)_x64_en-US\\.msi\\.zip",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://foreground.computer/static/builds/$matchBuild/Foreground_$version_x64_en-US.msi.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [Foreground](https://foreground.computer) — an automatic time and activity tracker by [Hello Code](https://hellocode.co/) (makers of Exist) that keeps all tracking data in a local database. Same category as `extras/rescuetime`, with a local-only privacy model.

Closes #18256

**Notes for review:**

- The vendor only publishes a zip-wrapped Tauri MSI (`Foreground_<version>_x64_en-US.msi.zip`; a bare `.msi` returns 404), so `pre_install` unwraps it with `Expand-MsiArchive` (same approach as `protonmail-bridge`/`enpass`). The MSI's file table contains a single `PFiles\Foreground\Foreground.exe` (verified by extraction).
- `checkver` matches the homepage download link and captures the `/static/builds/<Build>/` path segment for `autoupdate`, same pattern as `gitbutler`. All historical releases currently live under `builds/1/`, so the capture just future-proofs the template.
- Tracking data lives in `%LOCALAPPDATA%\HelloCode\Foreground`, outside the install directory, so no `persist` is applicable (noted in `notes`, as in `kanri`).
- `suggest`s `extras/webview2` since Scoop's MSI extraction bypasses the Tauri installer's WebView2 bootstrap.

**Verification done:**

- `bin/checkver.ps1 foreground` → `foreground: 1.1.0`; `-ForceUpdate` regenerates the exact download URL from the `autoupdate` template and the computed SHA256 matches the manifest hash (`82b28fb6…64ef`, from the official download).
- `bin/formatjson.ps1` produces no changes; the manifest validates against `ScoopInstaller/Scoop` `schema.json`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
