### PR TITLE
telegram: Update to version 7.2.7

### DIFF
--- a/bucket/telegram.json
+++ b/bucket/telegram.json
@@ -1,20 +1,20 @@
 {
-    "version": "7.2.5",
+    "version": "7.2.7",
     "description": "A messaging app with a focus on speed and security",
     "homepage": "https://telegram.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.2.5/tportable-x64.7.2.5.zip",
-            "hash": "aa25bb131ced8df0a8c6d2466dd71d2c06ae19c6e2c15b27a8426437e4b2eb3c"
+            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.2.7/td-portable-win-x64-7.2.7.zip",
+            "hash": "0f3ee1090cc49c17816eb18bb6d85c0da77aa9b307f080d703b729498729eaa6"
         },
         "32bit": {
-            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.2.5/tportable.7.2.5.zip",
-            "hash": "d0af574be25058c82e274c34492fcadaca64f36057564274390986a9907d5d77"
+            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.2.7/td-portable-win-x86-7.2.7.zip",
+            "hash": "28ca8da77717f23d76bbac66fe77768783a7f002ab78ff41557a6d86c7882a6d"
         },
         "arm64": {
-            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.2.5/tportable-arm64.7.2.5.zip",
-            "hash": "f130cfe8b0088bb1ef1c8013587cbb2b321ab753df766e2a0e511b927c30adbb"
+            "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.2.7/td-portable-win-arm-7.2.7.zip",
+            "hash": "43ad5cc1dcede33c6a8fc5a31eb999d5c19ba014a86794833721ea95cfbb46aa"
         }
     },
     "extract_dir": "Telegram",
@@ -33,13 +33,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable-x64.$version.zip"
+                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/td-portable-win-x64-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable.$version.zip"
+                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/td-portable-win-x86-$version.zip"
             },
             "arm64": {
-                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable-arm64.$version.zip"
+                "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/td-portable-win-arm-$version.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #18722

telegramdesktop/tdesktop renamed its release assets starting with 7.2.6 (the first stable release with the new naming is 7.2.7):

| Old name (≤ 7.2.5) | New name (≥ 7.2.6) |
| --- | --- |
| `tportable-x64.7.2.5.zip` | `td-portable-win-x64-7.2.7.zip` |
| `tportable.7.2.5.zip` | `td-portable-win-x86-7.2.7.zip` |
| `tportable-arm64.7.2.5.zip` | `td-portable-win-arm-7.2.7.zip` |

This updates the `autoupdate` URL templates accordingly and bumps the manifest to 7.2.7. Hashes were computed from the actual downloads (`checkver telegram -u` completes cleanly with the new templates), and all three URLs were verified to return 200.

Notes:
- `extract_dir` is unchanged: the new zips still contain a top-level `Telegram/` folder.
- `v7.2.6` is a prerelease whose assets carry an extra `-beta` suffix; since 7.2.7 is now the latest release, the plain `$version` template resolves correctly.
- The same rename likely affects other manifests built on tdesktop releases (forkgram, 64gram, kotatogram, ...).
