### PR TITLE
servy@8.9: Switch to portable releases

### DIFF
--- a/bucket/servy.json
+++ b/bucket/servy.json
@@ -5,15 +5,16 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/aelassas/servy/releases/download/v8.9/servy-8.9-x64-installer.exe",
-            "hash": "61a25d31bc9cfce24857bf97ef942155612cfa146c1a9fe1604401549a3235f1"
+            "url": "https://github.com/aelassas/servy/releases/download/v8.9/servy-8.9-x64-portable.7z",
+            "hash": "33a6faeba9aa2a3e9f96acd03b3a3050568752dbdc20267fc486cbacdebcb520",
+            "extract_dir": "servy-8.9-x64-portable"
         },
         "arm64": {
-            "url": "https://github.com/aelassas/servy/releases/download/v8.9/servy-8.9-arm64-installer.exe",
-            "hash": "90200dbd00020ec8a5285512e757ed3e6eee1bf98aa7ea599d7c5a0565e60708"
+            "url": "https://github.com/aelassas/servy/releases/download/v8.9/servy-8.9-arm64-portable.7z",
+            "hash": "bc618ef44eb7cfeff5021c7137618b1952bc6fc69e4db6268779680defe94bc5",
+            "extract_dir": "servy-8.9-arm64-portable"
         }
     },
-    "innosetup": true,
     "bin": "servy-cli.exe",
     "shortcuts": [
         [
@@ -31,10 +32,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-x64-installer.exe"
+                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-x64-portable.7z",
+                "extract_dir": "servy-$version-x64-portable"
             },
             "arm64": {
-                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-arm64-installer.exe"
+                "url": "https://github.com/aelassas/servy/releases/download/v$version/servy-$version-arm64-portable.7z",
+                "extract_dir": "servy-$version-arm64-portable"
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR switches the manifest from InnoSetup installers to portable `.7z` archives as [requested](https://github.com/ScoopInstaller/Extras/pull/18413#discussion_r3677767743) by bucket maintainers.

- **Archive Format:** `.7z` portable archives (nested directory extraction via `extract_dir`)
- **Architectures:** `x64`, `arm64`

## Verification & Hashes

### x64
- **URL:** `https://github.com/aelassas/servy/releases/download/v8.9/servy-8.9-x64-portable.7z`
- **SHA-256:** `33a6faeba9aa2a3e9f96acd03b3a3050568752dbdc20267fc486cbacdebcb520`

### arm64
- **URL:** `https://github.com/aelassas/servy/releases/download/v8.9/servy-8.9-arm64-portable.7z`
- **SHA-256:** `bc618ef44eb7cfeff5021c7137618b1952bc6fc69e4db6268779680defe94bc5`

## Manifest Changes

- Replaced installer executables with `.7z` portable URLs and SHA-256 checksums.
- Added `extract_dir` (`servy-$version-<arch>-portable`) to extract inner folder contents directly to root.
- Removed `"innosetup": true`.
- Updated `autoupdate` block to track portable `.7z` releases.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
