### PR TITLE
qling: Add version 1.2.0

### DIFF
--- a/bucket/qling.json
+++ b/bucket/qling.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.2.0",
+  "description": "轻灵 Qling — local-first Chinese AI Agent CLI workbench",
+  "homepage": "https://github.com/Zzy-min/qling",
+  "license": "MIT",
+  "notes": [
+    "Portable zip embeds Node.js runtime (no system Node required).",
+    "Source: https://github.com/Zzy-min/qling",
+    "API keys must be set as user environment variables (never commit secrets)."
+  ],
+  "url": "https://github.com/Zzy-min/qling/releases/download/v1.2.0/qling-win-x64.zip",
+  "hash": "sha256:5a41e35c38efd9a4574bdaeee538016383b24f27ac4fdb8a03a1c3d15c3a51c4",
+  "extract_dir": "qling-win-x64",
+  "bin": "qling.cmd",
+  "post_install": [
+    "Write-Host 'qling installed. Run: qling doctor && qling setup' -ForegroundColor Cyan"
+  ],
+  "checkver": {
+    "github": "https://github.com/Zzy-min/qling"
+  },
+  "autoupdate": {
+    "url": "https://github.com/Zzy-min/qling/releases/download/v$version/qling-win-x64.zip"
+  }
+}


### PR DESCRIPTION
## Description
Adds [Qling](https://github.com/Zzy-min/qling) — local-first Chinese AI Agent CLI workbench.

- Installer: GitHub Release portable zip (`qling-win-x64.zip`)
- Embeds Node.js runtime (no system Node required)
- Homepage: https://github.com/Zzy-min/qling
- License: MIT

## Checklist
- [x] Manifest tested locally
- [x] Hash is SHA256 of the release zip
- [x] checkver / autoupdate present