### PR TITLE
magnifysnap: Add version 1.2.2

### DIFF
--- a/bucket/magnifysnap.json
+++ b/bucket/magnifysnap.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.2.2",
+    "description": "Fast screen magnifier in the system tray. Middle-click zooms the screen to 200% while it stays fully interactive; hold to peek closer.",
+    "homepage": "https://violet2code.github.io/",
+    "license": "MIT",
+    "url": "https://github.com/violet2code/magnify-snap/releases/download/v1.2.2/MagnifySnap-1.2.2-windows-x64.exe#/MagnifySnap.exe",
+    "hash": "0a7cd8a03650beaafb1aa9421eb4663796b6aab8810f6e60907e60acfa3e6334",
+    "bin": "MagnifySnap.exe",
+    "shortcuts": [
+        [
+            "MagnifySnap.exe",
+            "Magnify.Snap"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/violet2code/magnify-snap"
+    },
+    "autoupdate": {
+        "url": "https://github.com/violet2code/magnify-snap/releases/download/v$version/MagnifySnap-$version-windows-x64.exe#/MagnifySnap.exe"
+    }
+}


### PR DESCRIPTION
Adds [Magnify.Snap](https://violet2code.github.io/) — a fast screen magnifier that lives in the system tray. Middle-click toggles fullscreen zoom while the screen stays fully interactive; holding the button temporarily peeks closer.

- Portable single-exe from a versioned GitHub release, MIT licensed
- Manifest includes checkver/autoupdate via GitHub releases
- Hash verified against the release asset