### PR TITLE
cherry-studio: Update to version 2.0.10, fix autoupdate

### DIFF
--- a/bucket/cherry-studio.json
+++ b/bucket/cherry-studio.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.9",
+    "version": "2.0.10",
     "description": "A desktop client that supports for multiple LLM providers.",
     "homepage": "https://cherry-ai.com",
     "license": "Apache-2.0",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.9/Cherry-Studio-2.0.9-x64-portable.exe#/cherry-studio.exe",
-            "hash": "9bc72d13dfaf0530f3a3ca85d987a11bdf2cab77f819867d58bb88599265eeaa"
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.10/Cherry-Studio-2.0.10-win-x64-portable.exe#/cherry-studio.exe",
+            "hash": "0bcdf88af673c1345c671072cd795337aa8a9f83a0bd8c87f747726f1a93a6ac"
         },
         "arm64": {
-            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.9/Cherry-Studio-2.0.9-arm64-portable.exe#/cherry-studio.exe",
-            "hash": "e0f1875cc9a86a867d3326ca366e6f8ef988579ebfe3553f58bd17b5d4f9e8bc"
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.10/Cherry-Studio-2.0.10-win-arm64-portable.exe#/cherry-studio.exe",
+            "hash": "9231b959f38d103399a4750e09a815602ee1b1dcd2acff79aeb2b9bb06a6c4a6"
         }
     },
     "pre_install": [
@@ -37,10 +37,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-x64-portable.exe#/cherry-studio.exe"
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-win-x64-portable.exe#/cherry-studio.exe"
             },
             "arm64": {
-                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-arm64-portable.exe#/cherry-studio.exe"
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-win-arm64-portable.exe#/cherry-studio.exe"
             }
         }
     }


### PR DESCRIPTION
Update Cherry Studio to version 2.0.10.

Closes #18638.

Cherry Studio renamed Windows portable assets to add the `win-` platform
prefix in [#19429](https://github.com/CherryHQ/cherry-studio/pull/19429), so the
old URLs return 404. Update both portable URLs and hashes, plus the
`autoupdate` templates.
