### PR TITLE
vpx: Add version 2.0.25

### DIFF
--- a/bucket/vpx.json
+++ b/bucket/vpx.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.0.25",
+    "description": "Desktop music player with a per-track demoscene oscilloscope. Plays ~70 formats, including MOD/XM/IT/S3M tracker modules.",
+    "homepage": "https://vpx-landing.vercel.app",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://vpx-landing.vercel.app"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hellfirespriston-art/vpx-releases/releases/download/v2.0.25/VPX-Setup.exe#/setup.exe",
+            "hash": "14c5c54291dd42fa947deb03bf2276690dc0f1a0b20ae1fe68b022267510975c"
+        }
+    },
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "VPX.exe",
+            "VPX"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/hellfirespriston-art/vpx-releases"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/hellfirespriston-art/vpx-releases/releases/download/v$version/VPX-Setup.exe#/setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds VPX, a Windows desktop music player with a per-track demoscene oscilloscope. It plays around 70 formats, including MOD/XM/IT/S3M tracker modules via libopenmpt.

- Homepage: https://vpx-landing.vercel.app
- Releases: https://github.com/hellfirespriston-art/vpx-releases
- Installer: Inno Setup, per-user (`PrivilegesRequired=lowest`), extracted with innounp.

Tested locally on Windows 11: `scoop install` extracts cleanly, `VPX.exe` and the shortcut are created, and `checkver` resolves 2.0.25. A winget manifest for the same package is in review at microsoft/winget-pkgs#413781.