### PR TITLE
realtimeclipboard: Add version 0.6.0

### DIFF
--- a/bucket/realtimeclipboard.json
+++ b/bucket/realtimeclipboard.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.6.0",
+    "description": "End-to-end encrypted online clipboard: sync clipboard text between devices and send files peer-to-peer",
+    "homepage": "https://realtimeclipboard.com",
+    "license": "MIT",
+    "notes": "Requires the Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10 systems).",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/akshaynikhare/RealtimeClipboard/releases/download/v0.6.0/RealtimeClipboard_0.6.0_x64-setup.exe#/dl.7z",
+            "hash": "7bc67a63f8e2e8ae14983d3ece08581c7bb60da04d96dd073036173866cb60d5"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse -ErrorAction Ignore",
+    "shortcuts": [
+        [
+            "RealtimeClipboard.exe",
+            "RealtimeClipboard"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/akshaynikhare/RealtimeClipboard"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/akshaynikhare/RealtimeClipboard/releases/download/v$version/RealtimeClipboard_$version_x64-setup.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/akshaynikhare/RealtimeClipboard/releases/download/v$version/SHA256SUMS"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
New manifest for [RealtimeClipboard](https://realtimeclipboard.com) — an end-to-end encrypted online clipboard that syncs text between devices and sends files peer-to-peer. Open source (MIT): https://github.com/akshaynikhare/RealtimeClipboard

- Tauri app; NSIS installer extracted via the `#/dl.7z` pattern (same as `pot`), with `post_install` cleanup of `$PLUGINSDIR`/uninstaller leftovers
- Hash matches the `SHA256SUMS` published with the [v0.6.0 release](https://github.com/akshaynikhare/RealtimeClipboard/releases/tag/v0.6.0); autoupdate extracts future hashes from the same file
- 64-bit only — upstream publishes only x64 Windows builds
- Note added for the WebView2 Runtime requirement

I'm the author of the upstream project.