### PR TITLE
netcatty: Add version 1.1.82

### DIFF
--- a/bucket/netcatty.json
+++ b/bucket/netcatty.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.1.73",
+    "version": "1.1.75",
     "description": "AI-powered SSH client, SFTP browser, and terminal manager",
     "homepage": "https://netcatty.app",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.73/Netcatty-1.1.73-portable-win-x64.exe#/Netcatty.exe",
-            "hash": "b794d1e6b6f9d68296baea8132c9dc24c046bd30e735639c818073a0a3cd39f9"
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.75/Netcatty-1.1.75-portable-win-x64.exe#/Netcatty.exe",
+            "hash": "d547c749551d85a33314172f4c86ba527cefcef22abd3e53ef48af76996b4964"
         },
         "arm64": {
-            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.73/Netcatty-1.1.73-portable-win-arm64.exe#/Netcatty.exe",
-            "hash": "a6b047c23419bb3e2672f932af6d25fa4c1c71f0ee5e4dcdb7e1fc02086da0c8"
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.75/Netcatty-1.1.75-portable-win-arm64.exe#/Netcatty.exe",
+            "hash": "d9923dc97ae532cb68e49c63e4d29706e896d3d151a17a15b3f10557e7c3ea95"
         }
     },
     "shortcuts": [

--- a/bucket/netcatty.json
+++ b/bucket/netcatty.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.1.75",
+    "version": "1.1.82",
     "description": "AI-powered SSH client, SFTP browser, and terminal manager",
     "homepage": "https://netcatty.app",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.75/Netcatty-1.1.75-portable-win-x64.exe#/Netcatty.exe",
-            "hash": "d547c749551d85a33314172f4c86ba527cefcef22abd3e53ef48af76996b4964"
-        },
-        "arm64": {
-            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.75/Netcatty-1.1.75-portable-win-arm64.exe#/Netcatty.exe",
-            "hash": "d9923dc97ae532cb68e49c63e4d29706e896d3d151a17a15b3f10557e7c3ea95"
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.82/Netcatty-1.1.82-portable-win-x64.exe#/Netcatty.exe",
+            "hash": "1284fe22cf402c8e87ff8d10d03860874a1e42aa38b135de8e74809cffd841d5"
         }
     },
     "shortcuts": [
@@ -27,9 +23,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/binaricat/Netcatty/releases/download/v$version/Netcatty-$version-portable-win-x64.exe#/Netcatty.exe"
-            },
-            "arm64": {
-                "url": "https://github.com/binaricat/Netcatty/releases/download/v$version/Netcatty-$version-portable-win-arm64.exe#/Netcatty.exe"
             }
         }
     }

--- a/bucket/netcatty.json
+++ b/bucket/netcatty.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.1.72",
+    "version": "1.1.73",
     "description": "AI-powered SSH client, SFTP browser, and terminal manager",
     "homepage": "https://netcatty.app",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.72/Netcatty-1.1.72-portable-win-x64.exe#/Netcatty.exe",
-            "hash": "840acace9cd037a8c64dd27a0caff40b2927fc7fb81d76e78c5b89fdcd35d658"
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.73/Netcatty-1.1.73-portable-win-x64.exe#/Netcatty.exe",
+            "hash": "b794d1e6b6f9d68296baea8132c9dc24c046bd30e735639c818073a0a3cd39f9"
         },
         "arm64": {
-            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.72/Netcatty-1.1.72-portable-win-arm64.exe#/Netcatty.exe",
-            "hash": "230f94e7d33cae167b0e5a06cdaf5b76ed246c0dc9981b906b4f5369ec64df1f"
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.73/Netcatty-1.1.73-portable-win-arm64.exe#/Netcatty.exe",
+            "hash": "a6b047c23419bb3e2672f932af6d25fa4c1c71f0ee5e4dcdb7e1fc02086da0c8"
         }
     },
     "shortcuts": [

--- a/bucket/netcatty.json
+++ b/bucket/netcatty.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.1.72",
+    "description": "AI-powered SSH client, SFTP browser, and terminal manager",
+    "homepage": "https://netcatty.app",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.72/Netcatty-1.1.72-portable-win-x64.exe#/Netcatty.exe",
+            "hash": "840acace9cd037a8c64dd27a0caff40b2927fc7fb81d76e78c5b89fdcd35d658"
+        },
+        "arm64": {
+            "url": "https://github.com/binaricat/Netcatty/releases/download/v1.1.72/Netcatty-1.1.72-portable-win-arm64.exe#/Netcatty.exe",
+            "hash": "230f94e7d33cae167b0e5a06cdaf5b76ed246c0dc9981b906b4f5369ec64df1f"
+        }
+    },
+    "shortcuts": [
+        [
+            "Netcatty.exe",
+            "Netcatty"
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "github": "https://github.com/binaricat/Netcatty"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/binaricat/Netcatty/releases/download/v$version/Netcatty-$version-portable-win-x64.exe#/Netcatty.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/binaricat/Netcatty/releases/download/v$version/Netcatty-$version-portable-win-arm64.exe#/Netcatty.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #18379 
Relates to #17756 

## Testing
- `formatjson` and `checkver -f`
- Windows x64 install, launch, persistence, and uninstall

- [x] Use conventional PR title: `netcatty: Add version 1.1.72`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)