### PR TITLE
leanrows@0.1.3, leanmark@0.2.0: Add manifests

### DIFF
--- a/bucket/leanmark.json
+++ b/bucket/leanmark.json
@@ -1,0 +1,36 @@
+{
+    "version": "0.2.0",
+    "description": "Read-only Markdown viewer with offline GitHub-flavored Markdown and Mermaid rendering",
+    "homepage": "https://abooodbah.github.io/leanmark/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/abooodbah/leanmark/releases/download/v0.2.0/LeanMark-v0.2.0-windows-x64.zip",
+            "hash": "2d701d4b66a2f9dd636f7244e8506fb1f79feb3da6483befa53258316b42a68d",
+            "extract_dir": "LeanMark-v0.2.0-windows-x64"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\installer\", \"$dir\\INSTALL.txt\" -Recurse -ErrorAction SilentlyContinue",
+    "bin": "LeanMark.exe",
+    "shortcuts": [
+        [
+            "LeanMark.exe",
+            "LeanMark"
+        ]
+    ],
+    "notes": "LeanMark uses the Microsoft Edge WebView2 runtime, which ships with Windows 11 and current Windows 10.",
+    "checkver": {
+        "github": "https://github.com/abooodbah/leanmark"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/abooodbah/leanmark/releases/download/v$version/LeanMark-v$version-windows-x64.zip",
+                "extract_dir": "LeanMark-v$version-windows-x64"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/leanrows.json
+++ b/bucket/leanrows.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.1.3",
+    "description": "Read-only viewer for large CSV, TSV, JSONL and log files that keeps memory bounded by the viewport",
+    "homepage": "https://abooodbah.github.io/leanrows/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/abooodbah/leanrows/releases/download/v0.1.3/LeanRows-v0.1.3-windows-x64-unsigned.zip",
+            "hash": "9bc275c6d4784637c5ed63174a580b1da5401abc5a024a4b76ded205aeffb0b7",
+            "extract_dir": "LeanRows-v0.1.3-windows-x64-unsigned"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\install.ps1\", \"$dir\\uninstall.ps1\" -ErrorAction SilentlyContinue",
+    "bin": "leanrows.exe",
+    "shortcuts": [
+        [
+            "leanrows.exe",
+            "leanrows"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/abooodbah/leanrows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/abooodbah/leanrows/releases/download/v$version/LeanRows-v$version-windows-x64-unsigned.zip",
+                "extract_dir": "LeanRows-v$version-windows-x64-unsigned"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Adds two small, MIT-licensed, portable Windows viewers.

**leanrows** — read-only viewer for large CSV/TSV/JSONL/log files. Indexes progressively and materializes only the rows in the viewport, so peak memory is governed by window size rather than file size. Measured: a 1.53 GB, 20,000,001-row CSV opens at 18.4 MB peak working set. 546 KB executable, no runtime dependency.
Homepage: https://abooodbah.github.io/leanrows/

**leanmark** — read-only Markdown viewer rendering GFM and Mermaid entirely offline via the system web runtime (WebView2), no bundled Chromium.
Homepage: https://abooodbah.github.io/leanmark/

Both manifests were checked locally: hashes verified against the published release archives, `extract_dir` and `bin` paths confirmed against the archive contents, and `checkver`/`autoupdate` wired to the GitHub releases with sidecar .sha256 files. `pre_install` strips the bundled per-user installer scripts so Scoop manages the install.

Related existing manifests in this bucket: tad, smoothcsv, klogg, glogg.