### PR TITLE
halky-launcher: Add version 1.0.4

### DIFF
--- a/bucket/halky-launcher.json
+++ b/bucket/halky-launcher.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.4",
-    "description": "Cross-platform modded Minecraft launcher, fork of PolyMC",
+    "description": "A modern fork of Freesm (Prism) Launcher featuring an improved user interface and additional functionality",
     "homepage": "https://github.com/oleksandr1811/HalkyLauncher",
     "license": "GPL-3.0-or-later",
     "architecture": {

--- a/bucket/halky-launcher.json
+++ b/bucket/halky-launcher.json
@@ -1,0 +1,35 @@
+{
+    "version": "1.0.4",
+    "description": "Cross-platform modded Minecraft launcher, fork of PolyMC",
+    "homepage": "https://github.com/oleksandr1811/HalkyLauncher",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/oleksandr1811/HalkyLauncher/releases/download/1.0.4/HalkyLauncher-Windows-MSVC-Portable-1.0.4.zip",
+            "hash": "27ead98e41dc67aff35a5f8d7e0689fd668a592412ae680619d66cd13c2d9618"
+        },
+        "arm64": {
+            "url": "https://github.com/oleksandr1811/HalkyLauncher/releases/download/1.0.4/HalkyLauncher-Windows-MSVC-arm64-Portable-1.0.4.zip",
+            "hash": "d0cf797ea9bed5b78b8fd3aa546151f82a49b2b42acbbe322efb59514d966691"
+        }
+    },
+    "extract_dir": "",
+    "bin": "HalkyLauncher.exe",
+    "shortcuts": [
+        [
+            "HalkyLauncher.exe",
+            "Halky Launcher"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/oleksandr1811/HalkyLauncher/releases/download/$version/HalkyLauncher-Windows-MSVC-Portable-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/oleksandr1811/HalkyLauncher/releases/download/$version/HalkyLauncher-Windows-MSVC-arm64-Portable-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [HalkyLauncher](https://github.com/oleksandr1811/HalkyLauncher) - Cross-platform modded Minecraft launcher, fork of PolyMC.