### PR TITLE
mongrel: Add version 5.71.42

### DIFF
--- a/bucket/mongrel.json
+++ b/bucket/mongrel.json
@@ -1,0 +1,32 @@
+{
+    "version": "5.71.41",
+    "description": "Desktop database workbench for 30+ database engines, with terminals, SFTP, Docker, Kubernetes, and an API client",
+    "homepage": "https://www.visorcraft.com/",
+    "license": "Proprietary",
+    "notes": "Paid annual license with a 7-day free trial.",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.visorcraft.com/api/downloads/mongrel/e94119f4-447d-471e-8bc1-7b35de91abc7#/dl.7z",
+            "hash": "0ca36770c371309faf42ad8267dc92dada21ad4e0522dc9240eea4cf596697b9"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse -ErrorAction Ignore",
+    "bin": "mongrel-cli.exe",
+    "shortcuts": [
+        [
+            "mongrel.exe",
+            "Mongrel"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.visorcraft.com/api/downloads/mongrel",
+        "regex": "\"id\":\"(?<id>[0-9a-f-]+)\"[^{}]*?\"file_name\":\"Mongrel_([\\d.]+)_x64-setup\\.exe\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.visorcraft.com/api/downloads/mongrel/$matchId#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/mongrel.json
+++ b/bucket/mongrel.json
@@ -20,7 +20,8 @@
     ],
     "checkver": {
         "url": "https://www.visorcraft.com/api/downloads/mongrel",
-        "regex": "\"id\":\"(?<id>[0-9a-f-]+)\"[^{}]*?\"file_name\":\"Mongrel_([\\d.]+)_x64-setup\\.exe\""
+        "regex": "\"id\":\"(?<id>[0-9a-f-]+)\"[^{}]*?\"file_name\":\"Mongrel_(?<version>[\\d.]+)_x64-setup\\.exe\"",
+        "replace": "${version}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/mongrel.json
+++ b/bucket/mongrel.json
@@ -1,13 +1,13 @@
 {
-    "version": "5.71.41",
+    "version": "5.71.42",
     "description": "Desktop database workbench for 30+ database engines, with terminals, SFTP, Docker, Kubernetes, and an API client",
     "homepage": "https://www.visorcraft.com/",
     "license": "Proprietary",
     "notes": "Paid annual license with a 7-day free trial.",
     "architecture": {
         "64bit": {
-            "url": "https://www.visorcraft.com/api/downloads/mongrel/e94119f4-447d-471e-8bc1-7b35de91abc7#/dl.7z",
-            "hash": "0ca36770c371309faf42ad8267dc92dada21ad4e0522dc9240eea4cf596697b9"
+            "url": "https://www.visorcraft.com/api/downloads/mongrel/a63a3203-4980-47de-89a4-646d1eab431c#/dl.7z",
+            "hash": "77e86815eed5c47002c0e226d132d8b24617c6e3852fc0b56712b11cf5bef688"
         }
     },
     "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse -ErrorAction Ignore",


### PR DESCRIPTION
Closes #18518

Adds a manifest for Mongrel 5.71.41, a desktop database systems workbench by VisorCraft covering 30+ database engines, plus SSH/Mosh/Telnet/Serial terminals, SFTP/SCP, Docker/Podman, Kubernetes, and an HTTP/GraphQL/WebSocket/gRPC API client.

Disclosure: this PR is submitted on behalf of VisorCraft, the vendor of Mongrel. Mongrel is proprietary, paid software (annual license) with a 7-day free trial; the manifest states `license: Proprietary` and notes the trial.

Notes on the download URL: Windows installers are served per-file through the vendor's downloads metadata API (https://www.visorcraft.com/api/downloads/mongrel), which lists every published file with its version and SHA-256; the manifest's `url` is the same per-file endpoint the vendor's download page uses. `checkver` reads that JSON and captures both the version and the file id, and `autoupdate` rebuilds the URL via `$matchId`. The x64 NSIS installer hash (0ca36770c371309faf42ad8267dc92dada21ad4e0522dc9240eea4cf596697b9) was verified against the published metadata. ARM64 NSIS and MSI installers are also published if maintainers would like them added.

The manifest follows the bucket's Tauri/NSIS extraction pattern (`#/dl.7z`, removal of `$PLUGINSDIR`/uninstaller on install), adds a Start Menu shortcut for `mongrel.exe`, and exposes the bundled `mongrel-cli.exe` via `bin`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
