### PR TITLE
hilp: Add version 12.0.0

### DIFF
--- a/bucket/hil.json
+++ b/bucket/hil.json
@@ -1,0 +1,26 @@
+{
+  "version": "12.0.0",
+  "description": "HIL LISP - Hardware Interfacing LISP for Arduino and media hardware",
+  "homepage": "https://github.com/SRashwan/hilp",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/SRashwan/hilp/releases/download/v12.0.0/hil-os-full-windows-x64.zip",
+      "hash": "D8E981909FAF4E9F37B799539314001B1255AEFB804BB0487724FCE59D1F454E"
+    }
+  },
+  "bin": [
+    "hil-cli.exe",
+    "hil-orchestrator.exe"
+  ],
+  "checkver": {
+    "github": "https://github.com/SRashwan/hilp"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/SRashwan/hilp/releases/download/v$version/hil-os-full-windows-x64.zip"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add HIL LISP package manager for Arduino and media hardware.

Package: hil
Version: 12.0.0
Source: https://github.com/SRashwan/hilp
NPM: @srashwan/hilp