### PR TITLE
norc-cli: Add version 0.1.9

### DIFF
--- a/bucket/norc-cli.json
+++ b/bucket/norc-cli.json
@@ -11,11 +11,11 @@
     },
     "bin": "norc.exe",
     "post_install": [
-        "& \"$dir\\..\\current\\norc.exe\" service install",
-        "& \"$dir\\..\\current\\norc.exe\" __dupe-check"
+        "& \"$dir\\norc.exe\" service install",
+        "& \"$dir\\norc.exe\" __dupe-check"
     ],
     "pre_uninstall": [
-        "& \"$dir\\..\\current\\norc.exe\" service uninstall"
+        "& \"$dir\\norc.exe\" service uninstall"
     ],
     "checkver": {
         "github": "https://github.com/RedcoatAsher/norc-cli-releases",

--- a/bucket/norc-cli.json
+++ b/bucket/norc-cli.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.1.9",
+    "description": "Headless cron job scheduler for norc — installs a per-user Scheduled Task (`norc bridge`) that syncs this machine's crontab with the norc web vault.",
+    "homepage": "https://norc.app/cli",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/RedcoatAsher/norc-cli-releases/releases/download/cli-v0.1.9/norc-win-x64.exe#/norc.exe",
+            "hash": "df49e5de39d94f71ce3ef290e347cf91bfd79e8ec4e920885a5d80d7ec20cc66"
+        }
+    },
+    "bin": "norc.exe",
+    "post_install": [
+        "& \"$dir\\..\\current\\norc.exe\" service install",
+        "& \"$dir\\..\\current\\norc.exe\" __dupe-check"
+    ],
+    "pre_uninstall": [
+        "& \"$dir\\..\\current\\norc.exe\" service uninstall"
+    ],
+    "checkver": {
+        "github": "https://github.com/RedcoatAsher/norc-cli-releases",
+        "regex": "cli-v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/RedcoatAsher/norc-cli-releases/releases/download/cli-v$version/norc-win-x64.exe#/norc.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds norc-cli, a headless cron job scheduler CLI that syncs a machine's crontab with the norc web vault.

- [x] Manifest validated against Extras' schema locally (JSON parses, follows existing manifest conventions)
- [x] `checkver` and `autoupdate` set (github checkver with custom tag regex `cli-v([\d.]+)`, since releases are tagged `cli-v0.1.9`)
- [x] Hash verified against the published release asset