### PR TITLE
thonny: Update to version 5.0.0, fix portable asset rename

### DIFF
--- a/bucket/thonny.json
+++ b/bucket/thonny.json
@@ -1,10 +1,10 @@
 {
-    "version": "4.1.7",
+    "version": "5.0.0",
     "description": "Python IDE for beginners",
     "homepage": "https://thonny.org",
     "license": "MIT",
-    "url": "https://github.com/thonny/thonny/releases/download/v4.1.7/thonny-4.1.7-windows-portable.zip",
-    "hash": "cdca6e2cd1c925749a0597250533d887f22ebe3d4fb48ba7db2871abc5d68fb4",
+    "url": "https://github.com/thonny/thonny/releases/download/v5.0.0/thonny-5.0.0-windows-portable-x64.zip",
+    "hash": "5b744151065bdbd6a0d823dfa791a72cbbc3372a549a5e4cb175434a9787eaee",
     "shortcuts": [
         [
             "thonny.exe",
@@ -18,9 +18,9 @@
     "checkver": {
         "github": "https://api.github.com/repos/thonny/thonny/releases",
         "jsonpath": "$[*].assets[*].browser_download_url",
-        "regex": "thonny-([\\d.]+)-windows-portable\\.zip"
+        "regex": "thonny-([\\d.]+)-windows-portable(?:-x64)?\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/thonny/thonny/releases/download/v$version/thonny-$version-windows-portable.zip"
+        "url": "https://github.com/thonny/thonny/releases/download/v$version/thonny-$version-windows-portable-x64.zip"
     }
 }

--- a/bucket/thonny.json
+++ b/bucket/thonny.json
@@ -3,8 +3,12 @@
     "description": "Python IDE for beginners",
     "homepage": "https://thonny.org",
     "license": "MIT",
-    "url": "https://github.com/thonny/thonny/releases/download/v5.0.0/thonny-5.0.0-windows-portable-x64.zip",
-    "hash": "5b744151065bdbd6a0d823dfa791a72cbbc3372a549a5e4cb175434a9787eaee",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/thonny/thonny/releases/download/v5.0.0/thonny-5.0.0-windows-portable-x64.zip",
+            "hash": "5b744151065bdbd6a0d823dfa791a72cbbc3372a549a5e4cb175434a9787eaee"
+        }
+    },
     "shortcuts": [
         [
             "thonny.exe",
@@ -21,6 +25,10 @@
         "regex": "thonny-([\\d.]+)-windows-portable(?:-x64)?\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/thonny/thonny/releases/download/v$version/thonny-$version-windows-portable-x64.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/thonny/thonny/releases/download/v$version/thonny-$version-windows-portable-x64.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #18318

Upstream 5.0.0 renamed the Windows portable zip to `thonny-$version-windows-portable-x64.zip`, so the old autoupdate pattern 404s. This PR bumps to 5.0.0, updates the hash from a full download of the new asset, and fixes checkver/autoupdate for the new name.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
