### PR TITLE
exifcleaner: Update to version 4.2.1, fix autoupdate, add 32bit support

### DIFF
--- a/bucket/exifcleaner.json
+++ b/bucket/exifcleaner.json
@@ -1,14 +1,22 @@
 {
-    "version": "3.6.0",
+    "version": "4.2.1",
     "description": "Image metadata cleaner",
     "homepage": "https://exifcleaner.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/szTheory/exifcleaner/releases/download/v3.6.0/ExifCleaner-Setup-3.6.0.exe#/dl.7z",
-            "hash": "sha512:4f0f6c77fefc89b05118e0b28fc4cde4ea5848b19dca381764576496e6fbcde87a88ef40b49d7ea413db2db3d751112f6eb2dd76fbf4cfc7c869be6f1e5ce93f",
+            "url": "https://github.com/szTheory/exifcleaner/releases/download/v4.2.1/ExifCleaner.Setup.4.2.1.exe#/dl.7z",
+            "hash": "64906e696158b0eebbc867289574cc44168b43f4055c89150469ea247e049271",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse"
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/szTheory/exifcleaner/releases/download/v4.2.1/ExifCleaner.Setup.4.2.1.exe#/dl.7z",
+            "hash": "64906e696158b0eebbc867289574cc44168b43f4055c89150469ea247e049271",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse"
             ]
         }
@@ -25,10 +33,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/szTheory/exifcleaner/releases/download/v$version/ExifCleaner-Setup-$version.exe#/dl.7z",
+                "url": "https://github.com/szTheory/exifcleaner/releases/download/v$version/ExifCleaner.Setup.$version.exe#/dl.7z",
                 "hash": {
-                    "url": "$baseurl/latest.yml",
-                    "regex": "(?smi)$basename.*?sha512:\\s+$base64"
+                    "url": "$baseurl/SHASUMS256.txt"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/szTheory/exifcleaner/releases/download/v$version/ExifCleaner.Setup.$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/SHASUMS256.txt"
                 }
             }
         }

--- a/bucket/exifcleaner.json
+++ b/bucket/exifcleaner.json
@@ -3,24 +3,17 @@
     "description": "Image metadata cleaner",
     "homepage": "https://exifcleaner.com",
     "license": "MIT",
+    "url": "https://github.com/szTheory/exifcleaner/releases/download/v4.2.1/ExifCleaner.Setup.4.2.1.exe#/dl.7z",
+    "hash": "64906e696158b0eebbc867289574cc44168b43f4055c89150469ea247e049271",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/szTheory/exifcleaner/releases/download/v4.2.1/ExifCleaner.Setup.4.2.1.exe#/dl.7z",
-            "hash": "64906e696158b0eebbc867289574cc44168b43f4055c89150469ea247e049271",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse"
-            ]
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
         },
         "32bit": {
-            "url": "https://github.com/szTheory/exifcleaner/releases/download/v4.2.1/ExifCleaner.Setup.4.2.1.exe#/dl.7z",
-            "hash": "64906e696158b0eebbc867289574cc44168b43f4055c89150469ea247e049271",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
-                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse"
-            ]
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\""
         }
     },
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse",
     "shortcuts": [
         [
             "ExifCleaner.exe",
@@ -31,19 +24,9 @@
         "github": "https://github.com/szTheory/exifcleaner"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/szTheory/exifcleaner/releases/download/v$version/ExifCleaner.Setup.$version.exe#/dl.7z",
-                "hash": {
-                    "url": "$baseurl/SHASUMS256.txt"
-                }
-            },
-            "32bit": {
-                "url": "https://github.com/szTheory/exifcleaner/releases/download/v$version/ExifCleaner.Setup.$version.exe#/dl.7z",
-                "hash": {
-                    "url": "$baseurl/SHASUMS256.txt"
-                }
-            }
+        "url": "https://github.com/szTheory/exifcleaner/releases/download/v$version/ExifCleaner.Setup.$version.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/SHASUMS256.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR updates the Exifcleaner manifest file to the latest version 4.2.1.
Releases of versions 4.X.X have different file names, added a 32bit variant in the installer and changed the hashes file.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
