### PR TITLE
gohide: Add version 1.1.10

### DIFF
--- a/bucket/gohide.json
+++ b/bucket/gohide.json
@@ -1,0 +1,39 @@
+{
+    "version": "1.1.10",
+    "description": "Hides app windows, taskbar buttons and system-tray icons with a global hotkey, then restores them exactly where they were.",
+    "homepage": "https://gohide.net",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://gohide.net/en/legal/terms"
+    },
+    "notes": [
+        "gohide needs administrator rights to hide other apps' windows and tray icons.",
+        "Free for up to 3 managed apps; Pro is a one-time purchase (https://gohide.net/en/pricing)."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gohide/GoHide/releases/download/v1.1.10/gohide-1.1.10-full.nupkg",
+            "hash": "sha1:6101f65c6bdf731b2524a1d966614f6bcb80802a"
+        }
+    },
+    "extract_dir": "lib\\app",
+    "shortcuts": [
+        [
+            "gohide.exe",
+            "gohide"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/gohide/GoHide"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gohide/GoHide/releases/download/v$version/gohide-$version-full.nupkg"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/RELEASES"
+        }
+    }
+}


### PR DESCRIPTION
Adds `gohide` 1.1.10 to the Extras bucket.

gohide is a Windows utility that hides the running apps you choose — their windows, taskbar buttons
and system-tray icons — with a single global hotkey, then restores everything exactly where it was.
It can also mute a hidden app or suspend it so a hidden game stops using CPU and GPU. Freeware for
up to 3 managed apps (no time limit, no account, no telemetry, fully offline); an optional Pro tier
is a one-time purchase. I am the developer.

- Homepage: https://gohide.net
- Source of binaries: https://github.com/gohide/GoHide/releases

Notes:

- The app ships as a Velopack package, so the manifest installs the portable `.nupkg` payload
  (`extract_dir: lib\app`) rather than running the Setup.exe bootstrapper — this keeps the install
  fully contained in the Scoop app directory, same approach as `dyad`, `folo` and `noi`.
- `autoupdate.hash` reads the SHA-1 from the Velopack/Squirrel `RELEASES` file published alongside
  each release.
- Tested end to end on Windows 11: `scoop install` downloads, passes the hash check, extracts, and
  creates a working `gohide.exe` shim/shortcut.
