### PR TITLE
flclash: Patch for recovering app built-in `manifest.json`

### DIFF
--- a/bucket/flclash.json
+++ b/bucket/flclash.json
@@ -20,6 +20,13 @@
             "hash": "94fac84fc3b779860d3754bed8ef84252d737e7d27eb64d4f0939d2a72f3c394"
         }
     },
+    "post_install": [
+        "Rename-Item -Path \"$dir\\manifest.json\" -NewName \"manifest.flclash.json\"",
+        "Write-Host \"`n============ FOR TUN MODE USERS ============\" -ForegroundColor Yellow",
+        "Write-Host \"Run following two commands one by one after each installation:\" -ForegroundColor Yellow",
+        "Write-Host \"Rename-Item -Path '$dir\\manifest.json' -NewName 'manifest.scoop.json'\" -ForegroundColor Yellow",
+        "Write-Host \"Rename-Item -Path '$dir\\manifest.flclash.json' -NewName 'manifest.json'\" -ForegroundColor Yellow"
+    ],
     "shortcuts": [
         [
             "FlClash.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

To solve the bug caused by file conflictions, this PR adds a backup script for conflicted file and prints notes for users to act

Closes #18529

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
