### PR TITLE
pydm: Add version 0.0.2

### DIFF
--- a/bucket/p/pydm.json
+++ b/bucket/p/pydm.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.0.2",
+    "description": "A modern Python download manager.",
+    "homepage": "https://github.com/TanmoyTheBoT/pydm",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TanmoyTheBoT/pydm/releases/download/v0.0.2/PyDM-v0.0.2-Windows-x64-Installer.exe",
+            "hash": "2e7b6e591e77190a44e2b626575de49fc496dbff7ac83871c04d1b75ac24f892"
+        }
+    },
+    "installer": {
+        "args": [
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$uninstaller = \"$env:ProgramFiles\\PyDM\\unins000.exe\"",
+            "if (Test-Path $uninstaller) {",
+            "    Start-Process $uninstaller -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART' -Wait",
+            "}"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/TanmoyTheBoT/pydm"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TanmoyTheBoT/pydm/releases/download/v$version/PyDM-v$version-Windows-x64-Installer.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
# PyDM

## Application

PyDM

## Description

PyDM is a modern Python download manager for Windows.

## Homepage

https://github.com/TanmoyTheBoT/pydm

## Download

https://github.com/TanmoyTheBoT/pydm/releases/tag/v0.0.2

## Details

* Package name: `pydm`
* Version: `0.0.2`
* Architecture: 64-bit
* License: MIT
* Windows application
* Inno Setup installer
* SHA256 verified
* Scoop installation and uninstallation tested locally

I would like to request PyDM to be added to the Scoop Extras bucket.
