### PR TITLE
s3browser: Update to version 13.5.5, fix checkver

### DIFF
--- a/bucket/s3browser.json
+++ b/bucket/s3browser.json
@@ -1,15 +1,15 @@
 {
-    "version": "13.3.5",
+    "version": "13.5.5",
     "description": "S3 Browser is a freeware Windows client for Amazon S3 and Amazon CloudFront.",
     "homepage": "https://s3browser.com/",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://s3browser.com/download/s3browser-13-3-5.zip",
-            "hash": "eeeaec40c2e72ba774bd8abd8b5d86be912e568421e9b5036cd81807efbe5af5"
+            "url": "https://s3browser.com/download/s3browser-13-5-5.zip",
+            "hash": "ebcd9a69efeca0eb2bd8ff0d9b12c9e210b7546f1bb4460c5c0708154de41828"
         }
     },
-    "extract_dir": "S3 Browser",
+    "extract_dir": "CS Browser",
     "extract_to": "",
     "bin": "s3browser-cli.exe",
     "shortcuts": [

--- a/bucket/s3browser.json
+++ b/bucket/s3browser.json
@@ -20,7 +20,7 @@
     ],
     "checkver": {
         "url": "https://s3browser.com/download.aspx",
-        "regex": "S3 Browser Version (?<version>[\\d\\.]+)"
+        "regex": "CS Browser Version (?<version>[\\d\\.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/s3browser.json
+++ b/bucket/s3browser.json
@@ -10,7 +10,6 @@
         }
     },
     "extract_dir": "CS Browser",
-    "extract_to": "",
     "bin": "s3browser-cli.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Relates to #18457

Updates the S3 Browser manifest to the 13.5.5 archive reported by the issue.

- updates the version and download URL
- records the SHA256 for the downloaded archive
- updates `extract_dir` to the directory shipped by the new archive (`CS Browser`)

Validation:

- parsed the manifest as JSON
- downloaded the 13.5.5 archive and matched its SHA256
- extracted the archive and verified `s3browser-cli.exe` and `s3browser-ui.exe` under the manifest extract directory
- `git diff --check`

- [x] I have read the Contributing Guide