### PR TITLE
gmkvextract@2.15.0: Switch to GitHub releases

### DIFF
--- a/bucket/gmkvextractgui.json
+++ b/bucket/gmkvextractgui.json
@@ -1,11 +1,11 @@
 {
     "version": "2.15.0",
     "description": "A GUI for mkvextract utility (part of MKVToolNix) which incorporates most (if not all) functionality of mkvextract and mkvinfo utilities.",
-    "homepage": "https://sourceforge.net/projects/gmkvextractgui/",
-    "license": "Public Domain",
+    "homepage": "https://github.com/Gpower2/gMKVExtractGUI",
+    "license": "Unlicense",
     "depends": "mkvtoolnix",
-    "url": "https://downloads.sourceforge.net/project/gmkvextractgui/v2.15.0/gMKVExtractGUI.v2.15.0.7z",
-    "hash": "sha1:5cf54d3b4a129334385b758646803e3db816a5c1",
+    "url": "https://github.com/Gpower2/gMKVExtractGUI/releases/download/v2.15.0/gMKVExtractGUI.v2.15.0.7z",
+    "hash": "00da9bf0c40e0afab111680288bd868917aa26462063bc4d5fde75b915ad6e24",
     "bin": "gMKVExtractGUI.exe",
     "shortcuts": [
         [
@@ -19,11 +19,8 @@
         "}"
     ],
     "persist": "gMKVExtractGUI.ini",
-    "checkver": {
-        "url": "https://sourceforge.net/projects/gmkvextractgui/files/",
-        "regex": "gmkvextractgui/files/v([\\d.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/gmkvextractgui/v$version/gMKVExtractGUI.v$version.7z"
+        "url": "https://github.com/Gpower2/gMKVExtractGUI/releases/download/v$version/gMKVExtractGUI.v$version.7z"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

---
This change is based on the [Doom9 post](https://forum.doom9.org/showthread.php?p=1668700#post1668700) by the developer.

> https://forum.doom9.org/showthread.php?p=1668700#post1668700
> Note: After version v2.9.0, I switched from [SourceForge](https://sourceforge.net/projects/gmkvextractgui/) to [Github](https://github.com/Gpower2/gMKVExtractGUI), and all new versions will be released there henceforth.

> https://sourceforge.net/projects/gmkvextractgui/
> The project has been moved in Github since v2.9.0 https://github.com/Gpower2/gMKVExtractGUI