### PR TITLE
clash-verge-rev: Remove admin privilege check on uninstall

### DIFF
--- a/bucket/clash-verge-rev.json
+++ b/bucket/clash-verge-rev.json
@@ -31,7 +31,6 @@
         ]
     },
     "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
         "Start-Process \"$dir\\resources\\clash-verge-service-uninstall.exe\" -Wait -Verb 'RunAs' -WindowStyle 'Hidden'; Start-Sleep -Seconds 3"
     ],
     "uninstaller": {


### PR DESCRIPTION
Remove the redundant admin rights check from `pre_uninstall`.

The service uninstaller already requests elevation via `-Verb RunAs`,
so requiring Scoop itself to run from an elevated terminal is unnecessary.

Closes #18630