### PR TITLE
roost: Add version 0.1.0

### DIFF
--- a/bucket/roost.json
+++ b/bucket/roost.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.1.0",
+    "description": "A resident Windows 11 tray utility that moves the active window to another virtual desktop from a type-to-search palette, and creates and names new desktops on the fly.",
+    "homepage": "https://github.com/WillyGarage/roost",
+    "license": "MIT",
+    "url": "https://github.com/WillyGarage/roost/releases/download/v0.1.0/Roost.exe",
+    "hash": "0b64a9a5efdfac33261c77b38ec1c6d53b1181d10aedda656281357c7db6c4b7",
+    "bin": "Roost.exe",
+    "shortcuts": [
+        [
+            "Roost.exe",
+            "Roost"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/WillyGarage/roost"
+    },
+    "autoupdate": {
+        "url": "https://github.com/WillyGarage/roost/releases/download/v$version/Roost.exe"
+    }
+}


### PR DESCRIPTION
New app: Roost, a resident Windows 11 tray utility that moves the active window to another virtual desktop from a type-to-search palette, and creates and names new desktops on the fly.

- Homepage: https://github.com/WillyGarage/roost
- License: MIT
- Single self-contained exe, no installer

Manifest checked against the schema; checkver/autoupdate point at GitHub releases for future version bumps.
