### PR TITLE
sift: Add version 0.5.0

### DIFF
--- a/bucket/sift.json
+++ b/bucket/sift.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.5.0",
+    "description": "Turns any video into a searchable, transcribed, summarized library — 100% local.",
+    "homepage": "https://github.com/dawid-ai/sift",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dawid-ai/sift/releases/download/v0.5.0/Sift-Setup.exe#/dl.7z",
+            "hash": "a15a01051e83a51306b9f7d1b07244b3146cbc85eddc4076a4e109f37015d7c9",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse -ErrorAction SilentlyContinue",
+    "bin": "Sift.exe",
+    "shortcuts": [
+        [
+            "Sift.exe",
+            "Sift"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/dawid-ai/sift"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dawid-ai/sift/releases/download/v$version/Sift-Setup.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds **Sift** — an open-source (MIT) Electron desktop app that downloads media from yt-dlp-supported platforms, transcribes it locally with whisper.cpp, and summarizes it with a user-supplied AI provider key. Media and API keys stay on the machine.

Homepage: https://github.com/dawid-ai/sift

### Packaging

electron-builder NSIS. Same shape as `extras/obsidian`: the `#/dl.7z` fragment has Scoop extract the installer on download, `pre_install` unpacks `$PLUGINSDIR/app-64.7z` into the app dir, and `post_install` clears the `$PLUGINSDIR`/`$R0` leftovers. No `persist` — Sift stores its library and settings in `%APPDATA%/Sift`, outside the Scoop dir, so it survives upgrades.

Note the installer is built in NSIS *assisted* mode (`nsis.oneClick: false`). That is sometimes assumed to rule this approach out, but the `$PLUGINSDIR/app-64.7z` payload layout comes from electron-builder and is present either way — confirmed against the published installer with `7z l`.

### Verified on a clean machine

- `scoop install` from the manifest completes; app dir contains the unpacked app with no `$PLUGINSDIR`/`$R0`/installer left behind
- `sift` shim resolves and is shimmed as a GUI binary
- Start Menu shortcut created
- app launches — confirmed by checking the *executable path* of the running process resolves to `~/scoop/apps/sift/current/Sift.exe` (a system-installed copy at `%LOCALAPPDATA%\Programs\Sift` runs alongside it, so checking only that a window appeared would be a false pass)
- `scoop uninstall` removes shim, shortcut and app dir cleanly

The installer is not code-signed, so SmartScreen shows an unknown-publisher prompt on first run.