### PR TITLE
tinta@3.2.0: Simplify description to high-level summary

### DIFF
--- a/bucket/tinta.json
+++ b/bucket/tinta.json
@@ -1,11 +1,11 @@
 {
-    "version": "3.0.0",
-    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, <1 MB, no Electron).",
+    "version": "3.1.0",
+    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, single small exe, no Electron).",
     "homepage": "https://tinta.cc",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oipoistar/tinta/releases/download/v3.0.0/tinta.exe",
+            "url": "https://github.com/oipoistar/tinta/releases/download/v3.1.0/tinta.exe",
             "hash": "48c94ed8140d95dfa7ddfa7e2e2f59d038cb33608a818e0c09e988101264585d"
         }
     },

--- a/bucket/tinta.json
+++ b/bucket/tinta.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oipoistar/tinta/releases/download/v3.1.0/tinta.exe",
-            "hash": "48c94ed8140d95dfa7ddfa7e2e2f59d038cb33608a818e0c09e988101264585d"
+            "hash": "f316e6f150b1e4326fbbe4480abca86eacceb3ab92831510fa9ab8f3f5c8ac15"
         }
     },
     "bin": "tinta.exe",


### PR DESCRIPTION
Updates tinta to 3.1.0 (new upstream release: export to HTML/DOCX/PDF, 22 native Mermaid diagram families) and corrects the size wording in the description; the binary is no longer under 1 MB.