### PR TITLE
seconv: Add version 5.1.0

### DIFF
--- a/bucket/seconv.json
+++ b/bucket/seconv.json
@@ -1,0 +1,32 @@
+{
+    "version": "5.0.0",
+    "description": "Headless version of Subtitle Edit",
+    "homepage": "https://www.nikse.dk/subtitleedit/",
+    "license": "GPL-3.0-only",
+    "notes": "",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SeConv-Windows-x64.zip",
+            "hash": "ae71f6f954d3cf442bdd9c3082f9410292669bd3704f50aa7dcc1d9da8f354e5"
+        },
+        "arm64": {
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SeConv-macOS-ARM64.zip",
+            "hash": "aeb784f40b0243cc0b1146e6bb8738a87db331a63d90739ddf9f60802aa22c71"
+        }
+    },
+    "bin": "seconv.exe",
+    "persist": [],
+    "checkver": {
+        "github": "https://github.com/SubtitleEdit/subtitleedit"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v$version/SeConv-Windows-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v$version/SeConv-Windows-ARM64.zip"
+            }
+        }
+    }
+}

--- a/bucket/seconv.json
+++ b/bucket/seconv.json
@@ -15,7 +15,6 @@
         }
     },
     "bin": "seconv.exe",
-    "persist": [],
     "checkver": {
         "github": "https://github.com/SubtitleEdit/subtitleedit"
     },

--- a/bucket/seconv.json
+++ b/bucket/seconv.json
@@ -10,7 +10,7 @@
             "hash": "ae71f6f954d3cf442bdd9c3082f9410292669bd3704f50aa7dcc1d9da8f354e5"
         },
         "arm64": {
-            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SeConv-macOS-ARM64.zip",
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SeConv-Windows-ARM64.zip",
             "hash": "aeb784f40b0243cc0b1146e6bb8738a87db331a63d90739ddf9f60802aa22c71"
         }
     },

--- a/bucket/seconv.json
+++ b/bucket/seconv.json
@@ -1,17 +1,16 @@
 {
-    "version": "5.0.0",
-    "description": "Headless version of Subtitle Edit",
+    "version": "5.1.0",
+    "description": "Subtitle Edit's headless command-line converter",
     "homepage": "https://www.nikse.dk/subtitleedit/",
     "license": "GPL-3.0-only",
-    "notes": "",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SeConv-Windows-x64.zip",
-            "hash": "ae71f6f954d3cf442bdd9c3082f9410292669bd3704f50aa7dcc1d9da8f354e5"
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.1.0/SeConv-Windows-x64.zip",
+            "hash": "ce081a6c6844d44cb1373ee501a963c9e37c788bf757c2fa0b39821ef9969839"
         },
         "arm64": {
-            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.0.0/SeConv-Windows-ARM64.zip",
-            "hash": "aeb784f40b0243cc0b1146e6bb8738a87db331a63d90739ddf9f60802aa22c71"
+            "url": "https://github.com/SubtitleEdit/subtitleedit/releases/download/v5.1.0/SeConv-Windows-ARM64.zip",
+            "hash": "26466399a00d54ec8d41e26d98dcdd4a286aa19a337fd393a2eda800eba8eef0"
         }
     },
     "bin": "seconv.exe",


### PR DESCRIPTION
This is a CLI-only version of Subtitle Edit that's not included in the subtitleedit manifest and is instead distributed separately.

https://github.com/SubtitleEdit/subtitleedit/releases/tag/v5.0.0





- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
