### PR TITLE
dynotable: Add version 1.4.3

### DIFF
--- a/bucket/dynotable.json
+++ b/bucket/dynotable.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.4.3",
+    "description": "DynoTable is a local-first DynamoDB GUI — real SQL with joins and aggregations, PartiQL, and an AI agent on your own Bedrock keys.",
+    "homepage": "https://dynotable.com",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://dynotable.com/terms"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dynotable.com/api/download/nupkg/1.4.3/dynotable-1.4.3-full.nupkg",
+            "hash": "5c8cee10a38ff46db0c4f7ddbf1b2aa6b8fa9c51290c56e8b7f1d527bbc3edab"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "bin": "dynotable.exe",
+    "shortcuts": [
+        [
+            "dynotable.exe",
+            "DynoTable"
+        ]
+    ],
+    "checkver": {
+        "url": "https://dynotable.com/api/version",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dynotable.com/api/download/nupkg/$version/dynotable-$version-full.nupkg"
+            }
+        }
+    }
+}


### PR DESCRIPTION
DynoTable is a desktop GUI for Amazon DynamoDB (macOS, Windows, Linux). Proprietary, freemium — permanent free tier, paid seats unlock the rest. Homepage: https://dynotable.com

Packaged with Squirrel.Windows, so this installs by extracting `lib\net45` from the `-full.nupkg` rather than running the Setup.exe — same approach as `github.json` in this bucket. The `-full` suffix is anchored because Squirrel also emits a `-delta.nupkg`, which is not installable.

The release repo is private, so `checkver.github` cannot read it. `checkver` instead points at a public version endpoint the vendor serves, `https://dynotable.com/api/version`, which returns the tag of the current release:

```json
{"version":"1.4.3","publishedAt":"2026-08-03T15:11:36Z","available":{"mac":true,"win":true,"deb":true,"rpm":true,"appimage":true}}
```

`autoupdate` interpolates `$version` into `/api/download/nupkg/$version/dynotable-$version-full.nupkg`, which 302s to the release asset, so no `hash` block is given and Scoop computes it on download.

Verified before submitting: the download resolves, and its SHA256 matches the checksum published in the release's `SHA256SUMS-windows.txt`.