### PR TITLE
sonic-pi@5.0.0: Fix download & autoupdate URLs, add arm64 support

### DIFF
--- a/bucket/sonic-pi.json
+++ b/bucket/sonic-pi.json
@@ -12,7 +12,7 @@
             "hash": "58c12ba5f66894dfdde3f62ca12649530b6fe80a6cc4f15af70b9349d76fdb48"
         }
     },
-    "pre_install": "Expand-MsiArchive \"$dir\\$fname\" \"$dir\" -ExtractDir 'PFiles\\Sonic Pi' -Removal",
+    "pre_install": "Expand-MsiArchive \"$dir\\$fname\" \"$dir\" -ExtractDir 'PFiles64\\Sonic Pi' -Removal",
     "shortcuts": [
         [
             "app\\gui\\build\\Release\\sonic-pi.exe",

--- a/bucket/sonic-pi.json
+++ b/bucket/sonic-pi.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://sonic-pi.net/files/releases/v5.0.0/Sonic-Pi-for-Win-x64-v5-0-0.msi#/dl.msi_",
+            "url": "https://sonic-pi.net/files/releases/v5.0.0/Sonic-Pi-for-Win-x64-v5.0.0.msi#/dl.msi_",
             "hash": "403524242c5ddff3fc9e50f22cd4859a556d533845236e2bc5b25a591ce5d29b"
         }
     },
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://sonic-pi.net/files/releases/v$version/Sonic-Pi-for-Win-x64-v$dashVersion.msi#/dl.msi_"
+                "url": "https://sonic-pi.net/files/releases/v$version/Sonic-Pi-for-Win-x64-v$version.msi#/dl.msi_"
             }
         }
     }

--- a/bucket/sonic-pi.json
+++ b/bucket/sonic-pi.json
@@ -8,11 +8,16 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://sonic-pi.net/files/releases/v5.0.0/Sonic-Pi-for-Win-x64-v5.0.0.msi#/dl.msi_",
-            "hash": "58c12ba5f66894dfdde3f62ca12649530b6fe80a6cc4f15af70b9349d76fdb48"
+            "url": "https://sonic-pi.net/files/releases/v5.0.0/Sonic-Pi-for-Win-x64-v5.0.0.msi",
+            "hash": "58c12ba5f66894dfdde3f62ca12649530b6fe80a6cc4f15af70b9349d76fdb48",
+            "extract_dir": "PFiles64\\Sonic Pi"
+        },
+        "arm64": {
+            "url": "https://sonic-pi.net/files/releases/v5.0.0/Sonic-Pi-for-Win-arm64-v5.0.0.msi",
+            "hash": "256e0281567f9f8dc4c187ce739d35866ab76e3439df20f74e645b899edf90bf",
+            "extract_dir": "PFiles64\\Sonic Pi"
         }
     },
-    "pre_install": "Expand-MsiArchive \"$dir\\$fname\" \"$dir\" -ExtractDir 'PFiles64\\Sonic Pi' -Removal",
     "shortcuts": [
         [
             "app\\gui\\build\\Release\\sonic-pi.exe",
@@ -25,8 +30,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://sonic-pi.net/files/releases/v$version/Sonic-Pi-for-Win-x64-v$version.msi#/dl.msi_"
+                "url": "https://sonic-pi.net/files/releases/v$version/Sonic-Pi-for-Win-x64-v$version.msi"
+            },
+            "arm64": {
+                "url": "https://sonic-pi.net/files/releases/v$version/Sonic-Pi-for-Win-arm64-v$version.msi"
             }
+        },
+        "hash": {
+            "url": "https://github.com/sonic-pi-net/sonic-pi/releases/tag/v$version",
+            "regex": "(?s)$basename.*?$sha256<"
         }
     }
 }

--- a/bucket/sonic-pi.json
+++ b/bucket/sonic-pi.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://sonic-pi.net/files/releases/v5.0.0/Sonic-Pi-for-Win-x64-v5.0.0.msi#/dl.msi_",
-            "hash": "403524242c5ddff3fc9e50f22cd4859a556d533845236e2bc5b25a591ce5d29b"
+            "hash": "58c12ba5f66894dfdde3f62ca12649530b6fe80a6cc4f15af70b9349d76fdb48"
         }
     },
     "pre_install": "Expand-MsiArchive \"$dir\\$fname\" \"$dir\" -ExtractDir 'PFiles\\Sonic Pi' -Removal",


### PR DESCRIPTION
Switching from `$dashVersion` to `$version` because sonic-pi 5.0.0 release otherwise not installable due to url change in the version.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #18475

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
