### PR TITLE
webrain: Add version 0.3.0

### DIFF
--- a/bucket/webrain.json
+++ b/bucket/webrain.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Portable LLM-driven browser-automation & web-scraping MCP server",
     "homepage": "https://github.com/prokopis3/webrain",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/prokopis3/webrain/releases/download/v0.1.1/webrain-windows.exe",
-            "hash": "205b3120dfcb29bea1d8be96684771a90f058809b3fe1288e550b69b1a9426e3"
+            "url": "https://github.com/prokopis3/webrain/releases/download/v0.2.0/webrain-windows.exe",
+            "hash": "4e0d746332eb5c75ba81f3144a61bcdf8008e1d956ec154ff107e905b684b9eb"
         }
     },
     "bin": [

--- a/bucket/webrain.json
+++ b/bucket/webrain.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Portable LLM-driven browser-automation & web-scraping MCP server",
     "homepage": "https://github.com/prokopis3/webrain",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/prokopis3/webrain/releases/download/v0.2.0/webrain-windows.exe",
-            "hash": "4e0d746332eb5c75ba81f3144a61bcdf8008e1d956ec154ff107e905b684b9eb"
+            "url": "https://github.com/prokopis3/webrain/releases/download/v0.3.0/webrain-windows.exe",
+            "hash": "83534e246e5b08472a865d1c5720a2b0253c041a9cbd40d3c09578625c87649a"
         }
     },
     "bin": [

--- a/bucket/webrain.json
+++ b/bucket/webrain.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.1.1",
+    "description": "Portable LLM-driven browser-automation & web-scraping MCP server",
+    "homepage": "https://github.com/prokopis3/webrain",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/prokopis3/webrain/releases/download/v0.1.1/webrain-windows.exe",
+            "hash": "205b3120dfcb29bea1d8be96684771a90f058809b3fe1288e550b69b1a9426e3"
+        }
+    },
+    "bin": [
+        ["webrain-windows.exe", "webrain"]
+    ],
+    "checkver": {
+        "github": "https://github.com/prokopis3/webrain"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/prokopis3/webrain/releases/download/v$version/webrain-windows.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #18454

Adds `bucket/webrain.json` — a portable, LLM-driven browser-automation & web-scraping MCP server (single self-contained `webrain.exe`, MIT).

- Portable single binary; no installer, no runtime deps (browser engines downloaded on demand via `webrain install`).
- `bin` shims `webrain-windows.exe` → `webrain`.
- `checkver`/`autoupdate` via GitHub releases (`v$version` asset naming).

Verified: `scoop bucket add webrain https://github.com/prokopis3/scoop-webrain; scoop install webrain` installs and `webrain doctor` runs (version 0.1.1, exit 0).