### PR TITLE
ente-photos: Add version 1.7.26

### DIFF
--- a/bucket/ente-photos.json
+++ b/bucket/ente-photos.json
@@ -1,0 +1,45 @@
+{
+    "version": "1.7.26",
+    "description": "Open source, end-to-end encrypted photo and video storage app.",
+    "homepage": "https://ente.io",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ente/photos-desktop/releases/download/v1.7.26/ente-1.7.26-x64.exe#/dl.7z",
+            "hash": "sha512:1ef94557f802dc1489e55f46378a83e7d71722574f422aa2ab113f3dece563857f6d5354cffedf3133f2f74a8b349364790fc7c8a89eed34771345dbf68bfc19",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        },
+        "arm64": {
+            "url": "https://github.com/ente/photos-desktop/releases/download/v1.7.26/ente-1.7.26-arm64.exe#/dl.7z",
+            "hash": "sha512:38d218bcbd774de42e78b042484e49057252b5c418d03b2a07c43ed29137f3dcdc4741da91408d7cb0cc514cf553e351adec17aa18cb6127f425c63ea47c3647",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\""
+        }
+    },
+    "post_install": [
+        "# app-update.yml removal disables the in-app updater, which conflicts with Scoop-managed updates (ente/ente#6397)",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*.exe\", \"$dir\\resources\\app-update.yml\" -Recurse -Force"
+    ],
+    "shortcuts": [
+        [
+            "ente.exe",
+            "Ente Photos"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ente/photos-desktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ente/photos-desktop/releases/download/v$version/ente-$version-x64.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/ente/photos-desktop/releases/download/v$version/ente-$version-arm64.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "regex": "$basename\\s+sha512:\\s$base64"
+        }
+    }
+}


### PR DESCRIPTION
Add [Ente Photos](https://ente.io), an open source, end-to-end encrypted photo and video storage app (desktop client), at v1.7.26.

Closes #15955
Supersedes #16257 (based on @zeldrisho's manifest, with credit; they gave the go-ahead in #15955)

- **Homepage:** https://ente.io
- **License:** AGPL-3.0-only
- **Installer:** NSIS built with electron-builder, x64 and arm64. Extracted with the `$PLUGINSDIR` pattern (same as `signal`, `obsidian`, `openwhispr`), so the installer itself never runs.
- **In-app updater:** `post_install` removes `resources\app-update.yml` so electron-updater doesn't fight Scoop-managed updates. Same goal as `notion`, `zcode` and `antigravity`, which comment out the `url:` line. Ente's file is provider-github format with no `url:` line, so removal is the working equivalent (it's also what the community manifest for this app has shipped since Oct 2025). See ente/ente#6397 for this exact conflict class on winget.
- **Hashes:** sha512 taken from the official electron-builder `latest.yml`. There's an explicit `autoupdate.hash` block because `#/dl.7z` URL fragments break the default checksum autodetection (ScoopInstaller/Scoop#6686).
- No `bin` (GUI app) and no `persist` (the app has no portable-config mode; user data lives in `%AppData%` by design).

Tested locally on Windows: `scoop install` (sha512 verified, extraction and post_install checked, no `$PLUGINSDIR` or `$R0` leftovers, `app-update.yml` gone), the app launches, a Start Menu shortcut is created, and `scoop uninstall` leaves everything clean.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
