### PR TITLE
vocalcode: Add version 0.4.19

### DIFF
--- a/bucket/vocalcode.json
+++ b/bucket/vocalcode.json
@@ -14,7 +14,6 @@
         }
     },
     "innosetup": true,
-    "bin": "VocalCode.exe",
     "shortcuts": [
         [
             "VocalCode.exe",

--- a/bucket/vocalcode.json
+++ b/bucket/vocalcode.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.4.19",
+    "description": "Push-to-talk voice input for coding with AI. Hold a key, talk, release — recognition runs on your own machine and the text lands in any app.",
+    "homepage": "https://vocalcode.app/",
+    "license": "Proprietary",
+    "notes": [
+        "VocalCode is a paid app with a 30-day trial; run it once to pick a language,",
+        "and the matching speech model is downloaded then (the installer ships without one)."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wudaming00/vocalcode-docs/releases/download/v0.4.19/VocalCodeSetup-0.4.19.exe",
+            "hash": "a6923de8f849b6c4ffe32ad124e34c536ed3cd4a6eac2bc242225ac4367e5dcb"
+        }
+    },
+    "innosetup": true,
+    "bin": "VocalCode.exe",
+    "shortcuts": [
+        [
+            "VocalCode.exe",
+            "VocalCode"
+        ]
+    ],
+    "persist": [
+        "models",
+        "vocalcode.toml",
+        "replacements.txt"
+    ],
+    "checkver": {
+        "url": "https://vocalcode.app/latest.json",
+        "jsonpath": "$.windows.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wudaming00/vocalcode-docs/releases/download/v$version/VocalCodeSetup-$version.exe"
+            }
+        },
+        "hash": {
+            "url": "https://vocalcode.app/latest.json",
+            "jsonpath": "$.windows.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Adds VocalCode, a push-to-talk dictation app for Windows. Recognition runs on the user's own machine.

- Homepage: https://vocalcode.app/
- Docs and issues: https://github.com/wudaming00/vocalcode-docs

Notes on the manifest:

- `innosetup: true` rather than the `#/dl.7z` route. I checked: plain 7-Zip extraction of this installer yields PE sections, not the application files.
- `checkver` and `autoupdate` read the project's own `latest.json`, so both version and hash come from the publisher.
- `persist` covers `models` (downloaded on first run), `vocalcode.toml` and `replacements.txt`, so settings and the speech model survive updates.
- The `url` points at a GitHub release asset rather than the product site, because the site serves the newest build at a fixed path and replaces the previous one.
- Authenticode-signed as `CN=Daming Wu, O=Daming Wu, L=Newberry, S=FL, C=US`.

I have not run `scoop install` end-to-end on a clean machine, so the extracted layout is unverified beyond the manifest itself.
