### PR TITLE
krokiet@12.0.1: Switch to skia_opengl variant

### DIFF
--- a/bucket/krokiet.json
+++ b/bucket/krokiet.json
@@ -5,13 +5,13 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qarmin/czkawka/releases/download/12.0.1/windows_krokiet_on_linux.exe",
-            "hash": "084fa6f9d97574704a5104d207b8805e510f3f1c9907e7828607e7fce6a67abf"
+            "url": "https://github.com/qarmin/czkawka/releases/download/12.0.1/windows_krokiet_on_windows_skia_opengl.exe",
+            "hash": "9f1a8e51b4d0825c57379fb2d0e13f153e7c559aeb1e4e7c129ffe6b24e3aa15"
         }
     },
     "shortcuts": [
         [
-            "windows_krokiet_on_linux.exe",
+            "windows_krokiet_on_windows_skia_opengl.exe",
             "Krokiet"
         ]
     ],
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_krokiet_on_linux.exe"
+                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_krokiet_on_windows_skia_opengl.exe"
             }
         }
     }


### PR DESCRIPTION
Krokiet stopped working for me, and on checking the source repo releases page, the developer recommends the `windows_krokiet_on_windows_skia_opengl.exe` variant over the `windows_krokiet_on_linux.exe` one.

The skia variant works for me 😄 



