### PR TITLE
hidemyshare: Add version 1.0.2

### DIFF
--- a/bucket/hidemyshare.json
+++ b/bucket/hidemyshare.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.2",
+    "description": "Hide any application window from screen sharing and recording. Works with Zoom, Teams, Google Meet, OBS, screen recorders and browsers, with auto-protection for newly opened windows.",
+    "homepage": "https://hidemyshare.site",
+    "license": "Proprietary",
+    "url": "https://dl.hidemyshare.site/HideMyShare-1.0.2-portable-x64.zip",
+    "hash": "sha256:e3572e66d1a4c9f59883d81eeae9b97da34c58432cab0620cd86e71e9a595e44",
+    "shortcuts": [
+        [
+            "HideMyShare.exe",
+            "HideMyShare"
+        ]
+    ],
+    "checkver": {
+        "url": "https://hidemyshare.site/updates/latest.yml",
+        "regex": "version:\\s*([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://dl.hidemyshare.site/HideMyShare-$version-portable-x64.zip"
+    }
+}


### PR DESCRIPTION
Adds [HideMyShare](https://hidemyshare.site) — a Windows utility that hides selected application windows from screen sharing and recording (Zoom, Teams, Google Meet, OBS, screen recorders, browsers).

- Portable zip (Electron app, `HideMyShare.exe` at archive root) served from the vendor CDN
- `checkver`/`autoupdate` track the vendor update feed (`latest.yml`)
- Proprietary freemium: 7-day full trial, one-time license

Manifest checklist: description is factual, shortcuts point to the root exe, hash is sha256 of the zip.