### PR TITLE
arduino@2.3.10: Switch to GitHub releases

### DIFF
--- a/bucket/arduino.json
+++ b/bucket/arduino.json
@@ -3,8 +3,12 @@
     "description": "Arduino IDE",
     "homepage": "https://www.arduino.cc",
     "license": "AGPL-3.0-or-later",
-    "url": "https://downloads.arduino.cc/arduino-ide/arduino-ide_2.3.10_Windows_64bit.zip",
-    "hash": "5dd9d6b2e2c9ef8dd9d98da7808f712daff97911a91d3ccfaf946355c6b6abb3",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/arduino/arduino-ide/releases/download/2.3.10/arduino-ide_2.3.10_Windows_64bit.zip",
+            "hash": "5dd9d6b2e2c9ef8dd9d98da7808f712daff97911a91d3ccfaf946355c6b6abb3"
+        }
+    },
     "bin": [
         [
             "Arduino IDE.exe",
@@ -18,10 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.arduino.cc/en/software/",
-        "regex": "Arduino IDE ([\\d.]+)<"
+        "github": "https://github.com/arduino/arduino-ide"
     },
     "autoupdate": {
-        "url": "https://downloads.arduino.cc/arduino-ide/arduino-ide_$version_Windows_64bit.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/arduino/arduino-ide/releases/download/$version/arduino-ide_$version_Windows_64bit.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
Downloads from GitHub releases are significantly faster than from downloads.arduino.cc.

- [x] Use conventional PR title: &grave;<manifest-name[@version]|chore>: <general summary of the pull request>&grave;
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)