### PR TITLE
kiwix: Update to version 2.5.1, fix checkver, persist user data

### DIFF
--- a/bucket/kiwix.json
+++ b/bucket/kiwix.json
@@ -13,13 +13,13 @@
         }
     },
     "pre_install": "Remove-Item \"$dir\\vc_redist.*.exe\"",
+    "post_install": "New-Item \"$dir\\.portable\" | Out-Null ",
     "shortcuts": [
         [
             "kiwix-desktop.exe",
             "Kiwix Desktop"
         ]
     ],
-    "post_install": "New-Item \"$dir\\.portable\" | Out-Null ",
     "persist": "data",
     "checkver": {
         "url": "https://download.kiwix.org/release/kiwix-desktop/feed.xml",

--- a/bucket/kiwix.json
+++ b/bucket/kiwix.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.1",
+    "version": "2.5.1",
     "homepage": "https://www.kiwix.org/en/",
     "description": "Store any website on your mobile phone or computer, easily.",
     "license": "GPL-3.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_windows_x64_2.0.1.zip",
-            "hash": "8a41d3871e27e8085e8cfdb0790ce16da0dc3363fd1f2564c54d0d637bf5b201"
+            "url": "https://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_windows_x64_2.5.1.zip",
+            "hash": "md5:0d1be45f654072c5133198074845e415"
         }
     },
     "pre_install": "Remove-Item \"$dir\\vc_redist.*.exe\"",
@@ -19,9 +19,12 @@
             "Kiwix Desktop"
         ]
     ],
+    "post_install": "New-Item \"$dir\\.portable\" | Out-Null ",
+    "persist": "data",
     "checkver": {
         "url": "https://download.kiwix.org/release/kiwix-desktop/feed.xml",
-        "regex": "kiwix-desktop_windows_x64_([\\d.]+)\\.zip"
+        "regex": "kiwix-desktop_windows_x64_([\\d.]+)\\.zip",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
@@ -30,7 +33,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256"
+            "url": "$url.md5"
         }
     }
 }


### PR DESCRIPTION
- Add checkver "reverse": true to pick the latest feed entry
- Switch hash source from .sha256 to .md5
- Add persist "data" and post_install .portable marker for portable mode

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #18282


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
