### PR TITLE
javascriptobfuscator: Add version 3.4.5

### DIFF
--- a/bucket/javascriptobfuscator.json
+++ b/bucket/javascriptobfuscator.json
@@ -1,0 +1,43 @@
+{
+    "version": "3.4.5",
+    "description": "Obfuscate and protect JavaScript source locally, with a desktop app and a CLI.",
+    "homepage": "https://javascriptobfuscator.com/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://javascriptobfuscator.com/terms.aspx"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://javascriptobfuscator.com/download/javascriptobfuscator-3.4.5.zip",
+            "hash": "e693523c9bc8d84becc67820404dc166915d24b23e3c12dd504669353c84d8bd"
+        }
+    },
+    "bin": [
+        "javascriptobfuscator.exe",
+        [
+            "cli\\jso-local.exe",
+            "jso-local"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "javascriptobfuscator.exe",
+            "JavaScript Obfuscator"
+        ]
+    ],
+    "checkver": {
+        "url": "https://javascriptobfuscator.com/downloads.aspx",
+        "regex": "javascriptobfuscator-([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://javascriptobfuscator.com/download/javascriptobfuscator-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "https://javascriptobfuscator.com/download/SHA256SUMS.txt",
+            "regex": "$sha256\\s+javascriptobfuscator-$version\\.zip"
+        }
+    }
+}


### PR DESCRIPTION
Adds `javascriptobfuscator` 3.4.5 — a commercial JavaScript source-protection
tool with a Windows desktop client (shipping since 2004) and a bundled CLI.

- `javascriptobfuscator.exe` — desktop app (x64), also registered as a shortcut
- `cli\jso-local.exe` — CLI, exposed as `jso-local`

Verified before opening this PR:

- `hash` was produced by downloading the URL and hashing the bytes. It matches
  the vendor's own published manifest at
  https://javascriptobfuscator.com/download/SHA256SUMS.txt
- The download URL is a permanent versioned path. The vendor publishes it
  specifically so a pinned hash stays valid; the mutable
  `/download/javascriptobfuscator.zip` was deliberately not used.
- `checkver` was run against the live page and returns exactly `3.4.5` (it does
  not pick up the separate legacy WinForms archive on the same page).
- The `autoupdate` hash regex was run against the live `SHA256SUMS.txt` and
  returns the same hash as the one in this manifest.
- Both `bin` paths were confirmed present inside the archive.
- Binaries are Authenticode signed as `CN=richscripts inc`.

Note: the app is proprietary and free to install, with paid tiers for larger
inputs and stronger protection. It runs without an account on a free tier.
