### PR TITLE
brows3: Persist user data

### DIFF
--- a/bucket/brows3.json
+++ b/bucket/brows3.json
@@ -10,6 +10,7 @@
             "extract_dir": "src-tauri\\target\\release\\bundle\\portable\\Brows3_0.2.44_x64-portable"
         }
     },
+    "persist": "data",
     "post_install": "Remove-Item \"$dir\\src-tauri\" -Recurse -ErrorAction SilentlyContinue",
     "shortcuts": [
         [

--- a/bucket/brows3.json
+++ b/bucket/brows3.json
@@ -10,7 +10,6 @@
             "extract_dir": "src-tauri\\target\\release\\bundle\\portable\\Brows3_0.2.44_x64-portable"
         }
     },
-    "persist": "data",
     "post_install": "Remove-Item \"$dir\\src-tauri\" -Recurse -ErrorAction SilentlyContinue",
     "shortcuts": [
         [
@@ -18,6 +17,7 @@
             "Brows3"
         ]
     ],
+    "persist": "data",
     "checkver": {
         "github": "https://github.com/rgcsekaraa/brows3",
         "regex": "app-v([\\d.]+)"


### PR DESCRIPTION
Persist `data` folder, which includes `brows3` portable installation's profiles.