### PR TITLE
markeron: Add version 1.5.1

### DIFF
--- a/bucket/markeron.json
+++ b/bucket/markeron.json
@@ -1,0 +1,35 @@
+{
+    "version": "1.5.1",
+    "description": "Lightweight open-source screen annotation tool with click-through mode",
+    "homepage": "https://markeron.cn/",
+    "license": {
+        "identifier": "MIT"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ifer47/markeron/releases/download/v1.5.1/MarkerOn_1.5.1_x64-setup.exe#/dl.7z",
+            "hash": "b41b048bd8ea8c24552b6ea4664cdc473e55649b17fa670427e011830e2b5db3"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse",
+    "shortcuts": [
+        [
+            "MarkerOn.exe",
+            "MarkerOn"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ifer47/markeron"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ifer47/markeron/releases/download/v$version/MarkerOn_$version_x64-setup.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "https://api.github.com/repos/ifer47/markeron/releases",
+            "jsonpath": "$..assets[?(@.browser_download_url == '$url')].digest"
+        }
+    }
+}

--- a/bucket/markeron.json
+++ b/bucket/markeron.json
@@ -1,17 +1,15 @@
 {
     "version": "1.5.1",
-    "description": "Lightweight open-source screen annotation tool with click-through mode",
-    "homepage": "https://markeron.cn/",
-    "license": {
-        "identifier": "MIT"
-    },
+    "description": "Lightweight open-source screen annotation tool with click-through mode.",
+    "homepage": "https://markeron.cn",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ifer47/markeron/releases/download/v1.5.1/MarkerOn_1.5.1_x64-setup.exe#/dl.7z",
             "hash": "b41b048bd8ea8c24552b6ea4664cdc473e55649b17fa670427e011830e2b5db3"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse -ErrorAction Ignore",
     "shortcuts": [
         [
             "MarkerOn.exe",
@@ -26,10 +24,6 @@
             "64bit": {
                 "url": "https://github.com/ifer47/markeron/releases/download/v$version/MarkerOn_$version_x64-setup.exe#/dl.7z"
             }
-        },
-        "hash": {
-            "url": "https://api.github.com/repos/ifer47/markeron/releases",
-            "jsonpath": "$..assets[?(@.browser_download_url == '$url')].digest"
         }
     }
 }


### PR DESCRIPTION
Closes #18299 

I created an issue ( https://github.com/ScoopInstaller/Scoop/issues/6686 ) because the default hash detection is not working as soon as I extend the download link with `#/dl.7z`. Added an `autoupdate.hash` for now.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
