### PR TITLE
meld: Update to version 3.24.0, fix checkver & autoupdate

### DIFF
--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -1,23 +1,24 @@
 {
-    "version": "3.22.2",
+    "version": "3.24.0",
     "description": "A visual diff and merge tool",
     "homepage": "http://meldmerge.org/",
     "license": "GPL-2.0-only",
-    "url": "https://download.gnome.org/binaries/win32/meld/3.22/Meld-3.22.2-mingw.msi",
-    "hash": "e1525657ff0e0d9762619b4930fa758756d5e766967764bd12c2f3914f16ece8",
-    "post_install": "Copy-Item \"$dir\\lib\\gdbus.exe\" \"$dir\\\"",
-    "bin": [
-        "Meld.exe",
-        "MeldConsole.exe"
-    ],
+    "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/3.24.0/meld-3.24.0.exe#/dl.7z",
+    "hash": "d25f98dce5e3d07a6c98f6c7a91acbfbacedac06ef5c4663dc4b614b52d2b993",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
+    "bin": "meld.exe",
     "shortcuts": [
         [
-            "Meld.exe",
+            "meld.exe",
             "Meld"
         ]
     ],
-    "checkver": "([\\d.]+)-mingw",
+    "checkver": {
+        "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/releases/permalink/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "([\\d.]+)"
+    },
     "autoupdate": {
-        "url": "https://download.gnome.org/binaries/win32/meld/$majorVersion.$minorVersion/Meld-$version-mingw.msi"
+        "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/$version/meld-$version.exe#/dl.7z"
     }
 }

--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -3,9 +3,13 @@
     "description": "A visual diff and merge tool",
     "homepage": "https://meldmerge.org/",
     "license": "GPL-2.0-or-later",
-    "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/3.24.0/meld-3.24.0.exe#/dl.7z",
-    "hash": "d25f98dce5e3d07a6c98f6c7a91acbfbacedac06ef5c4663dc4b614b52d2b993",
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
+    "architecture": {
+        "64bit": {
+            "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/3.24.0/meld-3.24.0.exe#/dl.7z",
+            "hash": "d25f98dce5e3d07a6c98f6c7a91acbfbacedac06ef5c4663dc4b614b52d2b993"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall*\" -Force -Recurse -ErrorAction Ignore",
     "bin": "meld.exe",
     "shortcuts": [
         [
@@ -19,6 +23,10 @@
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/$version/meld-$version.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/$version/meld-$version.exe#/dl.7z"
+            }
+        }
     }
 }

--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -1,8 +1,8 @@
 {
     "version": "3.24.0",
     "description": "A visual diff and merge tool",
-    "homepage": "http://meldmerge.org/",
-    "license": "GPL-2.0-only",
+    "homepage": "https://meldmerge.org/",
+    "license": "GPL-2.0-or-later",
     "url": "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fmeld/packages/generic/meld/3.24.0/meld-3.24.0.exe#/dl.7z",
     "hash": "d25f98dce5e3d07a6c98f6c7a91acbfbacedac06ef5c4663dc4b614b52d2b993",
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",


### PR DESCRIPTION
## 📖 Description

Closes #18451 — the manifest is stuck at 3.22.2 with a `download.gnome.org` URL that upstream no longer publishes to. Since 3.24, upstream distributes the Windows build (`meld-3.24.0.exe`, an NSIS installer) as a GitLab generic package on gitlab.gnome.org, and the release assets are linked from the GitLab release.

Changes:
- Switch `url`/`autoupdate.url` to the GitLab generic-package endpoint (`api/v4/projects/GNOME%2Fmeld/packages/generic/meld/$version/meld-$version.exe`), forced to 7z extraction with `#/dl.7z` per bucket convention for NSIS installers.
- Update to version 3.24.0 with the hash of the real downloaded installer.
- Replace `checkver` with the GitLab releases API (`releases/permalink/latest`, `jsonpath: $.tag_name`), following the in-bucket pattern used by `buildcache`/`ryzen-controller`.
- Adjust to the new installer layout: the build now ships a PyInstaller-style bundle (`meld.exe` + `_internal/`), so `bin` is `meld.exe`, the `MeldConsole.exe` shim and the `gdbus.exe` `post_install` copy are gone (neither file exists in the 3.24.0 installer), and `post_install` now just removes `$PLUGINSDIR`.

## 🧪 Test Plan

- Downloaded `meld-3.24.0.exe` from the new URL; computed sha256 matches both the manifest hash and the `file_sha256` reported by the GitLab package_files API (32,725,459 bytes).
- `releases/permalink/latest` returns `tag_name: 3.24.0`, matching the checkver `jsonpath`/`regex`.
- Verified the autoupdate URL template resolves (HTTP 200) with `$version` substituted.
- Listed the installer contents with 7z: NSIS-3 archive, `meld.exe` at root, no `MeldConsole.exe`/`gdbus.exe` present.
- Validated the manifest against the live Scoop schema (`schema.json` from ScoopInstaller/Scoop master).
- Environment note: this was prepared on a Linux host without a local scoop CLI — relying on maintainer CI `/verify` for the full install smoke test.

## ✅ Checklist

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] The PR title follows the conventional format.
- [x] The hash was computed from the actual downloaded file.
