### PR TITLE
servy@8.7: Add arm64 support

### DIFF
--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -1,12 +1,16 @@
 {
     "version": "8.7",
-    "description": "Servy lets you run any app as a native Windows service with full control over working directory, startup type, process priority, logging, health checks, pre-launch scripts and parameters.",
+    "description": "Servy lets you run any app as a native Windows service with full control over the working directory, startup type, process priority, logging, health checks, environment variables, dependencies, pre-launch and post-launch hooks, pre-stop and post-stop hooks, and parameters.",
     "homepage": "https://servy-win.github.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/aelassas/servy/releases/download/v8.7/servy-8.7-x64-installer.exe",
             "hash": "3f27bdf8f6100d3c6dc1ceda72137d4c54a330d1334dd5b6a08b5605f7193053"
+        },
+        "arm64": {
+            "url": "https://github.com/aelassas/servy/releases/download/v8.7/servy-8.7-arm64-installer.exe",
+            "hash": "e6cf8221a54f40f3a2566560d3ba32ce7c1c00cf39e19d4795636d88844c0967"
         }
     },
     "innosetup": true,
@@ -28,6 +32,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-x64-installer.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-arm64-installer.exe"
             }
         }
     }


### PR DESCRIPTION
## Description
This PR adds native `arm64` architecture support to the **Servy** manifest. 

Previously, Windows-on-ARM users installing Servy via Scoop received the `64bit` (x64) installer under emulation. The upstream project now officially builds and publishes native ARM64 release assets, so this updates the manifest (including the `autoupdate` block) to route those users to the native executable.

### Changes
* Added `arm64` asset URL and hash to the `architecture` block (version 8.7).
* Added `arm64` URL template to the `autoupdate.architecture` block so future version bumps via Scoop's auto-PR bot will automatically capture both architectures.
* Updated Servy's description

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
