### PR TITLE
installerclean: Update to version 2.2.0, fix autoupdate, update license

### DIFF
--- a/bucket/installerclean.json
+++ b/bucket/installerclean.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Open source tool to safely clean orphaned Windows Installer files and reclaim disk space.",
     "homepage": "https://github.com/no-faff/InstallerClean",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "notes": "Requires administrator privileges to access C:\\Windows\\Installer.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/no-faff/InstallerClean/releases/download/v2.1.0/InstallerClean-portable.exe",
-            "hash": "02d5ee995699b5698626da1aed6f6e21daef3a20bf629ebdf5751c5ecc7ff9ea"
+            "url": "https://github.com/no-faff/InstallerClean/releases/download/v2.2.0/InstallerClean-2.2.0-portable.exe#/InstallerClean-portable.exe",
+            "hash": "e0b3c8d7973414927ae397b229c0440db483b644ec5f3566fa6bc7c4c827e1f1"
         }
     },
     "shortcuts": [
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/no-faff/InstallerClean/releases/download/v$version/InstallerClean-portable.exe"
+                "url": "https://github.com/no-faff/InstallerClean/releases/download/v$version/InstallerClean-$version-portable.exe#/InstallerClean-portable.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Two changes, both things Excavator cannot do on its own.

**Versioned download filenames.** From v2.2.0 the portable download carries the version: `InstallerClean-2.2.0-portable.exe`. The autoupdate template now tracks the versioned name, with a `#/InstallerClean-portable.exe` fragment so the download is saved under the same name as before and the `shortcuts` entry keeps working; the hash still comes from the `$url.sha256` sidecar published with each release. The concrete `version`, `url` and `hash` are bumped to 2.2.0 (released today), since Excavator cannot cross the rename by itself.

**License.** InstallerClean relicensed from MIT to Apache 2.0 in v2.1.0 (https://github.com/no-faff/InstallerClean/blob/main/LICENSE). Excavator keeps `version`, `url` and `hash` current but does not touch `license`, so this needs doing by hand.