### PR TITLE
throttlestop@9.7.3: Fix download URL

### DIFF
--- a/bucket/throttlestop.json
+++ b/bucket/throttlestop.json
@@ -3,7 +3,7 @@
     "description": "Monitor and adjust CPU throttling on laptop computers.",
     "homepage": "https://www.techpowerup.com/download/techpowerup-throttlestop/",
     "license": "BSD-2-Clause",
-    "url": "http://nl1-dl.techpowerup.com/files/ThrottleStop_9.7.3.zip",
+    "url": "https://us1-dl.techpowerup.com/files/X5oAyateLT7r3Ieo5tP2-A/1789083640/ThrottleStop_9.7.3.zip",
     "hash": "7b5e1a650a845cdab200bd6a7766d8f56ae458f633a6f2f3df5a9ec72847098a",
     "pre_install": "if (!(Test-Path \"$persist_dir\\ThrottleStop.ini\")) { New-Item \"$dir\\ThrottleStop.ini\" | Out-Null }",
     "bin": "ThrottleStop.exe",


### PR DESCRIPTION
Old link is not working. Not sure if the current link is generated though.

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
