### PR TITLE
memento: Add version 1.3.0

### DIFF
--- a/bucket/memento.json
+++ b/bucket/memento.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.3.0",
+    "description": "Minimal screenshot tool that runs from the tray: region and display capture, PNG plus clipboard, ~8 MB idle, no telemetry.",
+    "homepage": "https://github.com/blancodagoat/memento",
+    "license": "MIT",
+    "url": "https://github.com/blancodagoat/memento/releases/download/v1.3.0/Memento.exe",
+    "hash": "a58a48e0bba8095040123a410d39fb65e90e74d8d7fb5f516c832da0302e8a83",
+    "bin": "Memento.exe",
+    "shortcuts": [
+        [
+            "Memento.exe",
+            "Memento"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/blancodagoat/memento/releases/download/v$version/Memento.exe"
+    }
+}


### PR DESCRIPTION
Adds Memento, my open-source screenshot tool for Windows: tray-only region and display capture, PNG plus clipboard, dated folders named after the source app. It idles at roughly 8 MB of RAM, downloads at under 1 MB, and has no editor, uploader, or telemetry. MIT licensed.

Homepage: https://github.com/blancodagoat/memento
The manifest points at a versioned release asset with its sha256, and carries checkver/autoupdate.

https://claude.ai/code/session_017raCgemh1CFLEo5kaZxwFt