### PR TITLE
imemodepersistence: Add version 0.9.19

### DIFF
--- a/bucket/imemodepersistence.json
+++ b/bucket/imemodepersistence.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.9.19",
+    "description": "Windows tray utility that carries your IME's native/alphanumeric mode across windows and binds programs to a fixed input language, including anti-cheat fullscreen games.",
+    "homepage": "https://github.com/mangokingTW/ImeModePersistence",
+    "license": "MIT",
+    "notes": [
+        "Unsigned: Windows SmartScreen or antivirus may warn. Source, build and provenance are public; verify with 'gh attestation verify'.",
+        "Elevated targets (most anti-cheat games) need an elevated copy: use 'Restart as administrator' from the tray menu."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mangokingTW/ImeModePersistence/releases/download/v0.9.19/ImeModePersistence-0.9.19-x64.zip",
+            "hash": "95c8950c9fb6741d01d6481032b51a7c4a698a6209691a34fb95268781804fb7"
+        },
+        "32bit": {
+            "url": "https://github.com/mangokingTW/ImeModePersistence/releases/download/v0.9.19/ImeModePersistence-0.9.19-x86.zip",
+            "hash": "60f86fb8556825543da4eaa9b12941fe79dfb44a52f3c56016fc3a579d8bdc61"
+        }
+    },
+    "bin": "ImeModePersistence.exe",
+    "shortcuts": [
+        [
+            "ImeModePersistence.exe",
+            "ImeModePersistence"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mangokingTW/ImeModePersistence/releases/download/v$version/ImeModePersistence-$version-x64.zip",
+                "hash": {
+                    "url": "https://github.com/mangokingTW/ImeModePersistence/releases/download/v$version/SHA256SUMS.txt"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/mangokingTW/ImeModePersistence/releases/download/v$version/ImeModePersistence-$version-x86.zip",
+                "hash": {
+                    "url": "https://github.com/mangokingTW/ImeModePersistence/releases/download/v$version/SHA256SUMS.txt"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [ImeModePersistence](https://github.com/mangokingTW/ImeModePersistence) — an open-source Windows tray utility that carries your IME's native/alphanumeric mode across windows and binds programs to a fixed input language (including anti-cheat fullscreen games).

- Portable zip, per-architecture (x64/x86), extracted to the Scoop app dir.
- `checkver` + `autoupdate` track GitHub releases; hashes pulled from the release's `SHA256SUMS.txt`.
- License: MIT. No installer, no network access.

### Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] The manifest is a single app and passes `checkver`/`autoupdate`.
- [x] Portable app; extracts cleanly with no elevation.