### PR TITLE
flclash@0.8.95: Avoid overwriting existing manifest.json

### DIFF
--- a/bucket/flclash.json
+++ b/bucket/flclash.json
@@ -1,14 +1,14 @@
 {
+    "##": "Extract to subfolder to avoid overwriting existing manifest.json.",
     "version": "0.8.95",
     "description": "A multi-platform proxy client based on ClashMeta, simple and easy to use, open-source and ad-free.",
     "homepage": "https://github.com/chen08209/FlClash",
     "license": "GPL-3.0-only",
     "notes": [
-        "Once you set up TUN mode successfully, the older versions of FlClash may be hard to remove by running 'scoop cleanup flclash'.",
-        "In that case, try running the following command with privilege.",
-        "sc.exe config FlClashHelperService binPath=\"$dir\\FlClashHelperService.exe\"",
-        "This command will modify the FlClashHelperService with a flexible path to the executable.",
-        "Also, FlClash may be hard to uninstall due the running FlClashHelperService, just kill it with Task Manager or run 'sc.exe stop FlClashHelperService' with privilege."
+        "Once you set up TUN mode successfully, you may find it hard to remove the older versions of FlClash by running 'scoop cleanup flclash'.",
+        "Also, FlClash may be hard to uninstall either.",
+        "In both cases, just kill the running FlClashHelperService with Task Manager,",
+        "or run 'sc.exe stop FlClashHelperService' with privilege."
     ],
     "architecture": {
         "64bit": {
@@ -20,9 +20,10 @@
             "hash": "94fac84fc3b779860d3754bed8ef84252d737e7d27eb64d4f0939d2a72f3c394"
         }
     },
+    "extract_to": "app",
     "shortcuts": [
         [
-            "FlClash.exe",
+            "app\\FlClash.exe",
             "FlClash"
         ]
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
flclash v0.8.95 introduced a new manifest.json, which is now crucial to running FlclashHelperService.
I believe we need a subfolder to hold flclash files, just like [trae](https://github.com/ScoopInstaller/Extras/blob/de838245fe791772075d6eb2093de2927270654a/bucket/trae.json#L2) and [vnote](https://github.com/ScoopInstaller/Extras/blob/de838245fe791772075d6eb2093de2927270654a/bucket/vnote.json#L2)

And the flexible path trick doesn't work for v0.8.95 any more, so notes were modified.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
