### PR TITLE
independesk: Add version 0.4.0

### DIFF
--- a/bucket/independesk.json
+++ b/bucket/independesk.json
@@ -1,0 +1,41 @@
+{
+    "version": "0.4.0",
+    "description": "Independent virtual desktops per monitor (macOS-style Spaces behavior)",
+    "homepage": "https://github.com/harungecit/IndepenDesk",
+    "license": "MIT",
+    "notes": "IndepenDesk starts with Windows by default. You can turn this off from its tray menu.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/harungecit/IndepenDesk/releases/download/v0.4.0/IndepenDesk-v0.4.0-win-x64.zip",
+            "hash": "32041c12d8fbe5b8b0a8be87d47ab35a587fccc1839af8008fe6e1e955d6250e"
+        },
+        "32bit": {
+            "url": "https://github.com/harungecit/IndepenDesk/releases/download/v0.4.0/IndepenDesk-v0.4.0-win-x86.zip",
+            "hash": "db52414b0567825aa340b9191c4334474f7702c1e89f70095b1a19b9f6cb3a40"
+        },
+        "arm64": {
+            "url": "https://github.com/harungecit/IndepenDesk/releases/download/v0.4.0/IndepenDesk-v0.4.0-win-arm64.zip",
+            "hash": "e83064da671c7f581af96a9c2177b7ccd1ffd4870450e0359902203a8522e6be"
+        }
+    },
+    "shortcuts": [
+        [
+            "IndepenDesk.exe",
+            "IndepenDesk"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/harungecit/IndepenDesk/releases/download/v$version/IndepenDesk-v$version-win-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/harungecit/IndepenDesk/releases/download/v$version/IndepenDesk-v$version-win-x86.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/harungecit/IndepenDesk/releases/download/v$version/IndepenDesk-v$version-win-arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [IndepenDesk](https://github.com/harungecit/IndepenDesk) — independent virtual desktops per monitor for Windows (macOS-style "Displays have separate Spaces" behavior). Tray app, MIT licensed, self-contained portable zips for x64/x86/arm64.

- I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- Manifest tested locally with `scoop install`: hash verified, extraction and shortcut OK.
- `checkver` (GitHub releases) and `autoupdate` are configured for all three architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)