### PR TITLE
tinta: Update to version 3.2.0

### DIFF
--- a/bucket/tinta.json
+++ b/bucket/tinta.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.1.0",
-    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, <1 MB, no Electron).",
+    "version": "3.2.0",
+    "description": "Fast, lightweight Markdown and Mermaid viewer (native Direct2D, ~2 MB, no Electron).",
     "homepage": "https://tinta.cc",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oipoistar/tinta/releases/download/v3.1.0/tinta.exe",
-            "hash": "f316e6f150b1e4326fbbe4480abca86eacceb3ab92831510fa9ab8f3f5c8ac15"
+            "url": "https://github.com/oipoistar/tinta/releases/download/v3.2.0/tinta.exe",
+            "hash": "25d33941493e84d5ec2b001b67580672d16cec545149376a793701d5295f903a"
         }
     },
     "bin": "tinta.exe",


### PR DESCRIPTION
Updates tinta to 3.2.0.

- Release: https://github.com/oipoistar/tinta/releases/tag/v3.2.0
- Hash verified against the release asset (SHA256, decoded as a single stream)
- Description size claim corrected to ~2 MB