### PR TITLE
dbtool: Add version 1.0.0

### DIFF
--- a/bucket/dbtool.json
+++ b/bucket/dbtool.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.0.0",
+    "description": "A free, open-source desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and SQL Server",
+    "homepage": "https://codemake.co/software",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/achi777/db-tool/releases/download/v1.0.0/DBTool-1.0.0-portable.exe#/DBTool.exe",
+            "hash": "c45c8e8bc2f71a4ec3e0cbf75184776b58feed9e44e7491b8b1dea5bfa45136b"
+        }
+    },
+    "bin": "DBTool.exe",
+    "shortcuts": [
+        [
+            "DBTool.exe",
+            "DBTool"
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "github": "https://github.com/achi777/db-tool"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/achi777/db-tool/releases/download/v$version/DBTool-$version-portable.exe#/DBTool.exe"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/achi777/db-tool/releases/download/v$version/SHA256SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION
Adds **DBTool 1.0.0** — a free, open-source desktop database client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server.

- Homepage: https://codemake.co/software
- Source: https://github.com/achi777/db-tool
- License: AGPL-3.0-only

The manifest points at the portable single-`.exe` build from the tagged GitHub release, so it needs no installer. `checkver` and `autoupdate` are wired to the repo's releases, and the hash is read from the `SHA256SUMS.txt` published with every release.

I am the author of this project.
