### PR TITLE
hex-editor-neo: Change license identifier from Freeware to Freemium

### DIFF
--- a/bucket/hex-editor-neo.json
+++ b/bucket/hex-editor-neo.json
@@ -3,7 +3,7 @@
     "description": "Binary file editor optimized for large files",
     "homepage": "https://www.hhdsoftware.com/free-hex-editor",
     "license": {
-        "identifier": "Freeware",
+        "identifier": "Freemium",
         "url": "https://docs.hhdsoftware.com/pdf/hex"
     },
     "url": "https://www.hhdsoftware.com/download/free-hex-editor-neo.exe#/dl.7z_",


### PR DESCRIPTION
As their [website currently indicates](https://hhdsoftware.com/free-hex-editor), this is distributed under "Freemium" model.

Some rather basic features, such as **Find All** and **Replace All** are unavailable in the basic version provided here.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
