### PR TITLE
ailimits: Add version 0.6.2

### DIFF
--- a/bucket/ailimits.json
+++ b/bucket/ailimits.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.6.2",
+    "description": "Native floating overlay showing AI provider usage limits (Claude, OpenAI Codex, GitHub Copilot, Google Antigravity)",
+    "homepage": "https://github.com/napxlexn/ailimits",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/napxlexn/ailimits/releases/download/v0.6.2/AiLimits-Portable-0.6.2.zip",
+    "hash": "35251398f7bab72f998cc52c9052f8d2167b2c49e51520445b6012573e67647e",
+    "bin": "ailimits-auth.exe",
+    "shortcuts": [
+        [
+            "ailimits.exe",
+            "AI Limits"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/napxlexn/ailimits/releases/download/v$version/AiLimits-Portable-$version.zip"
+    }
+}


### PR DESCRIPTION
New manifest for [AI Limits](https://github.com/napxlexn/ailimits), a native Windows 11 floating overlay that shows AI provider usage limits (Claude, OpenAI Codex, GitHub Copilot, Google Antigravity). GPL-3.0-or-later, ~3 MB statically linked exe.

- Points at the portable zip the project attaches to every GitHub release; hash matches the release digest.
- `bin` exposes the `ailimits-auth` credential CLI; the GUI gets a Start-menu shortcut.
- `checkver`/`autoupdate` follow GitHub releases.
- The app's built-in self-updater detects a copy it does not manage (this one) and stands down, so the Scoop-installed version stays under Scoop's control - verified by installing from this manifest locally (hash ok, shim ok, shortcut ok).
