### PR TITLE
posnic: Add version 1.6.1

### DIFF
--- a/bucket/posnic.json
+++ b/bucket/posnic.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.6.1",
+    "description": "Offline-first open-source POS and billing software for retail shops and restaurants.",
+    "homepage": "https://posnic.io/",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Posnic/POS/releases/download/v1.6.1/Posnic-1.6.1-windows-x64-portable.exe#/Posnic.exe",
+            "hash": "5105ed2ebdc782cc7ee7042c942681a9d9c40c82be744b77f44df8efa9b4b72a"
+        }
+    },
+    "shortcuts": [
+        [
+            "Posnic.exe",
+            "Posnic"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Posnic/POS"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Posnic/POS/releases/download/v$version/Posnic-$version-windows-x64-portable.exe#/Posnic.exe"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/Posnic/POS/releases/download/v$version/SHA256SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a Scoop Extras manifest for Posnic 1.6.1.

Posnic is offline-first open-source POS and billing software for retail shops and restaurants. This manifest uses the released Windows x64 portable executable from `Posnic/POS`, points the homepage to `https://www.posnic.com/`, uses the AGPL-3.0-only SPDX license identifier, adds a Start Menu shortcut, and configures GitHub release `checkver` plus autoupdate hashing from the published `SHA256SUMS.txt` release asset.

## Validation

- Parsed `bucket/posnic.json` with PowerShell `ConvertFrom-Json`
- Parsed and asserted version/homepage/url/hash fields with Node.js `JSON.parse`
- Verified the portable executable SHA-256 against `https://github.com/Posnic/POS/releases/download/v1.6.1/SHA256SUMS.txt`
- Verified the portable executable and checksum URLs return HTTP 200 after GitHub release redirects
- `git diff --check` passed

I could not run `bin/test.ps1` locally because this workstation does not have the required PowerShell module `BuildHelpers` 2.0.1 installed. I did not install global PowerShell modules on the workstation; the pull request CI should run the official bucket tests.
