### PR TITLE
quickimageviewer: Add version 3.0.0.368

### DIFF
--- a/bucket/quickimageviewer.json
+++ b/bucket/quickimageviewer.json
@@ -1,0 +1,34 @@
+{
+    "version": "3.0.0.368",
+    "description": "Portable image viewer for Windows, with an Android companion that turns a spare phone into a photo frame",
+    "homepage": "https://icyhoty2k.github.io/QuickImageViewer/",
+    "license": "AGPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/icyhoty2k/QuickImageViewer/releases/download/v3.0.0.368/QuickImageViewer.exe",
+            "hash": "bc89073c1adfcfa017648a5fdb7d2f8e2671edfa74d3ff786056bdcf16536ca1"
+        }
+    },
+    "bin": [
+        [
+            "QuickImageViewer.exe",
+            "qiv"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "QuickImageViewer.exe",
+            "QuickImageViewer"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/icyhoty2k/QuickImageViewer"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/icyhoty2k/QuickImageViewer/releases/download/v$version/QuickImageViewer.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `quickimageviewer`.

**QuickImageViewer (qIV)** is a free, portable image viewer for Windows 10 and 11 — a single 9.7 MB executable, AGPLv3, no installer, no ads and no telemetry. It opens HEIC, AVIF, JPEG XL, WebP, SVG, OpenEXR and camera RAW, renders through Direct2D with a GPU bitmap cache, and carries 230 keyboard shortcuts. It also has a free Android companion that turns a spare phone or tablet into a remote, a second screen or a photo frame the PC drives over the local network.

Manifest notes:

- **A bare `.exe`, no archive.** The release asset is the program itself, so there is no `extract_dir`.
- **`hash`** is the SHA256 of the published `v3.0.0.368` asset: `bc89073c1adfcfa017648a5fdb7d2f8e2671edfa74d3ff786056bdcf16536ca1`.
- **`bin` carries the `qiv` alias**, which is what the project calls itself and what its own documentation uses.
- **`checkver`/`autoupdate`** follow the GitHub releases. Tags carry a `v` prefix, hence `v$version` in the autoupdate URL.
- **No `persist`.** Settings live in the registry by default, or in an `.ini` beside the executable when it is launched with `-config` — neither needs persisting for an ordinary install.
- The binary links the CRT statically, so there is no Visual C++ Redistributable dependency.

Homepage: https://icyhoty2k.github.io/QuickImageViewer/
Source: https://github.com/icyhoty2k/QuickImageViewer
