### PR TITLE
codiff@1.10.1: Remove `extract_dir`

### DIFF
--- a/bucket/codiff.json
+++ b/bucket/codiff.json
@@ -6,8 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/nkzw-tech/codiff/releases/download/v1.10.1/Codiff-win32-x64-1.10.1.zip",
-            "hash": "25956048670a7c5f24e95ce329456753a9d1050448c38b6f8687f28d72245af9",
-            "extract_dir": "Codiff-win32-x64"
+            "hash": "25956048670a7c5f24e95ce329456753a9d1050448c38b6f8687f28d72245af9"
         }
     },
     "bin": "codiff.exe",


### PR DESCRIPTION
`extract_dir` is no longer needed now.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
