### PR TITLE
refract: Add version 1.3.4

### DIFF
--- a/bucket/refract.json
+++ b/bucket/refract.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "version":  "1.3.4",
     "description":  "Fast, open-source Minecraft launcher built with Tauri and React",
     "homepage":  "https://refractmc.net",

--- a/bucket/refract.json
+++ b/bucket/refract.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.3.4",
+  "description": "Fast, open-source Minecraft launcher built with Tauri and React",
+  "homepage": "https://refractmc.net",
+  "license": "GPL-3.0-only",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/RefractMC/Refract_MC/releases/download/v1.3.4/Refract-Windows-x64.exe",
+      "hash": "e5454c9b9cf3b497a0f879573011116f5ce07d6446450d08aa6ed7a3e170b0be"
+    }
+  },
+  "installer": {
+    "args": ["/S"]
+  },
+  "uninstaller": {
+    "file": "$env:LOCALAPPDATA\\Refract\\uninstall.exe",
+    "args": ["/S"]
+  },
+  "shortcuts": [
+    ["Refract.exe", "Refract"]
+  ],
+  "checkver": {
+    "github": "https://github.com/RefractMC/Refract_MC"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/RefractMC/Refract_MC/releases/download/v$version/Refract-Windows-x64.exe"
+      }
+    }
+  }
+}

--- a/bucket/refract.json
+++ b/bucket/refract.json
@@ -1,32 +1,33 @@
-{
-  "version": "1.3.4",
-  "description": "Fast, open-source Minecraft launcher built with Tauri and React",
-  "homepage": "https://refractmc.net",
-  "license": "GPL-3.0-only",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/RefractMC/Refract_MC/releases/download/v1.3.4/Refract-Windows-x64.exe",
-      "hash": "e5454c9b9cf3b497a0f879573011116f5ce07d6446450d08aa6ed7a3e170b0be"
-    }
-  },
-  "installer": {
-    "args": ["/S"]
-  },
-  "uninstaller": {
-    "file": "$env:LOCALAPPDATA\\Refract\\uninstall.exe",
-    "args": ["/S"]
-  },
-  "shortcuts": [
-    ["Refract.exe", "Refract"]
-  ],
-  "checkver": {
-    "github": "https://github.com/RefractMC/Refract_MC"
-  },
-  "autoupdate": {
-    "architecture": {
-      "64bit": {
-        "url": "https://github.com/RefractMC/Refract_MC/releases/download/v$version/Refract-Windows-x64.exe"
-      }
-    }
-  }
+﻿{
+    "version":  "1.3.4",
+    "description":  "Fast, open-source Minecraft launcher built with Tauri and React",
+    "homepage":  "https://refractmc.net",
+    "license":  "GPL-3.0-only",
+    "architecture":  {
+                         "64bit":  {
+                                       "url":  "https://github.com/RefractMC/Refract_MC/releases/download/v1.3.4/Refract-Windows-x64.exe",
+                                       "hash":  "e5454c9b9cf3b497a0f879573011116f5ce07d6446450d08aa6ed7a3e170b0be"
+                                   }
+                     },
+    "installer":  {
+                      "args":  [
+                                   "/S"
+                               ]
+                  },
+    "uninstaller":  {
+                        "file":  "$env:LOCALAPPDATA\\Refract\\uninstall.exe",
+                        "args":  [
+                                     "/S"
+                                 ]
+                    },
+    "checkver":  {
+                     "github":  "https://github.com/RefractMC/Refract_MC"
+                 },
+    "autoupdate":  {
+                       "architecture":  {
+                                            "64bit":  {
+                                                          "url":  "https://github.com/RefractMC/Refract_MC/releases/download/v$version/Refract-Windows-x64.exe"
+                                                      }
+                                        }
+                   }
 }


### PR DESCRIPTION
﻿## Summary

Add Refract, an open-source Minecraft launcher, to the Extras bucket.

## Details

- Uses the stable GitHub Release NSIS installer alias for Windows x64.
- Uses the authentic v1.3.4 SHA-256 checksum.
- Uses the NSIS /S silent install and uninstall switches.
- Includes GitHub checkver/autoupdate metadata.

The installer is a GUI application, so Extras is the intended bucket rather than Main.
