### PR TITLE
koharu: Update to version 0.77.4, Update license

### DIFF
--- a/bucket/koharu.json
+++ b/bucket/koharu.json
@@ -1,18 +1,21 @@
 {
-    "version": "0.61.2",
+    "version": "0.77.4",
     "description": "ML-powered manga translator, written in Rust.",
     "homepage": "https://koharu.rs/",
-    "license": "GPL-3.0-only",
+    "license": "GPL-3.0-only|Apache-2.0",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mayocream/koharu/releases/download/0.61.2/koharu_windows_x64.exe#/koharu.exe",
-            "hash": "8795dd1a3845ca1dd246ed1534b00a39511c2ff1cc0ad05882c1b3116a33de3f"
+            "url": "https://github.com/mayocream/koharu/releases/download/0.77.4/koharu_0.77.4_x64-setup.exe#/dl.7z",
+            "hash": "154ce2c34f1057ef22480677cf9f0152f6842c7dca68770af581922412be3e5f"
         }
     },
-    "pre_install": "if (!(Test-Path \"$persist_dir\\config.toml\")) { New-Item \"$dir\\config.toml\" -ItemType File | Out-Null }",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\config.toml\")) { New-Item \"$dir\\config.toml\" -ItemType File | Out-Null }",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+    ],
     "bin": "koharu.exe",
     "shortcuts": [
         [
@@ -34,7 +37,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mayocream/koharu/releases/download/$version/koharu_windows_x64.exe#/koharu.exe"
+                "url": "https://github.com/mayocream/koharu/releases/download/$version/koharu_$version_x64-setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

> Koharu is now dual-licensed under the MIT or Apache 2.0 License, at your option. This aligns with the Rust ecosystem and gives developers who depend on Koharu more freedom.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
