### PR TITLE
jellyfin-mpv-shim: Update to version 3.0.0, add arm64 support, drop 32bit support

### DIFF
--- a/bucket/jellyfin-mpv-shim.json
+++ b/bucket/jellyfin-mpv-shim.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v3.0.0/jellyfin-mpv-shim_3.0.0_installer.exe",
             "hash": "d32d1c49c3b0e2070edf83da91ef9fc57c509b90898d299d52c0e1ead7a37a2f"
+        },
+        "arm64": {
+            "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v3.0.0/jellyfin-mpv-shim_3.0.0_ARM64_installer.exe",
+            "hash": "8233363825573fb653b53d245daa8d8da802e28190cba2fca6004e1842c90963"
         }
     },
     "innosetup": true,
@@ -23,6 +27,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v$version/jellyfin-mpv-shim_$version_installer.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v$version/jellyfin-mpv-shim_$version_ARM64_installer.exe"
             }
         }
     }

--- a/bucket/jellyfin-mpv-shim.json
+++ b/bucket/jellyfin-mpv-shim.json
@@ -1,16 +1,12 @@
 {
-    "version": "2.10.0",
+    "version": "3.0.0",
     "description": "A fully featured, cross-platform desktop and cast client for Jellyfin",
     "homepage": "https://github.com/jellyfin/jellyfin-mpv-shim",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v2.10.0/jellyfin-mpv-shim_2.10.0_installer.exe",
-            "hash": "120f29af6ec795914236e2d4d087132c7cd8c13484de1f009599430187151ce9"
-        },
-        "32bit": {
-            "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v2.10.0/jellyfin-mpv-shim_2.10.0_LEGACY32_installer.exe",
-            "hash": "23af117178606773f1a4ef652a370d9129f95d6b9a25c6fa4f413a510dede79c"
+            "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v3.0.0/jellyfin-mpv-shim_3.0.0_installer.exe",
+            "hash": "d32d1c49c3b0e2070edf83da91ef9fc57c509b90898d299d52c0e1ead7a37a2f"
         }
     },
     "innosetup": true,
@@ -27,9 +23,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v$version/jellyfin-mpv-shim_$version_installer.exe"
-            },
-            "32bit": {
-                "url": "https://github.com/jellyfin/jellyfin-mpv-shim/releases/download/v$version/jellyfin-mpv-shim_$version_LEGACY32_installer.exe"
             }
         }
     }


### PR DESCRIPTION
Update jellyfin-mpv-shim to 3.0.0 and remove 32-bit option as developer has dropped support.  Also adds ARM64 build to the manifest.

Closes #18710

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
