### PR TITLE
theia-ide: Add context menu entry

### DIFF
--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -5,7 +5,7 @@
     "license": "EPL-2.0, GPL-2.0, MIT",
     "notes": [
         "Added 'Open with Theia IDE' as a context menu option by running:",
-        "reg import \"$dir\\install-context.reg\",
+        "reg import \"$dir\\install-context.reg\"",
         "Context-menu entry is removed automatically when Theia IDE is uninstalled",
         "Settings in '%APPDATA%\\Theia IDE' not persisted by Scoop"
     ],

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -3,12 +3,27 @@
     "description": "A modern and open IDE for cloud and desktop. Theia platform based. Formerly “Theia Blueprint”.",
     "homepage": "https://theia-ide.org/#theiaide",
     "license": "EPL-2.0, GPL-2.0, MIT",
-    "notes": "Settings are stored in '%APPDATA%\\Theia IDE', and are not persisted by Scoop.",
+    "notes": [
+        "Added 'Open with Theia IDE' as a context menu option by running:",
+        "reg import \"$dir\\install-context.reg\",
+        "Context-menu entry is removed automatically when Theia IDE is uninstalled",
+        "Settings in '%APPDATA%\\Theia IDE' not persisted by Scoop"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://www.eclipse.org/downloads/download.php?mirror_id=1&file=/theia/ide/1.75.0/windows/TheiaIDESetup-1.75.0.exe#/dl.7z",
             "hash": "sha512:a3c4a862800ffdc0502a3b73f6bea872f714b009831969d4c7d328deb0cd7e81c2d2993ef1e075393ee39259aaeab8354d86d0eb09f0cf48880c6ec3b46e73e9"
         }
+    },
+    "uninstaller": {
+        "script": [
+            "if ($cmd -eq 'uninstall')",
+            "{",
+            "    if (Test-Path \"$dir\\uninstall-context.reg\") {",
+            "        reg import \"$dir\\uninstall-context.reg\"",
+            "    }",
+            "}"
+        ]
     },
     "extract_dir": "$PLUGINSDIR",
     "installer": {

--- a/bucket/theia-ide.json
+++ b/bucket/theia-ide.json
@@ -1,13 +1,13 @@
 {
     "version": "1.75.0",
-    "description": "A modern and open IDE for cloud and desktop. Theia platform based. Formerly “Theia Blueprint”.",
+    "description": "A modern and open IDE for cloud and desktop. Theia platform based. Formerly \"Theia Blueprint\".",
     "homepage": "https://theia-ide.org/#theiaide",
     "license": "EPL-2.0, GPL-2.0, MIT",
     "notes": [
-        "Added 'Open with Theia IDE' as a context menu option by running:",
+        "To add 'Open with Theia IDE' context menu option, run:",
         "reg import \"$dir\\install-context.reg\"",
-        "Context-menu entry is removed automatically when Theia IDE is uninstalled",
-        "Settings in '%APPDATA%\\Theia IDE' not persisted by Scoop"
+        "Context-menu entry can be removed by running:",
+        "reg import \"$dir\\uninstall-context.reg\""
     ],
     "architecture": {
         "64bit": {
@@ -15,10 +15,19 @@
             "hash": "sha512:a3c4a862800ffdc0502a3b73f6bea872f714b009831969d4c7d328deb0cd7e81c2d2993ef1e075393ee39259aaeab8354d86d0eb09f0cf48880c6ec3b46e73e9"
         }
     },
+    "post_install": [
+        "$theia_dir = \"$dir\\TheiaIDE.exe\".Replace('\\', '\\\\').Replace('.exe', '')",
+        "'install-context', 'uninstall-context' | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\theia-ide\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\theia-ide\\$_.reg\"",
+        "    $content = $content.Replace('{{theia_dir}}', $theia_dir)",
+        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
+        "  }",
+        "}"
+    ],
     "uninstaller": {
         "script": [
-            "if ($cmd -eq 'uninstall')",
-            "{",
+            "if ($cmd -eq 'uninstall') {",
             "    if (Test-Path \"$dir\\uninstall-context.reg\") {",
             "        reg import \"$dir\\uninstall-context.reg\"",
             "    }",

--- a/scripts/theia-ide/install-context.reg
+++ b/scripts/theia-ide/install-context.reg
@@ -1,0 +1,17 @@
+Windows Registry Editor Version 5.00
+
+; Register context menu entry: 'Open with Theia IDE'
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Theia IDE]
+@="Open with &Theia IDE"
+"Icon"="{{theia_dir}}\\TheiaIDE.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Theia IDE\command]
+@="\"{{theia_dir}}\\TheiaIDE.exe\" \"%V\""
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Theia IDE]
+@="Open with &Theia IDE"
+"Icon"="{{theia_dir}}\\TheiaIDE.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Theia IDE\command]
+@="\"{{theia_dir}}\\TheiaIDE.exe\" \"%V\""

--- a/scripts/theia-ide/uninstall-context.reg
+++ b/scripts/theia-ide/uninstall-context.reg
@@ -1,0 +1,7 @@
+Windows Registry Editor Version 5.00
+
+; Unregister context menu entry: 'Open with Theia IDE'
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\Open with &Theia IDE]
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Open with &Theia IDE]


### PR DESCRIPTION
Adds optional Windows context menu for Theia IDE. Users can right-click directories and open them with Theia IDE.

Changes:

    bucket/theia-ide.json — Adds post-install script to prepare registry files, uninstall script for cleanup
    scripts/theia-ide/install-context.reg — Registry template for the context menu entry
    scripts/theia-ide/uninstall-context.reg — Registry template to remove the context menu


- [X]  Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
