### PR TITLE
notepad3: Update to version 7.26.602.1, fix checkver

### DIFF
--- a/bucket/notepad3.json
+++ b/bucket/notepad3.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.26.426.1",
+    "version": "7.26.602.1",
     "description": "Notepad-like text editor based on the Scintilla source code",
     "homepage": "https://www.rizonesoft.com/downloads/notepad3/",
     "license": "BSD-3-Clause",
@@ -9,12 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rizonesoft/Notepad3/releases/download/RELEASE_7.26.426.1/Notepad3_7.26.426.1_x64_Portable.zip",
-            "hash": "6270dc551f82a0a40998ebe0129c5379146691d2cb7d207111a9e229212ceaca"
+            "url": "https://github.com/rizonesoft/Notepad3/releases/download/RELEASE_7.26.602.1/Notepad3_7.26.602.1_x64_Portable.zip",
+            "hash": "4f8d02c5c1d5943cd0495c4322ee2e3d07c4734f15d29e2e24ae6f5fcbc1a9eb"
         },
         "32bit": {
-            "url": "https://github.com/rizonesoft/Notepad3/releases/download/RELEASE_7.26.426.1/Notepad3_7.26.426.1_x86_Portable.zip",
-            "hash": "08f7e7fcd3fb34e0d90052c408f5ff6cac4e030d1d9ad4451e35ed21e237a3e8"
+            "url": "https://github.com/rizonesoft/Notepad3/releases/download/RELEASE_7.26.602.1/Notepad3_7.26.602.1_x86_Portable.zip",
+            "hash": "08ba4efd7dbbb014e7605ca2d3348ea1d4320a7b168826e1e6fbf510fec88147"
         }
     },
     "post_install": [

--- a/bucket/notepad3.json
+++ b/bucket/notepad3.json
@@ -56,7 +56,8 @@
     ],
     "checkver": {
         "github": "https://github.com/rizonesoft/Notepad3",
-        "regex": "tag/RELEASE_([\\d.]+)"
+        "jsonpath": "$.tag_name",
+        "regex": "RELEASE_([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
## Summary
- Bump `notepad3` `7.26.426.1` → `7.26.602.1`
- Refresh portable zip URLs/hashes for x64/x86 from `rizonesoft/Notepad3` `RELEASE_7.26.602.1`

## Test plan
- [ ] Hash verified via SHA256 download of both portable zips
- [ ] Scoop CI / HashCheck
