### PR TITLE
stormsewer: Add version 0.9.6

### DIFF
--- a/bucket/stormsewer.json
+++ b/bucket/stormsewer.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.9.6",
+    "description": "Storm sewer design and analysis: Rational method, Manning, HGL/EGL backwater, HEC-22 inlets.",
+    "homepage": "https://github.com/mf4633/stormsewer",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mf4633/stormsewer/releases/download/v0.9.6/StormSewer-windows-x64.zip",
+            "hash": "488326a4b928fdd0527b132835ec942989ac44220ebf7dd199d64dfa5f328049"
+        }
+    },
+    "bin": "StormSewer.exe",
+    "shortcuts": [
+        [
+            "StormSewer.exe",
+            "StormSewer"
+        ]
+    ],
+    "notes": [
+        "Sample projects are in the examples folder of the install directory.",
+        "The build is not code-signed, so SmartScreen may warn on first run.",
+        "The mesa folder holds a software OpenGL renderer used automatically on a machine with no usable GPU driver. Do not delete it."
+    ],
+    "checkver": {
+        "github": "https://github.com/mf4633/stormsewer"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mf4633/stormsewer/releases/download/v$version/StormSewer-windows-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
StormSewer is a free and open-source desktop program for gravity storm-drain design and analysis: Rational method, Manning for circular, box, elliptical and arch conduits, standard-step HGL/EGL backwater, and HEC-22 inlet interception.

https://github.com/mf4633/stormsewer

- Installs from the project's portable archive, so `StormSewer.exe` is at the archive root and no `extract_dir` is needed.
- I unpacked the archive and checked its contents against the manifest before opening this. The `mesa` folder in it is a software OpenGL renderer the app falls back to on machines with no usable GPU driver, which is why the archive is larger than the app alone.
- `checkver` uses the GitHub release tag; `autoupdate` follows the same asset name, which has been stable.
- GPL-3.0-or-later. The build is not code-signed, and the manifest says so in `notes` rather than leaving a user to wonder about the SmartScreen prompt.

I also keep a personal bucket for this app, so if you would rather not carry it here that is no trouble at all.