### PR TITLE
idea-community: Add version 2026.2

### DIFF
--- a/bucket/idea-community.json
+++ b/bucket/idea-community.json
@@ -15,14 +15,14 @@
     },
     "extract_to": "IDE",
     "post_install": [
-		"$file = \"$persist_dir\\IDE\\bin\\idea.properties\"",
-		"$content = Get-Content $file",
-		"$content = $content -replace '^#\\s*idea\\.config\\.path=.*$', \"idea.config.path=$persist_dir\\config\"",
-		"$content = $content -replace '^#\\s*idea\\.system\\.path=.*$', \"idea.system.path=$persist_dir\\system\"",
-		"$content = $content -replace '^#\\s*idea\\.plugins\\.path=.*$', \"idea.plugins.path=$persist_dir\\plugins\"",
-		"$content = $content -replace '^#\\s*idea\\.log\\.path=.*$', \"idea.log.path=$persist_dir\\logs\"",
-		"$content | Set-Content $file"
-	],
+        "$file = \"$persist_dir\\IDE\\bin\\idea.properties\"",
+        "$content = Get-Content $file",
+        "$content = $content -replace '^#\\s*idea\\.config\\.path=.*$', \"idea.config.path=$persist_dir\\config\"",
+        "$content = $content -replace '^#\\s*idea\\.system\\.path=.*$', \"idea.system.path=$persist_dir\\system\"",
+        "$content = $content -replace '^#\\s*idea\\.plugins\\.path=.*$', \"idea.plugins.path=$persist_dir\\plugins\"",
+        "$content = $content -replace '^#\\s*idea\\.log\\.path=.*$', \"idea.log.path=$persist_dir\\logs\"",
+        "$content | Set-Content $file"
+    ],
     "bin": [
         [
             "IDE\\bin\\idea64.exe",
@@ -35,9 +35,7 @@
             "JetBrains\\IDEA"
         ]
     ],
-    "persist": [
-        "IDE\\bin\\idea.properties"
-    ],
+    "persist": "IDE\\bin\\idea.properties",
     "checkver": {
         "url": "https://api.github.com/repos/JetBrains/intellij-community/releases",
         "jsonpath": "$.[*].tag_name",

--- a/bucket/idea-community.json
+++ b/bucket/idea-community.json
@@ -1,0 +1,66 @@
+{
+    "version": "2026.1.4",
+    "description": "Cross-Platform IDE for Java by JetBrains - Open Source Community Edition",
+    "homepage": "https://github.com/JetBrains/intellij-community",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F2026.1.4/idea-2026.1.4.win.zip",
+            "hash": "da0f2da6bd7e3b113be1a119f44d28efd40758f3249623a636fa8368ec559cc5"
+        },
+        "arm64": {
+            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F2026.1.4/idea-2026.1.4-aarch64.win.zip",
+            "hash": "ba9c9615e75c3e2e3c53a6604a912221146d5c773c9c9fd655039198777ec63a"
+        }
+    },
+    "extract_to": "IDE",
+    "post_install": [
+		"$file = \"$persist_dir\\IDE\\bin\\idea.properties\"",
+		"$content = Get-Content $file",
+		"$content = $content -replace '^#\\s*idea\\.config\\.path=.*$', \"idea.config.path=$persist_dir\\config\"",
+		"$content = $content -replace '^#\\s*idea\\.system\\.path=.*$', \"idea.system.path=$persist_dir\\system\"",
+		"$content = $content -replace '^#\\s*idea\\.plugins\\.path=.*$', \"idea.plugins.path=$persist_dir\\plugins\"",
+		"$content = $content -replace '^#\\s*idea\\.log\\.path=.*$', \"idea.log.path=$persist_dir\\logs\"",
+		"$content | Set-Content $file"
+	],
+    "bin": [
+        [
+            "IDE\\bin\\idea64.exe",
+            "idea"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "IDE\\bin\\idea64.exe",
+            "JetBrains\\IDEA"
+        ]
+    ],
+    "persist": [
+        "IDE\\bin\\idea.properties"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/JetBrains/intellij-community/releases",
+        "jsonpath": "$.[*].tag_name",
+        "regex": "\"idea/([\\d.]+)\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version.win.zip",
+                "hash": {
+                    "mode": "json",
+                    "url": "https://api.github.com/repos/JetBrains/intellij-community/releases/tags/idea%2F$version",
+                    "jsonpath": "$.assets[?(@.name == 'idea-$version.win.zip')].digest"
+                }
+            },
+            "arm64": {
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version-aarch64.win.zip",
+                "hash": {
+                    "mode": "json",
+                    "url": "https://api.github.com/repos/JetBrains/intellij-community/releases/tags/idea%2F$version",
+                    "jsonpath": "$.assets[?(@.name == 'idea-$version-aarch64.win.zip')].digest"
+                }
+            }
+        }
+    }
+}

--- a/bucket/idea-community.json
+++ b/bucket/idea-community.json
@@ -1,6 +1,6 @@
 {
     "version": "2025.2.6.3",
-    "description": "Cross-Platform IDE for Java by JetBrains - Open Source Community Edition",
+    "description": "Cross-Platform IDE for Java by JetBrains (Open Source Community Edition).",
     "homepage": "https://github.com/JetBrains/intellij-community",
     "license": "Apache-2.0",
     "architecture": {
@@ -38,19 +38,17 @@
         }
     },
     "extract_to": "IDE",
-    "post_install": [
-        "$file = \"$persist_dir\\IDE\\bin\\idea.properties\"",
-        "$content = Get-Content $file",
-        "$content = $content -replace '^#\\s*idea\\.config\\.path=.*$', \"idea.config.path=$persist_dir\\config\"",
-        "$content = $content -replace '^#\\s*idea\\.system\\.path=.*$', \"idea.system.path=$persist_dir\\system\"",
-        "$content = $content -replace '^#\\s*idea\\.plugins\\.path=.*$', \"idea.plugins.path=$persist_dir\\plugins\"",
-        "$content = $content -replace '^#\\s*idea\\.log\\.path=.*$', \"idea.log.path=$persist_dir\\logs\"",
-        "$content | Set-Content $file"
+    "installer": {
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" \"$dir\" \"$persist_dir\""
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "IDE\\bin\\idea64.exe.vmoptions",
+        "profile"
     ],
-    "persist": "IDE\\bin\\idea.properties",
     "checkver": {
         "github": "https://api.github.com/repos/JetBrains/intellij-community/releases",
-        "jsonpath": "$.[*].tag_name",
+        "jsonpath": "$[*].tag_name",
         "regex": "\"idea/([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/idea-community.json
+++ b/bucket/idea-community.json
@@ -1,12 +1,12 @@
 {
-    "version": "2025.2.6.3",
+    "version": "2026.2",
     "description": "Cross-Platform IDE for Java by JetBrains (Open Source Community Edition).",
     "homepage": "https://github.com/JetBrains/intellij-community",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/2025.2.6.3/ideaIC-2025.2.6.3.win.zip",
-            "hash": "0c5ea801530c8b9f8b2f9429580d29e7aace7dd338e2a0c62a89e034f498ded5",
+            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/2026.2/idea-2026.2.win.zip",
+            "hash": "4ceacd1b7dda88ee9e8f7f81f100e337ccbc03f84c75c20da2b2333056002f29",
             "bin": [
                 [
                     "IDE\\bin\\idea64.exe",
@@ -21,8 +21,8 @@
             ]
         },
         "arm64": {
-            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/2025.2.6.3/ideaIC-2025.2.6.3-aarch64.win.zip",
-            "hash": "b8cbbae02362d72932d65b5db798bf8889f4e4afef6bd130af0b3638d37f2b9c",
+            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/2026.2/idea-2026.2-aarch64.win.zip",
+            "hash": "3485182d4a0068e76b8bfc5f2bc19d9257f90b6efb229f8d8a3f0176137bd865",
             "bin": [
                 [
                     "IDE\\bin\\idea64.exe",
@@ -48,16 +48,23 @@
     ],
     "checkver": {
         "github": "https://api.github.com/repos/JetBrains/intellij-community/releases",
-        "jsonpath": "$[*].tag_name",
-        "regex": "\"idea/([\\d.]+)\""
+        "script": [
+            "$releases = $page | ConvertFrom-Json -ErrorAction Stop",
+            "$versions = $releases | Where-Object { $_.tag_name -match '^idea/(?<version>[\\d.]+)$' } | ForEach-Object { [version]$Matches['version'] }",
+            "$latest_version = $versions | Sort-Object -Descending | Select-Object -First 1",
+            "$version_info = @{ result = \"$($latest_version.ToString())\" } | ConvertTo-Json -Compress",
+            "Write-Output $version_info"
+        ],
+        "jsonpath": "$.result",
+        "regex": "^(?<version>[\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/$version/ideaIC-$version.win.zip"
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/$version/idea-$version.win.zip"
             },
             "arm64": {
-                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/$version/ideaIC-$version-aarch64.win.zip"
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/$version/idea-$version-aarch64.win.zip"
             }
         }
     }

--- a/bucket/idea-community.json
+++ b/bucket/idea-community.json
@@ -1,16 +1,40 @@
 {
-    "version": "2026.1.4",
+    "version": "2025.2.6.3",
     "description": "Cross-Platform IDE for Java by JetBrains - Open Source Community Edition",
     "homepage": "https://github.com/JetBrains/intellij-community",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F2026.1.4/idea-2026.1.4.win.zip",
-            "hash": "da0f2da6bd7e3b113be1a119f44d28efd40758f3249623a636fa8368ec559cc5"
+            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/2025.2.6.3/ideaIC-2025.2.6.3.win.zip",
+            "hash": "0c5ea801530c8b9f8b2f9429580d29e7aace7dd338e2a0c62a89e034f498ded5",
+            "bin": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "idea"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "JetBrains\\IDEA (Community Edition)"
+                ]
+            ]
         },
         "arm64": {
-            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F2026.1.4/idea-2026.1.4-aarch64.win.zip",
-            "hash": "ba9c9615e75c3e2e3c53a6604a912221146d5c773c9c9fd655039198777ec63a"
+            "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/2025.2.6.3/ideaIC-2025.2.6.3-aarch64.win.zip",
+            "hash": "b8cbbae02362d72932d65b5db798bf8889f4e4afef6bd130af0b3638d37f2b9c",
+            "bin": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "idea"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "JetBrains\\IDEA (Community Edition)"
+                ]
+            ]
         }
     },
     "extract_to": "IDE",
@@ -23,18 +47,6 @@
         "$content = $content -replace '^#\\s*idea\\.log\\.path=.*$', \"idea.log.path=$persist_dir\\logs\"",
         "$content | Set-Content $file"
     ],
-    "bin": [
-        [
-            "IDE\\bin\\idea64.exe",
-            "idea"
-        ]
-    ],
-    "shortcuts": [
-        [
-            "IDE\\bin\\idea64.exe",
-            "JetBrains\\IDEA"
-        ]
-    ],
     "persist": "IDE\\bin\\idea.properties",
     "checkver": {
         "github": "https://api.github.com/repos/JetBrains/intellij-community/releases",
@@ -44,10 +56,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version.win.zip"
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/$version/ideaIC-$version.win.zip"
             },
             "arm64": {
-                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version-aarch64.win.zip"
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea/$version/ideaIC-$version-aarch64.win.zip"
             }
         }
     }

--- a/bucket/idea-community.json
+++ b/bucket/idea-community.json
@@ -37,27 +37,17 @@
     ],
     "persist": "IDE\\bin\\idea.properties",
     "checkver": {
-        "url": "https://api.github.com/repos/JetBrains/intellij-community/releases",
+        "github": "https://api.github.com/repos/JetBrains/intellij-community/releases",
         "jsonpath": "$.[*].tag_name",
         "regex": "\"idea/([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version.win.zip",
-                "hash": {
-                    "mode": "json",
-                    "url": "https://api.github.com/repos/JetBrains/intellij-community/releases/tags/idea%2F$version",
-                    "jsonpath": "$.assets[?(@.name == 'idea-$version.win.zip')].digest"
-                }
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version.win.zip"
             },
             "arm64": {
-                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version-aarch64.win.zip",
-                "hash": {
-                    "mode": "json",
-                    "url": "https://api.github.com/repos/JetBrains/intellij-community/releases/tags/idea%2F$version",
-                    "jsonpath": "$.assets[?(@.name == 'idea-$version-aarch64.win.zip')].digest"
-                }
+                "url": "https://github.com/JetBrains/intellij-community/releases/download/idea%2F$version/idea-$version-aarch64.win.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #17528 

Made the `extract_to` match the `idea` manifest. `persist` has been designed as suggested in the issue.

Not sure if this should be in the `versions` bucket.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Edit:typo
