### PR TITLE
proxelar: Add version 0.5.1

### DIFF
--- a/bucket/proxelar.json
+++ b/bucket/proxelar.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.5.0",
+    "description": "Scriptable local traffic workbench (MITM proxy) to inspect, intercept, replay, and rewrite HTTP/HTTPS and WebSocket traffic",
+    "homepage": "https://github.com/emanuele-em/proxelar",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/emanuele-em/proxelar/releases/download/v0.5.0/proxelar-v0.5.0-x86_64-pc-windows-msvc.zip",
+            "hash": "821d45776a2d60ccb37ad38010dc537775ba2fc17d13a7b135c6c0d7cee2a985"
+        }
+    },
+    "bin": "proxelar.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/emanuele-em/proxelar/releases/download/v$version/proxelar-v$version-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}

--- a/bucket/proxelar.json
+++ b/bucket/proxelar.json
@@ -1,6 +1,6 @@
 {
     "version": "0.5.0",
-    "description": "Scriptable local traffic workbench (MITM proxy) to inspect, intercept, replay, and rewrite HTTP/HTTPS and WebSocket traffic",
+    "description": "Scriptable local traffic workbench (MITM proxy) to inspect, intercept, replay, and rewrite HTTP/HTTPS and WebSocket traffic.",
     "homepage": "https://github.com/emanuele-em/proxelar",
     "license": "MIT",
     "architecture": {
@@ -16,6 +16,9 @@
             "64bit": {
                 "url": "https://github.com/emanuele-em/proxelar/releases/download/v$version/proxelar-v$version-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }

--- a/bucket/proxelar.json
+++ b/bucket/proxelar.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Scriptable local traffic workbench (MITM proxy) to inspect, intercept, replay, and rewrite HTTP/HTTPS and WebSocket traffic.",
     "homepage": "https://github.com/emanuele-em/proxelar",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/emanuele-em/proxelar/releases/download/v0.5.0/proxelar-v0.5.0-x86_64-pc-windows-msvc.zip",
-            "hash": "821d45776a2d60ccb37ad38010dc537775ba2fc17d13a7b135c6c0d7cee2a985"
+            "url": "https://github.com/emanuele-em/proxelar/releases/download/v0.5.1/proxelar-v0.5.1-x86_64-pc-windows-msvc.zip",
+            "hash": "081c5f397e6a8bd937cc6a94a7dbaeff55a8aa5233349cc383db8b6efd453fca"
         }
     },
     "bin": "proxelar.exe",


### PR DESCRIPTION
Adds [proxelar](https://github.com/emanuele-em/proxelar), a single-binary, MIT-licensed scriptable MITM proxy / traffic debugging tool for developers (TUI, web GUI, Lua scripting, HAR export).

- Portable zip from the official GitHub release containing a single `proxelar.exe`
- Hash verified against the release's published `SHA256SUMS`
- `checkver: github` and `autoupdate` configured so future releases update automatically
- Not available in the main bucket or other known buckets