### PR TITLE
halaldl: Add version 0.5.1

### DIFF
--- a/bucket/halaldl.json
+++ b/bucket/halaldl.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.5.1",
+    "description": "Local-first Windows media downloader powered by yt-dlp.",
+    "homepage": "https://halaldl.vercel.app",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Asdmir786/HalalDL/releases/download/v0.5.1/HalalDL-Portable-v0.5.1-win10%2B11-x64.zip",
+            "hash": "0791bbba0e5edece9a23395d204c52e5227911db06b5e9a3dbae14ceaaf691a0"
+        }
+    },
+    "bin": "HalalDL.exe",
+    "shortcuts": [
+        [
+            "HalalDL.exe",
+            "HalalDL"
+        ]
+    ],
+    "persist": "portable-data"
+}


### PR DESCRIPTION
Closes #18433

Adds HalalDL (portable ZIP) for Windows x64.

- Source: https://github.com/Asdmir786/HalalDL/releases/tag/v0.5.1
- Hash from release `SHA256SUMS.txt`
- Persists `portable-data` (settings, archive, thumbnails, managed tools)
- No checkver/autoupdate in this first PR

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)