### PR TITLE
systeminformer: Update to version 4.0.26241.138, fix autoupdate

### DIFF
--- a/bucket/systeminformer.json
+++ b/bucket/systeminformer.json
@@ -1,10 +1,10 @@
 {
-    "version": "3.2.25011.2103",
+    "version": "4.0.26241.138",
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
     "homepage": "https://systeminformer.sourceforge.io/",
     "license": "MIT",
-    "url": "https://github.com/winsiderss/systeminformer/releases/download/v3.2.25011.2103/systeminformer-3.2.25011-release-bin.zip",
-    "hash": "7e72019361eec58479604597dbfcd911c6d23c45da22c0bedc2bc319ab5b331a",
+    "url": "https://github.com/winsiderss/systeminformer/releases/download/v4.0.26241.138/systeminformer-4.0.26241.138-bin.zip",
+    "hash": "3e12cc4f1ffa1cc34ab9202a9dfe410724cb8b68aaf2efa43c01d3705b27219e",
     "architecture": {
         "64bit": {
             "extract_dir": "amd64"
@@ -30,6 +30,6 @@
         "github": "https://github.com/winsiderss/systeminformer"
     },
     "autoupdate": {
-        "url": "https://github.com/winsiderss/systeminformer/releases/download/v$version/systeminformer-$matchHead-release-bin.zip"
+        "url": "https://github.com/winsiderss/systeminformer/releases/download/v$version/systeminformer-$version-bin.zip"
     }
 }


### PR DESCRIPTION
Update `systeminformer` to version 4.0.26241.138 and adjust `autoupdate.url` to match the new v4 release asset naming scheme (`-bin.zip` instead of `-release-bin.zip`).

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
