### PR TITLE
reasonix-desktop@1.19.3: Fix shortcut

### DIFF
--- a/bucket/reasonix-desktop.json
+++ b/bucket/reasonix-desktop.json
@@ -17,8 +17,7 @@
         [
             "reasonix-launcher.exe",
             "Reasonix Desktop",
-            "launch --detach",
-            "reasonix-desktop.exe"
+            "launch --detach"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Closes #18445

## Problem

Reasonix Desktop 1.19.3 changed its portable package from a flat layout to a versioned layout. The desktop executable now lives at `versions/v1.19.3/reasonix-desktop.exe`, but the manifest still specifies a root-level `reasonix-desktop.exe` as the shortcut icon.

Scoop requires an explicitly configured icon to exist, so installing or resetting the package fails to create the Start Menu shortcut.

## Fix

- Remove only the invalid explicit icon field.
- Keep `reasonix-launcher.exe` as the shortcut target.
- Preserve the existing `launch --detach` compatibility arguments.
- Let Windows use the icon embedded in the launcher.

This PR intentionally does not change the package version, URLs, or hashes. The upstream launcher compatibility problem with Scoop’s `current` junction remains separately tracked in esengine/DeepSeek-Reasonix#7269; it does not block restoring shortcut creation here.

## Verification

- Parsed the updated manifest as JSON.
- Verified the exact three-field shortcut tuple.
- Confirmed all 38 manifest lines retain CRLF endings.
- Matched both manifest hashes against the published GitHub Release asset digests.
- Confirmed the published archive keeps `reasonix-launcher.exe` at the root and moves `reasonix-desktop.exe` under `versions/v1.19.3`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)