### PR TITLE
dejavu: Add version 1.1.0

### DIFF
--- a/bucket/dejavu.json
+++ b/bucket/dejavu.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.1.0",
+    "description": "Instant replay for Windows with a crash-safe disk buffer: one key saves your last 5 to 25 minutes as a clip. Any GPU, no telemetry.",
+    "homepage": "https://github.com/blancodagoat/DejaVu",
+    "license": "MIT",
+    "url": "https://github.com/blancodagoat/DejaVu/releases/download/v1.1.0/DejaVu.exe",
+    "hash": "723954a2e4603fdac2c688123df0659b140a60da7f61d265ea20f56bdd88af7e",
+    "bin": "DejaVu.exe",
+    "shortcuts": [
+        [
+            "DejaVu.exe",
+            "DejaVu"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/blancodagoat/DejaVu/releases/download/v$version/DejaVu.exe"
+    }
+}


### PR DESCRIPTION
Adds DejaVu, my open-source instant replay tool for Windows: a rolling 5 to 25 minute buffer of the screen kept in crash-safe segments on disk, saved as a clip on a hotkey. A crash or power cut becomes a recovered clip at the next launch. Works on any GPU with a hardware encoder, records AV1 on modern cards, single exe. MIT licensed.

Homepage: https://github.com/blancodagoat/DejaVu
The manifest points at a versioned release asset with its sha256, and carries checkver/autoupdate.

https://claude.ai/code/session_017raCgemh1CFLEo5kaZxwFt