### PR TITLE
dictator: Add version 2.2.322

### DIFF
--- a/bucket/dictator.json
+++ b/bucket/dictator.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.2.322",
+    "description": "Speech-to-text, dictation, live subtitles and offline translation that run locally on your own machine",
+    "homepage": "https://dictator.my/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://dictator.my/terms.html"
+    },
+    "notes": [
+        "Recognition models are downloaded on first run into ~/.dictator/models.",
+        "Settings and history live in ~/.dictator and survive 'scoop update'."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://dictator.my/release/Dictator_2.2.322_x64-setup.exe#/dl.7z",
+            "hash": "a21ae6f882272e7498254dd7e313ea8d3c9a0a24d10c657d5350b4868f2f9ddb"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Recurse -Force -ErrorAction SilentlyContinue"
+    ],
+    "bin": "dictator-desktop.exe",
+    "shortcuts": [
+        [
+            "dictator-desktop.exe",
+            "Dictator"
+        ]
+    ],
+    "checkver": {
+        "url": "https://dictator.my/release/latest.json",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dictator.my/release/Dictator_$version_x64-setup.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a manifest for **Dictator** — a desktop speech-to-text / dictation app
(local Whisper recognition on the GPU, live captions, text-to-speech, offline
translation). Windows build is a Tauri NSIS installer, extracted with 7-Zip via
the `#/dl.7z` fragment, so nothing is executed at install time.

- `checkver` reads the version straight from the site's `latest.json`, and
  `autoupdate` follows the same URL pattern, so the manifest self-updates.
- `pre_install` drops `$PLUGINSDIR` and `uninstall.exe` left over by the NSIS
  extraction.
- User data (settings, history, recognition models) lives in `~/.dictator`,
  outside the app directory, so it survives `scoop update` — no `persist`
  needed.

Verified locally: `scoop install .\dictator.json` downloads, matches the hash,
extracts cleanly and shims `dictator-desktop.exe`.
