### PR TITLE
(chore): Update to latest version, fix checkver/autoupdate logic

### DIFF
--- a/bucket/ayugram.json
+++ b/bucket/ayugram.json
@@ -15,10 +15,7 @@
         ]
     ],
     "persist": "tdata",
-    "checkver": {
-        "url": "https://github.com/AyuGram/AyuGramDesktop",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/AyuGram/AyuGramDesktop/releases/download/v$version/AyuGram.zip"
     }

--- a/bucket/bifrost.json
+++ b/bucket/bifrost.json
@@ -1,19 +1,19 @@
 {
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "Samsung Firmware Downloader",
-    "homepage": "https://bifrost.zwander.dev/",
+    "homepage": "https://bifrost.zwander.dev",
     "license": {
         "identifier": "MIT",
         "url": "https://github.com/zacharee/Bifrost/blob/master/LICENSE.txt"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zacharee/Bifrost/releases/download/2.1.2/bifrost-2.1.2-windows-amd64.zip",
-            "hash": "4f383d18a2353aabd8c651a3b14c5740574b7d70f82ea9f2c0ef3f50c4055f02"
+            "url": "https://github.com/zacharee/Bifrost/releases/download/2.1.2/bifrost-2.1.3-windows-amd64.zip",
+            "hash": "56ccdab35d4383fef3cd5f8edfcaf0ae342582c52e63aef8fe5f44933ce8e7b8"
         },
         "arm64": {
-            "url": "https://github.com/zacharee/Bifrost/releases/download/2.1.2/bifrost-2.1.2-windows-aarch64.zip",
-            "hash": "c65435276fa58fc2a8321a8e923db0dda817931d45d53ec7645451f31c957892"
+            "url": "https://github.com/zacharee/Bifrost/releases/download/2.1.2/bifrost-2.1.3-windows-aarch64.zip",
+            "hash": "520e605102bba8ade1e221c8d1d06c024d641cbb43895bcff24940a44d7af40d"
         }
     },
     "bin": "bin/Bifrost.exe",
@@ -24,15 +24,35 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/zacharee/Bifrost"
+        "github": "https://api.github.com/repos/zacharee/Bifrost/releases?per_page=15",
+        "script": [
+            "$releases = $page | ConvertFrom-Json -ErrorAction Stop",
+            "$version_sort = { if ($_.tag_name -match '([\\d.]+)$') { [version]$Matches[1] } }",
+            "$valid_releases = $releases.Where({ -not $_.prerelease -and $_.assets.Count -gt 0 }) |",
+            "        Sort-Object -Property $version_sort -Descending",
+            "$latest_windows_asset = $null",
+            "foreach ($item in $valid_releases) {",
+            "    $windows_assets = $item.assets.Where({ $_.name -like '*windows*' })",
+            "    if ($windows_assets.Count -eq 0) { continue }",
+            "    $latest_windows_asset = $windows_assets | Sort-Object -Property updated_at -Descending |",
+            "            Select-Object -ExpandProperty name -First 1",
+            "    if ($latest_windows_asset -match 'bifrost-(?<version>[\\d.]+)-windows') {",
+            "        $version_info = @{ result = \"$($item.tag_name), $($Matches['version'])\" } | ConvertTo-Json -Compress",
+            "        Write-Output $version_info",
+            "        break",
+            "    }",
+            "}"
+        ],
+        "jsonpath": "$.result",
+        "regex": "(?<tag>[^,]+), (?<version>[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zacharee/Bifrost/releases/download/$version/bifrost-$version-windows-amd64.zip"
+                "url": "https://github.com/zacharee/Bifrost/releases/download/$matchTag/bifrost-$version-windows-amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/zacharee/Bifrost/releases/download/$version/bifrost-$version-windows-aarch64.zip"
+                "url": "https://github.com/zacharee/Bifrost/releases/download/$matchTag/bifrost-$version-windows-aarch64.zip"
             }
         }
     }

--- a/bucket/browseros.json
+++ b/bucket/browseros.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0-only,BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/browseros-ai/BrowserOS/releases/download/untagged-a16e20eb4bb4c33d494c/BrowserOS_v0.47.18_x64_installer.exe#/dl.7z",
+            "url": "https://github.com/browseros-ai/BrowserOS/releases/download/v0.47.18/BrowserOS_v0.47.18_x64_installer.exe#/dl.7z",
             "hash": "3a35cfe26e98120bc9e07235a113de26d4258c44f485e69cbf08082126c13a01"
         }
     },
@@ -30,9 +30,9 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "github": "https://api.github.com/repos/browseros-ai/BrowserOS/releases/latest",
-        "jsonpath": "$.assets[*].browser_download_url",
-        "regex": "download/(?<tag>[^/]+)/BrowserOS_v(?<version>[\\d.]+)_x64_installer\\.exe"
+        "github": "https://api.github.com/repos/browseros-ai/BrowserOS/releases?per_page=45",
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /^BrowserOS/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/BrowserOS_v(?<version>[\\d.]+)_x64_installer\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/caret.json
+++ b/bucket/caret.json
@@ -16,8 +16,7 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/careteditor/releases",
-        "regex": "tag/([\\w\\.-]+)"
+        "github": "https://github.com/careteditor/releases"
     },
     "autoupdate": {
         "url": "https://github.com/careteditor/releases/releases/download/$version/Caret-$version-full.nupkg",

--- a/bucket/discord.json
+++ b/bucket/discord.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.9232-25",
     "description": "Free Voice and Text Chat",
-    "homepage": "https://discord.com/",
+    "homepage": "https://discord.com",
     "license": {
         "identifier": "Freeware",
         "url": "https://discord.com/terms"
@@ -23,8 +23,7 @@
         "log"
     ],
     "checkver": {
-        "url": "https://github.com/portapps/discord-portable",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+        "github": "https://github.com/portapps/discord-portable"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/enso.json
+++ b/bucket/enso.json
@@ -16,7 +16,11 @@
             "enso"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://api.github.com/repos/GChristensen/enso-portable/releases",
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /(?<!beta.+)exe$/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/-]+)/enso-open-source-([\\w.]+)-x86_64"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/fylepad.json
+++ b/bucket/fylepad.json
@@ -1,18 +1,21 @@
 {
-    "version": "3.0.0",
+    "version": "4.0.0",
     "description": "Notepad for effortless note-taking — featuring rich text editing, multiple tabs, cloud sync, and built-in support for Mermaid/PlantUML diagrams, tables, code blocks, and more.",
     "homepage": "https://fylepad.vercel.app",
     "license": "MIT",
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/imrofayel/fylepad/releases/download/app-v3.0.0/fylepad_3.0.0_x64_en-US.msi",
-            "hash": "69a12bf6cd7799394429ffad177267cb6e246bfe61fd033cc8bbd747c3523d3b"
+            "url": "https://github.com/imrofayel/fylepad/releases/download/app-v4.0.0/fylepad-zen_4.0.0_x64_en-US.msi",
+            "hash": "0df380c75db693fd528ceca5a60afea1112e677d9fe43f7d59a23ae2ee800a20"
         }
     },
-    "extract_dir": "PFiles\\fylepad",
+    "extract_dir": "PFiles\\fylepad-zen",
     "shortcuts": [
         [
-            "fylepad.exe",
+            "fylepad-zen.exe",
             "fylepad"
         ]
     ],
@@ -23,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/imrofayel/fylepad/releases/download/app-v$version/fylepad_$version_x64_en-US.msi"
+                "url": "https://github.com/imrofayel/fylepad/releases/download/app-v$version/fylepad-zen_$version_x64_en-US.msi"
             }
         }
     }

--- a/bucket/gittyup.json
+++ b/bucket/gittyup.json
@@ -25,8 +25,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/Murmele/Gittyup",
-        "regex": "gittyup_v([\\d.]+)"
+        "github": "https://api.github.com/repos/Murmele/Gittyup/releases?per_page=15",
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /win64/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>[^/]+)/Gittyup-win64-([\\d.]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/gonavi.json
+++ b/bucket/gonavi.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.6",
+    "version": "0.9.0",
     "description": "A modern lightweight database client built with Wails and React.",
     "homepage": "https://github.com/Syngnat/GoNavi",
     "license": "Apache-2.0",
@@ -9,17 +9,17 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Syngnat/GoNavi/releases/download/v0.8.6/GoNavi-0.8.6-Windows-Amd64.exe#/gonavi.exe",
-            "hash": "edfb048aaa740fffd9648679e131fc4c4afe4f3c4a3eed8f294bb0bd188fdd5e"
+            "url": "https://github.com/Syngnat/GoNavi/releases/download/v0.9.0/GoNavi-0.9.0-Windows-Amd64-Portable.exe#/GoNavi.exe",
+            "hash": "1c40fd4f0042bb31c52ac1e7ebe8453de8543509d7e154bc60359179e3970751"
         },
         "arm64": {
-            "url": "https://github.com/Syngnat/GoNavi/releases/download/v0.8.6/GoNavi-0.8.6-Windows-Arm64.exe#/gonavi.exe",
-            "hash": "285424e6124cc64cae6a26b0ba4f67e64048d2706b64b5a32238966b712c7939"
+            "url": "https://github.com/Syngnat/GoNavi/releases/download/v0.9.0/GoNavi-0.9.0-Windows-Arm64-Portable.exe#/GoNavi.exe",
+            "hash": "88a319bc535a7fa63af7f30c256b20c5c8961178d71b774d024d67bf04a9d182"
         }
     },
     "shortcuts": [
         [
-            "gonavi.exe",
+            "GoNavi.exe",
             "GoNavi"
         ]
     ],
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Syngnat/GoNavi/releases/download/v$version/GoNavi-$version-Windows-Amd64.exe#/gonavi.exe"
+                "url": "https://github.com/Syngnat/GoNavi/releases/download/v$version/GoNavi-$version-Windows-Amd64-Portable.exe#/GoNavi.exe"
             },
             "arm64": {
-                "url": "https://github.com/Syngnat/GoNavi/releases/download/v$version/GoNavi-$version-Windows-Arm64.exe#/gonavi.exe"
+                "url": "https://github.com/Syngnat/GoNavi/releases/download/v$version/GoNavi-$version-Windows-Arm64-Portable.exe#/GoNavi.exe"
             }
         },
         "hash": {

--- a/bucket/hosts-file-editor.json
+++ b/bucket/hosts-file-editor.json
@@ -1,11 +1,19 @@
 {
-    "version": "1.2.0",
+    "version": "1.5.2",
     "description": "Easily edit and manage the hosts file",
     "homepage": "https://hostsfileeditor.com",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/scottlerch/HostsFileEditor/releases/download/v1.2.0/HostsFileEditorSetup-1.2.0.msi",
-    "hash": "52db892868e2094de82690f2825e1cc08187b11e850463daa33d9a829da34753",
-    "bin": "HostsFileEditor.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.2/HostsFileEditor-1.5.2-x64.zip",
+            "hash": "b06a0a11dbc6fefde08589b535e5dc3527480a6633aa3f09e759cefc1fd050eb"
+        },
+        "arm64": {
+            "url": "https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.2/HostsFileEditor-1.5.2-arm64.zip",
+            "hash": "78719fceffa5dc7e035e390829a5d45e07d10b7d08ec658289b199e7736191af"
+        }
+    },
+    "bin": "hfe.exe",
     "shortcuts": [
         [
             "HostsFileEditor.exe",
@@ -16,6 +24,13 @@
         "github": "https://github.com/scottlerch/HostsFileEditor"
     },
     "autoupdate": {
-        "url": "https://github.com/scottlerch/HostsFileEditor/releases/download/v$version/HostsFileEditorSetup-$version.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/scottlerch/HostsFileEditor/releases/download/v$version/HostsFileEditor-$version-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/scottlerch/HostsFileEditor/releases/download/v$version/HostsFileEditor-$version-arm64.zip"
+            }
+        }
     }
 }

--- a/bucket/jamovi.json
+++ b/bucket/jamovi.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.7.30.0",
+    "version": "2.7.38.0",
     "description": "Statistical spreadsheet",
     "homepage": "https://www.jamovi.org",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://dl.jamovi.org/jamovi-2.7.30.0-win-x64.zip",
-            "hash": "b1c8843fa640b9a6d4807c2bf3b3646c2d1d272247ffb1fb3b8adc2fe565edab",
+            "url": "https://www.jamovi.org/downloads/jamovi-2.7.38.0-win-x64.zip",
+            "hash": "1a8c8f9ad8d4ef977e8e78d49fde31290126f0b322d24e64812e7129f21a2d83",
             "extract_dir": "jamovi"
         }
     },
@@ -18,12 +18,12 @@
     ],
     "checkver": {
         "url": "https://www.jamovi.org/download.html",
-        "regex": "(?sm)/jamovi-([\\d.]+)\\-win-x64\\.exe.*?solid"
+        "regex": "jamovi-([\\d.]+)-win"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.jamovi.org/jamovi-$version-win-x64.zip"
+                "url": "https://www.jamovi.org/downloads/jamovi-$version-win-x64.zip"
             }
         }
     }

--- a/bucket/kanata-cmd.json
+++ b/bucket/kanata-cmd.json
@@ -1,23 +1,56 @@
 {
-    "##": "Deprecate this manifest after 2026-09-01.",
-    "version": "1.9.0",
+    "##": "Deprecate this manifest after 2026-12-01.",
+    "version": "1.12.0",
     "description": "A software keyboard remapper, compiled with cmd support (Deprecated, please use `extras/kanata` instead).",
     "homepage": "https://github.com/jtroo/kanata",
     "license": "LGPL-3.0-only",
-    "notes": "This manifest is deprecated and scheduled for removal on 2026-09-01. Please use `extras/kanata` instead.",
+    "notes": "This manifest is deprecated and scheduled for removal on 2026-12-01. Please use `extras/kanata` instead.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jtroo/kanata/releases/download/v1.9.0/kanata_cmd_allowed.exe#/kanata-cmd.exe",
-            "hash": "8b4f9e9c8b67bdb989e40d4152c5ac18d722108177cdb980cd7b2c395f95152f"
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.12.0/windows-binaries-x64.zip",
+            "hash": "13947ed78cfa3284bfef854e3c542c74ab366236b72fd9f7e039f8638deead9d",
+            "bin": [
+                [
+                    "kanata_windows_tty_winIOv2_cmd_allowed_x64.exe",
+                    "Kanata-cmd"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "kanata_windows_gui_winIOv2_cmd_allowed_x64.exe",
+                    "Kanata-cmd"
+                ]
+            ]
+        },
+        "arm64": {
+            "url": "https://github.com/jtroo/kanata/releases/download/v1.12.0/windows-binaries-arm64.zip",
+            "hash": "f6970ebda03c03c370a1dedf8a75cb73a1690cfd3095f459b5bb3f527aa75407",
+            "bin": [
+                [
+                    "kanata_windows_tty_winIOv2_cmd_allowed_arm64.exe",
+                    "Kanata-cmd"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "kanata_windows_gui_winIOv2_cmd_allowed_arm64.exe",
+                    "Kanata-cmd"
+                ]
+            ]
         }
     },
-    "bin": "kanata-cmd.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jtroo/kanata/releases/download/v$version/kanata_cmd_allowed.exe#/kanata-cmd.exe"
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/windows-binaries-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/jtroo/kanata/releases/download/v$version/windows-binaries-arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sums"
         }
     }
 }

--- a/bucket/keyviz.json
+++ b/bucket/keyviz.json
@@ -1,18 +1,19 @@
 {
-    "version": "1.0.6",
+    "version": "2.1.1",
     "description": "A free and open-source tool to visualize your keystrokes in real-time.",
-    "homepage": "https://mularahul.github.io/keyviz/",
+    "homepage": "https://keyviz.org",
     "license": "GPL-3.0-only",
     "suggest": {
-        "vcredist": "extras/vcredist2022"
+        "vcredist": "extras/vcredist2022",
+        "Microsoft Edge WebView2": "extras/webview2"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mulaRahul/keyviz/releases/download/v1.0.6/keyviz-v1.0.6.zip",
-            "hash": "a72bc18a0da07d7a6adb9c0795fbc8d439146ad009fd99cd622acd90c68edb94"
+            "url": "https://github.com/mulaRahul/keyviz/releases/download/v2.1.1/keyviz_2.1.1_windows.msi",
+            "hash": "b58263eb3be44cbba6c5f7518a63bcf7ae31396493dfc1ff143677e7ab710b3a"
         }
     },
-    "pre_install": "Get-ChildItem \"$dir\" 'keyviz-v*.exe' | Select-Object -First 1 -ExpandProperty FullName | Expand-InnoArchive -Destination \"$dir\" -Removal",
+    "extract_dir": "PFiles\\keyviz",
     "shortcuts": [
         [
             "keyviz.exe",
@@ -25,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mulaRahul/keyviz/releases/download/v$version/keyviz-v$version.zip"
+                "url": "https://github.com/mulaRahul/keyviz/releases/download/v$version/keyviz_$version_windows.msi"
             }
         }
     }

--- a/bucket/libresprite.json
+++ b/bucket/libresprite.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.0",
+    "version": "1.1",
     "description": "Animated sprite editor & pixel art tool",
-    "homepage": "https://github.com/LibreSprite/LibreSprite",
+    "homepage": "https://libresprite.github.io",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LibreSprite/LibreSprite/releases/download/v1.0/LibreSprite-Windows-x86_64.zip",
-            "hash": "fcc7fe9f122e228b991299863b73539c5b7707137559d52dc9e91b104a96004b"
-        },
-        "32bit": {
-            "url": "https://github.com/LibreSprite/LibreSprite/releases/download/v1.0/LibreSprite-Windows-x86_32.zip",
-            "hash": "697b1e98f2567fcc2ff9542534ac9e05a6e1de879e526100c480ae08c8603c06"
+            "url": "https://github.com/LibreSprite/LibreSprite/releases/download/v1.1/libresprite-development-windows-x86_64.zip",
+            "hash": "b6b078a8342a20277b16cae4aa6b880ffced7db1f1b8bd5d0387193a7c3fe43d"
         }
     },
     "bin": "libresprite.exe",
@@ -20,14 +16,13 @@
             "LibreSprite"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/LibreSprite/LibreSprite"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/LibreSprite/LibreSprite/releases/download/v$version/LibreSprite-Windows-x86_64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/LibreSprite/LibreSprite/releases/download/v$version/LibreSprite-Windows-x86_32.zip"
+                "url": "https://github.com/LibreSprite/LibreSprite/releases/download/v$version/libresprite-development-windows-x86_64.zip"
             }
         }
     }

--- a/bucket/miniforge3.json
+++ b/bucket/miniforge3.json
@@ -1,5 +1,5 @@
 {
-    "version": "26.3.2-0",
+    "version": "26.3.2-3",
     "description": "Community-driven minimalistic conda installer using the conda-forge channel as default.",
     "homepage": "https://github.com/conda-forge/miniforge",
     "license": "BSD-3-Clause",
@@ -12,8 +12,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/conda-forge/miniforge/releases/download/26.3.2-0/Miniforge3-26.3.2-0-Windows-x86_64.exe",
-            "hash": "4d91e816e43996566db9d687a22f29ad898ac1871b76554981163cb6d906dbb6"
+            "url": "https://github.com/conda-forge/miniforge/releases/download/26.3.2-3/Miniforge3-26.3.2-3-Windows-x86_64.exe",
+            "hash": "14a8635465b5190537ddad6286746ffebbc55a1ed2a7bb14a506595fe3191e1e"
         }
     },
     "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
@@ -47,10 +47,7 @@
             "New-Item \"$dir\\envs\" -ItemType Directory | Out-Null"
         ]
     },
-    "checkver": {
-        "github": "https://github.com/conda-forge/miniforge",
-        "regex": "tag/([\\d.-]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
### Summary

Updates multiple manifests (`bifrost`, `fylepad`, `gonavi`, `hosts-file-editor`, `jamovi`, `kanata-cmd`, `keyviz`, `libresprite`, `miniforge3`) to their latest versions and refactors `checkver` and `autoupdate` blocks across several packages using modern GitHub API filtering, JSONPath, and explicit named capture variables (`$matchTag`/`$matchVersion`) to ensure reliable automated updates.

### Related issues or pull requests

- Relates to https://github.com/ScoopInstaller/Extras/commit/6a83d9acc30cf5b9a01c4ed14211aa1cd3ada8db

### Changes

- **Version Updates:**
  - **bifrost**: Update to **2.1.3**, rewrite `checkver` script to properly sort releases and filter Windows assets, and update homepage URL.
  - **fylepad**: Update to **4.0.0**, rename binary and shortcut targets to `fylepad-zen`, and add `webview2` suggestion.
  - **gonavi**: Update to **0.9.0**, switch to portable executable targets, and update shortcut casing.
  - **hosts-file-editor**: Update to **1.5.2**, switch distribution to `.zip` archives, add `arm64` support, and set binary to `hfe.exe`.
  - **jamovi**: Update to **2.7.38.0**, fix download URL source, and adjust `checkver` regex.
  - **kanata-cmd**: Update to **1.12.0**, extend deprecation date to **2026-12-01**, add `arm64` support, and update binary extract paths.
  - **keyviz**: Update to **2.1.1**, switch to `.msi` archive extraction, add `webview2` suggestion, and update homepage.
  - **libresprite**: Update to **1.1**, update asset URLs and homepage, and remove 32-bit architecture support.
  - **miniforge3**: Update to **26.3.2-3** and simplify `checkver`.
- **Checkver & Autoupdate Optimizations:**
  - Modernize `checkver` with GitHub API (`jsonpath` and specific asset filtering) for **browseros**, **enso**, **gittyup**, and **bifrost**.
  - Simplify `checkver` to `"github"` or generic endpoints for **ayugram**, **caret**, **discord**, and **miniforge3**.
  - Fix release download URLs and hash schemes.

### Notes

* 32-bit support for `libresprite` has been removed as upstream development releases now exclusively target 64-bit Windows builds.
* Since the deprecation notice was added in commit 6a83d9acc30cf5b9a01c4ed14211aa1cd3ada8db in ScoopInstaller/Extras, this manifest has not been updated automatically. As a result, users who installed the software earlier may not have been aware of the notice. Therefore, the deprecation timeline has been extended while updating to the newer version.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
