### PR TITLE
recite: Add version 1.1.0

### DIFF
--- a/bucket/recite.json
+++ b/bucket/recite.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.1.0",
+    "description": "Copy text from anything on screen with Windows' built-in OCR: hotkey, drag, and it's on the clipboard. Works offline.",
+    "homepage": "https://github.com/blancodagoat/recite",
+    "license": "MIT",
+    "url": "https://github.com/blancodagoat/recite/releases/download/v1.1.0/Recite.exe",
+    "hash": "d94c8114679e5b2ff58b8e5e8d41ef88fee2fe99ace6444d9ee69d88e3c156e6",
+    "bin": "Recite.exe",
+    "shortcuts": [
+        [
+            "Recite.exe",
+            "Recite"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/blancodagoat/recite/releases/download/v$version/Recite.exe"
+    }
+}


### PR DESCRIPTION
Adds Recite, my open-source screen OCR tool for Windows: a hotkey freezes the screen, you drag over any visible text (error dialogs, subtitles, images, games) and it lands on the clipboard. It uses the OCR engines that ship with Windows, works offline, and is a single exe under 1 MB. MIT licensed.

Homepage: https://github.com/blancodagoat/recite
The manifest points at a versioned release asset with its sha256, and carries checkver/autoupdate.

https://claude.ai/code/session_017raCgemh1CFLEo5kaZxwFt