### PR TITLE
windows-maintenance-tool: Add version 6.6

### DIFF
--- a/bucket/windows-maintenance-tool.json
+++ b/bucket/windows-maintenance-tool.json
@@ -1,0 +1,32 @@
+{
+    "version": "6.6",
+    "description": "WMT is an AIO GUI toolkit for repairing, cleaning, updating, and tuning Windows systems.",
+    "homepage": "https://github.com/Chaython/Windows-Maintenance-Tool",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Chaython/Windows-Maintenance-Tool/releases/download/6.6/WindowsMaintenanceTool.exe",
+            "hash": "F8319810412168EE476A4CF0328CD236E571405CDC8724398222187095AD9F51"
+        }
+    },
+    "bin": [
+        [
+            "WindowsMaintenanceTool.exe",
+            "wmt"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "WindowsMaintenanceTool.exe",
+            "Windows Maintenance Tool"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Chaython/Windows-Maintenance-Tool/releases/download/$version/WindowsMaintenanceTool.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Adds `windows-maintenance-tool`, an all-in-one GUI toolkit for repairing, cleaning, updating, and tuning Windows systems. It consolidates common administrative tasks into a single interface for power users and technicians.
- [x] Use conventional PR title: `windows-maintenance-tool@6.6: Add new package`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
