### PR TITLE
winremap: Add version 0.3.0

### DIFF
--- a/bucket/winremap.json
+++ b/bucket/winremap.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.3.0",
+    "description": "A per-application key remapper for Windows, written in Rust.",
+    "homepage": "https://github.com/DaikiSuganuma/winremap",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/DaikiSuganuma/winremap/releases/download/v0.3.0/winremap.exe",
+            "hash": "b0c7d43b80edf2fe142fb6eb8afe596bd0f665e9fc28d2f1555d3b2c56d1ce45"
+        }
+    },
+    "bin": "winremap.exe",
+    "notes": [
+        "WinRemap reads %APPDATA%\\winremap\\config.toml. Create it, then run 'winremap'.",
+        "See https://daikisuganuma.github.io/winremap/config.html for the configuration guide."
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/DaikiSuganuma/winremap/releases/download/v$version/winremap.exe"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/DaikiSuganuma/winremap/releases/download/v$version/SHA256SUMS"
+        }
+    }
+}


### PR DESCRIPTION
### winremap 0.3.0 (new app)

A per-application key remapper for Windows, written in Rust (MIT).

- Homepage / repo: https://github.com/DaikiSuganuma/winremap
- Portable single exe (`winremap.exe`) from GitHub Releases
- `autoupdate` is defined; hashes come from the release `SHA256SUMS`

I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).