### PR TITLE
look: Add version 0.6.10

### DIFF
--- a/bucket/look.json
+++ b/bucket/look.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.6.10",
+    "description": "Keyboard-first local-first desktop launcher",
+    "homepage": "https://github.com/kunkka19xx/look",
+    "license": "GPL-3.0-only",
+    "notes": [
+        "User data is stored in %LOCALAPPDATA%\\look.",
+        "Global hotkey is Alt+Space."
+    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kunkka19xx/look/releases/download/v0.6.10/Look_0.6.10_x64-setup.exe#/dl.7z",
+            "hash": "579484d0aaab0ab553dd0085b16ff8c42f78c451ced8286e3ef98afc713263a6"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$*\" -Recurse -Force -ErrorAction SilentlyContinue",
+    "shortcuts": [
+        [
+            "lookapp.exe",
+            "Look"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/kunkka19xx/look"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kunkka19xx/look/releases/download/v$version/Look_$version_x64-setup.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/kunkka19xx/look/releases/download/v$version/Look-$version-windows-checksums.txt",
+            "regex": "([a-fA-F0-9]{64})\\s+Look_$version_x64-setup\\.exe"
+        }
+    }
+}

--- a/bucket/look.json
+++ b/bucket/look.json
@@ -1,8 +1,8 @@
 {
     "version": "0.6.10",
     "description": "Keyboard-first local-first desktop launcher",
-    "homepage": "https://github.com/kunkka19xx/look",
-    "license": "GPL-3.0-only",
+    "homepage": "https://noah-code.com/docs/look",
+    "license": "GPL-3.0-or-later",
     "notes": [
         "User data is stored in %LOCALAPPDATA%\\look.",
         "Global hotkey is Alt+Space."
@@ -33,8 +33,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/kunkka19xx/look/releases/download/v$version/Look-$version-windows-checksums.txt",
-            "regex": "([a-fA-F0-9]{64})\\s+Look_$version_x64-setup\\.exe"
+            "url": "https://github.com/kunkka19xx/look/releases/download/v$version/Look-$version-windows-checksums.txt"
         }
     }
 }

--- a/bucket/look.json
+++ b/bucket/look.json
@@ -4,7 +4,7 @@
     "homepage": "https://noah-code.com/docs/look",
     "license": "GPL-3.0-or-later",
     "notes": [
-        "User data is stored in %LOCALAPPDATA%\\look.",
+        "User data is stored in %LOCALAPPDATA%\\look, and not persisted by Scoop.",
         "Global hotkey is Alt+Space."
     ],
     "suggest": {
@@ -16,7 +16,7 @@
             "hash": "579484d0aaab0ab553dd0085b16ff8c42f78c451ced8286e3ef98afc713263a6"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$*\" -Recurse -Force -ErrorAction SilentlyContinue",
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninst*\" -Recurse -Force -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
             "lookapp.exe",
@@ -33,7 +33,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/kunkka19xx/look/releases/download/v$version/Look-$version-windows-checksums.txt"
+            "url": "$baseurl/Look-$version-windows-checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Closes #18496

## Summary
- add `look` manifest for the published 64-bit Windows release
- use the upstream NSIS release asset via `#/dl.7z` with the published checksum file
- suggest `extras/webview2` and include `checkver`/`autoupdate`

## Validation
- `./bin/checkhashes.ps1 look`
- `./bin/checkver.ps1 look`
- `./bin/checkurls.ps1 look`