### PR TITLE
afterglow: Add version 1.0.1

### DIFF
--- a/bucket/afterglow.json
+++ b/bucket/afterglow.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.1",
+    "description": "Open-source tuning and monitoring for NVIDIA RTX GPUs. Overclocking, measured V/F-curve undervolting, per-fan curves, FPS metrics, and an error-checked stress test, with no kernel driver and no telemetry.",
+    "homepage": "https://github.com/minewefu/afterglow",
+    "license": "MIT",
+    "url": "https://github.com/minewefu/afterglow/releases/download/v1.0.1/Afterglow-1.0.1-portable.zip",
+    "hash": "93767abab6e7e076aa9454fcced8d61e1fedd410e4c435f44eb0fdb8a8342560",
+    "bin": "afterglow-cli.exe",
+    "shortcuts": [
+        [
+            "Afterglow.exe",
+            "Afterglow"
+        ]
+    ],
+    "notes": "Tuning writes need administrator rights; Afterglow asks for elevation when launched (declining leaves it in monitoring-only mode).",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/minewefu/afterglow/releases/download/v$version/Afterglow-$version-portable.zip"
+    }
+}


### PR DESCRIPTION
Adds **afterglow** — open-source tuning and monitoring for NVIDIA RTX GPUs (MIT licensed, no kernel driver, no telemetry). Homepage: https://github.com/minewefu/afterglow

- Portable zip straight from the project's GitHub release; hash matches the release's published `SHA256SUMS.txt`
- `checkver: github` + `autoupdate` configured
- App self-elevates for tuning writes (declining UAC leaves it in monitoring-only mode) — noted in `notes`
- GUI exposed as a shortcut, `afterglow-cli` on the shim path
