### PR TITLE
equilotl: Add version 2.2.6

### DIFF
--- a/bucket/equilotl.json
+++ b/bucket/equilotl.json
@@ -1,0 +1,31 @@
+{
+    "version": "2.2.6",
+    "description": "A GUI app for installing Equicord, a Discord client mod forked from Vencord",
+    "homepage": "https://equicord.org/",
+    "license": "GPL-3.0-only",
+    "suggest": {
+        "discord": "extras/discord"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Equicord/Equilotl/releases/download/v2.2.6/Equilotl.exe",
+            "hash": "b4196dba3e7d2e3662fda38bdd99160880c702a6d08b4c17b6d9505432294104"
+        }
+    },
+    "shortcuts": [
+        [
+            "Equilotl.exe",
+            "Equicord Installer"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Equicord/Equilotl"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Equicord/Equilotl/releases/download/v$version/Equilotl.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Equicord Installer, also called Equilotl.
Closes #18422

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

# Testing

```
PS C:\Users\amy\scoop\apps\scoop\current> .\bin\checkver.ps1 -App "C:\Users\amy\Downloads\equilotl.json" -f
equilotl: 2.2.6 (scoop version is 2.2.6)
Forcing autoupdate!
Autoupdating equilotl
DEBUG[1785436377.16243] [$updatedProperties] = [url hash] -> C:\Users\amy\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1785436377.17796] $substitutions (hashtable) -> C:\Users\amy\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1785436377.17796] $substitutions.$buildVersion                                                              
DEBUG[1785436377.17796] $substitutions.$match1                        2.2.6                                       
DEBUG[1785436377.17796] $substitutions.$preReleaseVersion             2.2.6                                       
DEBUG[1785436377.17796] $substitutions.$version                       2.2.6                                       
DEBUG[1785436377.17796] $substitutions.$patchVersion                  6                                           
DEBUG[1785436377.17796] $substitutions.$urlNoExt                      https://github.com/Equicord/Equilotl/releases/download/v2.2.6/Equilotl
DEBUG[1785436377.17796] $substitutions.$dotVersion                    2.2.6                                       
DEBUG[1785436377.17796] $substitutions.$cleanVersion                  226                                         
DEBUG[1785436377.17796] $substitutions.$underscoreVersion             2_2_6                                       
DEBUG[1785436377.17796] $substitutions.$minorVersion                  2                                           
DEBUG[1785436377.17796] $substitutions.$url                           https://github.com/Equicord/Equilotl/releases/download/v2.2.6/Equilotl.exe
DEBUG[1785436377.17796] $substitutions.$majorVersion                  2                                           
DEBUG[1785436377.17796] $substitutions.$matchTail                                                                 
DEBUG[1785436377.17796] $substitutions.$basenameNoExt                 Equilotl                                    
DEBUG[1785436377.17796] $substitutions.$basename                      Equilotl.exe                                
DEBUG[1785436377.17796] $substitutions.$dashVersion                   2-2-6                                       
DEBUG[1785436377.17796] $substitutions.$baseurl                       https://github.com/Equicord/Equilotl/releases/download/v2.2.6
DEBUG[1785436377.17796] $substitutions.$matchHead                     2.2.6                                       
DEBUG[1785436377.19807] $hashfile_url = $null -> C:\Users\amy\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1785436377.7017] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/Equicord/Equilotl/releases/download/v2.2.6/Equilotl.exe')].digest -> C:\Users\amy\scoop\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: b4196dba3e7d2e3662fda38bdd99160880c702a6d08b4c17b6d9505432294104 using Github Mode
Writing updated equilotl manifest
PS C:\Users\amy\scoop\apps\scoop\current> .\bin\formatjson.ps1 -App "equilotl" -Dir "C:\Users\amy\Downloads"
PS C:\Users\amy\scoop\apps\scoop\current> scoop install C:\Users\amy\Downloads\equilotl.json
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
WARN  To disable this warning, run 'scoop config aria2-warning-enabled false'.
Installing 'equilotl' (2.2.6) [64bit] from 'C:\Users\amy\Downloads\equilotl.json'
Loading Equilotl.exe from cache.
Checking hash of Equilotl.exe ... ok.
Linking ~\scoop\apps\equilotl\current => ~\scoop\apps\equilotl\2.2.6
Creating shortcut for Equicord Installer (Equilotl.exe)
'equilotl' (2.2.6) was installed successfully!
'equilotl' suggests installing 'extras/discord'.
PS C:\Users\amy\scoop\apps\scoop\current>
```