### PR TITLE
vnote@4.4.3: Fix extraction, update homepage & description

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,11 +1,9 @@
 {
+    "##": "Extract to subfolder to avoid overwriting existing manifest.json.",
     "version": "4.4.3",
     "description": "A pleasant note-taking platform",
     "homepage": "https://docs.vnote.fun",
     "license": "LGPL-3.0-only",
-    "suggest": {
-        "vcredist": "extras/vcredist2022"
-    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/vnotex/vnote/releases/download/v4.4.3/VNote-4.4.3-win64.zip",
@@ -13,10 +11,11 @@
             "extract_dir": "VNote-4.4.3-win64"
         }
     },
-    "bin": "vnote.exe",
+    "extract_to": "app",
+    "bin": "app\\vnote.exe",
     "shortcuts": [
         [
-            "vnote.exe",
+            "app\\vnote.exe",
             "VNote"
         ]
     ],

--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,7 +1,7 @@
 {
     "version": "4.4.2",
-    "description": "A Vim-inspired note-taking platform",
-    "homepage": "https://app.vnote.fun",
+    "description": "A pleasant note-taking platform",
+    "homepage": "https://docs.vnote.fun",
     "license": "LGPL-3.0-only",
     "suggest": {
         "vcredist": "extras/vcredist2022"
@@ -10,7 +10,7 @@
         "64bit": {
             "url": "https://github.com/vnotex/vnote/releases/download/v4.4.2/VNote-4.4.2-win64.zip",
             "hash": "2d2368566f5ba71d0aa3c2a10c6bfef241c3accd9af7aae38779a3c30072b6eb",
-            "extract_dir": "VNote-4.4.2-win64\\bin"
+            "extract_dir": "VNote-4.4.2-win64"
         }
     },
     "bin": "vnote.exe",
@@ -27,7 +27,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/vnotex/vnote/releases/download/v$version/VNote-$version-win64.zip",
-                "extract_dir": "VNote-$version-win64\\bin"
+                "extract_dir": "VNote-$version-win64"
             }
         }
     }


### PR DESCRIPTION
Update the VNote bin folder location, website, and description.