### PR TITLE
maxto: Update to version 3.0.1

### DIFF
--- a/bucket/maxto.json
+++ b/bucket/maxto.json
@@ -1,26 +1,49 @@
 {
-    "version": "2.2.1",
-    "description": "A window manager to divide your screen, increase your productivity.",
+    "version": "3.0.1",
+    "description": "Window manager that snaps windows into custom per-monitor grids via global hotkeys.",
     "homepage": "https://maxto.net",
     "license": "Shareware",
-    "url": "https://files.maxto.net/releases/2.2.1/MaxTo-2.2.1-full.nupkg",
-    "hash": "sha1:27992b86b6fef4f53ccca676105551a3ec2fb2db",
-    "extract_dir": "lib\\net472",
+    "suggest": {
+        ".NET Desktop Runtime": "extras/windowsdesktop-runtime"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/domino-as/maxto/releases/download/v3.0.1/MaxTo-3.0.1-win-x64.zip",
+            "hash": "729431e513e023442fef5b798072ae6f64c12c0720bccfb3af8582ae7dcf14d2"
+        },
+        "32bit": {
+            "url": "https://github.com/domino-as/maxto/releases/download/v3.0.1/MaxTo-3.0.1-win-x86.zip",
+            "hash": "6aeaef7071e8bdf581be5e018cab3259edac8f173ae12b113a5850dce1117864"
+        },
+        "arm64": {
+            "url": "https://github.com/domino-as/maxto/releases/download/v3.0.1/MaxTo-3.0.1-win-arm64.zip",
+            "hash": "c0b47f7238c9ff0d3bc6418aff2274c94e6f9bf94642510cd218a9f8d0b3bdd5"
+        }
+    },
     "bin": "MaxTo.exe",
     "shortcuts": [
         [
-            "MaxTo.Core.exe",
+            "MaxTo.exe",
             "MaxTo"
         ]
     ],
     "checkver": {
-        "url": "https://maxto.net/en/release",
-        "regex": "MaxTo-([\\d.]+)\\.zip"
+        "github": "https://github.com/domino-as/maxto"
     },
     "autoupdate": {
-        "url": "https://files.maxto.net/releases/$version/MaxTo-$version-full.nupkg",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/domino-as/maxto/releases/download/v$version/MaxTo-$version-win-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/domino-as/maxto/releases/download/v$version/MaxTo-$version-win-x86.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/domino-as/maxto/releases/download/v$version/MaxTo-$version-win-arm64.zip"
+            }
+        },
         "hash": {
-            "url": "$baseurl/RELEASES"
+            "url": "https://github.com/domino-as/maxto/releases/download/v$version/SHA256SUMS.txt"
         }
     }
 }

--- a/bucket/maxto.json
+++ b/bucket/maxto.json
@@ -43,7 +43,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/domino-as/maxto/releases/download/v$version/SHA256SUMS.txt"
+            "url": "$baseurl/SHA256SUMS.txt"
         }
     }
 }


### PR DESCRIPTION
Updates the long-stale `maxto` manifest (2.2.1, from the pre-2021 product) to MaxTo 3.0.1 and modernizes it. I work on MaxTo at Domi.no AS (the vendor).

- **New download source**: official public releases repo (https://github.com/domino-as/maxto/releases). The old `files.maxto.net` Squirrel `.nupkg` URLs are legacy; 3.x ships plain per-architecture zips (`MaxTo-{version}-win-{x64,x86,arm64}.zip`) containing the signed application payload with no self-updater, so Scoop fully owns updates.
- **Adds `32bit` and `arm64`** alongside `64bit`.
- **`checkver`**: GitHub releases (stable releases only are published as latest); **`autoupdate`** hashes come from the `SHA256SUMS.txt` asset published with every release.
- **`suggest`**: `extras/windowsdesktop-runtime` — the app is a framework-dependent .NET 10 WPF app.
- Shortcut target updated (`MaxTo.Core.exe` no longer exists in 3.x; the executable is `MaxTo.exe`).

Verified: manifest hashes computed from the published 3.0.1 assets; JSON validity; asset URLs are live. The vendor''s release pipeline now publishes these zips + checksums for every stable release, so autoupdate should keep working going forward.