### PR TITLE
subtitleedit: Update to version 5.0.0, add arm64 version

### DIFF
--- a/bucket/subtitleedit.json
+++ b/bucket/subtitleedit.json
@@ -3,6 +3,7 @@
     "description": "Video subtitles editor",
     "homepage": "https://www.nikse.dk/subtitleedit/",
     "license": "GPL-3.0-only",
+    "notes": "For 4.x versions, please use `subtitleedit4` from Versions bucket.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SubtitleEdit-Windows-x64.zip",

--- a/bucket/subtitleedit.json
+++ b/bucket/subtitleedit.json
@@ -1,27 +1,38 @@
 {
-    "version": "4.0.16",
+    "version": "5.0.0",
     "description": "Video subtitles editor",
-    "homepage": "http://www.nikse.dk/subtitleedit/",
+    "homepage": "https://www.nikse.dk/subtitleedit/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/4.0.16/SE4016.zip",
-    "hash": "f59328d651a250538474573f54ee7b15be7afc58749edd668779c7f39037e150",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\Settings.xml\")) { New-Item \"$dir\\Settings.xml\" | Out-Null }",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SubtitleEdit-Windows-x64.zip",
+            "hash": "904357a0f173494f3a177dda56e81c9b473c794b60e0ab63d32f46892ae59a30"
+        },
+        "arm64": {
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SubtitleEdit-Windows-ARM64.zip",
+            "hash": "d1b317d0c4a049416206dcc805a84b561a1447f157d2c2ed30890cbebd9dafc6"
+        }
+    },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\Settings.json\")) { New-Item \"$dir\\Settings.json\" | Out-Null }",
     "bin": "SubtitleEdit.exe",
     "shortcuts": [
         [
             "SubtitleEdit.exe",
-            "SubtitleEdit"
+            "Subtitle Edit"
         ]
     ],
-    "persist": "Settings.xml",
+    "persist": "Settings.json",
     "checkver": {
         "github": "https://github.com/SubtitleEdit/subtitleedit"
     },
     "autoupdate": {
-        "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/$version/SE$cleanVersion.zip",
-        "hash": {
-            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/tag/$version/",
-            "regex": "(?sm)$basename.*?SHA256 Checksum:\\s*<code>$sha256</"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v$version/SubtitleEdit-Windows-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v$version/SubtitleEdit-Windows-ARM64.zip"
+            }
         }
     }
 }


### PR DESCRIPTION
Update to version 5.0.0, add arm64 version, update settings handling.

As from [SE 5.0.0 release notes](https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/change-log.txt):

>   Please read before upgrading:
>  
>   Subtitle Edit 5 is a new application, not just an update of Subtitle Edit 4.
>   It has been rebuilt from the ground up to be cross-platform, so:
>  
>   - It is not 100% the same app. The look, layout, and some workflows have
>     changed. Some things are in different places, and a few behave differently
>     than in SE4.
>   - Not every SE4 feature exists in SE5 yet. SE5 covers all the core editing,
>     conversion, sync, video playback, OCR, and online services, but some of the
>     more specialized SE4 tools are not available yet. Features will continue to
>     be added.
>  
>   If you rely on a specific SE4 feature that is missing, please keep SE4
>   installed alongside SE5. The easiest way to run both side by side is to use
>   the Portable versions of SE4 and SE5, which keep their settings separate and
>   do not interfere with each other.
>  
>   Which version should I use?
>    
>   - Subtitle Edit 5: recommended for most users on Windows 10 (22H2) or newer,
>     macOS 12+, and Linux.
>   - Subtitle Edit 4: please continue to use SE4 if you are on an older Windows
>     version (Windows 7/8), or on older / slower computers where SE5 may not run well. 
>     SE4 remains available and is the right choice in those cases.

Wonder if manifest for SE 4.x should be placed into `Versions` bucket before merging update.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
