### PR TITLE
diskmaster: Add version 1.1

### DIFF
--- a/bucket/diskmaster.json
+++ b/bucket/diskmaster.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.1",
+    "description": "Drive health monitor: native SMART, an explained health score, surface scans that name the files on bad sectors, history and alerts",
+    "homepage": "https://github.com/hclivess/diskmaster",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hclivess/diskmaster/releases/download/v1.1/diskmaster-1.1-windows-x64.zip",
+            "hash": "c69dc66fa9817c5275ac378f25039865a52b34d841a7b66b20ab78f1d50ece42"
+        }
+    },
+    "extract_dir": "diskmaster-1.1-windows-x64",
+    "shortcuts": [
+        [
+            "diskmaster.exe",
+            "diskmaster"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/hclivess/diskmaster/releases/download/v$version/diskmaster-$version-windows-x64.zip"
+            }
+        },
+        "extract_dir": "diskmaster-$version-windows-x64"
+    }
+}


### PR DESCRIPTION
Adds [diskmaster](https://github.com/hclivess/diskmaster) — a drive health monitor: native SMART, an explained health score, surface scans that name the files sitting on bad sectors, history and alerts. MIT-licensed, portable onedir build with a published `.sha256` per release; `checkver`/`autoupdate` wired to GitHub releases. I am the author.