### PR TITLE
kbcalc: Add version 1.1.0

### DIFF
--- a/bucket/kbcalc.json
+++ b/bucket/kbcalc.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.1.0",
+    "description": "Floating translucent calculator with a built-in Winamp-style MP3 player (visualizer, EQ, playlists, podcasts, internet radio)",
+    "homepage": "https://github.com/tengolabs/kbcalc",
+    "license": "MIT",
+    "url": "https://github.com/tengolabs/kbcalc/releases/download/v1.1.0/kbCalc.1.1.0.exe#/kbCalc.exe",
+    "hash": "b46f238ef67531b7b94d39fbd73565e1bc210038df1146e59e4c1e7d79b565a7",
+    "shortcuts": [
+        [
+            "kbCalc.exe",
+            "kbCalc"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/tengolabs/kbcalc/releases/download/v$version/kbCalc.$version.exe#/kbCalc.exe"
+    }
+}


### PR DESCRIPTION
Adds **kbcalc** 1.1.0 — an open source (MIT) floating, translucent calculator with a built-in Winamp-style MP3 player (Electron; visualizer, EQ, playlists, podcasts, internet radio).

- Portable exe from the official GitHub Release of [tengolabs/kbcalc](https://github.com/tengolabs/kbcalc/releases/tag/v1.1.0); hash matches the published `SHA256SUMS-windows-latest.txt`.
- `checkver: github` + `autoupdate` included.
- Authored on Linux, so `scoop install` was not run locally — happy to fix anything CI flags.
