### PR TITLE
windirstat: Fix download URL and update checkver to use GitHub API

### DIFF
--- a/bucket/jd-gui-duo.json
+++ b/bucket/jd-gui-duo.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.0.113",
+    "version": "2.0.114",
     "description": "A Java Decompiler based on JD-CORE v0 and v1, supporting 3rd party decompilers",
     "homepage": "https://github.com/nbauma109/jd-gui-duo",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/nbauma109/jd-gui-duo/releases/download/2.0.113/jd-gui-duo-windows-2.0.113.tar.xz",
-    "hash": "7b3cf32ebe000704b165253f28e09651581435e1f637973f0da1ce737024f3c0",
+    "url": "https://github.com/nbauma109/jd-gui-duo/releases/download/2.0.114/jd-gui-duo-windows-2.0.114.tar.xz",
+    "hash": "9d0d22c8afdc9c5c9d7f6173c48545273e524f7c9c86f69283857b0aa64b62c1",
     "pre_install": "Move-Item \"$dir\\jd-gui-duo-$version.exe\" \"$dir\\jd-gui-duo.exe\"",
     "bin": "jd-gui-duo.bat",
     "shortcuts": [

--- a/bucket/lunatranslator.json
+++ b/bucket/lunatranslator.json
@@ -1,17 +1,17 @@
 {
-    "version": "10.16.1.7",
+    "version": "10.16.1.8",
     "description": "A Visual Novel translation tool, with HOOK / OCR / clipboard support",
     "homepage": "https://github.com/HIllya51/LunaTranslator",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/HIllya51/LunaTranslator/releases/download/v10.16.1.7/LunaTranslator_x64.zip",
-            "hash": "732b540ce9d67473cdf4941547354b22a1bb2c0ae00ca63bd1def6ad84e63cff",
+            "url": "https://github.com/HIllya51/LunaTranslator/releases/download/v10.16.1.8/LunaTranslator_x64.zip",
+            "hash": "02fc637aa33dace9450eb94f2549bf8f13d073eb9168aa2edd26eb202b79b132",
             "extract_dir": "LunaTranslator_x64"
         },
         "32bit": {
-            "url": "https://github.com/HIllya51/LunaTranslator/releases/download/v10.16.1.7/LunaTranslator_x86_win7.zip",
-            "hash": "49b7aa466af164cb7ed2e0be893d76df61c5d526999fb4c75b2d6e3c24c912cb",
+            "url": "https://github.com/HIllya51/LunaTranslator/releases/download/v10.16.1.8/LunaTranslator_x86_win7.zip",
+            "hash": "ff421a381071c89d1430d95b71302b071524c144bc7d3c51e7317bfa31f09f81",
             "extract_dir": "LunaTranslator_x86_win7"
         }
     },

--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -1,5 +1,5 @@
 {
-    "version": "202607241230",
+    "version": "202607251327",
     "description": "A free, open source, and cross-platform media player",
     "homepage": "https://mpv.io",
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
@@ -12,12 +12,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-07-24-0fb136f685/mpv-x86_64-20260724-git-0fb136f685.7z",
-            "hash": "181ecdd540456d38dfd029dc9b36ee4a3b57daf5d90b5bbbdb45eeaf72ff8514"
+            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-07-25-8c67647b50/mpv-x86_64-20260725-git-8c67647b50.7z",
+            "hash": "bb22076eeda8531c3118b6e15c025224e4ae953ffce0e6fb5d1817eb2815e2d8"
         },
         "arm64": {
-            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-07-24-0fb136f685/mpv-aarch64-20260724-git-0fb136f685.7z",
-            "hash": "703def53c2b397365e312d0ba390b9b74d384e5daf1a9667aa1e98f53a3456c0"
+            "url": "https://github.com/zhongfly/mpv-winbuild/releases/download/2026-07-25-8c67647b50/mpv-aarch64-20260725-git-8c67647b50.7z",
+            "hash": "6b6bf0dac2ba0611aa857097bcee286ca9cc69509d9cdcd86d7019d86c43374e"
         }
     },
     "pre_install": "'updater.bat', 'installer' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",

--- a/bucket/nekobox.json
+++ b/bucket/nekobox.json
@@ -1,20 +1,20 @@
 {
-    "version": "5.11.28",
+    "version": "5.11.28.1",
     "description": "A lightweight proxy client, empowered by sing-box and thrift.",
     "homepage": "https://github.com/qr243vbi/nekobox",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.11.28/nekobox-5.11.28-windows64.zip",
-            "hash": "041f2f7bd89930433df4014f163dfd2dd18ecbb711fc0cd83e707419e4ce966a"
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.11.28.1/nekobox-5.11.28.1-windows64.zip",
+            "hash": "de967cee66e75c37b8000ae5c16b9d7deebc24ec4ccabfd15cd2c52cc1170a49"
         },
         "32bit": {
-            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.11.28/nekobox-5.11.28-windows32.zip",
-            "hash": "ea7639c4099ba31219736f6f00155c748a41bcd573e4a453ccad9612d644330b"
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.11.28.1/nekobox-5.11.28.1-windows32.zip",
+            "hash": "7ab9424dfdbe548a7bb026422bec7602d7806358470f843c5448b74eb8079f76"
         },
         "arm64": {
-            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.11.28/nekobox-5.11.28-windows-arm64.zip",
-            "hash": "9d652c6402d0551e8a53811ee894b4594ab855f33b93bc0b24c3e5f7ca65f50d"
+            "url": "https://github.com/qr243vbi/nekobox/releases/download/5.11.28.1/nekobox-5.11.28.1-windows-arm64.zip",
+            "hash": "954c93b1a6ff5c9dbda2a932533fba9bee8c00cd3923e48442bcc24f50bf73b1"
         }
     },
     "extract_dir": "nekobox",

--- a/bucket/nightingale.json
+++ b/bucket/nightingale.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.9.0",
+    "version": "1.0.0",
     "description": "Machine learning powered Karaoke app (with scores!).",
     "homepage": "https://nightingale.cafe",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rzru/nightingale/releases/download/v0.9.0/Nightingale_0.9.0_x64_en-US.msi",
-            "hash": "23e9fbd885dedf6a417882170df25eec5f8c22ef8cd4f40d12e7399cfc0850cd"
+            "url": "https://github.com/rzru/nightingale/releases/download/v1.0.0/Nightingale_1.0.0_x64_en-US.msi",
+            "hash": "fb9e4b3b4d44fa4b0d76499eaa3ef51eeda0dca9592e5b3981c226563786fb4b"
         }
     },
     "extract_dir": "PFiles\\Nightingale",

--- a/bucket/treesheets.json
+++ b/bucket/treesheets.json
@@ -1,18 +1,18 @@
 {
-    "version": "3277",
+    "version": "3279",
     "description": "A free form data organizer and a replacement for spreadsheets, mind mappers, outliners, PIMs, text editors and small databases.",
     "homepage": "https://strlen.com/treesheets",
     "license": "ZLIB",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aardappel/treesheets/releases/download/3277/TreeSheets-3277-winx64.zip",
-            "hash": "6f97ac16f179187cbf33250a0c0450777d5df8912fe1786c2a5f968038f6a693",
-            "extract_dir": "TreeSheets-3277-winx64"
+            "url": "https://github.com/aardappel/treesheets/releases/download/3279/TreeSheets-3279-winx64.zip",
+            "hash": "5e0389e070067c377737006d6ee1bbf99077b90c7bbca98209f3aca5b0a6c51b",
+            "extract_dir": "TreeSheets-3279-winx64"
         },
         "arm64": {
-            "url": "https://github.com/aardappel/treesheets/releases/download/3277/TreeSheets-3277-winarm64.zip",
-            "hash": "dbd72dc1939ced701c1a0a189c8686474290dc5bc9be95014b8e9b637aa43751",
-            "extract_dir": "TreeSheets-3277-winarm64"
+            "url": "https://github.com/aardappel/treesheets/releases/download/3279/TreeSheets-3279-winarm64.zip",
+            "hash": "b97ba0ba15adc578423a71ea5d78b46077616203d656fa55e7964738ef72da22",
+            "extract_dir": "TreeSheets-3279-winarm64"
         }
     },
     "pre_install": [

--- a/bucket/trilium.json
+++ b/bucket/trilium.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.104.0",
+    "version": "0.104.1",
     "description": "Build your personal knowledge base with Trilium Notes",
     "homepage": "https://github.com/TriliumNext/Trilium",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/TriliumNext/Trilium/releases/download/v0.104.0/TriliumNotes-v0.104.0-windows-x64.zip",
-            "hash": "0c4c559e85e0d92f48e23bc6d375b1ed8959d22c523bcd5cd5b08ecb435ef0e0"
+            "url": "https://github.com/TriliumNext/Trilium/releases/download/v0.104.1/TriliumNotes-v0.104.1-windows-x64.zip",
+            "hash": "5e8d2bce4305b3abed1113e3d9fc6137eedeea11c8e0a8d750be083cf58a7367"
         },
         "arm64": {
-            "url": "https://github.com/TriliumNext/Trilium/releases/download/v0.104.0/TriliumNotes-v0.104.0-windows-arm64.zip",
-            "hash": "58b1a777242c181f734f232f4c8a471c0dea25e41bf35af8ceef81d45e544e0e"
+            "url": "https://github.com/TriliumNext/Trilium/releases/download/v0.104.1/TriliumNotes-v0.104.1-windows-arm64.zip",
+            "hash": "c8d9eaa3748e04ff41956a05ed914212a7b4bf53828e4a73bb0c08ec876a8e99"
         }
     },
     "pre_install": [

--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.2.0",
+    "version": "4.3.0",
     "description": "A Vim-inspired note-taking platform",
     "homepage": "https://app.vnote.fun",
     "license": "LGPL-3.0-only",
@@ -8,9 +8,9 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vnotex/vnote/releases/download/v4.2.0/VNote-4.2.0-win64.zip",
-            "hash": "9acbdfa45156f8ebbb627edaec3cf0322867fdf2b12c2be9ef057ae9a729d8cc",
-            "extract_dir": "VNote-4.2.0-win64\\bin"
+            "url": "https://github.com/vnotex/vnote/releases/download/v4.3.0/VNote-4.3.0-win64.zip",
+            "hash": "9e6ee1b561bfc7c8cadd74b4cedce2968f814b0ef486706b37d8841a5e767532",
+            "extract_dir": "VNote-4.3.0-win64\\bin"
         }
     },
     "bin": "vnote.exe",

--- a/bucket/windirstat.json
+++ b/bucket/windirstat.json
@@ -3,7 +3,7 @@
     "description": "A disk usage statistics viewer and cleanup tool.",
     "homepage": "https://windirstat.net",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/windirstat/windirstat/releases/download/release%2Fv2.7.0/WinDirStat.7z",
+    "url": "https://github.com/windirstat/windirstat/releases/download/release/v2.7.0/WinDirStat.7z",
     "hash": "08bc6b6e5ad4080e7648ea06c78826a68fbb3289f709803c19b177fb23e3e025",
     "architecture": {
         "64bit": {
@@ -23,13 +23,15 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/windirstat/windirstat/releases",
+        "url": "https://api.github.com/repos/windirstat/windirstat/releases/latest",
+        "jsonpath": "$.tag_name",
         "regex": "release/v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/windirstat/windirstat/releases/download/release%2Fv$version/WinDirStat.7z",
+        "url": "https://github.com/windirstat/windirstat/releases/download/release/v$version/WinDirStat.7z",
         "hash": {
-            "url": "$baseurl/WinDirStat-Hashes.txt"
+            "url": "$baseurl/WinDirStat-Hashes.txt",
+            "regex": "$sha256\\s+WinDirStat\\.7z"
         }
     }
 }

--- a/bucket/zen-browser.json
+++ b/bucket/zen-browser.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.21.8b",
+    "version": "1.21.9b",
     "description": "A open-source browser based on the Firefox engine",
     "homepage": "https://www.zen-browser.app/",
     "license": "MPL-2.0",
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zen-browser/desktop/releases/download/1.21.8b/zen.installer.exe#/dl.7z",
-            "hash": "94c183802d1291c20f3d69f33425fac559b2572dfd191d32bfa704aba536776d"
+            "url": "https://github.com/zen-browser/desktop/releases/download/1.21.9b/zen.installer.exe#/dl.7z",
+            "hash": "d64a89c7df07dfbdff23d73c19b23dfa5c852eab92c6156d9e20e18cfd826b27"
         },
         "arm64": {
-            "url": "https://github.com/zen-browser/desktop/releases/download/1.21.8b/zen.installer-arm64.exe#/dl.7z",
-            "hash": "d4f5cf051d101f5419b4cc5565942e817abd841d1358ebcd9ab3db8cc63a232c"
+            "url": "https://github.com/zen-browser/desktop/releases/download/1.21.9b/zen.installer-arm64.exe#/dl.7z",
+            "hash": "1abd9828c79294964902b58ca4b16c7c1d67b44bd93da5bf3c60d00dc0ba6bce"
         }
     },
     "post_install": [


### PR DESCRIPTION
The current manifest uses a URL-encoded slash (`%2F`) in the download URL which can cause issues. Updated to use the canonical URL format shown on the [WinDirStat download page](https://windirstat.net/download.html).

Changes:
- **Download URL**: Use `release/v$version` instead of `release%2Fv$version`
- **Checkver**: Use GitHub API (`/releases/latest`) with `jsonpath` instead of scraping the HTML releases page
- **Hash**: Add explicit regex for parsing `WinDirStat-Hashes.txt` during autoupdate