### PR TITLE
yyztools: Add version 1.0.5.1500

### DIFF
--- a/bucket/yyztools.json
+++ b/bucket/yyztools.json
@@ -12,6 +12,9 @@
                           "yyzTools"
                       ]
                   ],
+    "depends":  [
+                    "webview2"
+                ],
     "persist":  [
                     "Config"
                 ],

--- a/bucket/yyztools.json
+++ b/bucket/yyztools.json
@@ -1,0 +1,24 @@
+{
+    "version":  "1.0.5.1500",
+    "description":  "Windows desktop productivity toolkit: command palette, translation, OCR, file preview, clipboard history, app usage stats, dynamic wallpaper and more",
+    "homepage":  "https://yyztools.com",
+    "license":  "Freeware",
+    "url":  "https://github.com/jearry/yyzTools/releases/download/v1.0.5.1500/yyzTools-v1.0.5.1500-portable.7z",
+    "hash":  "8c4f6c7933f535952f5cf6bc3e749e511f1e22f87844bf4efd80dee24841e522",
+    "bin":  "yyzTools.exe",
+    "shortcuts":  [
+                      [
+                          "yyzTools.exe",
+                          "yyzTools"
+                      ]
+                  ],
+    "persist":  [
+                    "Config"
+                ],
+    "checkver":  {
+                     "github":  "https://github.com/jearry/yyzTools"
+                 },
+    "autoupdate":  {
+                       "url":  "https://github.com/jearry/yyzTools/releases/download/v$version/yyzTools-v$version-portable.7z"
+                   }
+}


### PR DESCRIPTION
Resolves #18663 (package request)

**yyztools** - Windows desktop productivity toolkit (command palette, translation, OCR, file preview, clipboard history, app usage stats, dynamic wallpaper and more).

- Portable 7z from https://github.com/jearry/yyzTools/releases - SHA256 verified against the local build
- checkver/autoupdate included (Excavator can follow future releases)
- `depends: ["webview2"]` - all pages run in WebView2, hard requirement (per review)