### PR TITLE
kane-cli: Add version 0.8.1

### DIFF
--- a/bucket/kane-cli.json
+++ b/bucket/kane-cli.json
@@ -1,18 +1,19 @@
 {
-    "version": "0.6.6",
+    "version": "0.8.1",
     "description": "Natural-language browser automation and AI test authoring CLI by TestMu AI",
     "homepage": "https://www.testmuai.com/kane-cli",
     "license": "Apache-2.0",
     "notes": [
         "Authenticate before first use:",
         "  kane-cli login",
-        "In CI, use flags instead: kane-cli login --username <user> --access-key <key>",
+        "In CI, use flags instead:",
+        "  kane-cli login --username <user> --access-key <key>",
         "Get your access key from the TestMu AI dashboard under Settings -> Keys."
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LambdaTest/kane-cli/releases/download/0.6.6/kane-cli-win-x64.exe#/kane-cli.exe",
-            "hash": "cedc4eb3805c95573ed5fbf45c6e8eb5f5151bacee3753d2976c1d8cf2c120f5"
+            "url": "https://github.com/LambdaTest/kane-cli/releases/download/0.8.1/kane-cli-win-x64.exe#/kane-cli.exe",
+            "hash": "f935836cd0c25a0611cb64e330a8e7693d5c35ebb17eb543a29fd9d3d7f9cd3b"
         }
     },
     "bin": "kane-cli.exe",
@@ -22,12 +23,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/LambdaTest/kane-cli/releases/download/$version/kane-cli-win-x64.exe#/kane-cli.exe",
-                "hash": {
-                    "url": "https://github.com/LambdaTest/kane-cli/releases/download/$version/SHA256SUMS",
-                    "regex": "$sha256\\s+kane-cli-win-x64\\.exe"
-                }
+                "url": "https://github.com/LambdaTest/kane-cli/releases/download/$version/kane-cli-win-x64.exe#/kane-cli.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }

--- a/bucket/kane-cli.json
+++ b/bucket/kane-cli.json
@@ -2,7 +2,7 @@
     "version": "0.6.6",
     "description": "Natural-language browser automation and AI test authoring CLI by TestMu AI",
     "homepage": "https://www.testmuai.com/kane-cli",
-    "license": "Freeware",
+    "license": "Apache-2.0",
     "notes": [
         "Authenticate before first use:",
         "  kane-cli login",

--- a/bucket/kane-cli.json
+++ b/bucket/kane-cli.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.6.4",
+    "version": "0.6.6",
     "description": "Natural-language browser automation and AI test authoring CLI by TestMu AI",
     "homepage": "https://www.testmuai.com/kane-cli",
-    "license": "Apache-2.0",
+    "license": "Freeware",
     "notes": [
         "Authenticate before first use:",
         "  kane-cli login",
@@ -11,8 +11,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/LambdaTest/kane-cli/releases/download/0.6.4/kane-cli-win-x64.exe#/kane-cli.exe",
-            "hash": "3c09c4768da2da2c6360c9ca7469465dcb841449104aefa374af04fa9e07ba28"
+            "url": "https://github.com/LambdaTest/kane-cli/releases/download/0.6.6/kane-cli-win-x64.exe#/kane-cli.exe",
+            "hash": "cedc4eb3805c95573ed5fbf45c6e8eb5f5151bacee3753d2976c1d8cf2c120f5"
         }
     },
     "bin": "kane-cli.exe",

--- a/bucket/kane-cli.json
+++ b/bucket/kane-cli.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.6.4",
+    "description": "Natural-language browser automation and AI test authoring CLI by TestMu AI",
+    "homepage": "https://www.testmuai.com/kane-cli",
+    "license": "Apache-2.0",
+    "notes": [
+        "Authenticate before first use:",
+        "  kane-cli login",
+        "In CI, use flags instead: kane-cli login --username <user> --access-key <key>",
+        "Get your access key from the TestMu AI dashboard under Settings -> Keys."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/LambdaTest/kane-cli/releases/download/0.6.4/kane-cli-win-x64.exe#/kane-cli.exe",
+            "hash": "3c09c4768da2da2c6360c9ca7469465dcb841449104aefa374af04fa9e07ba28"
+        }
+    },
+    "bin": "kane-cli.exe",
+    "checkver": {
+        "github": "https://github.com/LambdaTest/kane-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/LambdaTest/kane-cli/releases/download/$version/kane-cli-win-x64.exe#/kane-cli.exe",
+                "hash": {
+                    "url": "https://github.com/LambdaTest/kane-cli/releases/download/$version/SHA256SUMS",
+                    "regex": "$sha256\\s+kane-cli-win-x64\\.exe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Kane CLI by TestMu AI — a natural-language browser automation and AI test authoring CLI. Tested install and uninstall locally; autoupdate is configured via SHA256SUMS.
