### PR TITLE
vscode: Fix file association icon paths and stale registrations

### DIFF
--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -28,7 +28,7 @@
         "$dirpath = \"$dir\".Replace('\\', '\\\\')",
         "$exepath = \"$dir\\Code.exe\".Replace('\\', '\\\\')",
         "$versionfolder = Get-ChildItem -LiteralPath $dir -Directory | Where-Object {",
-        "    ($_.Name -match '^[a-fA-F0-9]+$') -and (Test-Path -LiteralPath \"$($_.FullName)\\resources\")",
+        "    ($_.Name -match '^[a-fA-F0-9]+$') -and (Test-Path -LiteralPath \"$($_.FullName)\\resources\" -PathType Container)",
         "} | Select-Object -First 1 -ExpandProperty Name",
         "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context', 'install-github-integration', 'uninstall-github-integration' | ForEach-Object {",
         "    if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -47,7 +47,7 @@
         "    }",
         "}",
         "# Re-register file associations if they are already registered to this installation",
-        "$regpath = 'HKCU:\\Software\\Classes\\CodeOSS.ascx\\shell\\open\\command'",
+        "$regpath = 'HKCU:\\Software\\Classes\\CodeOSS.*\\shell\\open\\command'",
         "if ($global) {",
         "    $regpath = $regpath.Replace('HKCU', 'HKLM')",
         "}",

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -24,27 +24,39 @@
             "hash": "d1829928593cfd6d959433dd96b6c24a73a83dacb62ca445cc0d070aa2801caf"
         }
     },
-    "env_add_path": "bin",
-    "shortcuts": [
-        [
-            "code.exe",
-            "Visual Studio Code"
-        ]
-    ],
     "post_install": [
         "$dirpath = \"$dir\".Replace('\\', '\\\\')",
         "$exepath = \"$dir\\Code.exe\".Replace('\\', '\\\\')",
+        "$versionfolder = Get-ChildItem -LiteralPath $dir -Directory | Where-Object {",
+        "    ($_.Name -match '^[a-fA-F0-9]+$') -and (Test-Path -LiteralPath \"$($_.FullName)\\resources\")",
+        "} | Select-Object -First 1 -ExpandProperty Name",
         "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context', 'install-github-integration', 'uninstall-github-integration' | ForEach-Object {",
-        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",
-        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\"",
-        "    $content = $content.Replace('$codedir', $dirpath)",
-        "    $content = $content.Replace('$code', $exepath)",
-        "    if ($global) {",
-        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",
+        "        $content = Get-Content \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\"",
+        "        $content = $content.Replace('$codedir', $dirpath)",
+        "        $content = $content.Replace('$code', $exepath)",
+        "        if ($versionfolder) {",
+        "            $content = $content.Replace('$versionfolder', $versionfolder)",
+        "        } else {",
+        "            $content = $content.Replace('\\\\$versionfolder', '')",
+        "        }",
+        "        if ($global) {",
+        "            $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "        }",
+        "        $content | Set-Content -Path \"$dir\\$_.reg\"",
         "    }",
-        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
-        "  }",
         "}",
+        "# Re-register file associations if they are already registered to this installation",
+        "$regpath = 'HKCU:\\Software\\Classes\\CodeOSS.ascx\\shell\\open\\command'",
+        "if ($global) {",
+        "    $regpath = $regpath.Replace('HKCU', 'HKLM')",
+        "}",
+        "$command = Get-ItemPropertyValue $regpath -Name '(default)' -ErrorAction Ignore",
+        "if ($command -and ($command -match [regex]::escape($(appdir $app $global)))) {",
+        "    info 'Re-registering file associations...'",
+        "    reg import \"$dir\\install-associations.reg\"",
+        "}",
+        "",
         "if (!(Test-Path \"$dir\\data\\extensions\") -and (Test-Path \"$env:USERPROFILE\\.vscode\\extensions\")) {",
         "    info '[Portable Mode] Copying extensions...'",
         "    Copy-Item \"$env:USERPROFILE\\.vscode\\extensions\" \"$dir\\data\" -Recurse",
@@ -59,16 +71,23 @@
         "    (Get-Content \"$extensions_file\") -replace '(?<=vscode(/|\\\\\\\\)).*?(?=(/|\\\\\\\\)data(/|\\\\\\\\)extensions)', $version | Set-Content \"$extensions_file\"",
         "}"
     ],
+    "env_add_path": "bin",
+    "shortcuts": [
+        [
+            "code.exe",
+            "Visual Studio Code"
+        ]
+    ],
+    "persist": "data",
     "uninstaller": {
         "script": [
-            "if ($cmd -eq 'uninstall')",
-            "{",
-            "   reg import \"$dir\\uninstall-context.reg\" ",
-            "   reg import \"$dir\\uninstall-github-integration.reg\" ",
+            "if ($cmd -eq 'uninstall') {",
+            "    reg import \"$dir\\uninstall-context.reg\"",
+            "    reg import \"$dir\\uninstall-associations.reg\"",
+            "    reg import \"$dir\\uninstall-github-integration.reg\"",
             "}"
         ]
     },
-    "persist": "data",
     "checkver": {
         "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/stable/latest",
         "jsonpath": "$.name"

--- a/scripts/vscode/install-associations.reg
+++ b/scripts/vscode/install-associations.reg
@@ -9,7 +9,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\xml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ascx\shell\open]
 "Icon"="\"$code\""
@@ -27,7 +27,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.asp\shell\open]
 "Icon"="\"$code\""
@@ -45,7 +45,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.aspx\shell\open]
 "Icon"="\"$code\""
@@ -63,7 +63,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash\shell\open]
 "Icon"="\"$code\""
@@ -81,7 +81,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_login\shell\open]
 "Icon"="\"$code\""
@@ -99,7 +99,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_logout\shell\open]
 "Icon"="\"$code\""
@@ -117,7 +117,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bash_profile\shell\open]
 "Icon"="\"$code\""
@@ -135,7 +135,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bashrc\shell\open]
 "Icon"="\"$code\""
@@ -153,7 +153,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bib\shell\open]
 "Icon"="\"$code\""
@@ -171,7 +171,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\bower.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\bower.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.bowerrc\shell\open]
 "Icon"="\"$code\""
@@ -189,7 +189,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.c++\shell\open]
 "Icon"="\"$code\""
@@ -207,7 +207,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.c\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\c.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\c.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.c\shell\open]
 "Icon"="\"$code\""
@@ -225,7 +225,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cc\shell\open]
 "Icon"="\"$code\""
@@ -243,7 +243,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cfg\shell\open]
 "Icon"="\"$code\""
@@ -261,7 +261,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\javascript.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cjs\shell\open]
 "Icon"="\"$code\""
@@ -279,7 +279,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.clj\shell\open]
 "Icon"="\"$code\""
@@ -297,7 +297,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljs\shell\open]
 "Icon"="\"$code\""
@@ -315,7 +315,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cljx\shell\open]
 "Icon"="\"$code\""
@@ -333,7 +333,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.clojure\shell\open]
 "Icon"="\"$code\""
@@ -351,7 +351,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cls\shell\open]
 "Icon"="\"$code\""
@@ -369,7 +369,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.code-workspace\shell\open]
 "Icon"="\"$code\""
@@ -387,7 +387,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cmake\shell\open]
 "Icon"="\"$code\""
@@ -405,7 +405,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.coffee\shell\open]
 "Icon"="\"$code\""
@@ -423,7 +423,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.config\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.config\shell\open]
 "Icon"="\"$code\""
@@ -441,7 +441,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.containerfile\shell\open]
 "Icon"="\"$code\""
@@ -459,7 +459,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cpp\shell\open]
 "Icon"="\"$code\""
@@ -477,7 +477,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\csharp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\csharp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cs\shell\open]
 "Icon"="\"$code\""
@@ -495,7 +495,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cshtml\shell\open]
 "Icon"="\"$code\""
@@ -513,7 +513,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\xml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.csproj\shell\open]
 "Icon"="\"$code\""
@@ -531,7 +531,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.css\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\css.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\css.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.css\shell\open]
 "Icon"="\"$code\""
@@ -549,7 +549,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.csv\shell\open]
 "Icon"="\"$code\""
@@ -567,7 +567,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\csharp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\csharp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.csx\shell\open]
 "Icon"="\"$code\""
@@ -585,7 +585,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ctp\shell\open]
 "Icon"="\"$code\""
@@ -603,7 +603,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.cxx\shell\open]
 "Icon"="\"$code\""
@@ -621,7 +621,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dart\shell\open]
 "Icon"="\"$code\""
@@ -639,7 +639,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.diff\shell\open]
 "Icon"="\"$code\""
@@ -657,7 +657,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dockerfile\shell\open]
 "Icon"="\"$code\""
@@ -675,7 +675,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dot\shell\open]
 "Icon"="\"$code\""
@@ -693,7 +693,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\xml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.dtd\shell\open]
 "Icon"="\"$code\""
@@ -711,7 +711,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.editorconfig\shell\open]
 "Icon"="\"$code\""
@@ -729,7 +729,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.edn\shell\open]
 "Icon"="\"$code\""
@@ -747,7 +747,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\ruby.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\ruby.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.erb\shell\open]
 "Icon"="\"$code\""
@@ -765,7 +765,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\yaml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyaml\shell\open]
 "Icon"="\"$code\""
@@ -783,7 +783,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\yaml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.eyml\shell\open]
 "Icon"="\"$code\""
@@ -801,7 +801,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fs\shell\open]
 "Icon"="\"$code\""
@@ -819,7 +819,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsi\shell\open]
 "Icon"="\"$code\""
@@ -837,7 +837,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsscript\shell\open]
 "Icon"="\"$code\""
@@ -855,7 +855,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.fsx\shell\open]
 "Icon"="\"$code\""
@@ -873,7 +873,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\ruby.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\ruby.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gemspec\shell\open]
 "Icon"="\"$code\""
@@ -891,7 +891,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitattributes\shell\open]
 "Icon"="\"$code\""
@@ -909,7 +909,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitconfig\shell\open]
 "Icon"="\"$code\""
@@ -927,7 +927,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gitignore\shell\open]
 "Icon"="\"$code\""
@@ -945,7 +945,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.go\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\go.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\go.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.go\shell\open]
 "Icon"="\"$code\""
@@ -963,7 +963,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.gradle\shell\open]
 "Icon"="\"$code\""
@@ -981,7 +981,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.groovy\shell\open]
 "Icon"="\"$code\""
@@ -999,7 +999,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.h\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\c.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\c.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.h\shell\open]
 "Icon"="\"$code\""
@@ -1017,7 +1017,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.handlebars\shell\open]
 "Icon"="\"$code\""
@@ -1035,7 +1035,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hbs\shell\open]
 "Icon"="\"$code\""
@@ -1053,7 +1053,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.h++\shell\open]
 "Icon"="\"$code\""
@@ -1071,7 +1071,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hh\shell\open]
 "Icon"="\"$code\""
@@ -1089,7 +1089,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hpp\shell\open]
 "Icon"="\"$code\""
@@ -1107,7 +1107,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.htm\shell\open]
 "Icon"="\"$code\""
@@ -1125,7 +1125,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.html\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.html\shell\open]
 "Icon"="\"$code\""
@@ -1143,7 +1143,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\cpp.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\cpp.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.hxx\shell\open]
 "Icon"="\"$code\""
@@ -1161,7 +1161,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\config.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\config.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ini\shell\open]
 "Icon"="\"$code\""
@@ -1179,7 +1179,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ipynb\shell\open]
 "Icon"="\"$code\""
@@ -1197,7 +1197,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\jade.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\jade.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jade\shell\open]
 "Icon"="\"$code\""
@@ -1215,7 +1215,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\java.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\java.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jav\shell\open]
 "Icon"="\"$code\""
@@ -1233,7 +1233,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.java\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\java.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\java.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.java\shell\open]
 "Icon"="\"$code\""
@@ -1251,7 +1251,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.js\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\javascript.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.js\shell\open]
 "Icon"="\"$code\""
@@ -1269,7 +1269,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\react.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\react.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsx\shell\open]
 "Icon"="\"$code\""
@@ -1287,7 +1287,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\javascript.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jscsrc\shell\open]
 "Icon"="\"$code\""
@@ -1305,7 +1305,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\javascript.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshintrc\shell\open]
 "Icon"="\"$code\""
@@ -1323,7 +1323,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jshtm\shell\open]
 "Icon"="\"$code\""
@@ -1341,7 +1341,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.json\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\json.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\json.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.json\shell\open]
 "Icon"="\"$code\""
@@ -1359,7 +1359,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.jsp\shell\open]
 "Icon"="\"$code\""
@@ -1377,7 +1377,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.less\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\less.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\less.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.less\shell\open]
 "Icon"="\"$code\""
@@ -1395,7 +1395,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.log\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.log\shell\open]
 "Icon"="\"$code\""
@@ -1413,7 +1413,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.lua\shell\open]
 "Icon"="\"$code\""
@@ -1431,7 +1431,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.m\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.m\shell\open]
 "Icon"="\"$code\""
@@ -1449,7 +1449,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.makefile\shell\open]
 "Icon"="\"$code\""
@@ -1467,7 +1467,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.markdown\shell\open]
 "Icon"="\"$code\""
@@ -1485,7 +1485,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.md\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.md\shell\open]
 "Icon"="\"$code\""
@@ -1503,7 +1503,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdoc\shell\open]
 "Icon"="\"$code\""
@@ -1521,7 +1521,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdown\shell\open]
 "Icon"="\"$code\""
@@ -1539,7 +1539,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtext\shell\open]
 "Icon"="\"$code\""
@@ -1557,7 +1557,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdtxt\shell\open]
 "Icon"="\"$code\""
@@ -1575,7 +1575,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mdwn\shell\open]
 "Icon"="\"$code\""
@@ -1593,7 +1593,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mk\shell\open]
 "Icon"="\"$code\""
@@ -1611,7 +1611,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkd\shell\open]
 "Icon"="\"$code\""
@@ -1629,7 +1629,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\markdown.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\markdown.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mkdn\shell\open]
 "Icon"="\"$code\""
@@ -1647,7 +1647,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ml\shell\open]
 "Icon"="\"$code\""
@@ -1665,7 +1665,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mli\shell\open]
 "Icon"="\"$code\""
@@ -1683,7 +1683,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\javascript.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\javascript.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.mjs\shell\open]
 "Icon"="\"$code\""
@@ -1701,7 +1701,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.npmignore\shell\open]
 "Icon"="\"$code\""
@@ -1719,7 +1719,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.php\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\php.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\php.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.php\shell\open]
 "Icon"="\"$code\""
@@ -1737,7 +1737,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.phtml\shell\open]
 "Icon"="\"$code\""
@@ -1755,7 +1755,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl\shell\open]
 "Icon"="\"$code\""
@@ -1773,7 +1773,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pl6\shell\open]
 "Icon"="\"$code\""
@@ -1791,7 +1791,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\plist.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\plist.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.plist\shell\open]
 "Icon"="\"$code\""
@@ -1809,7 +1809,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm\shell\open]
 "Icon"="\"$code\""
@@ -1827,7 +1827,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pm6\shell\open]
 "Icon"="\"$code\""
@@ -1845,7 +1845,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pod\shell\open]
 "Icon"="\"$code\""
@@ -1863,7 +1863,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pp\shell\open]
 "Icon"="\"$code\""
@@ -1881,7 +1881,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.profile\shell\open]
 "Icon"="\"$code\""
@@ -1899,7 +1899,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.properties\shell\open]
 "Icon"="\"$code\""
@@ -1917,7 +1917,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\powershell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\powershell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ps1\shell\open]
 "Icon"="\"$code\""
@@ -1935,7 +1935,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\powershell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\powershell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.psd1\shell\open]
 "Icon"="\"$code\""
@@ -1953,7 +1953,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.psgi\shell\open]
 "Icon"="\"$code\""
@@ -1971,7 +1971,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\powershell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\powershell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.psm1\shell\open]
 "Icon"="\"$code\""
@@ -1989,7 +1989,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.py\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\python.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\python.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.py\shell\open]
 "Icon"="\"$code\""
@@ -2007,7 +2007,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\python.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\python.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.pyi\shell\open]
 "Icon"="\"$code\""
@@ -2025,7 +2025,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.r\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.r\shell\open]
 "Icon"="\"$code\""
@@ -2043,7 +2043,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\ruby.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\ruby.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rb\shell\open]
 "Icon"="\"$code\""
@@ -2061,7 +2061,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rhistory\shell\open]
 "Icon"="\"$code\""
@@ -2079,7 +2079,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rprofile\shell\open]
 "Icon"="\"$code\""
@@ -2097,7 +2097,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rs\shell\open]
 "Icon"="\"$code\""
@@ -2115,7 +2115,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rst\shell\open]
 "Icon"="\"$code\""
@@ -2133,7 +2133,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.rt\shell\open]
 "Icon"="\"$code\""
@@ -2151,7 +2151,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\sass.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\sass.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.sass\shell\open]
 "Icon"="\"$code\""
@@ -2169,7 +2169,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\sass.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\sass.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.scss\shell\open]
 "Icon"="\"$code\""
@@ -2187,7 +2187,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.sh\shell\open]
 "Icon"="\"$code\""
@@ -2205,7 +2205,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.shtml\shell\open]
 "Icon"="\"$code\""
@@ -2223,7 +2223,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\sql.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\sql.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.sql\shell\open]
 "Icon"="\"$code\""
@@ -2241,7 +2241,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.svg\shell\open]
 "Icon"="\"$code\""
@@ -2259,7 +2259,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.svgz\shell\open]
 "Icon"="\"$code\""
@@ -2277,7 +2277,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.t\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.t\shell\open]
 "Icon"="\"$code\""
@@ -2295,7 +2295,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.tex\shell\open]
 "Icon"="\"$code\""
@@ -2313,7 +2313,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\typescript.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\typescript.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.ts\shell\open]
 "Icon"="\"$code\""
@@ -2331,7 +2331,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.toml\shell\open]
 "Icon"="\"$code\""
@@ -2349,7 +2349,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\react.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\react.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.tsx\shell\open]
 "Icon"="\"$code\""
@@ -2367,7 +2367,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.txt\shell\open]
 "Icon"="\"$code\""
@@ -2385,7 +2385,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.vb\shell\open]
 "Icon"="\"$code\""
@@ -2403,7 +2403,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\vue.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\vue.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.vue\shell\open]
 "Icon"="\"$code\""
@@ -2421,7 +2421,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxi\shell\open]
 "Icon"="\"$code\""
@@ -2439,7 +2439,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxl\shell\open]
 "Icon"="\"$code\""
@@ -2457,7 +2457,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\default.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\default.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.wxs\shell\open]
 "Icon"="\"$code\""
@@ -2475,7 +2475,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\xml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.xaml\shell\open]
 "Icon"="\"$code\""
@@ -2493,7 +2493,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\html.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\html.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.xhtml\shell\open]
 "Icon"="\"$code\""
@@ -2511,7 +2511,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\xml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\xml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.xml\shell\open]
 "Icon"="\"$code\""
@@ -2529,7 +2529,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\yaml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.yaml\shell\open]
 "Icon"="\"$code\""
@@ -2547,7 +2547,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\yaml.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\yaml.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.yml\shell\open]
 "Icon"="\"$code\""
@@ -2565,7 +2565,7 @@ Windows Registry Editor Version 5.00
 "AppUserModelID"="Microsoft.CodeOSS"
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh\DefaultIcon]
-@="\"$codedir\\resources\\app\\resources\\win32\\shell.ico\""
+@="\"$codedir\\$versionfolder\\resources\\app\\resources\\win32\\shell.ico\""
 
 [HKEY_CURRENT_USER\Software\Classes\CodeOSS.zsh\shell\open]
 "Icon"="\"$code\""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
#### Motivation
VS Code's release archive now nests the resources folder inside a commit-hash folder (e.g. `110a328ea5\resources\app\...`) (https://github.com/microsoft/vscode/issues/249239), which broke all DefaultIcon paths in `install-associations.reg`.
#### Changes
- Detect the hash folder at install time (`hex name + resources` child) and substitute a `$versionfolder` token in the .reg templates; fall back to the old root layout when no such folder exists.
- Backwards compatible with the legacy layout where `resources` sits directly in the app root — tested on 1.107.1 as well as 1.134.0.
- Stale registrations left by previous updates are repaired automatically: on update, associations are re-imported when they already point at this installation (`appdir` match, HKCU/HKLM aware)
- Uninstaller now also imports `uninstall-associations.reg`, so file associations no longer leak after removal.
#### Alternative considered
A symlink/junction from the app root (`<vscode_root>\resources`) to the version folder (`<vscode_root>\<version_folder>\resources`) would fix the paths with far less scripting, but it's unclear whether extensions or other components rely on the relative position of these directories, so that route was not taken to avoid subtle breakage.
#### Related PRs/issues
Closes #17186
Closes https://github.com/ScoopInstaller/Scoop/issues/6721
Supersedes #17196
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
