### PR TITLE
lmstudio-bionic: Add version 1.0.5-7

### DIFF
--- a/bucket/lmstudio-bionic.json
+++ b/bucket/lmstudio-bionic.json
@@ -1,0 +1,50 @@
+{
+    "version": "1.0.5-7",
+    "description": "Local-first AI agent for work and code. Runs open models on your machine (llama.cpp) or in LM Studio Cloud, with codebase, document and voice tools.",
+    "homepage": "https://lmstudio.ai",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://lmstudio.ai/app-terms"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://bionic-installers.lmstudio.ai/win32/x64/1.0.5-7/Bionic-1.0.5-7-x64.exe#/dl.7z",
+            "hash": "65d02acaf5bf8833c537d5ec0c5c151d199b5fa324f345d4c6761f4f1ebd5555"
+        }
+    },
+    "installer": {
+        "script": [
+            "Get-Item -Path \"$dir\\`$PLUGINSDIR\\app*.7z\" | Expand-7zipArchive -DestinationPath \"$dir\"",
+            "Remove-Item -Path \"$dir\\`$*\", \"$dir\\Uninst*.exe\" -Force -Recurse -ErrorAction Ignore"
+        ]
+    },
+    "bin": [
+        [
+            "resources\\app\\.webpack-bionic\\lms.exe",
+            "lmsb"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Bionic.exe",
+            "LM Studio Bionic"
+        ]
+    ],
+    "checkver": {
+        "script": [
+            "$request = [System.Net.WebRequest]::Create('https://lmstudio.ai/download/bionic/latest/win32/x64')",
+            "$request.Method = 'HEAD'",
+            "$response = $request.GetResponse()",
+            "$response.ResponseUri.AbsoluteUri",
+            "$response.Close()"
+        ],
+        "regex": "Bionic-(?<version>[\\d.]+-\\d+)-x64\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://bionic-installers.lmstudio.ai/win32/x64/$version/Bionic-$version-x64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #18466

### New manifest: `lmstudio-bionic`

Adds a manifest for [LM Studio Bionic](https://lmstudio.ai) — a local-first AI agent for work and code from the makers of LM Studio. It inspects and edits local codebases with inline diffs, works on documents/PDFs/spreadsheets in a sandbox with checkpoints, and supports local voice transcription; models run locally (llama.cpp), over LM Link, or in LM Studio Secure Cloud.

Bionic is a **separate app** from the existing `lmstudio` manifest — different installer host (`bionic-installers.lmstudio.ai`), different product name (`Bionic.exe`, `ProductName: Bionic`) and an independent version line (1.x vs LM Studio's 0.4.x). Both can be installed side by side.

#### Extras acceptance criteria

- [x] **Reasonably well-known / widely used** — same vendor as `lmstudio`; org [lmstudio-ai](https://github.com/lmstudio-ai) has ~11.8k followers, CLI repo [lms](https://github.com/lmstudio-ai/lms) ~5.1k stars / 433 forks. Bionic is the primary download promoted on the lmstudio.ai front page ([announcement](https://lmstudio.ai/blog/introducing-lm-studio-bionic)).
- [x] **English UI and documentation** — interface and [docs](https://lmstudio.ai/docs/bionic) are in English.
- [x] **Latest stable release** — 1.0.5-7.
- [x] **Full version** — free to download and use with local models under the [app terms](https://lmstudio.ai/app-terms) (which explicitly cover Bionic); an account/paid plan is only required for optional cloud inference and web search.
- [x] **Standard install / Scoop-compatible extraction** — electron-builder NSIS, handled with the same `#/dl.7z` + `Expand-7zipArchive $PLUGINSDIR\app-*.7z` pattern already used by `lmstudio` and `signal`.

#### Manifest details

- **Architectures:** `64bit` only. Upstream publishes no Windows arm64 build — `https://lmstudio.ai/download/bionic/latest/win32/arm64` returns 503 and the corresponding installer path 404s; the site offers only `win32/x64` and `darwin/arm64` for Bionic.
- **Shortcut:** `LM Studio Bionic` → `Bionic.exe`
- **Bin:** `lmsb` — the LM Studio CLI shipped at `resources\app\.webpack-bionic\lms.exe` (note the `-bionic` suffix on the webpack directory), aliased so it does not collide with the `lms` shim from the existing `lmstudio` manifest. Bionic and LM Studio are co-installable, so an unqualified `lms` would otherwise be ambiguous.
- **checkver / autoupdate:** the Bionic version is not embedded in any page's HTML (the `/download` page's Next.js flight data only carries the LM Studio 0.4.x `versionsData`, and the Bionic release-notes page is client-rendered), so `checkver` uses a `script` that issues a `HEAD` request to `https://lmstudio.ai/download/bionic/latest/win32/x64` and matches the version out of the resolved redirect URL.

#### Validation

- `bin\formatjson.ps1 -App lmstudio-bionic` — no changes (already canonical)
- `bin\checkver.ps1 -App lmstudio-bionic` — resolves `1.0.5-7`, matches the manifest
- `bin\checkurls.ps1 -App lmstudio-bionic` — 1/1 URLs OK
- `bin\checkhashes.ps1 -App lmstudio-bionic` — OK
- Installer verified directly: NSIS-3 Unicode, payload `$PLUGINSDIR\app-64.7z`, uninstaller at `$R0\Uninstall Bionic.exe` (both covered by the existing `Remove-Item "$dir\`$*"` line); `Bionic.exe` sits at the extracted root and `resources\app\.webpack-bionic\lms.exe` is the working `lms` CLI.
- `scoop install lmstudio-bionic` on Windows 11 x64 (transcript taken before the shim was renamed — the shim is now created as `lmsb`, everything else is unchanged):

```console
$ scoop install lmstudio-bionic

Installing 'lmstudio-bionic' (1.0.5-7) [64bit] from 'extras' bucket
Bionic-1.0.5-7-x64.exe (603.9 MB) [====================================================================] 100%
Checking hash of Bionic-1.0.5-7-x64.exe ... ok.
Extracting Bionic-1.0.5-7-x64.exe ... done.
Running installer script...done.
Linking E:\opt\scoop\apps\lmstudio-bionic\current => E:\opt\scoop\apps\lmstudio-bionic\1.0.5-7
Creating shim for 'lms'.
Creating shortcut for LM Studio Bionic (Bionic.exe)
'lmstudio-bionic' (1.0.5-7) was installed successfully!
```
