### PR TITLE
no-bloat-pdf: Add version 1.4.0

### DIFF
--- a/bucket/no-bloat-pdf.json
+++ b/bucket/no-bloat-pdf.json
@@ -1,0 +1,39 @@
+{
+    "version": "1.4.0",
+    "description": "A tiny, fast, private PDF viewer. Opens instantly and makes zero network calls.",
+    "homepage": "https://www.nobloatpdf.com",
+    "license": "MIT",
+    "notes": [
+        "Settings and reading positions live in the WebView2 user data folder, not in the Scoop",
+        "directory, so they survive updates.",
+        "",
+        "To make it the default PDF viewer: Settings > Apps > Default apps > .pdf > No Bloat PDF."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bgalvan1277/NoBloatPDF/releases/download/v1.4.0/NoBloatPDF-Setup-1.4.0.exe#/dl.7z",
+            "hash": "13033f5c2492c102298df938622886ca75857609d2130742f9d2a10dcf493fd1",
+            "pre_install": [
+                "Remove-Item \"$dir\\`$*\" -Force -Recurse",
+                "Remove-Item \"$dir\\uninstall.exe\" -Force -ErrorAction SilentlyContinue"
+            ]
+        }
+    },
+    "bin": "no-bloat-pdf.exe",
+    "shortcuts": [
+        [
+            "no-bloat-pdf.exe",
+            "No Bloat PDF"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/bgalvan1277/NoBloatPDF"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bgalvan1277/NoBloatPDF/releases/download/v$version/NoBloatPDF-Setup-$version.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [No Bloat PDF](https://www.nobloatpdf.com), a free MIT-licensed PDF viewer for Windows.

- Homepage: https://www.nobloatpdf.com
- Source: https://github.com/bgalvan1277/NoBloatPDF
- Installer: 4.6 MB, signed with a Microsoft-verified publisher identity (Brian Galvan)

**Extraction rather than install.** The upstream download is an NSIS installer, so the manifest uses the `#/dl.7z` idiom to unpack it instead of running it. `pre_install` removes the installer scaffolding (`$PLUGINSDIR`, `uninstall.exe`), leaving `no-bloat-pdf.exe` and its file-association icon.

I verified the extracted executable runs standalone and renders a multi-page PDF, so nothing in the installer is load-bearing at runtime.

No `persist` block: the app keeps its settings in the WebView2 user data folder under `%LOCALAPPDATA%`, not in the Scoop directory, so they already survive updates.

`checkver` and `autoupdate` follow the GitHub releases.

Disclosure: I am submitting on behalf of the developer.