### PR TITLE
universal-x86-tuning-utility: Add version 26.2.0

### DIFF
--- a/bucket/universal-x86-tuning-utility.json
+++ b/bucket/universal-x86-tuning-utility.json
@@ -1,0 +1,44 @@
+{
+    "version": "26.2.0",
+    "description": "Advanced tuning utility for AMD and Intel powered laptops, handhelds and mini PCs",
+    "homepage": "https://github.com/JamesCJ60/Universal-x86-Tuning-Utility",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/blob/master/LICENSE"
+    },
+    "notes": "Universal x86 Tuning Utility must be run as administrator to access CPU/APU registers.",
+    "suggest": {
+        ".NET Desktop Runtime 10.0": "versions/windowsdesktop-runtime-10.0"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/releases/download/26.2.0/Universal.x86.Tuning.Utility.Portable.zip",
+            "hash": "81dd6e8fba122a447d05a9220259cad9b14ba01e141cac320a0c53206ffc6553"
+        }
+    },
+    "extract_dir": "net10.0-windows10.0.22621.0",
+    "pre_install": [
+        "'apuPresets.json', 'amdDtCpuPresets.json', 'intelPresets.json' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { Set-Content \"$dir\\$_\" '{}' -Encoding Ascii }",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "Universal x86 Tuning Utility.exe",
+            "Universal x86 Tuning Utility"
+        ]
+    ],
+    "persist": [
+        "apuPresets.json",
+        "amdDtCpuPresets.json",
+        "intelPresets.json"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/JamesCJ60/Universal-x86-Tuning-Utility/releases/download/$version/Universal.x86.Tuning.Utility.Portable.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #18406

Adds [Universal x86 Tuning Utility](https://github.com/JamesCJ60/Universal-x86-Tuning-Utility) (2.7k stars, 87 forks, GPL-3.0), an open-source tuning utility for AMD/Intel laptops, handhelds and mini PCs.

Uses the official portable zip from the latest **stable** release (`26.2.0`); pre-releases are skipped by the default `github` checkver.

Notes on the manifest:

- `extract_dir` strips the `net10.0-windows10.0.22621.0` folder the portable zip ships with.
- The app is framework-dependent (`runtimeconfig.json` targets `net10.0` / `Microsoft.WindowsDesktop.App`), hence the `versions/windowsdesktop-runtime-10.0` suggestion.
- Custom presets are written next to the executable (`Settings.Default.Path` is the assembly directory), so `apuPresets.json`, `amdDtCpuPresets.json` and `intelPresets.json` are persisted. The `pre_install` script seeds them with `{}` because the app's `PresetManager` deserializes the file unconditionally when it exists, and an empty file created by `persist` would yield a null dictionary.

Verified locally:

- `bin/checkver.ps1 universal-x86-tuning-utility` -> 26.2.0
- `bin/checkurls.ps1` -> 1/1 OK
- `bin/checkhashes.ps1` -> OK
- `bin/checkver.ps1 -ForceUpdate` regenerates an identical manifest
- `scoop install`/`uninstall -p` round-trip: shortcut, extract_dir and all three persisted files behave as expected