### PR TITLE
duskplug: Add version 1.0.1

### DIFF
--- a/bucket/duskplug.json
+++ b/bucket/duskplug.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.0",
+    "description": "Windows tray app that turns a Tuya smart plug on at dusk and off at dawn",
+    "homepage": "https://github.com/MrChriZ/DuskPlug",
+    "license": "MIT",
+    "url": "https://github.com/MrChriZ/DuskPlug/releases/download/v1.0.0/DuskPlug-Windows.zip",
+    "hash": "sha256:f35c3f47279b2565376bbab4c3e9b3c234f706a1f22f581a01ab90cdb565411d",
+    "bin": "DuskPlug.exe",
+    "shortcuts": [
+        [
+            "DuskPlug.exe",
+            "DuskPlug"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/MrChriZ/DuskPlug"
+    },
+    "autoupdate": {
+        "url": "https://github.com/MrChriZ/DuskPlug/releases/download/v$version/DuskPlug-Windows.zip"
+    }
+}

--- a/bucket/duskplug.json
+++ b/bucket/duskplug.json
@@ -3,8 +3,12 @@
     "description": "Windows tray app that turns a Tuya smart plug on at dusk and off at dawn",
     "homepage": "https://github.com/DuskPlug/DuskPlug",
     "license": "MIT",
-    "url": "https://github.com/DuskPlug/DuskPlug/releases/download/v1.0.1/DuskPlug-Windows.zip",
-    "hash": "sha256:298d73e89d0cb346278b6c57795d06d57938965c77185f851be2fd6772dd62a8",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/DuskPlug/DuskPlug/releases/download/v1.0.1/DuskPlug-Windows.zip",
+            "hash": "sha256:298d73e89d0cb346278b6c57795d06d57938965c77185f851be2fd6772dd62a8"
+        }
+    },
     "bin": "DuskPlug.exe",
     "shortcuts": [
         [
@@ -16,6 +20,10 @@
         "github": "https://github.com/DuskPlug/DuskPlug"
     },
     "autoupdate": {
-        "url": "https://github.com/DuskPlug/DuskPlug/releases/download/v$version/DuskPlug-Windows.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/DuskPlug/DuskPlug/releases/download/v$version/DuskPlug-Windows.zip"
+            }
+        }
     }
 }

--- a/bucket/duskplug.json
+++ b/bucket/duskplug.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Windows tray app that turns a Tuya smart plug on at dusk and off at dawn",
-    "homepage": "https://github.com/MrChriZ/DuskPlug",
+    "homepage": "https://github.com/DuskPlug/DuskPlug",
     "license": "MIT",
-    "url": "https://github.com/MrChriZ/DuskPlug/releases/download/v1.0.0/DuskPlug-Windows.zip",
-    "hash": "sha256:f35c3f47279b2565376bbab4c3e9b3c234f706a1f22f581a01ab90cdb565411d",
+    "url": "https://github.com/DuskPlug/DuskPlug/releases/download/v1.0.1/DuskPlug-Windows.zip",
+    "hash": "sha256:298d73e89d0cb346278b6c57795d06d57938965c77185f851be2fd6772dd62a8",
     "bin": "DuskPlug.exe",
     "shortcuts": [
         [
@@ -13,9 +13,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/MrChriZ/DuskPlug"
+        "github": "https://github.com/DuskPlug/DuskPlug"
     },
     "autoupdate": {
-        "url": "https://github.com/MrChriZ/DuskPlug/releases/download/v$version/DuskPlug-Windows.zip"
+        "url": "https://github.com/DuskPlug/DuskPlug/releases/download/v$version/DuskPlug-Windows.zip"
     }
 }


### PR DESCRIPTION
Adds DuskPlug — a Windows tray app for Tuya smart plugs.

- Release: https://github.com/DuskPlug/DuskPlug/releases/tag/v1.0.1
- Manifest is 64-bit only (`architecture.64bit`) to match the shipped zip.

I have read the Contributing Guide.

Made with [Cursor](https://cursor.com)