### PR TITLE
metrolist-desktop: Add version 2.9.2

### DIFF
--- a/bucket/metrolist-desktop.json
+++ b/bucket/metrolist-desktop.json
@@ -1,0 +1,35 @@
+{
+    "version": "2.9.2",
+    "description": "A free, open source YouTube Music client for Windows. Portable, no installer, no ads.",
+    "homepage": "https://github.com/Doctordefector/Metrolist-Desktop",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Doctordefector/Metrolist-Desktop/releases/download/v2.9.2/Metrolist-2.9.2-portable.zip",
+            "hash": "6f1602574424e45080d51ec5a17b4b4aadf264eec607cab184b374aeab52a87c",
+            "extract_dir": "Metrolist"
+        }
+    },
+    "shortcuts": [
+        [
+            "Metrolist.exe",
+            "Metrolist Desktop"
+        ]
+    ],
+    "persist": [
+        "data",
+        "Downloads"
+    ],
+    "notes": [
+        "Metrolist keeps its database, login and downloads in the persisted 'data' and 'Downloads' folders, so 'scoop update' will not sign you out.",
+        "Update with 'scoop update metrolist-desktop' rather than the in-app updater in Settings - the in-app one overwrites the Scoop install directory."
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Doctordefector/Metrolist-Desktop/releases/download/v$version/Metrolist-$version-portable.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for **Metrolist Desktop** — a free, open source (GPL-3.0) YouTube Music client
for Windows 10 and 11, written in Compose Desktop (JVM). It is not a browser wrapper: it has its
own VLC-based player, local database and two-way library sync.

- Repo: https://github.com/Doctordefector/Metrolist-Desktop
- Release: https://github.com/Doctordefector/Metrolist-Desktop/releases/tag/v2.9.2

Notes on the manifest:

- Ships as a portable ZIP with the VLC engine, ffmpeg and its own Java runtime bundled, so
  `extract_dir` is `Metrolist` and there is nothing to install.
- The app is portable by design and writes its database, credentials, preferences and downloads
  next to the executable — hence `persist` on `data` and `Downloads`, so `scoop update` does not
  sign the user out or drop their library.
- `checkver: github` + `autoupdate` follow the release asset naming
  (`Metrolist-$version-portable.zip`).
- `notes` points users at `scoop update` rather than the app's own in-app updater, which would
  otherwise overwrite the Scoop install directory. The in-app updater is manual-only (a button in
  Settings), so it never fires on its own.
