### PR TITLE
raspberry-pi-imager: Fix registry path

### DIFF
--- a/bucket/raspberry-pi-imager.json
+++ b/bucket/raspberry-pi-imager.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "notes": [
         "To opt out of telemetry, run:",
-        "Set-ItemProperty 'HKCU:/Software/Raspberry Pi/Raspberry Pi Imager' telemetry false"
+        "Set-ItemProperty 'HKCU:/Software/Raspberry Pi/Imager' telemetry false"
     ],
     "architecture": {
         "64bit": {


### PR DESCRIPTION
I'm unsure of whether or not I made a mistake when I wrote this in the past, or if the actual registry path changed.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
