### PR TITLE
auto-dark-mode@11.1.1.1: Fix broken install layout

### DIFF
--- a/bucket/auto-dark-mode.json
+++ b/bucket/auto-dark-mode.json
@@ -13,11 +13,10 @@
             "hash": "57e6520c812ff699e4b3984c45b8c15b1c25697063471103fef15b1f0af2a887"
         }
     },
-    "extract_dir": "adm-app",
-    "bin": "core\\AutoDarkModeShell.exe",
+    "bin": "adm-app\\core\\AutoDarkModeShell.exe",
     "shortcuts": [
         [
-            "ui\\AutoDarkModeApp.exe",
+            "adm-app\\ui\\AutoDarkModeApp.exe",
             "Auto Dark Mode"
         ]
     ],

--- a/bucket/auto-dark-mode.json
+++ b/bucket/auto-dark-mode.json
@@ -1,4 +1,5 @@
 {
+    "##": "The top-level directory must be kept during extraction for AutoDarkModeSvc to function correctly.",
     "version": "11.1.1.1",
     "description": "Automatically switches between the dark and light theme of Windows 10 and Windows 11.",
     "homepage": "https://github.com/AutoDarkMode/Windows-Auto-Night-Mode",


### PR DESCRIPTION
## Problem

The manifest's `"extract_dir": "adm-app"` strips the ZIP's top-level `adm-app/` directory during extraction, flattening `core/` and `ui/` into the version directory root:

```
apps/auto-dark-mode/11.1.0.23/
├── core/AutoDarkModeSvc.exe     ← should be adm-app/core/...
└── ui/AutoDarkModeApp.exe       ← should be adm-app/ui/...
```

ADM's runtime requires the parent of `core/` to be named `adm-app` (`AutoDarkModeLib/Helper.cs`, `GetValidatedBasePath()`). With the stripped layout the service crashes on launch:

```
System.InvalidOperationException: Expected directory 'adm-app' but found 'current'.
```

So after `scoop install auto-dark-mode`, `AutoDarkModeSvc.exe` never starts: no tray icon, no theme switching, and the UI's tray actions are dead.

## Root cause

The upstream release ZIP **does** contain the `adm-app/` top-level directory (plus `adm-updater/`). The upstream layout is correct and matches the MSI install. This manifest's `extract_dir` was written under a wrong assumption and breaks the layout the runtime expects.

## Fix

Extract the ZIP as-is and point `bin`/`shortcuts` at the real paths:

```diff
-    "extract_dir": "adm-app",
-    "bin": "core\\AutoDarkModeShell.exe",
+    "bin": "adm-app\\core\\AutoDarkModeShell.exe",
     "shortcuts": [
         [
-            "ui\\AutoDarkModeApp.exe",
+            "adm-app\\ui\\AutoDarkModeApp.exe",
             "Auto Dark Mode"
         ]
     ],
```

## Verification

Extracted `AutoDarkMode_11.1.0.23_x64.zip` as-is (1030 entries; top level `adm-app/` + `adm-updater/`) and launched `adm-app\core\AutoDarkModeSvc.exe` from the extracted tree. The service passes the path validation (no "Expected directory" error) and reaches normal startup. Also confirmed the runtime path resolution in `Helper.cs` expects exactly this layout.

Tested on Windows 11 24H2 (build 26200.9168), Scoop 0.5.3, ADM 11.1.0.23.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
