### PR TITLE
psysonic: Update to version 1.51.0, fix checkver

### DIFF
--- a/bucket/psysonic.json
+++ b/bucket/psysonic.json
@@ -24,7 +24,7 @@
     ],
     "checkver": {
         "github": "https://github.com/Psysonic/psysonic",
-        "regex": "releases/tag/app-v([\\d.]+)"
+        "regex": "app-v([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/Psysonic/psysonic/releases/download/app-v$version/Psysonic_$version_x64-setup.exe"

--- a/bucket/psysonic.json
+++ b/bucket/psysonic.json
@@ -1,18 +1,18 @@
 {
-    "version": "1.50.0",
+    "version": "1.51.0",
     "description": "A lean desktop music player for Subsonic-compatible servers.",
     "homepage": "https://www.psysonic.de/",
     "license": {
         "identifier": "GPL-3.0-or-later",
-        "url": "https://github.com/Psychotoxical/psysonic/blob/main/LICENSE"
+        "url": "https://github.com/Psysonic/psysonic/blob/main/LICENSE"
     },
     "suggest": {
         "Microsoft Edge WebView2": "extras/webview2"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Psychotoxical/psysonic/releases/download/app-v1.50.0/Psysonic_1.50.0_x64-setup.exe",
-            "hash": "cd1ff4cc7184cc966efd9e6e4ed33ae5e6acedc9e6fbcb484c1c9b054a450cae"
+            "url": "https://github.com/Psysonic/psysonic/releases/download/app-v1.51.0/Psysonic_1.51.0_x64-setup.exe",
+            "hash": "7e05b07a7b497dd0193c5dc233555c34e139ed6273df3e7d9167e998bca35fde"
         }
     },
     "innosetup": true,
@@ -23,10 +23,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/Psychotoxical/psysonic",
-        "regex": "Psysonic v([\\d.]+)"
+        "github": "https://github.com/Psysonic/psysonic",
+        "regex": "releases/tag/app-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Psychotoxical/psysonic/releases/download/app-v$version/Psysonic_$version_x64-setup.exe"
+        "url": "https://github.com/Psysonic/psysonic/releases/download/app-v$version/Psysonic_$version_x64-setup.exe"
     }
 }


### PR DESCRIPTION
The upstream repository moved from `Psychotoxical/psysonic` to `Psysonic/psysonic` (organization transfer). All URLs updated; the old ones still redirect, so nothing was broken.

Also fixes autoupdate, which is why this manifest sat at 1.50.0: `checkver` scraped the repository landing page for `Psysonic v([\d.]+)`, and that string is no longer present in its HTML. It now reads `/releases/latest` and matches the project's `app-v` tag prefix, which also keeps release candidates out.

Checksum is GitHub's own digest for the published installer.