### PR TITLE
dev-hud: Add version 0.1.0

### DIFF
--- a/bucket/dev-hud.json
+++ b/bucket/dev-hud.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.1.0",
+    "description": "Always-on desktop HUD for your AI dev stack: Claude/Codex usage rings, repo pulse, system and hardware telemetry in one glass widget",
+    "homepage": "https://github.com/soldforaloss/dev-hud",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/soldforaloss/dev-hud/releases/download/v0.1.0/dev-hud_0.1.0_x64-setup.exe#/dl.7z",
+            "hash": "e9e140effd1e97c4d6ac488ac5a4f177d42bef39f00db70823d363f8a1907e12"
+        }
+    },
+    "post_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force -ErrorAction SilentlyContinue"
+    ],
+    "shortcuts": [
+        [
+            "dev-hud.exe",
+            "Dev HUD"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/soldforaloss/dev-hud/releases/download/v$version/dev-hud_${version}_x64-setup.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds **Dev HUD** — an open-source (MIT) always-on desktop HUD for AI-assisted development: Claude/Codex rate-limit rings and burn, GitHub repo pulse, and system/hardware telemetry in one Tauri 2 glass widget.

- Homepage: https://github.com/soldforaloss/dev-hud
- Release asset: NSIS installer, handled via the standard `#/dl.7z` extraction pattern

Verified locally:
- SHA256 matches the published release asset
- 7-Zip extraction of the NSIS installer yields `dev-hud.exe` at the archive root (plus `$PLUGINSDIR`, removed in `post_install`)
- `checkver: github` + autoupdate template follow the release asset naming `dev-hud_<version>_x64-setup.exe`

Note: I'm the package author. First release went out today; happy to adjust the manifest to reviewer preferences.