### PR TITLE
deviceshelf: Add version 1.7.7

### DIFF
--- a/bucket/deviceshelf.json
+++ b/bucket/deviceshelf.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.6.24",
+    "version": "1.7.7",
     "description": "Local-first network scanner that finds and identifies every device on your LAN, with open-port and security reporting.",
     "homepage": "https://deviceshelf.app",
     "license": {
@@ -7,15 +7,22 @@
         "url": "https://deviceshelf.app/terms"
     },
     "notes": [
-        "DeviceShelf is commercial software with a 7-day trial.",
-        "The installer is not code-signed, so SmartScreen may warn on first run."
+        "DeviceShelf needs Npcap to scan. The x64 build links wpcap.dll at load time, so without it the app will not start at all:",
+        "  scoop install extras/npcap    (or https://npcap.com/#download)",
+        "The regular installer warns about this; a Scoop install bypasses that warning, hence this note.",
+        "",
+        "DeviceShelf is commercial software with a 7-day trial. The installer is not code-signed, so SmartScreen may warn on first run."
     ],
     "architecture": {
         "64bit": {
-            "url": "https://downloads.deviceshelf.app/DeviceShelf-1.6.24-setup.exe#/dl.7z",
-            "hash": "2ae502845b5f6241def870fd82f5ecc9293f557e8bdbb166578e9e05a0d35ec0"
+            "url": "https://downloads.deviceshelf.app/DeviceShelf-1.7.7-setup.exe#/dl.7z",
+            "hash": "3fef98d4ae45ede595f6c02d5220074c9cb4aa63662bb830d94de0137cbabbc7"
         }
     },
+    "post_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "Remove-Item \"$dir\\uninstall.exe\" -Force -ErrorAction SilentlyContinue"
+    ],
     "shortcuts": [
         [
             "DeviceShelf.exe",

--- a/bucket/deviceshelf.json
+++ b/bucket/deviceshelf.json
@@ -7,10 +7,8 @@
         "url": "https://deviceshelf.app/terms"
     },
     "notes": [
-        "DeviceShelf needs Npcap to scan. The x64 build links wpcap.dll at load time, so without it the app will not start at all:",
-        "  scoop install extras/npcap    (or https://npcap.com/#download)",
-        "The regular installer warns about this; a Scoop install bypasses that warning, hence this note.",
-        "",
+        "DeviceShelf requires Npcap. The x64 build links wpcap.dll at load time, so without it the app will not start at all. Install it in \"WinPcap API-compatible Mode\" from https://npcap.com/#download",
+        "The regular installer prompts for Npcap; a Scoop install extracts the archive and bypasses that prompt, hence this note.",
         "DeviceShelf is commercial software with a 7-day trial. The installer is not code-signed, so SmartScreen may warn on first run."
     ],
     "architecture": {

--- a/bucket/deviceshelf.json
+++ b/bucket/deviceshelf.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.6.24",
+    "description": "Local-first network scanner that finds and identifies every device on your LAN, with open-port and security reporting.",
+    "homepage": "https://deviceshelf.app",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://deviceshelf.app/terms"
+    },
+    "notes": [
+        "DeviceShelf is commercial software with a 7-day trial.",
+        "The installer is not code-signed, so SmartScreen may warn on first run."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.deviceshelf.app/DeviceShelf-1.6.24-setup.exe#/dl.7z",
+            "hash": "2ae502845b5f6241def870fd82f5ecc9293f557e8bdbb166578e9e05a0d35ec0"
+        }
+    },
+    "shortcuts": [
+        [
+            "DeviceShelf.exe",
+            "DeviceShelf"
+        ]
+    ],
+    "checkver": {
+        "url": "https://deviceshelf.app/latest.json",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.deviceshelf.app/DeviceShelf-$version-setup.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for DeviceShelf 1.6.24, a local-first network scanner for Windows, macOS, Linux and mobile.

Closes #18385

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

### Verification

- The installer is fetched from a version-specific URL and the SHA256 in the manifest was computed from the downloaded file, not copied from a release note.
- Installation was tested on Windows 11 (build 26200) via the equivalent Chocolatey package built from the same installer: the download hash matched and the NSIS silent switch completed without prompting.
- `checkver` reads `$.version` from https://deviceshelf.app/latest.json, which currently returns `1.6.24`, so `autoupdate` resolves future releases without a manual edit.

### Note on licensing

DeviceShelf is commercial software with a 7-day trial; the manifest installs the complete application and the licence is entered in-app. This is stated in the manifest `notes`, along with the fact that the installer is unsigned, so SmartScreen may warn on first run.
