### PR TITLE
keywise: Add version 2.1.0

### DIFF
--- a/bucket/keywise.json
+++ b/bucket/keywise.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.1.0",
+    "description": "Terminal UI to view a local Firefox profile's saved logins",
+    "homepage": "https://github.com/lkraider/keywise",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lkraider/keywise/releases/download/v2.1.0/Keywise-2.1.0-windows-x86_64.zip",
+            "hash": "0ce0d0b0563e1e9a8b7cf49fb1e4ff39a9ca8789896a9f1b6da2303972153f46"
+        },
+        "arm64": {
+            "url": "https://github.com/lkraider/keywise/releases/download/v2.1.0/Keywise-2.1.0-windows-arm64.zip",
+            "hash": "1f375b66cb6ceddaffb77ab3730817220f7057c5393b223a842238cd2f67318f"
+        }
+    },
+    "bin": "Keywise.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lkraider/keywise/releases/download/v$version/Keywise-$version-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/lkraider/keywise/releases/download/v$version/Keywise-$version-windows-arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Keywise](https://github.com/lkraider/keywise) reads a local Firefox profile's saved logins and shows them to the profile owner.

- Win32 native app, ships as a single exe
- Two architectures: x86_64 and arm64
- `checkver` uses `"github"` (reads the latest release tag)
- `autoupdate` URLs follow the release asset naming convention