### PR TITLE
leopardwm: Add version 0.2.8

### DIFF
--- a/bucket/leopardwm.json
+++ b/bucket/leopardwm.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.8",
+    "description": "Scroll-first tiling window manager for Windows, inspired by niri.",
+    "homepage": "https://github.com/jcardama/LeopardWM",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jcardama/LeopardWM/releases/download/v0.2.8/LeopardWM-0.2.8-x86_64-windows.zip",
+            "hash": "71ffaf586654b8f706d6b9a3f18f1a2f39e48b115b927d68872a7c00ea9f9a26",
+            "extract_dir": "LeopardWM-0.2.8-x86_64-windows"
+        }
+    },
+    "bin": [
+        "leopardwm.exe",
+        "leopardwm-cli.exe",
+        "lwm.exe"
+    ],
+    "notes": [
+        "Run 'leopardwm-cli run' to start the daemon, or 'leopardwm-cli help' for the full command list.",
+        "Configuration lives at %APPDATA%\\leopardwm\\config\\config.toml (created on first run)."
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jcardama/LeopardWM/releases/download/v$version/LeopardWM-$version-x86_64-windows.zip",
+                "extract_dir": "LeopardWM-$version-x86_64-windows"
+            }
+        }
+    }
+}

--- a/bucket/leopardwm.json
+++ b/bucket/leopardwm.json
@@ -15,6 +15,9 @@
         "leopardwm-cli.exe",
         "lwm.exe"
     ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "notes": [
         "Run 'leopardwm-cli run' to start the daemon, or 'leopardwm-cli help' for the full command list.",
         "Configuration lives at %APPDATA%\\leopardwm\\config\\config.toml (created on first run)."

--- a/bucket/leopardwm.json
+++ b/bucket/leopardwm.json
@@ -3,6 +3,13 @@
     "description": "Scroll-first tiling window manager for Windows, inspired by niri.",
     "homepage": "https://github.com/jcardama/LeopardWM",
     "license": "GPL-3.0-only",
+    "notes": [
+        "Run 'leopardwm-cli run' to start the daemon, or 'leopardwm-cli help' for the full command list.",
+        "Configuration lives at %APPDATA%\\leopardwm\\config\\config.toml (created on first run)."
+    ],
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/jcardama/LeopardWM/releases/download/v0.2.8/LeopardWM-0.2.8-x86_64-windows.zip",
@@ -14,13 +21,6 @@
         "leopardwm.exe",
         "leopardwm-cli.exe",
         "lwm.exe"
-    ],
-    "suggest": {
-        "Microsoft Edge WebView2": "extras/webview2"
-    },
-    "notes": [
-        "Run 'leopardwm-cli run' to start the daemon, or 'leopardwm-cli help' for the full command list.",
-        "Configuration lives at %APPDATA%\\leopardwm\\config\\config.toml (created on first run)."
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
Closes #18623

Re-submission of #17777 and #18099 with the current v0.2.8 manifest.

### Verification

- Installed from the local manifest with Scoop; URL, SHA-256, extraction and all three shims passed
- `leopardwm-cli help` ran successfully from the installed package
- Uninstall removed the app and shims and restored the previous local state
- `checkver` detected v0.2.8 and forced autoupdate regenerated the expected URL, hash and extraction directory
- Official formatter and URL checker passed

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
