### PR TITLE
forkgram@7.0.5: Fix extracted folder structure

### DIFF
--- a/bucket/forkgram.json
+++ b/bucket/forkgram.json
@@ -16,7 +16,13 @@
             "hash": "f29440aee81de3ca2c0e1eb728f093495da4e9e66c113642646e8b2ccfa7b8d9"
         }
     },
-    "pre_install": "if (Test-Path \"$persist_dir\\log.txt\") { Copy-Item \"$persist_dir\\log.txt\" \"$dir\\\" }",
+    "pre_install": [
+        "if (Test-Path \"$dir\\Telegram\\Telegram.exe\") {",
+        "    Get-ChildItem \"$dir\\Telegram\" | Move-Item -Destination \"$dir\\\" -Force",
+        "    Remove-Item \"$dir\\Telegram\" -Recurse -Force",
+        "}",
+        "if (Test-Path \"$persist_dir\\log.txt\") { Copy-Item \"$persist_dir\\log.txt\" \"$dir\\\" }"
+    ],
     "pre_uninstall": "if (Test-Path \"$dir\\log.txt\") { Copy-Item \"$dir\\log.txt\" \"$persist_dir\\\" }",
     "bin": [
         "Telegram.exe",


### PR DESCRIPTION
### Problem
Upstream changed the zip archive structure in `v7.0.4` by wrapping the executable inside an outer `Telegram` folder. 
### Fix
Added a dynamic detection block in `pre_install`. It checks if the nested `$dir\Telegram` folder exists. If so, it moves all contents to the root `$dir`. This safely ensures backward compatibility with older releases (e.g., `v7.0.3`). Tested both structures locally. 
*(Note: The PowerShell compatibility script and this PR description were assisted by Gemini.)*

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
