### PR TITLE
whatpulse: Add version 6.3

### DIFF
--- a/bucket/whatpulse.json
+++ b/bucket/whatpulse.json
@@ -1,0 +1,40 @@
+{
+    "version": "6.3",
+    "description": "Measures your keyboard, mouse, application and network usage",
+    "homepage": "https://whatpulse.org",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://whatpulse.org/terms/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://releases.whatpulse.org/latest/windows/whatpulse-win-latest.exe",
+            "hash": "56407a2875b3c3d45f7edd53b885a39d4627f9f694455bbe30737a1693fed0ee"
+        }
+    },
+    "installer": {
+        "script": "Start-Process -FilePath \"$dir\\whatpulse-win-latest.exe\" -ArgumentList @('--root', \"$dir\", '--accept-messages', '--accept-licenses', '--confirm-command', 'install') -Wait"
+    },
+    "post_install": "Remove-Item \"$dir\\whatpulse-win-latest.exe\" -Force -ErrorAction SilentlyContinue",
+    "shortcuts": [
+        [
+            "WhatPulse.exe",
+            "WhatPulse"
+        ]
+    ],
+    "pre_uninstall": "Stop-Process -Name 'whatpulse' -ErrorAction SilentlyContinue",
+    "uninstaller": {
+        "script": "Start-Process -FilePath \"$dir\\WhatPulseMaintenanceTool.exe\" -ArgumentList @('--confirm-command', 'remove', 'com.whatpulse.client') -Wait"
+    },
+    "checkver": {
+        "url": "https://whatpulse.org/downloads/",
+        "regex": "id=\"latest-client-version\" data-version=\"([\\d.]+)\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://releases.whatpulse.org/latest/windows/whatpulse-win-latest.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds WhatPulse 6.3 (keyboard/mouse/application/network usage tracker, https://whatpulse.org).

**Why:** WhatPulse is not currently installable via scoop. The vendor's own bucket ([whatpulse/scoop-whatpulse](https://github.com/whatpulse/scoop-whatpulse)) is stale.

**Manifest notes:**
- The vendor only publishes an unversioned installer URL (`whatpulse-win-latest.exe`). `checkver` is anchored to the site's dedicated `id="latest-client-version" data-version="..."` marker, and `autoupdate` refreshes the hash against the static URL.
- Install/uninstall uses the Qt Installer Framework 4.7 headless CLI (`--root "$dir" --accept-messages --accept-licenses --confirm-command install`), the same pattern as the vendor's manifest.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)