### PR TITLE
workbuddy: Add version 5.5.2.37849279

### DIFF
--- a/bucket/workbuddy.json
+++ b/bucket/workbuddy.json
@@ -1,0 +1,38 @@
+{
+    "version": "5.5.2.37849279",
+    "description": "A full-scenario AI workbench from Tencent.",
+    "homepage": "https://www.workbuddy.ai",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.workbuddy.ai/document/term"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://codebuddy-1328495429.cos.accelerate.myqcloud.com/workbuddy/saas/win32-x64-user/WorkBuddy-win32-x64-user-5.5.2.37849279-910352f0.exe#/dl.7z",
+            "hash": "19b107bdccb918d49e84cfc3407ced578439a1643a7714a493da7d88b9fd786b"
+        }
+    },
+    "installer": {
+        "script": [
+            "Get-Item \"$dir\\`$PLUGINSDIR\\app*.7z\" | Select-Object -First 1 | Expand-7zipArchive -DestinationPath $dir",
+            "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Force -Recurse -ErrorAction Ignore"
+        ]
+    },
+    "shortcuts": [
+        [
+            "WorkBuddyAI.exe",
+            "WorkBuddyAI"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.workbuddy.ai/v2/update?platform=workbuddy-win32-x64-user",
+        "regex": "WorkBuddy-win32-x64-user-(?<version>\\d+(?:\\.\\d+)+)-(?<sha>[0-9a-f]+).exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://codebuddy-1328495429.cos.accelerate.myqcloud.com/workbuddy/saas/win32-x64-user/WorkBuddy-win32-x64-user-$version-$matchSha.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
This PR adds the international version of WorkBuddy. Data resides in the user directory; not persisted by Scoop.

Note: The China (www.workbuddy.ai) and international (www.workbuddy.cn) editions differ in content and versioning.
- https://www.workbuddy.ai/v2/update?platform=workbuddy-win32-x64-user
- https://www.workbuddy.cn/v2/update?platform=workbuddy-win32-x64-user

Closes #18664
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
