### PR TITLE
zephyr: Add version 2.4.3

### DIFF
--- a/bucket/zephyr.json
+++ b/bucket/zephyr.json
@@ -3,6 +3,9 @@
     "description": "A modern, lightweight Mihomo GUI client built with Rust and Tauri v2",
     "homepage": "https://github.com/Juwan-Hwang/Zephyr",
     "license": "MIT",
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_x64-portable.zip",

--- a/bucket/zephyr.json
+++ b/bucket/zephyr.json
@@ -29,10 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v/Zephyr_x64-portable.zip"
+                "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v$version/Zephyr_x64-portable.zip"
             },
             "arm64": {
-                "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v/Zephyr_arm64-portable.zip"
+                "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v$version/Zephyr_arm64-portable.zip"
             }
         }
     }

--- a/bucket/zephyr.json
+++ b/bucket/zephyr.json
@@ -1,0 +1,39 @@
+{
+  "version": "2.4.3",
+  "description": "A modern, lightweight Mihomo GUI client built with Rust and Tauri v2",
+  "homepage": "https://github.com/Juwan-Hwang/Zephyr",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_x64-portable.zip",
+      "hash": "34a080869c1d40b461e9c24b2d0fc39534957a2a1ee36cac50512ee941b98199"
+    },
+    "arm64": {
+      "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_arm64-portable.zip",
+      "hash": "46c5f4fe2b7c9b624d2c9a15345149d60a200f138c5bc11e6b2c32c8f08b7d66"
+    }
+  },
+  "bin": "Zephyr.exe",
+  "shortcuts": [
+    [
+      "Zephyr.exe",
+      "Zephyr"
+    ]
+  ],
+  "persist": [
+    "core",
+    "profiles",
+    "prism"
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v$version/Zephyr_x64-portable.zip"
+      },
+      "arm64": {
+        "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v$version/Zephyr_arm64-portable.zip"
+      }
+    }
+  }
+}

--- a/bucket/zephyr.json
+++ b/bucket/zephyr.json
@@ -1,39 +1,39 @@
 {
-  "version": "2.4.3",
-  "description": "A modern, lightweight Mihomo GUI client built with Rust and Tauri v2",
-  "homepage": "https://github.com/Juwan-Hwang/Zephyr",
-  "license": "MIT",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_x64-portable.zip",
-      "hash": "34a080869c1d40b461e9c24b2d0fc39534957a2a1ee36cac50512ee941b98199"
-    },
-    "arm64": {
-      "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_arm64-portable.zip",
-      "hash": "46c5f4fe2b7c9b624d2c9a15345149d60a200f138c5bc11e6b2c32c8f08b7d66"
-    }
-  },
-  "bin": "Zephyr.exe",
-  "shortcuts": [
-    [
-      "Zephyr.exe",
-      "Zephyr"
-    ]
-  ],
-  "persist": [
-    "core",
-    "profiles",
-    "prism"
-  ],
-  "checkver": "github",
-  "autoupdate": {
+    "version": "2.4.3",
+    "description": "A modern, lightweight Mihomo GUI client built with Rust and Tauri v2",
+    "homepage": "https://github.com/Juwan-Hwang/Zephyr",
+    "license": "MIT",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v$version/Zephyr_x64-portable.zip"
-      },
-      "arm64": {
-        "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v$version/Zephyr_arm64-portable.zip"
-      }
+        "64bit": {
+            "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_x64-portable.zip",
+            "hash": "34a080869c1d40b461e9c24b2d0fc39534957a2a1ee36cac50512ee941b98199"
+        },
+        "arm64": {
+            "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_arm64-portable.zip",
+            "hash": "46c5f4fe2b7c9b624d2c9a15345149d60a200f138c5bc11e6b2c32c8f08b7d66"
+        }
+    },
+    "bin": "Zephyr.exe",
+    "shortcuts": [
+        [
+            "Zephyr.exe",
+            "Zephyr"
+        ]
+    ],
+    "persist": [
+        "core",
+        "profiles",
+        "prism"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v/Zephyr_x64-portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Juwan-Hwang/Zephyr/releases/download/v/Zephyr_arm64-portable.zip"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
Closes #18547

### Package Details

- **Package Name**: \zephyr\
- **Description**: A modern, lightweight Mihomo GUI client built with Rust and Tauri v2
- **Homepage**: https://github.com/Juwan-Hwang/Zephyr (685+ stars, 40+ forks)
- **License**: MIT
- **Release**: https://github.com/Juwan-Hwang/Zephyr/releases/tag/v2.4.3
