### PR TITLE
wallrotate: Add version 1.0.0

### DIFF
--- a/bucket/wallrotate.json
+++ b/bucket/wallrotate.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.0",
+    "description": "Low-footprint multi-monitor wallpaper rotator with animated GIF and video backgrounds",
+    "homepage": "https://github.com/elazarza/wallrotate",
+    "license": "MIT",
+    "url": "https://github.com/elazarza/wallrotate/releases/download/v1.0.0/wallrotate.exe",
+    "hash": "dde29bf3bddac95696cecb5962c0551e98927d03e583cf3cb41021e8c801f33f",
+    "bin": "wallrotate.exe",
+    "shortcuts": [
+        [
+            "wallrotate.exe",
+            "WallRotate"
+        ]
+    ],
+    "notes": "Run 'wallrotate' to start it in the tray. It registers itself to start at sign-in (toggle in the tray menu).",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/elazarza/wallrotate/releases/download/v$version/wallrotate.exe",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Adds [WallRotate](https://github.com/elazarza/wallrotate) 1.0.0 — a low-footprint multi-monitor wallpaper rotator for Windows with animated GIF and video backgrounds (MIT, Rust, single portable exe).

- A different wallpaper per screen, rotation every 12 h and on Win+Ctrl+R
- Animated GIF / video desktop backgrounds drawn behind the desktop icons
- 0% CPU / ~3 MB idle; animation pauses whenever the wallpaper is not visible

Manifest points at the [v1.0.0 GitHub release](https://github.com/elazarza/wallrotate/releases/tag/v1.0.0); the release also ships a `.sha256` asset, which `autoupdate.hash.url` uses.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/Extras/blob/master/CONTRIBUTING.md)
- [x] `checkver` and `autoupdate` are configured (GitHub releases)
- [x] Hash verified against the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)