### PR TITLE
emacs@31.1: Switch download source to `ftp.gnu.org`

### DIFF
--- a/bucket/emacs.json
+++ b/bucket/emacs.json
@@ -34,9 +34,6 @@
             "64bit": {
                 "url": "https://ftp.gnu.org/gnu/emacs/windows/emacs-$majorVersion/emacs-$version.zip"
             }
-        },
-        "hash": {
-            "url": "$baseurl/emacs-$version-sha256sum.txt"
         }
     }
 }

--- a/bucket/emacs.json
+++ b/bucket/emacs.json
@@ -6,7 +6,7 @@
     "notes": "For 32-bit version, install 'versions/emacs27.2'",
     "architecture": {
         "64bit": {
-            "url": "https://ftpmirror.gnu.org/gnu/emacs/windows/emacs-31/emacs-31.1.zip",
+            "url": "https://ftp.gnu.org/gnu/emacs/windows/emacs-31/emacs-31.1.zip",
             "hash": "96a1018e9de877e77768ca884007f1a9df44889e9ae81ae3ca3d904b5681b8b6"
         }
     },
@@ -32,7 +32,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://ftpmirror.gnu.org/gnu/emacs/windows/emacs-$majorVersion/emacs-$version.zip"
+                "url": "https://ftp.gnu.org/gnu/emacs/windows/emacs-$majorVersion/emacs-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
switched from `ftpmirror` in the url to use `ftp`. the `ftpmirror` doesn't have `emacs@31.1`

<!-- Provide a general summary of your changes in the title above -->

`ftpmirror.gnu.org` doesn't have the latest version of emacs. Tried `ftp.gnu.org` and it installed correctly.

Closes #18701

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
