### PR TITLE
tsukimi@26.6.1: Disable checkver, add notice for end of Windows support

### DIFF
--- a/bucket/tsukimi.json
+++ b/bucket/tsukimi.json
@@ -6,6 +6,12 @@
         "identifier": "GPL-3.0-or-later",
         "url": "https://github.com/tsukinaha/tsukimi/blob/HEAD/LICENSE"
     },
+    "notes": [
+        "Upstream removed all Windows-related code starting with version 26.6.2.",
+        "Version 26.6.1 may be the last available release for Windows, but its functionality cannot be guaranteed.",
+        "Users who require a stable Jellyfin client for Windows should consider using an alternative solution.",
+        "For more information, see https://github.com/tsukinaha/tsukimi/pull/605."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/tsukinaha/tsukimi/releases/download/v26.6.1/tsukimi-ucrt64-x86_64-windows-gnu.7z",
@@ -18,7 +24,6 @@
             "Tsukimi"
         ]
     ],
-    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
### Summary

Adds upstream notice regarding [the removal of Windows support](https://github.com/tsukinaha/tsukimi/releases/tag/v26.6.2#:~:text=Remove%20Windows%20specific%20code%20by%20%40tsukinaha%20in%20%23605) after version 26.6.1 and removes the `checkver` block to prevent invalid automated updates.

### Related issues or pull requests

- Relates to https://github.com/tsukinaha/tsukimi/pull/605
- Relates to #17862 

### Changes

- Add `notes` explaining that upstream removed Windows support starting with version 26.6.2.
- Remove `checkver` as version 26.6.1 is expected to be the final Windows release.

### Notes

> Due to absolute eyesore graphic performance, we decided to remove all code wrote for Windows.

* https://github.com/tsukinaha/tsukimi/pull/605
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
