### PR TITLE
speaktype: Add version 0.16.0

### DIFF
--- a/bucket/speaktype.json
+++ b/bucket/speaktype.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.16.0",
+    "description": "Hold-to-talk voice typing with offline speech recognition (SenseVoice, Parakeet, whisper.cpp)",
+    "homepage": "https://speaktype.zalize.com",
+    "license": "MIT",
+    "url": "https://github.com/wookat/speaktype/releases/download/v0.16.0/SpeakType-0.16.0-portable.exe#/SpeakType.exe",
+    "hash": "0f17eed0a08ecc8ab6d3f425e37657e950908800d2f0e9b5146edf91867b9b8d",
+    "shortcuts": [
+        [
+            "SpeakType.exe",
+            "SpeakType"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/wookat/speaktype"
+    },
+    "autoupdate": {
+        "url": "https://github.com/wookat/speaktype/releases/download/v$version/SpeakType-$version-portable.exe#/SpeakType.exe"
+    }
+}


### PR DESCRIPTION
Adds [SpeakType](https://github.com/wookat/speaktype), an MIT-licensed hold-to-talk voice typing app for Windows with offline speech recognition (SenseVoice / Parakeet / whisper.cpp) and optional OpenAI-compatible cloud providers.

Uses the portable single-exe release asset. Verified hash against the v0.16.0 GitHub release.