### PR TITLE
exhyperv: Update to version 1.5.0, fix autoupdate

### DIFF
--- a/bucket/exhyperv.json
+++ b/bucket/exhyperv.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.5.0/ExHyperV_1.5.0_x64.zip",
+            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.5.0/ExHyperV_V1.5.0_x64.zip",
             "hash": "264196112949937c9ecb860d22e953ab8e7a14ea17d299a55759d8041d09f78d"
         },
         "arm64": {
-            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.5.0/ExHyperV_1.5.0_arm64.zip",
+            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.5.0/ExHyperV_V1.5.0_arm64.zip",
             "hash": "2ebd924685195e66494c89ee7312a2fe8b4634c5de354a7dee0e415a6a7a8ba3"
         }
     },
@@ -36,10 +36,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Justsenger/ExHyperV/releases/download/$matchTag/ExHyperV_$version_x64.zip"
+                "url": "https://github.com/Justsenger/ExHyperV/releases/download/$matchTag/ExHyperV_V$version_x64.zip"
             },
             "arm64": {
-                "url": "https://github.com/Justsenger/ExHyperV/releases/download/$matchTag/ExHyperV_$version_arm64.zip"
+                "url": "https://github.com/Justsenger/ExHyperV/releases/download/$matchTag/ExHyperV_V$version_arm64.zip"
             }
         }
     }

--- a/bucket/exhyperv.json
+++ b/bucket/exhyperv.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.3",
+    "version": "1.5.0",
     "description": "A graphical Hyper-V management tool that allows mere mortals to easily master advanced Hyper-V features.",
     "homepage": "https://github.com/Justsenger/ExHyperV",
     "license": "GPL-3.0-only",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.4.3/ExHyperV_1.4.3_x64.zip",
-            "hash": "17d4f765fb81e9af528b2c0470fa5680a225735eb95010c43ad60272ffa19730"
+            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.5.0/ExHyperV_1.5.0_x64.zip",
+            "hash": "264196112949937c9ecb860d22e953ab8e7a14ea17d299a55759d8041d09f78d"
         },
         "arm64": {
-            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.4.3/ExHyperV_1.4.3_arm64.zip",
-            "hash": "4c1bcaf3289f1d75e8e137e7a959abacc0ac2088a78612aa69e8327a82045bc0"
+            "url": "https://github.com/Justsenger/ExHyperV/releases/download/V1.5.0/ExHyperV_1.5.0_arm64.zip",
+            "hash": "2ebd924685195e66494c89ee7312a2fe8b4634c5de354a7dee0e415a6a7a8ba3"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Update ExHyperV to version 1.5.0.

- Update x64 and arm64 download URLs
- Update SHA256 hashes
- ~~Keep existing autoupdate configuration~~ Update x64 and arm64 autoupdate URLs

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)