### PR TITLE
rebased@1.1.7: Fix executable name in bin, shortcuts and persist

### DIFF
--- a/bucket/rebased.json
+++ b/bucket/rebased.json
@@ -21,19 +21,19 @@
     },
     "bin": [
         [
-            "IDE\\bin\\idea64.exe",
+            "IDE\\bin\\rebased64.exe",
             "rebased"
         ]
     ],
     "shortcuts": [
         [
-            "IDE\\bin\\idea64.exe",
+            "IDE\\bin\\rebased64.exe",
             "Rebased"
         ]
     ],
     "persist": [
         "IDE\\bin\\idea.properties",
-        "IDE\\bin\\idea64.exe.vmoptions",
+        "IDE\\bin\\rebased64.exe.vmoptions",
         "profile"
     ],
     "checkver": "github",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

rename executable from "idea" to "rebased"

https://github.com/DetachHead/rebased/releases/tag/1.1.7

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
