### PR TITLE
kriag: Add version 0.1.0

### DIFF
--- a/bucket/kriag.json
+++ b/bucket/kriag.json
@@ -1,0 +1,25 @@
+{
+    "$schema":  "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version":  "0.1.0",
+    "description":  "Controle local e auditÃ¡vel para executar agentes de cÃ³digo em paralelo no Windows",
+    "homepage":  "https://github.com/igormassaroo/kriag",
+    "license":  "MIT",
+    "architecture":  {
+                         "64bit":  {
+                                       "url":  "https://github.com/igormassaroo/kriag/releases/download/v0.1.0/kriag-v0.1.0-windows-x64.zip",
+                                       "hash":  "602bdbe4d86ae229fdbbea30ca39f7da0bf967b4871c7321f21e06b66a9a3028",
+                                       "bin":  [
+                                                   "kriag.exe",
+                                                   "kriag-tui.exe"
+                                               ]
+                                   }
+                     },
+    "checkver":  "github",
+    "autoupdate":  {
+                       "architecture":  {
+                                            "64bit":  {
+                                                          "url":  "https://github.com/igormassaroo/kriag/releases/download/v$version/kriag-v$version-windows-x64.zip"
+                                                      }
+                                        }
+                   }
+}


### PR DESCRIPTION
Adds KRIAG, a local and auditable Windows CLI for orchestrating coding agents.

- Public, version-specific GitHub release URL
- SHA-256 verified against the published asset
- Archive smoke-tested with `kriag --version`
- Includes GitHub checkver and autoupdate metadata
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the Contributing Guide

Release: https://github.com/igormassaroo/kriag/releases/tag/v0.1.0

Note: I have not linked a package-request issue because the project does not yet satisfy the issue form's required popularity threshold. This submission is intentionally transparent about that criterion.