### PR TITLE
llama-desktop: Add version 1.1.0

### DIFF
--- a/bucket/llama-desktop.json
+++ b/bucket/llama-desktop.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.1.0",
+    "description": "Portable, zero-dependency Windows desktop shell for llama.cpp llama-server with embedded official Web UI, hardware auto-tuning and PID-verified safe process lifecycle.",
+    "homepage": "https://github.com/ChevalGrand520/llama-desktop",
+    "license": "MIT",
+    "suggest": {
+        "Microsoft Edge WebView2": "extras/webview2"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ChevalGrand520/llama-desktop/releases/download/v1.1.0/llama-desktop-win-x64-v1.1.0.zip",
+            "hash": "559e751b74165ff6ba1e4b73dee775222e98a321b97e3cb9ddf7c3b5ceb90bc9"
+        }
+    },
+    "shortcuts": [
+        [
+            "LlamaDesktop.exe",
+            "Llama Desktop"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ChevalGrand520/llama-desktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ChevalGrand520/llama-desktop/releases/download/v$version/llama-desktop-win-x64-v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

Adds a new manifest for **Llama Desktop** (v1.1.0): an MIT-licensed, open-source, portable (no installer) Windows desktop shell for the official llama.cpp `llama-server`, with an embedded official Web UI, hardware auto-tuning and PID-verified process lifecycle. C#/.NET 8 WPF GUI, Windows 10/11 x64.

- Repository: https://github.com/ChevalGrand520/llama-desktop (MIT)
- Release asset: https://github.com/ChevalGrand520/llama-desktop/releases/download/v1.1.0/llama-desktop-win-x64-v1.1.0.zip
- SHA-256: `559e751b74165ff6ba1e4b73dee775222e98a321b97e3cb9ddf7c3b5ceb90bc9`
- The zip's root contains `LlamaDesktop.exe` (plus `llama-server.exe` and runtime libs) directly, with no outer folder, so no `extract_dir` is required.
- `checkver`/`autoupdate` use the upstream GitHub-release naming pattern `llama-desktop-win-x64-v{version}.zip` under tag `v{version}`.
