### PR TITLE
pastejump: Add version 2026.1.0.229

### DIFF
--- a/bucket/pastejump.json
+++ b/bucket/pastejump.json
@@ -1,0 +1,44 @@
+{
+    "version": "2026.1.0.229",
+    "description": "Keyboard-driven multiple-clipboard manager. Hold Ctrl, tap V to walk back through what you copied, release to paste.",
+    "homepage": "https://lokeshgovindu.github.io/PasteJump/",
+    "license": "MIT",
+    "notes": [
+        "PasteJump keeps its clips in a 'data' folder beside the executable, which scoop persists across",
+        "updates - your history survives 'scoop update pastejump'.",
+        "",
+        "The build is not signed with a paid certificate, so SmartScreen may warn on first run.",
+        "",
+        "To start it with Windows, use the tray menu's 'Run at Startup' rather than a shortcut in the",
+        "Startup folder: it registers a scheduled task, which is also what makes 'Always Run as",
+        "Administrator' possible without a prompt at every logon."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lokeshgovindu/PasteJump/releases/download/2026.1/PasteJump-2026.1.0.229-win-x64.zip",
+            "hash": "33ba0351dd8b8cb6c00ba2fe64362ea210cc3fb9bb19e5f6a976e05f33569940",
+            "extract_dir": "PasteJump-2026.1.0.229-win-x64"
+        }
+    },
+    "bin": "PasteJump.exe",
+    "shortcuts": [
+        [
+            "PasteJump.exe",
+            "PasteJump"
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "url": "https://github.com/lokeshgovindu/PasteJump/releases/latest",
+        "regex": "releases/download/(?<tag>[^/\"]+)/PasteJump-(?<ver>[\\d.]+)-win-x64\\.zip",
+        "replace": "${ver}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lokeshgovindu/PasteJump/releases/download/$matchTag/PasteJump-$version-win-x64.zip",
+                "extract_dir": "PasteJump-$version-win-x64"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds **pastejump** 2026.1.0.229.

PasteJump is a keyboard-driven multiple-clipboard manager for Windows: hold <kbd>Ctrl</kbd>, tap <kbd>V</kbd> to walk back through what you have copied, release to paste. MIT-licensed and open source; I am its author.

- Homepage: https://lokeshgovindu.github.io/PasteJump/
- Repository: https://github.com/lokeshgovindu/PasteJump

### Manifest notes

- **`"persist": "data"` matters more than usual here.** PasteJump is portable and keeps its clip store and settings in a `data` folder *beside the executable*, so without persisting it a `scoop update` would take the user's whole clipboard history with it.
- `extract_dir` is `PasteJump-2026.1.0.229-win-x64` — the archive carries a top-level folder named after itself. Read out of the published archive rather than assumed.
- The hash matches the SHA256 published in the release notes, verified by downloading the asset and re-hashing it.
- **`checkver` cannot use the tag.** The tag is `2026.1` while the version is `2026.1.0.229`, because the fourth part is the commit count. So `checkver` captures both the tag and the version out of the release page's asset link, and `autoupdate` uses `$matchTag` for the URL and `$version` for the file name and `extract_dir`.
- The build is not code-signed, so SmartScreen reports an unknown publisher on first run. That is deliberate upstream — a certificate that fails validation looks worse than none — and every release publishes a SHA256 per file. The `notes` field mentions it so it is not a surprise.
