### PR TITLE
altgo: Add version 2.6.4

### DIFF
--- a/bucket/altgo.json
+++ b/bucket/altgo.json
@@ -1,12 +1,19 @@
 {
-    "version": "2.6.4",
+    "version": "2.6.5",
     "description": "桌面语音转文字工具：按住触发键说话，松开后自动转写并写入剪贴板",
     "homepage": "https://github.com/cislunarspace/altgo",
     "license": "MIT",
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cislunarspace/altgo/releases/download/v2.6.4/altgo_2.6.4_x64-setup.exe#/dl.7z",
-            "hash": "4ccbd0f71c69eff981036aa8eed11cefa49e7013012189a33bcbbbfe1d9f2ac8"
+            "url": "https://github.com/cislunarspace/altgo/releases/download/v2.6.5/altgo_2.6.5_x64-setup.exe#/dl.7z",
+            "hash": "2a54654bc4f2456c2d53450433bd5c53125f73e62a437b7084797b7965d75590"
+        },
+        "arm64": {
+            "url": "https://github.com/cislunarspace/altgo/releases/download/v2.6.5/altgo_2.6.5_arm64-setup.exe#/dl.7z",
+            "hash": "5216eaa74cb8aea9c6f2f00cf281b4fc41a73414241f8ba6d7506ef017632a13"
         }
     },
     "pre_install": [
@@ -28,11 +35,14 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/altgo_$version_x64-setup.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/altgo_$version_arm64-setup.exe#/dl.7z"
             }
         },
         "hash": {
             "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/checksums.txt",
-            "regex": "(?m)^([a-f0-9]{64})\\s+\\./nsis/altgo_$version_x64-setup\\.exe$"
+            "regex": "(?m)^([a-f0-9]{64})\\s+\\./nsis/$basename$"
         }
     }
 }

--- a/bucket/altgo.json
+++ b/bucket/altgo.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.6.4",
+    "description": "桌面语音转文字工具：按住触发键说话，松开后自动转写并写入剪贴板",
+    "homepage": "https://github.com/cislunarspace/altgo",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cislunarspace/altgo/releases/download/v2.6.4/altgo_2.6.4_x64-setup.exe#/dl.7z",
+            "hash": "4ccbd0f71c69eff981036aa8eed11cefa49e7013012189a33bcbbbfe1d9f2ac8"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "Remove-Item \"$dir\\`$TEMP\" -Recurse -Force -ErrorAction SilentlyContinue",
+        "Get-ChildItem \"$dir\" -Filter 'Uninstall*.exe' | Remove-Item -Force"
+    ],
+    "bin": "altgo.exe",
+    "shortcuts": [
+        [
+            "altgo.exe",
+            "altgo"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/cislunarspace/altgo"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/altgo_$version_x64-setup.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/cislunarspace/altgo/releases/download/v$version/checksums.txt",
+            "regex": "(?m)^([a-f0-9]{64})\\s+\\./nsis/altgo_$version_x64-setup\\.exe$"
+        }
+    }
+}


### PR DESCRIPTION
altgo is a desktop speech-to-text tool: hold a trigger key to record, release to transcribe locally with SenseVoice (embedded sherpa-onnx), optionally polish with an LLM, and write the result to the clipboard.

Homepage: https://github.com/cislunarspace/altgo

The manifest reuses the published NSIS installer (extracted via 7zip; `altgo.exe` sits at the archive root — verified). Hash matches the release `checksums.txt`. `checkver` tracks GitHub releases and `autoupdate` pulls the hash from `checksums.txt`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] Use conventional PR title: `<manifest-name>: <summary>`