### PR TITLE
tinta: Add version 2.4.5

### DIFF
--- a/bucket/tinta.json
+++ b/bucket/tinta.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.4.5",
+    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, <1 MB, no Electron)",
+    "homepage": "https://tinta.cc",
+    "license": "MIT",
+    "url": "https://github.com/oipoistar/tinta/releases/download/v2.4.5/tinta.exe",
+    "hash": "224f98895defae1f5f480c84d38580e16c1ce9eb5a0f9a2a2db057d2f0d06252",
+    "bin": "tinta.exe",
+    "checkver": {
+        "github": "https://github.com/oipoistar/tinta"
+    },
+    "autoupdate": {
+        "url": "https://github.com/oipoistar/tinta/releases/download/v$version/tinta.exe"
+    }
+}

--- a/bucket/tinta.json
+++ b/bucket/tinta.json
@@ -1,15 +1,23 @@
 {
     "version": "2.4.5",
-    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, <1 MB, no Electron)",
+    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, <1 MB, no Electron).",
     "homepage": "https://tinta.cc",
     "license": "MIT",
-    "url": "https://github.com/oipoistar/tinta/releases/download/v2.4.5/tinta.exe",
-    "hash": "224f98895defae1f5f480c84d38580e16c1ce9eb5a0f9a2a2db057d2f0d06252",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/oipoistar/tinta/releases/download/v2.4.5/tinta.exe",
+            "hash": "224f98895defae1f5f480c84d38580e16c1ce9eb5a0f9a2a2db057d2f0d06252"
+        }
+    },
     "bin": "tinta.exe",
     "checkver": {
         "github": "https://github.com/oipoistar/tinta"
     },
     "autoupdate": {
-        "url": "https://github.com/oipoistar/tinta/releases/download/v$version/tinta.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/oipoistar/tinta/releases/download/v$version/tinta.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #18485

Adds [Tinta](https://github.com/oipoistar/tinta) — a fast, lightweight Markdown and Mermaid viewer for Windows. Native Direct2D rendering, single portable exe under 1 MB, statically linked CRT (no VCRedist dependency), MIT licensed.

Resubmission of #18253, which I closed myself because the project didn't yet meet the Extras notability bar. It does now: **101 stars**, [in winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/o/oipoistar/Tinta) since 2.0.1 (currently 2.4.5), and on the [Microsoft Store](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF). The manifest has been continuously maintained in a [personal bucket](https://github.com/oipoistar/scoop-bucket) since then with checkver/autoupdate running on every release.

- Manifest validated and installed locally with `scoop install`
- `checkver` and `autoupdate` verified working (auto-bumped 2.3.0 → 2.4.0 → 2.4.2 → 2.4.5 in the personal bucket)
- Binary is self-contained; no dependencies, no persist needed (settings live in %APPDATA%)