### PR TITLE
posnic: Add version 1.6.1

### DIFF
--- a/bucket/posnic.json
+++ b/bucket/posnic.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.6.1",
+    "description": "Offline-first open-source POS and billing software for retail shops and restaurants.",
+    "homepage": "https://posnic.io/",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Posnic/POS/releases/download/v1.6.1/Posnic-1.6.1-windows-x64-portable.exe#/Posnic.exe",
+            "hash": "5105ed2ebdc782cc7ee7042c942681a9d9c40c82be744b77f44df8efa9b4b72a"
+        }
+    },
+    "shortcuts": [
+        [
+            "Posnic.exe",
+            "Posnic"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Posnic/POS"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Posnic/POS/releases/download/v$version/Posnic-$version-windows-x64-portable.exe#/Posnic.exe"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/Posnic/POS/releases/download/v$version/SHA256SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Scoop manifest for Posnic 1.6.1.
- Use the official Posnic Windows x64 portable release from Posnic/POS and link the Posnic homepage.

## Validation
- Parsed bucket/posnic.json with Node.js.
- Confirmed upstream has no existing bucket/posnic.json.
- Confirmed the Windows portable release URL returns HTTP 200.
- Confirmed the manifest hash matches SHA256SUMS.txt for Posnic-1.6.1-windows-x64-portable.exe.
- git diff --check upstream/master...HEAD