### PR TITLE
reasonix-desktop: Update to version 1.19.4

### DIFF
--- a/bucket/reasonix-desktop.json
+++ b/bucket/reasonix-desktop.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.19.3",
+    "version": "1.19.4",
     "description": "Reasonix Desktop, official GUI for Reasonix, a DeepSeek-native AI coding agent built to reduce API costs through aggressive context caching.",
     "homepage": "https://reasonix.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.19.3/Reasonix-windows-amd64.zip",
-            "hash": "27370e1705d36e0fd3cc0050b0b36bbb809cff5ef8f815cb931af9b18fe3b530"
+            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.19.4/Reasonix-windows-amd64.zip",
+            "hash": "11c6314082aac08220921b4f730baeb60b34bfd020afbe00df5c3e96368ea3b3"
         },
         "arm64": {
-            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.19.3/Reasonix-windows-arm64.zip",
-            "hash": "80828a95e58b8a8b58182434810ac9c03ce938bd1b1cd705a5abea271a62a222"
+            "url": "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.19.4/Reasonix-windows-arm64.zip",
+            "hash": "ce8b31b93e39a575b1cc5d0b2fb2096efea6e1d4c2c2cbfcb445c789513d8628"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
Updates Reasonix Desktop to the newly published stable v1.19.4 release.

This release contains the upstream Windows launcher fix for the `current`-path shortcut failure reported in #18445. The manifest keeps the valid launcher-based shortcut introduced by #18446 and updates both architecture URLs and SHA-256 hashes to the signed 1.19.4 artifacts.

Validation:
- Parsed the manifest with `jq`
- Downloaded both Windows ZIP assets and independently verified their SHA-256 hashes
- Upstream stable release postflight passed for CLI, npm, Desktop, R2, Homebrew, and changelog