### PR TITLE
reasonix-desktop@1.18.0: Fix shortcut

### DIFF
--- a/bucket/reasonix-desktop.json
+++ b/bucket/reasonix-desktop.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.17.17",
+    "version": "1.17.18",
     "description": "Reasonix Desktop, official GUI for Reasonix, a DeepSeek-native AI coding agent built to reduce API costs through aggressive context caching.",
     "homepage": "https://reasonix.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.17.17/Reasonix-windows-amd64.zip",
-            "hash": "614724075c1dfb08090d59342b2f8681d11242865e22ee24e3472bce2bb2f331"
+            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.17.18/Reasonix-windows-amd64.zip",
+            "hash": "ef3cc39bd8ef271e93f59e65e275c59936187ff2e1985e730d61eab2d6557d2f"
         },
         "arm64": {
-            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.17.17/Reasonix-windows-arm64.zip",
-            "hash": "4497ce0a24919311f36714af92f43de211186dcd5b3d6ffb89d6bec776d3f394"
+            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.17.18/Reasonix-windows-arm64.zip",
+            "hash": "c9248d125a73ab5bbd53eac9aae1e0ffa0ad07d70cbf6b3b28f2a1de2dfe07bd"
         }
     },
     "shortcuts": [

--- a/bucket/reasonix-desktop.json
+++ b/bucket/reasonix-desktop.json
@@ -15,8 +15,10 @@
     },
     "shortcuts": [
         [
-            "Reasonix.exe",
-            "Reasonix Desktop"
+            "reasonix-launcher.exe",
+            "Reasonix Desktop",
+            "launch --detach",
+            "reasonix-desktop.exe"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Closes #18363

## Problem

The `reasonix-desktop` shortcut targets `Reasonix.exe`, but that entry was overwritten by the bundled CLI in the current upstream Windows portable archive. Opening **Reasonix Desktop** therefore starts the CLI instead of the GUI.

## Fix

- Update the manifest to the current 1.17.18 release and published SHA256 hashes.
- Target the archive's canonical `reasonix-launcher.exe`.
- Pass the same `launch --detach` arguments used by the official Windows installer.
- Use `reasonix-desktop.exe` as the shortcut icon.

This fixes the current package immediately while preserving the Guard launch path for failed-update rollback, crash recovery, and Safe Mode. The upstream archive collision is addressed separately by [esengine/DeepSeek-Reasonix#6806](https://github.com/esengine/DeepSeek-Reasonix/pull/6806).

## Verification

- Matched both architecture hashes against the 1.17.18 GitHub release asset digests.
- Parsed the updated manifest and verified the exact four-field shortcut contract.
- Confirmed all 39 manifest lines retain CRLF endings.
- Confirmed the 1.17.18 archive contains `reasonix-launcher.exe` and `reasonix-desktop.exe`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
