### PR TITLE
powertoys: Roll back to version 0.100.2, restrict checkver to stable releases

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.101.2242.0",
+    "version": "0.100.2",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
@@ -12,12 +12,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.101.2242.0/PowerToysUserSetup-0.101.2242.0-x64.exe",
-            "hash": "b8fc5941ddf7d4f6b2551f5cd846bfde83c39d108ec63602fce515ec244a88a1"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.100.2/PowerToysUserSetup-0.100.2-x64.exe",
+            "hash": "945fdf327e4d38e4ced61b0727b7ab8a1222958782982052989ddf7cb7096f62"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.101.2242.0/PowerToysUserSetup-0.101.2242.0-arm64.exe",
-            "hash": "bd954fd99e9fa881b58c2de85f263f975b718aa336c94fe52f8c85db8aacc9d6"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.100.2/PowerToysUserSetup-0.100.2-arm64.exe",
+            "hash": "5554984d72c30d5fd26355569d1ca8d63b74f0062ee4e59e0186e28216c837ae"
         }
     },
     "installer": {
@@ -59,6 +59,12 @@
         "    Invoke-Expression -Command \"& `\"$dir\\install-context.ps1`\"\"",
         "}"
     ],
+    "shortcuts": [
+        [
+            "PowerToys.exe",
+            "PowerToys"
+        ]
+    ],
     "uninstaller": {
         "script": [
             "$regpath = 'HKCU:\\Software\\Classes\\powertoys'",
@@ -73,17 +79,7 @@
             "}"
         ]
     },
-    "shortcuts": [
-        [
-            "PowerToys.exe",
-            "PowerToys"
-        ]
-    ],
-    "checkver": {
-        "github": "https://api.github.com/repos/microsoft/PowerToys/releases",
-        "jsonpath": "$[0].assets[*].browser_download_url",
-        "regex": "/releases/download/(?<tag>[\\w.]+)/PowerToysUserSetup-([\\d.]+)-x64\\.exe"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -92,10 +88,6 @@
             "arm64": {
                 "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysUserSetup-$version-arm64.exe"
             }
-        },
-        "hash": {
-            "url": "https://github.com/microsoft/PowerToys/releases/tag/v$version",
-            "regex": "(?sm)$basename.*?>$sha256<"
         }
     }
 }


### PR DESCRIPTION
Closes <https://github.com/ScoopInstaller/Extras/issues/18522>

It probably broke due to <https://github.com/ScoopInstaller/Scoop/pull/6641>?

Changes:

* Downgrade to latest stable
* Checkver: Use Scoop default method for GitHub
  * Automatic checkver logic has become hardened and more robust: <https://github.com/ScoopInstaller/Scoop/pull/6641>
* Hash: Use Scoop default method for GitHub
  * Came in v0.5.3: <https://github.com/ScoopInstaller/Scoop/releases/tag/v0.5.3>
* Manifest properties order: Shortcuts before Uninstall

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
