### PR TITLE
orcaslicer: Update to version 2.4.2, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/orcaslicer.json
+++ b/bucket/orcaslicer.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.4.0",
+    "version": "2.4.2",
     "description": "G-code generator for 3D printers (Bambu, Prusa, Voron, VzBot, RatRig, Creality, etc.)",
     "homepage": "https://github.com/SoftFever/OrcaSlicer",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SoftFever/OrcaSlicer/releases/download/v2.4.0/OrcaSlicer_Windows_V2.4.0_portable.zip",
-            "hash": "fb6766b847fe064b20eb4fd7574c66ff0354e1f0e3ca38fc2daa603ad3691e25"
+            "url": "https://github.com/SoftFever/OrcaSlicer/releases/download/v2.4.2/OrcaSlicer_Windows_V2.4.2_x64_portable.zip",
+            "hash": "feba3009dfb9d268779cca5758a1a5bc3b7d0722bf8fa48d5c57340de975d6be"
         }
     },
     "shortcuts": [
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/SoftFever/OrcaSlicer/releases/download/v$version/OrcaSlicer_Windows_V$version_portable.zip"
+                "url": "https://github.com/SoftFever/OrcaSlicer/releases/download/v$version/OrcaSlicer_Windows_V$version_x64_portable.zip"
             }
         }
     }

--- a/bucket/orcaslicer.json
+++ b/bucket/orcaslicer.json
@@ -1,12 +1,16 @@
 {
     "version": "2.4.2",
     "description": "G-code generator for 3D printers (Bambu, Prusa, Voron, VzBot, RatRig, Creality, etc.)",
-    "homepage": "https://github.com/SoftFever/OrcaSlicer",
+    "homepage": "https://github.com/OrcaSlicer/OrcaSlicer",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SoftFever/OrcaSlicer/releases/download/v2.4.2/OrcaSlicer_Windows_V2.4.2_x64_portable.zip",
+            "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v2.4.2/OrcaSlicer_Windows_V2.4.2_x64_portable.zip",
             "hash": "feba3009dfb9d268779cca5758a1a5bc3b7d0722bf8fa48d5c57340de975d6be"
+        },
+        "arm64": {
+            "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v2.4.2/OrcaSlicer_Windows_V2.4.2_arm64_portable.zip",
+            "hash": "428a26878ca39dcd87f52fe3faea55aa76c9d477c369377f62e047194cdef06b"
         }
     },
     "shortcuts": [
@@ -19,7 +23,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/SoftFever/OrcaSlicer/releases/download/v$version/OrcaSlicer_Windows_V$version_x64_portable.zip"
+                "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v$version/OrcaSlicer_Windows_V$version_x64_portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v$version/OrcaSlicer_Windows_V$version_arm64_portable.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Fixes package installer url and update to newest release.

> https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/v2.4.1
With the new ARM64 builds, the Windows x64 installer and portable downloads now carry an _x64 suffix in their filenames to distinguish them from the ARM64 ones.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #18267
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
