### PR TITLE
faster-dooit: Add version 0.1.0

### DIFF
--- a/bucket/faster-dooit.json
+++ b/bucket/faster-dooit.json
@@ -3,22 +3,30 @@
     "description": "A vim-style TUI todo manager written in Go. Unaffiliated with the dooit project; AI-assisted, hobby project.",
     "homepage": "https://github.com/XiaTian-AC/faster-dooit",
     "license": "MIT",
-    "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v0.1.0/faster-dooit-windows-amd64.zip",
-    "hash": "sha256:88487983a5387c5b77e116b989a975040e92f5ede60587c56cd3de9f0cecb5ec",
-    "bin": [
-        [
-            "faster-dooit.exe",
-            "fdooit"
-        ]
-    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v0.1.0/faster-dooit-windows-amd64.zip",
+            "hash": "sha256:88487983a5387c5b77e116b989a975040e92f5ede60587c56cd3de9f0cecb5ec",
+            "bin": [
+                [
+                    "fdooit.exe",
+                    "fdooit"
+                ]
+            ]
+        }
+    },
     "checkver": {
         "github": "https://github.com/XiaTian-AC/faster-dooit"
     },
     "autoupdate": {
-        "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v$version/faster-dooit-windows-amd64.zip",
-        "hash": {
-            "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v$version/checksums.txt",
-            "regex": "$sha256\\s+faster-dooit-windows-amd64.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v$version/faster-dooit-windows-amd64.zip",
+                "hash": {
+                    "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v$version/checksums.txt",
+                    "regex": "$sha256\\s+faster-dooit-windows-amd64.zip"
+                }
+            }
         }
     }
 }

--- a/bucket/faster-dooit.json
+++ b/bucket/faster-dooit.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.1.0",
+    "description": "A vim-style TUI todo manager written in Go. Unaffiliated with the dooit project; AI-assisted, hobby project.",
+    "homepage": "https://github.com/XiaTian-AC/faster-dooit",
+    "license": "MIT",
+    "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v0.1.0/faster-dooit-windows-amd64.zip",
+    "hash": "sha256:88487983a5387c5b77e116b989a975040e92f5ede60587c56cd3de9f0cecb5ec",
+    "bin": [
+        [
+            "faster-dooit.exe",
+            "fdooit"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/XiaTian-AC/faster-dooit"
+    },
+    "autoupdate": {
+        "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v$version/faster-dooit-windows-amd64.zip",
+        "hash": {
+            "url": "https://github.com/XiaTian-AC/faster-dooit/releases/download/v$version/checksums.txt",
+            "regex": "$sha256\\s+faster-dooit-windows-amd64.zip"
+        }
+    }
+}


### PR DESCRIPTION
Add faster-dooit 0.1.0.

- **Source**: https://github.com/XiaTian-AC/faster-dooit
- **Description**: A vim-style TUI todo manager written in Go. Unaffiliated with the dooit project.
- **License**: MIT
- **Bin**: installs as \dooit\
- **Checkver/Autoupdate**: configured (GitHub releases + checksums.txt)

AI-assisted hobby project by a middle-school student developer.