### PR TITLE
mailspring: Persist user data

### DIFF
--- a/bucket/mailspring.json
+++ b/bucket/mailspring.json
@@ -6,6 +6,17 @@
     "url": "https://github.com/Foundry376/Mailspring/releases/download/1.23.0/Mailspring-1.23.0-full.nupkg",
     "hash": "sha1:88efc433326d5bbbbf943dbd6678bdc3bb3cc46a",
     "extract_dir": "lib\\net45",
+    "post_install": [
+        "if (Test-Path $env:APPDATA\\Mailspring) {",
+        "    Write-Host \"`r`nMove config from non-portable version...\"",
+        "    Copy-Item -Path $env:APPDATA\\Mailspring\\* -Destination \"$persist_dir\\UserData\" -Force -Recurse | Out-Null",
+        "    Remove-Item $env:APPDATA\\Mailspring -Force -Recurse",
+        "}",
+        "New-Item -ItemType Junction -Path $env:APPDATA\\Mailspring -Target $persist_dir\\UserData | Out-Null"
+    ],
+    "uninstaller": {
+        "script": "Remove-Item $env:APPDATA\\Mailspring -Force -Recurse"
+    },
     "bin": "Mailspring.exe",
     "shortcuts": [
         [
@@ -13,6 +24,7 @@
             "Mailspring"
         ]
     ],
+    "persist": "UserData",
     "checkver": {
         "github": "https://github.com/Foundry376/Mailspring"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Mailspring (Electron, Squirrel `nupkg`) stores all user data — accounts, settings, local mail cache — in `%APPDATA%\Mailspring`, so it is lost on reinstall/reset and never lands in Scoop's persist folder (requested in #18349).

This PR persists it the same way other Electron apps in the bucket do (mirrors the merged `folo` and `g-helper` manifests):

- `persist`: `UserData`
- `post_install`: migrates any existing `%APPDATA%\Mailspring` contents into the persist directory, then creates a junction `%APPDATA%\Mailspring` → `<persist>\mailspring\UserData`
- `uninstaller`: removes the junction on uninstall

Config path confirmed against upstream source: `Foundry376/Mailspring` `app/src/browser/main.js` (`setupConfigDir` → `path.join(app.getPath('appData'), 'Mailspring')`, `productName: "Mailspring"`).

Closes #18349

**Test plan**

Manifest JSON validated and hash/version checked against the latest release (1.23.0); the script is character-identical to the merged `folo`/`g-helper` pattern. I authored this from a Linux host, so I could not run a live Windows install — runtime verification per the checklist below is appreciated:

- [ ] Fresh `scoop install mailspring` — app launches, config is written through the junction into `persist\mailspring\UserData`
- [ ] Install over an existing non-Scoop Mailspring (`%APPDATA%\Mailspring` present) — settings/accounts migrate and survive
- [ ] `scoop update mailspring` — settings persist across versions
- [ ] `scoop uninstall mailspring` — junction removed, persisted data kept in the persist folder

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
