### PR TITLE
croppickvoice: Add version 1.0.0

### DIFF
--- a/bucket/croppickvoice.json
+++ b/bucket/croppickvoice.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0.0",
+    "description": "Free on-device voice typing for any app, plus Crop & Speak — annotate a region of your screen and narrate it into ChatGPT or Claude.",
+    "homepage": "https://voice.croppick.com",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://voice.croppick.com/terms"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dl-voice.croppick.com/v1.0.0/CroppickVoice-windows-amd64.zip",
+            "hash": "18ff380a9a69c1063bf070e2c055f74824eb906795d43ddb06682206b92cadf0"
+        }
+    },
+    "extract_dir": "CroppickVoice",
+    "shortcuts": [
+        [
+            "CroppickVoice.exe",
+            "CroppickVoice"
+        ]
+    ],
+    "checkver": {
+        "url": "https://dl-voice.croppick.com/latest.json",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dl-voice.croppick.com/v$version/CroppickVoice-windows-amd64.zip",
+                "hash": {
+                    "url": "https://dl-voice.croppick.com/latest.json",
+                    "jsonpath": "$.assets['windows-amd64'].portable.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
New manifest for CroppickVoice — free on-device voice typing for any app, plus Crop & Speak (https://voice.croppick.com).

- `scoop install` and `scoop uninstall` tested locally on Windows 11 x64 (hash, extract_dir, shortcut all verified)
- `checkver` and `autoupdate` (with -ForceUpdate) verified against the publisher release manifest at https://dl-voice.croppick.com/latest.json — hash is extracted via JSONPath, so excavator can auto-update future versions
- Installer files are publisher-hosted at versioned, immutable URLs