### PR TITLE
pc-remote: Add version 1.5.0

### DIFF
--- a/bucket/pc-remote.json
+++ b/bucket/pc-remote.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.5.0",
+    "description": "Control a Windows PC from any phone browser over the local network. No mobile app, account, or cloud service required.",
+    "homepage": "https://github.com/mimaxon1/pc-remote",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mimaxon1/pc-remote/releases/download/v1.5.0/PC-Remote-1.5.0-windows-x64-portable.zip",
+            "hash": "ad627237fbf0f9562ed18afaa5b165b52c7cb2e6b1f4a2a36d70d1ac1895f1fe"
+        }
+    },
+    "extract_dir": "PC Remote",
+    "shortcuts": [
+        [
+            "PC Remote.exe",
+            "PC Remote"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/mimaxon1/pc-remote"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mimaxon1/pc-remote/releases/download/v$version/PC-Remote-$version-windows-x64-portable.zip"
+            }
+        }
+    }
+}

--- a/bucket/pc-remote.json
+++ b/bucket/pc-remote.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/mimaxon1/pc-remote/releases/download/v1.5.0/PC-Remote-1.5.0-windows-x64-portable.zip",
-            "hash": "ad627237fbf0f9562ed18afaa5b165b52c7cb2e6b1f4a2a36d70d1ac1895f1fe"
+            "hash": "f919db1f5aec5e7ed79b218646913defd1d12c5e40f629e1ae8295d69b8e4271"
         }
     },
     "extract_dir": "PC Remote",


### PR DESCRIPTION
## Summary
- add PC Remote version 1.5.0 to the Extras bucket
- use the official portable ZIP release asset
- include SHA-256 verification and GitHub checkver/autoupdate

## Validation
- portable ZIP URL points to the immutable v1.5.0 release asset
- SHA-256 was generated by the passing release workflow
- manifest JSON and release metadata were validated locally

Release: https://github.com/mimaxon1/pc-remote/releases/tag/v1.5.0
Workflow: https://github.com/mimaxon1/pc-remote/actions/runs/34115176506