### PR TITLE
glabels: Add version 3.99-master639

### DIFF
--- a/bucket/glabels.json
+++ b/bucket/glabels.json
@@ -1,0 +1,45 @@
+{
+    "version": "3.99-master639",
+    "description": "Designer for labels, business cards and barcodes, with a large template database (unofficial Windows build of gLabels 4)",
+    "homepage": "https://github.com/ibsorn/glabels-windows",
+    "license": "GPL-3.0-or-later",
+    "notes": [
+        "These are unofficial community builds of gLabels 4 (glabels-qt), which upstream does not distribute for Windows.",
+        "gLabels 4 is still in development: treat it as pre-release software and keep backups of your projects.",
+        "Report application bugs at https://github.com/j-evins/glabels-qt/issues and packaging problems at https://github.com/ibsorn/glabels-windows/issues"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ibsorn/glabels-windows/releases/download/win-3.99-master639/gLabels-3.99-master639-win64-portable.zip",
+            "hash": "8e0323862bfdb85e929ecef5c05d2188d7a47200a27ee3f55d16c5f8ea8dd0d4",
+            "extract_dir": "gLabels-3.99-master639-win64"
+        }
+    },
+    "bin": [
+        [
+            "bin\\glabels-batch-qt.exe",
+            "glabels-batch-qt"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bin\\glabels-qt.exe",
+            "gLabels"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/ibsorn/glabels-windows/releases/latest",
+        "regex": "\"tag_name\":\\s*\"win-([\\w.-]+)\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ibsorn/glabels-windows/releases/download/win-$version/gLabels-$version-win64-portable.zip",
+                "extract_dir": "gLabels-$version-win64"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/ibsorn/glabels-windows/releases/download/win-$version/SHA256SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION
Adds **glabels** — a designer for labels, business cards and barcodes, with a template database covering 35+ stationery vendors and document-merge from CSV.

gLabels is GPLv3 software by Jaye Evins and contributors. The Qt version (`glabels-qt`) builds fine on Windows but upstream publishes no Windows binaries, so this manifest points at an unofficial community build. The manifest's description and `notes` both state that plainly and send application bugs upstream rather than to the packager. Upstream has been notified the builds exist: https://github.com/j-evins/glabels-qt/issues/31#issuecomment-5055774938

The archive is produced by a public GitHub Actions workflow from unmodified upstream sources — [one workflow file](https://github.com/ibsorn/glabels-windows/blob/main/.github/workflows/build-windows.yml), no vendored code. Every build runs the upstream unit tests and then renders a PDF from the *packaged* tree, so an archive that does not actually run never gets published.

Manifest notes:

- Uses the portable ZIP, which needs no installer. The application locates its templates as `../share/glabels-qt` relative to the executable, so `extract_dir` keeps the archive's own `bin/` + `share/` layout intact.
- Only the CLI renderer `glabels-batch-qt` is shimmed into `bin`; the GUI gets a shortcut.
- `checkver` reads the release tag from the GitHub API, and `autoupdate` takes hashes from the `SHA256SUMS.txt` published alongside every release.
- Validated against `schema.json`; `scoop install`/`scoop uninstall` conventions follow the existing portable-archive manifests in this bucket.
