### PR TITLE
aegisub@3.4.2: Persist more files

### DIFF
--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -18,7 +18,7 @@
     "extract_dir": "aegisub-portable",
     "pre_install": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "Get-ChildItem -LiteralPath \"$persist_dir\" -File | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
+        "Get-ChildItem -LiteralPath \"$persist_dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
         "    if (Test-Path -LiteralPath \"$persist_dir\\$($_.Name)\" -PathType Leaf) {",
         "        Copy-Item -Path \"$persist_dir\\$($_.Name)\" -Destination \"$dir\\$($_.Name)\" -Force",
         "    }",
@@ -47,7 +47,7 @@
     ],
     "pre_uninstall": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "Get-ChildItem -LiteralPath \"$dir\" -File | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
+        "Get-ChildItem -LiteralPath \"$dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
         "    if (Test-Path -LiteralPath \"$dir\\$($_.Name)\" -PathType Leaf) {",
         "        ensure $persist_dir | Out-Null",
         "        Copy-Item -Path \"$dir\\$($_.Name)\" -Destination \"$persist_dir\\$($_.Name)\" -Force",

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -18,7 +18,7 @@
     "extract_dir": "aegisub-portable",
     "pre_install": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "Test-Path -LiteralPath \"$persist_dir\" {",
+        "if (Test-Path -LiteralPath \"$persist_dir\") {",
         "    Get-ChildItem -LiteralPath \"$persist_dir\" -File -Filter '*.json' | ForEach-Object {",
         "        if (Test-Path -LiteralPath \"$persist_dir\\$($_.Name)\" -PathType Leaf) {",
         "            Copy-Item -Path \"$persist_dir\\$($_.Name)\" -Destination \"$dir\\$($_.Name)\" -Force",

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -18,13 +18,7 @@
     "extract_dir": "aegisub-portable",
     "pre_install": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "if (Test-Path -LiteralPath \"$persist_dir\") {",
-        "    Get-ChildItem -LiteralPath \"$persist_dir\" -File -Filter '*.json' | ForEach-Object {",
-        "        if (Test-Path -LiteralPath \"$persist_dir\\$($_.Name)\" -PathType Leaf) {",
-        "            Copy-Item -Path \"$persist_dir\\$($_.Name)\" -Destination \"$dir\\$($_.Name)\" -Force",
-        "        }",
-        "    }",
-        "}"
+        "Get-ChildItem -LiteralPath \"$persist_dir\" -File -Filter '*.json' -ErrorAction Ignore | Copy-Item -Destination $dir -Force"
     ],
     "post_install": [
         "'automation' | ForEach-Object {",
@@ -49,12 +43,8 @@
     ],
     "pre_uninstall": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "Get-ChildItem -LiteralPath \"$dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
-        "    if (Test-Path -LiteralPath \"$dir\\$($_.Name)\" -PathType Leaf) {",
-        "        ensure $persist_dir | Out-Null",
-        "        Copy-Item -Path \"$dir\\$($_.Name)\" -Destination \"$persist_dir\\$($_.Name)\" -Force",
-        "    }",
-        "}"
+        "ensure $persist_dir | Out-Null",
+        "Get-ChildItem -LiteralPath \"$dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Copy-Item -Destination $persist_dir"
     ],
     "checkver": {
         "github": "https://github.com/TypesettingTools/Aegisub"

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -18,9 +18,11 @@
     "extract_dir": "aegisub-portable",
     "pre_install": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "Get-ChildItem -LiteralPath \"$persist_dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
-        "    if (Test-Path -LiteralPath \"$persist_dir\\$($_.Name)\" -PathType Leaf) {",
-        "        Copy-Item -Path \"$persist_dir\\$($_.Name)\" -Destination \"$dir\\$($_.Name)\" -Force",
+        "Test-Path -LiteralPath \"$persist_dir\" {",
+        "    Get-ChildItem -LiteralPath \"$persist_dir\" -File -Filter '*.json' | ForEach-Object {",
+        "        if (Test-Path -LiteralPath \"$persist_dir\\$($_.Name)\" -PathType Leaf) {",
+        "            Copy-Item -Path \"$persist_dir\\$($_.Name)\" -Destination \"$dir\\$($_.Name)\" -Force",
+        "        }",
         "    }",
         "}"
     ],

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -18,9 +18,9 @@
     "extract_dir": "aegisub-portable",
     "pre_install": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "'config.json' | ForEach-Object {",
-        "    if (Test-Path -LiteralPath \"$persist_dir\\$_\" -PathType Leaf) {",
-        "        Copy-Item -Path \"$persist_dir\\$_\" -Destination \"$dir\\$_\" -Force",
+        "Get-ChildItem -LiteralPath \"$persist_dir\" -File | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
+        "    if (Test-Path -LiteralPath \"$persist_dir\\$($_.Name)\" -PathType Leaf) {",
+        "        Copy-Item -Path \"$persist_dir\\$($_.Name)\" -Destination \"$dir\\$($_.Name)\" -Force",
         "    }",
         "}"
     ],
@@ -47,10 +47,10 @@
     ],
     "pre_uninstall": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
-        "'config.json' | ForEach-Object {",
-        "    if (Test-Path -LiteralPath \"$dir\\$_\" -PathType Leaf) {",
+        "Get-ChildItem -LiteralPath \"$dir\" -File | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | ForEach-Object {",
+        "    if (Test-Path -LiteralPath \"$dir\\$($_.Name)\" -PathType Leaf) {",
         "        ensure $persist_dir | Out-Null",
-        "        Copy-Item -Path \"$dir\\$_\" -Destination \"$persist_dir\\$_\" -Force",
+        "        Copy-Item -Path \"$dir\\$($_.Name)\" -Destination \"$persist_dir\\$($_.Name)\" -Force",
         "    }",
         "}"
     ],

--- a/bucket/aegisub.json
+++ b/bucket/aegisub.json
@@ -44,7 +44,7 @@
     "pre_uninstall": [
         "# Hardlinks won't work properly here to persist files, because this app creates a new file instead of writing to the existing one.",
         "ensure $persist_dir | Out-Null",
-        "Get-ChildItem -LiteralPath \"$dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Copy-Item -Destination $persist_dir"
+        "Get-ChildItem -LiteralPath \"$dir\" -File -Filter '*.json' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Copy-Item -Destination $persist_dir -Force"
     ],
     "checkver": {
         "github": "https://github.com/TypesettingTools/Aegisub"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Dynamically add to the persist all JSON configuration files that are placed by automations directly in the app's root directory

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
