### PR TITLE
krokiet@12.0.1: Switch to all backends asset

### DIFF
--- a/bucket/krokiet.json
+++ b/bucket/krokiet.json
@@ -5,13 +5,13 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/qarmin/czkawka/releases/download/12.0.1/windows_krokiet_on_linux.exe",
-            "hash": "084fa6f9d97574704a5104d207b8805e510f3f1c9907e7828607e7fce6a67abf"
+            "url": "https://github.com/qarmin/czkawka/releases/download/12.0.1/windows_krokiet_on_windows_all_backends.zip",
+            "hash": "13f68c9b29b7667caf913c1223dbcdb58e9e51b8a050e00ed1f1fd31508d17b5"
         }
     },
     "shortcuts": [
         [
-            "windows_krokiet_on_linux.exe",
+            "krokiet.exe",
             "Krokiet"
         ]
     ],
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_krokiet_on_linux.exe"
+                "url": "https://github.com/qarmin/czkawka/releases/download/$version/windows_krokiet_on_windows_all_backends.zip"
             }
         }
     }

--- a/bucket/krokiet.json
+++ b/bucket/krokiet.json
@@ -3,6 +3,9 @@
     "description": "Krokiet is the Slint frontend for Czkawka, helping you remove unnecessary files from your computer.",
     "homepage": "https://github.com/qarmin/czkawka",
     "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/qarmin/czkawka/releases/download/12.0.1/windows_krokiet_on_windows_all_backends.zip",


### PR DESCRIPTION
Follow-up of https://github.com/ScoopInstaller/Extras/pull/18431#pullrequestreview-4875641601.

Please note that the quoted FAQ section itself is outdated. Currently the exe in `windows_krokiet_on_windows_all_backends.zip` can detect backend automatically, thus having better compatibility than the recommended `windows_krokiet_on_linux.exe`. Because of this, I think it's fine to not create multiple shortcuts.

Supersedes #18431
Relates to https://github.com/qarmin/czkawka/issues/2055

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 