### PR TITLE
druk: Add version 1.14.0

### DIFF
--- a/bucket/druk.json
+++ b/bucket/druk.json
@@ -1,0 +1,13 @@
+{
+    "version": "1.14.0",
+    "description": "Terminal code editor with a file tree, tabs, search, git integration and syntax highlighting",
+    "homepage": "https://github.com/letstri/druk",
+    "license": "MIT",
+    "url": "https://github.com/letstri/druk/releases/download/v1.14.0/druk-windows-x64.zip",
+    "hash": "4045bf424c9252ada91a6bc0d6317251a4f9e727783fd1d623d374b8a2121ba8",
+    "bin": "druk.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/letstri/druk/releases/download/v$version/druk-windows-x64.zip"
+    }
+}


### PR DESCRIPTION
Closes ScoopInstaller/Main#8361

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Adds druk, a terminal code editor shipped as one self-contained windows-x64 executable. The release zip is flat with `druk.exe` at its root, the download URL is version-specific, and `checkver: github` plus the autoupdate stanza track upstream's tagged releases (currently every few days). Hash verified against the v1.14.0 asset.
