### PR TITLE
summoner: Add version 1.2

### DIFF
--- a/bucket/summoner.json
+++ b/bucket/summoner.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.2",
+    "description": "Photo developer: drop raws or JPEGs in, press Start, get developed photos. Per-photo auto analysis, six profiles, live before/after preview, no catalogue",
+    "homepage": "https://github.com/hclivess/summoner",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hclivess/summoner/releases/download/v1.2/summoner-1.2-windows-x64.zip",
+            "hash": "b24a4e85828fa1989b784f28fc914cac6957ed5d948e44f95b2643128c29f225"
+        }
+    },
+    "extract_dir": "summoner-1.2-windows-x64",
+    "shortcuts": [
+        [
+            "summoner.exe",
+            "summoner"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/hclivess/summoner/releases/download/v$version/summoner-$version-windows-x64.zip"
+            }
+        },
+        "extract_dir": "summoner-$version-windows-x64"
+    }
+}


### PR DESCRIPTION
Adds [summoner](https://github.com/hclivess/summoner) — a photo developer: drop raws or JPEGs in, press Start, get developed photos in a `developed/` folder next to the originals. Per-photo auto analysis (white balance, highlight-protected exposure, local tone mapping), six profiles, live before/after preview, no catalogue. MIT-licensed, portable onedir build with a published `.sha256` per release; `checkver`/`autoupdate` wired to GitHub releases. I am the author.