### PR TITLE
gstreamer: Add version 1.26.5

### DIFF
--- a/bucket/gstreamer.json
+++ b/bucket/gstreamer.json
@@ -1,0 +1,47 @@
+{
+    "version": "1.26.5",
+    "description": "GStreamer multimedia framework, runtime + development files (MSVC x86_64)",
+    "homepage": "https://gstreamer.freedesktop.org/",
+    "license": "LGPL-2.1-or-later",
+    "notes": [
+        "GSTREAMER_1_0_ROOT_MSVC_X86_64, GST_PLUGIN_PATH and PKG_CONFIG_PATH are set for the user.",
+        "Reopen the terminal, then run 'gst-inspect-1.0 --version' to check the install."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://gstreamer.freedesktop.org/data/pkg/windows/1.26.5/msvc/gstreamer-1.0-msvc-x86_64-1.26.5.msi",
+                "https://gstreamer.freedesktop.org/data/pkg/windows/1.26.5/msvc/gstreamer-1.0-devel-msvc-x86_64-1.26.5.msi"
+            ],
+            "hash": [
+                "fd232941f1d59ef30735b2940eeda024451da8c2cac6b79a31d26da1c352f2e6",
+                "f45120e7599ce0a1ca0e2f7387db6c19419d740f46cac6f14cb2902f2c3065ef"
+            ]
+        }
+    },
+    "extract_dir": [
+        "PFiles64\\gstreamer\\1.0\\msvc_x86_64",
+        "PFiles64\\gstreamer\\1.0\\msvc_x86_64"
+    ],
+    "env_set": {
+        "GSTREAMER_1_0_ROOT_MSVC_X86_64": "$dir",
+        "GST_PLUGIN_PATH": "$dir\\lib\\gstreamer-1.0",
+        "PKG_CONFIG_PATH": "$dir\\lib\\pkgconfig;$dir\\lib\\gstreamer-1.0\\pkgconfig"
+    },
+    "env_add_path": "bin",
+    "checkver": {
+        "url": "https://gstreamer.freedesktop.org/data/pkg/windows/",
+        "regex": "href=\"(?<version>1\\.\\d*[02468]\\.\\d+)/\"",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://gstreamer.freedesktop.org/data/pkg/windows/$version/msvc/gstreamer-1.0-msvc-x86_64-$version.msi",
+                    "https://gstreamer.freedesktop.org/data/pkg/windows/$version/msvc/gstreamer-1.0-devel-msvc-x86_64-$version.msi"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
gstreamer@1.26.5: Add manifest

Closes #18679

Adds the GStreamer multimedia framework, MSVC x86_64 build, from the official
runtime + development MSIs.

- Both MSIs are extracted (no installer run, no elevation); `extract_dir` is
  given per URL because each MSI installs under `PFiles64\gstreamer\1.0\msvc_x86_64`
- `env_set`: `GSTREAMER_1_0_ROOT_MSVC_X86_64` (what the official installer sets),
  `GST_PLUGIN_PATH`, `PKG_CONFIG_PATH` (library and plugin `.pc` directories);
  `bin` on PATH
- `checkver` restricted to even minors: GStreamer's odd minors are development
  releases; `reverse` because the directory listing is ascending
- Validated on Windows 11: install, `gst-inspect-1.0 --version`, headers and
  `gstreamer-1.0.pc` present, `checkhashes` OK

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the Contributing Guide