### PR TITLE
rolltape: Add version 0.1.0

### DIFF
--- a/bucket/rolltape.json
+++ b/bucket/rolltape.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.1.0",
+    "description": "Push-to-hold screen clip recorder. Hold a key, tape rolls; release to save an editor-safe 60fps MP4.",
+    "homepage": "https://github.com/JasonCZMeng/rolltape",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/JasonCZMeng/rolltape/releases/download/v0.1.0/rolltape.0.1.0.exe#/rolltape.exe",
+            "hash": "0591ecbb24c912cddaff9342523b4cb13446eb9c24e9548424ac1e12788f9d46"
+        }
+    },
+    "shortcuts": [
+        [
+            "rolltape.exe",
+            "rolltape"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/JasonCZMeng/rolltape"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/JasonCZMeng/rolltape/releases/download/v$version/rolltape.$version.exe#/rolltape.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds **rolltape** 0.1.0 — an open-source (MIT) push-to-hold screen clip recorder for Windows GUI app. Hold a hotkey and the chosen monitor records with system audio; release to save an editor-safe constant-60fps H.264 MP4. Portable single exe.

- Homepage: https://github.com/JasonCZMeng/rolltape
- Release with SHA256 checksums: https://github.com/JasonCZMeng/rolltape/releases/tag/v0.1.0
- Manifest includes `checkver` (GitHub releases) and `autoupdate` with a stable `#/rolltape.exe` rename so shortcuts survive version bumps.
