### PR TITLE
yazses: Add version 2.17.0

### DIFF
--- a/bucket/yazses.json
+++ b/bucket/yazses.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.17.0",
+    "description": "Offline hold-to-talk voice dictation that types into any focused app",
+    "homepage": "https://mskazemi.com/yazses/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/MSKazemi/yazses/releases/download/v2.17.0/YazSes-2.17.0-windows-x64.exe#/dl.7z",
+            "hash": "ece08306544af68f85fcefdf03b8b997b8c0a6db897f05e64fe8edd12f6d1bdf"
+        }
+    },
+    "innosetup": true,
+    "shortcuts": [
+        [
+            "YazSes.exe",
+            "YazSes"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/MSKazemi/yazses"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/MSKazemi/yazses/releases/download/v$version/YazSes-$version-windows-x64.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [YazSes](https://github.com/MSKazemi/yazses) — an Apache-2.0 offline voice dictation app. Hold a key, speak, release, and the text is typed into whatever window has focus. Speech recognition runs locally via faster-whisper; no cloud service or account involved.

**Manifest notes**

- The release artifact is an **Inno Setup** installer, so `"innosetup": true` with the `#/dl.7z` URL fragment, following the existing convention in this bucket.
- `hash` was computed from the published asset `YazSes-2.17.0-windows-x64.exe` (99,848,444 bytes).
- PyInstaller produces a single **windowed** `YazSes.exe` (`console=False`), which Inno installs to `{app}`. So this declares `shortcuts` only — a `bin` shim would be misleading for a GUI-only executable.
- `checkver` uses the GitHub strategy and `autoupdate` follows the stable `YazSes-$version-windows-x64.exe` asset naming.

**Upfront:** the installer is **unsigned** — it is built in CI by Inno Setup from the public repo, but there is no code-signing certificate yet, so SmartScreen will warn on first run. Also note I do not have a Windows machine to hand, so I have not personally run `scoop install` against this manifest; the schema and hash are verified, but the install itself is unproven by me. Happy to fix anything the bucket's checks flag.