### PR TITLE
grok-bot: Add version 0.30.0

### DIFF
--- a/bucket/grok-bot.json
+++ b/bucket/grok-bot.json
@@ -5,7 +5,7 @@
     "license": "Proprietary",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/0.24.0/Grok_Bot_0.24.0_Setup.exe",
+            "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/0.24.0/Grok_Bot_0.24.0_Setup.exe#/dl.7z",
             "hash": "ca83a45ee489371d18d919b17fa49c547f9e9229b8cb0a2406b8e708d59dff7d",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/$version/Grok_Bot_$version_Setup.exe"
+                "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/$version/Grok_Bot_$version_Setup.exe#/dl.7z"
             }
         }
     }

--- a/bucket/grok-bot.json
+++ b/bucket/grok-bot.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.24.0",
-    "description": "Always-on AI agents from xAI and Cursor that work autonomously across your tools and apps",
-    "homepage": "https://x.ai/news/introducing-grok-bot",
-    "license": "Proprietary",
+    "version": "0.30.0",
+    "description": "Always-on AI agents from xAI and Cursor that work autonomously across your tools and apps.",
+    "homepage": "https://x.ai/bot",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://x.ai/legal/terms-of-service"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/0.24.0/Grok_Bot_0.24.0_Setup.exe#/dl.7z",
-            "hash": "ca83a45ee489371d18d919b17fa49c547f9e9229b8cb0a2406b8e708d59dff7d",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\Uninstall Grok Bot.exe\" -Recurse -Force -ErrorAction SilentlyContinue"
-            ]
+            "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/0.30.0/Grok_Bot_0.30.0_Setup.exe#/dl.7z",
+            "hash": "cb1a5ef75b4d3ebeee7e7833ecdd66440e2639864f255e18ec6d5029058e814d",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
         }
     },
-    "bin": "Grok Bot.exe",
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse -ErrorAction Ignore",
     "shortcuts": [
         [
             "Grok Bot.exe",
@@ -21,8 +21,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://x.ai/news/introducing-grok-bot",
-        "regex": "grokbot/stable/darwin-arm64/([\\d.]+)/"
+        "url": "https://api2.cursor.sh/updates/api/update/win32-x64/sand/0.0.0/stable",
+        "jsonpath": "$.version",
+        "regex": "^([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/grok-bot.json
+++ b/bucket/grok-bot.json
@@ -11,6 +11,11 @@
             "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/0.30.0/Grok_Bot_0.30.0_Setup.exe#/dl.7z",
             "hash": "cb1a5ef75b4d3ebeee7e7833ecdd66440e2639864f255e18ec6d5029058e814d",
             "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        },
+        "arm64": {
+            "url": "https://downloads.cursor.com/grokbot/stable/win32-arm64/0.30.0/Grok_Bot_0.30.0_Setup.exe#/dl.7z",
+            "hash": "492d228f8becb4b5a54f8be126215593567fa040a358cf65a2e75299e4cf1768",
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\""
         }
     },
     "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse -ErrorAction Ignore",
@@ -29,6 +34,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/$version/Grok_Bot_$version_Setup.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://downloads.cursor.com/grokbot/stable/win32-arm64/$version/Grok_Bot_$version_Setup.exe#/dl.7z"
             }
         }
     }

--- a/bucket/grok-bot.json
+++ b/bucket/grok-bot.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.24.0",
+    "description": "Always-on AI agents from xAI and Cursor that work autonomously across your tools and apps",
+    "homepage": "https://x.ai/news/introducing-grok-bot",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/0.24.0/Grok_Bot_0.24.0_Setup.exe",
+            "hash": "ca83a45ee489371d18d919b17fa49c547f9e9229b8cb0a2406b8e708d59dff7d",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\Uninstall Grok Bot.exe\" -Recurse -Force -ErrorAction SilentlyContinue"
+            ]
+        }
+    },
+    "bin": "Grok Bot.exe",
+    "shortcuts": [
+        [
+            "Grok Bot.exe",
+            "Grok Bot"
+        ]
+    ],
+    "checkver": {
+        "url": "https://x.ai/news/introducing-grok-bot",
+        "regex": "grokbot/stable/darwin-arm64/([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.cursor.com/grokbot/stable/win32-x64/$version/Grok_Bot_$version_Setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Windows manifest for Grok Bot (xAI/Cursor always-on AI agents), v0.24.0.

- Official download hosted on downloads.cursor.com (same CDN as the Cursor editor manifest)
- NSIS/electron-builder installer, extracted via the standard #/dl.7z pattern
- Verified: scoop install succeeds, app launches (Grok Bot.exe), checkver/checkhashes/formatjson all pass