### PR TITLE
wox@2.3.0: Fix homepage URL

### DIFF
--- a/bucket/wox.json
+++ b/bucket/wox.json
@@ -1,7 +1,7 @@
 {
     "version": "2.3.0",
     "description": "A full-featured launcher, access programs and web contents as you type.",
-    "homepage": "http://www.wox.one",
+    "homepage": "https://github.com/Wox-launcher/Wox",
     "license": {
         "identifier": "GPL-3.0-or-later",
         "url": "https://github.com/Wox-launcher/Wox/blob/master/LICENSE"


### PR DESCRIPTION
## Summary

- Update Wox's homepage URL to the official GitHub repository.

> https://github.com/ScoopInstaller/Extras/pull/18525#discussion_r3785621103
> Because the official website links may change. For example, Wox's original domain was `getwox.com`, and later the second maintainer changed it to `wox.one`. Now, as the original developer, I have taken over maintenance again. So I don't want Wox's resources to be tied to any external resources (including domains, server for hosting plugin stores, etc.). These external resources require the Wox maintainer to pay for upkeep, and we can't guarantee that this payment will continue indefinitely. Even if I stop maintaining Wox in the future, when someone else in the community takes over, all brand resources will remain unaffected—they just need access to Wox's GitHub repository.

## Change

- `http://www.wox.one` → `https://github.com/Wox-launcher/Wox`

No download URL, version, or hash changes.