### PR TITLE
kid3@3.10.1: Fix extract_dir

### DIFF
--- a/bucket/kid3.json
+++ b/bucket/kid3.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/kid3/kid3/3.10.1/kid3-3.10.1-win32-x64.zip",
             "hash": "sha1:650b1f2f9502c5e08ad38114a579874b52c90a53",
-            "extract_dir": "kid3-3.10.1-win64"
+            "extract_dir": "kid3-3.10.1-win32-x64"
         }
     },
     "bin": [
@@ -28,7 +28,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://downloads.sourceforge.net/project/kid3/kid3/$matchShort/kid3-$version-win32-x64.zip",
-                "extract_dir": "kid3-$matchShort-win64"
+                "extract_dir": "kid3-$matchShort-win32-x64"
             }
         },
         "hash": {


### PR DESCRIPTION
- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Kid3 Tag Editor updated and the subdirectory inside of the archive matches the archive's name now.

I tested the change locally, it works.