### PR TITLE
alldup: Update URLs to `alldup.de`

### DIFF
--- a/bucket/alldup.json
+++ b/bucket/alldup.json
@@ -1,9 +1,9 @@
 {
     "version": "4.5.72",
     "description": "Duplicate file remover",
-    "homepage": "https://www.alldup.info",
+    "homepage": "https://www.alldup.de",
     "license": "Freeware",
-    "url": "https://www.alldup.info/download/AllDupPortable.zip",
+    "url": "https://www.alldup.de/download/AllDupPortable.zip",
     "hash": "sha1:c7c638580321c5cc0bc690875e0e11a64569f0bc",
     "pre_install": "if (!(Test-Path \"$persist_dir\\config4.ini\")) { New-Item \"$dir\\config4.ini\" | Out-Null }",
     "bin": [
@@ -30,9 +30,9 @@
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.alldup.info/download/AllDupPortable.zip",
+        "url": "https://www.alldup.de/download/AllDupPortable.zip",
         "hash": {
-            "url": "https://www.alldup.info/en_download_alldup.php",
+            "url": "https://www.alldup.de/en_download_alldup.php",
             "regex": "(?s)$basename.*?$sha1"
         }
     }


### PR DESCRIPTION
Consistently use alldup.de instead of splitting functions across alldupe.de and alldup.info

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
