### PR TITLE
ldplayer: Update to version 14.0.22.0, enable checkver

### DIFF
--- a/bucket/ldplayer.json
+++ b/bucket/ldplayer.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.ldplayer.net",
     "license": "Unknown",
     "notes": "Administrator privileges are required to run repairer",
-    "url": "https://static.ldrescdn.com/download/package/LDPlayer_5.0.13.1.exe#/setup.exe",
+    "url": "https://static.ldrescdn.com/download/package/LDPlayer_9.5.27.0.exe#/setup.exe",
     "hash": "dad4e80883fd2f4a28ba917547d70ee044e1b6c485888e78ba4ba63054161b4a",
     "shortcuts": [
         [

--- a/bucket/ldplayer.json
+++ b/bucket/ldplayer.json
@@ -1,12 +1,11 @@
 {
-    "##": "It cannot be updated to 9.0 or higher because the installer cannot be extracted properly.",
-    "version": "5.0.13.1",
+    "version": "9.5.27.0",
     "description": "An Android emulator optimized for mobile gaming with lower resource consumption",
     "homepage": "https://www.ldplayer.net",
     "license": "Unknown",
     "notes": "Administrator privileges are required to run repairer",
-    "url": "https://static.ldrescdn.com/download/package/LDPlayer_5.0.13.1.exe#/dl.7z",
-    "hash": "88d0342c2a6d82c6091a40c2697557e3c6d7f00b9f570613b0b20e5fd5f8756f",
+    "url": "https://static.ldrescdn.com/download/package/LDPlayer_5.0.13.1.exe#/setup.exe",
+    "hash": "dad4e80883fd2f4a28ba917547d70ee044e1b6c485888e78ba4ba63054161b4a",
     "shortcuts": [
         [
             "dnplayer.exe",
@@ -21,8 +20,17 @@
             "LDPlayer\\LDPlayer Repairer"
         ]
     ],
-    "uninstaller": {
-        "file": "dnuninst.exe"
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\setup.exe\" \"$dir\\installer\" -Switches \"-t#\"",
+            "@('4.7z', '6.7z') | ForEach-Object {",
+            "    Remove-Item \"$dir\\installer\\$_\"",
+            "}",
+            "(Get-ChildItem \"$dir\\installer\\*.7z\").FullName | ForEach-Object {",
+            "    Expand-7zipArchive $_ \"$dir\" ",
+            "}",
+            "Remove-Item \"$dir\\installer\", \"$dir\\setup.exe\" -Force -Recurse"
+        ]
     },
     "persist": [
         "ldrecord\\video",
@@ -30,9 +38,9 @@
     ],
     "checkver": {
         "url": "https://www.ldplayer.net/other/version-history-and-release-notes.html",
-        "regex": "download/package/LDPlayer_(5[\\d.]+)\\.exe"
+        "regex": "download/package/LDPlayer_([\\d.]+)\\.exe"
     },
     "autoupdate": {
-        "url": "https://static.ldrescdn.com/download/package/LDPlayer_$version.exe#/dl.7z"
+        "url": "https://static.ldrescdn.com/download/package/LDPlayer_$version.exe#/setup.exe"
     }
 }

--- a/bucket/ldplayer.json
+++ b/bucket/ldplayer.json
@@ -32,6 +32,9 @@
             "Remove-Item \"$dir\\installer\", \"$dir\\setup.exe\" -Force -Recurse"
         ]
     },
+    "uninstaller": {
+        "file": "dnuninst.exe"
+    },
     "persist": [
         "ldrecord\\video",
         "vms"

--- a/bucket/ldplayer.json
+++ b/bucket/ldplayer.json
@@ -2,8 +2,14 @@
     "version": "14.0.22.0",
     "description": "An Android emulator optimized for mobile gaming with lower resource consumption",
     "homepage": "https://www.ldplayer.net",
-    "license": "Unknown",
-    "notes": "Administrator privileges are required to run repairer",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.ldplayer.net/other/terms-of-use.html"
+    },
+    "notes": [
+        "Administrator privileges are required to run repairer.",
+        "For LDPlayer 5, use `versions/ldplayer5`; for LDPlayer 9, use `versions/ldplayer9`."
+    ],
     "url": "https://static.ldrescdn.com/download/package/LDPlayer_14.0.22.0.exe",
     "hash": "f351d39360a2be22274123d139c68108020aafa8276f8533cab7f0e6686354dc",
     "installer": {

--- a/bucket/ldplayer.json
+++ b/bucket/ldplayer.json
@@ -1,11 +1,20 @@
 {
-    "version": "9.5.27.0",
+    "version": "14.0.22.0",
     "description": "An Android emulator optimized for mobile gaming with lower resource consumption",
     "homepage": "https://www.ldplayer.net",
     "license": "Unknown",
     "notes": "Administrator privileges are required to run repairer",
-    "url": "https://static.ldrescdn.com/download/package/LDPlayer_9.5.27.0.exe#/setup.exe",
-    "hash": "dad4e80883fd2f4a28ba917547d70ee044e1b6c485888e78ba4ba63054161b4a",
+    "url": "https://static.ldrescdn.com/download/package/LDPlayer_14.0.22.0.exe",
+    "hash": "f351d39360a2be22274123d139c68108020aafa8276f8533cab7f0e6686354dc",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\$fname\" \"$dir\\installer\" -Switches \"-t#\" -Removal",
+            "Get-ChildItem -LiteralPath \"$dir\\installer\" -Filter '*.7z' -File | ForEach-Object {",
+            "    Expand-7zipArchive $_.FullName $dir",
+            "}",
+            "Remove-Item \"$dir\\installer\" -Force -Recurse"
+        ]
+    },
     "shortcuts": [
         [
             "dnplayer.exe",
@@ -20,18 +29,6 @@
             "LDPlayer\\LDPlayer Repairer"
         ]
     ],
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\setup.exe\" \"$dir\\installer\" -Switches \"-t#\"",
-            "@('4.7z', '6.7z') | ForEach-Object {",
-            "    Remove-Item \"$dir\\installer\\$_\"",
-            "}",
-            "(Get-ChildItem \"$dir\\installer\\*.7z\").FullName | ForEach-Object {",
-            "    Expand-7zipArchive $_ \"$dir\" ",
-            "}",
-            "Remove-Item \"$dir\\installer\", \"$dir\\setup.exe\" -Force -Recurse"
-        ]
-    },
     "uninstaller": {
         "file": "dnuninst.exe"
     },
@@ -44,6 +41,6 @@
         "regex": "download/package/LDPlayer_([\\d.]+)\\.exe"
     },
     "autoupdate": {
-        "url": "https://static.ldrescdn.com/download/package/LDPlayer_$version.exe#/setup.exe"
+        "url": "https://static.ldrescdn.com/download/package/LDPlayer_$version.exe"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
I looked at a few installers for post-9.0 versions of LDPlayer in 7-Zip File Manager to see where the files are located, and I was able to find them consistently under two specific 7z files that are obtained by running it through 7-Zip's parser mode.

Relates to #16560, #16066
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
