### PR TITLE
feat: add orbt 0.1.9

### DIFF
--- a/bucket/orbt.json
+++ b/bucket/orbt.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.1.9",
+    "description": "Universal terminal workspace with AI agent runtime — sessions, panes, SSH attach, and embedded satellite management",
+    "homepage": "https://github.com/linuszz/orbt",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/linuszz/orbt/releases/download/v0.1.9/orbt-windows-x86_64.zip",
+            "hash": "d464fffb2efbfb5b8f84a62b153da33145d97b02a8e368be58533f6cd6f9c2fc"
+        }
+    },
+    "bin": "orbt.exe",
+    "shortcuts": [["orbt.exe", "orbt"]],
+    "checkver": {
+        "github": "https://github.com/linuszz/orbt"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/linuszz/orbt/releases/download/v$version/orbt-windows-x86_64.zip",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

New manifest for **orbt** — a universal terminal workspace with first-class AI agent runtime.

- **What it does**: Terminal multiplexer (tmux/zellij heritage) with embedded AI satellite management (Claude Code, Codex, Copilot CLI detection + state tracking), SSH remote attach, OSC 52 clipboard bridge, and multi-protocol image rendering.
- **Homepage**: https://github.com/linuszz/orbt
- **License**: AGPL-3.0-only
- **Installer type**: portable zip (single `.exe`, no registry writes, no UAC required)
- **Architecture**: x64

## Manifest

- `autoupdate` configured with GitHub release detection
- SHA256 hash verified against v0.1.9 release asset

## Checklist

- [x] `version` matches latest release tag
- [x] `hash` is correct SHA256 of the zip
- [x] `checkver` points to GitHub releases
- [x] `autoupdate` configured
- [x] App is portable (no registry, no UAC)
- [x] License is open source (AGPL-3.0)