### PR TITLE
trace: Add version 2026.8.15

### DIFF
--- a/bucket/trace.json
+++ b/bucket/trace.json
@@ -1,6 +1,6 @@
 {
     "version": "2026.8.15",
-    "description": "Trace — a clipboard manager that lives on the left edge of your screen and expands on hover. Zero-click panel, native OLE drag & drop, task layer and AI suggestions.",
+    "description": "A clipboard manager that lives on the left edge of your screen and expands on hover. Zero-click panel, native OLE drag & drop, task layer and AI suggestions.",
     "homepage": "https://github.com/PaRr0tBoY/Trace",
     "license": "MIT",
     "architecture": {
@@ -8,7 +8,7 @@
             "url": "https://github.com/PaRr0tBoY/Trace/releases/download/v2026.8.15/Trace-Setup-2026.8.15.exe",
             "hash": "2fcaa90af26a4389c0b236d80d3023d357ba6a81df9bfcbfcd1d21418065b9ca",
             "installer": {
-                "script": "Start-Process \"$dir\\Trace-Setup-2026.8.15.exe\" -ArgumentList '/S' -Wait"
+                "script": "Start-Process \"$dir\\Trace-Setup-$version.exe\" -ArgumentList '/S' -Wait"
             }
         }
     },

--- a/bucket/trace.json
+++ b/bucket/trace.json
@@ -1,0 +1,34 @@
+{
+    "version": "2026.8.15",
+    "description": "Trace — a clipboard manager that lives on the left edge of your screen and expands on hover. Zero-click panel, native OLE drag & drop, task layer and AI suggestions.",
+    "homepage": "https://github.com/PaRr0tBoY/Trace",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PaRr0tBoY/Trace/releases/download/v2026.8.15/Trace-Setup-2026.8.15.exe",
+            "hash": "2fcaa90af26a4389c0b236d80d3023d357ba6a81df9bfcbfcd1d21418065b9ca",
+            "installer": {
+                "script": "Start-Process \"$dir\\Trace-Setup-2026.8.15.exe\" -ArgumentList '/S' -Wait"
+            }
+        }
+    },
+    "uninstaller": {
+        "script": [
+            "$u = Get-ItemProperty 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*' | Where-Object { $_.DisplayName -eq 'Trace' } | Select-Object -First 1;",
+            "if ($u) { Start-Process ($u.UninstallString -replace '\"','') -ArgumentList '/S' -Wait }"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/PaRr0tBoY/Trace"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PaRr0tBoY/Trace/releases/download/v$version/Trace-Setup-$version.exe",
+                "hash": {
+                    "url": "https://github.com/PaRr0tBoY/Trace/releases/download/v$version/Trace-Setup-$version.exe.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description:**
Add [Trace](https://github.com/PaRr0tBoY/Trace) — Windows-only clipboard manager (zero-click left-edge panel, OLE drag & drop). NSIS installer, silent /S, per-user.

**Automatic update:**
- [x] Manifest contains checkver (github) and utoupdate
- [x] Checksum source: release asset Trace-Setup-\.exe.sha256 (published alongside each release)
